### PR TITLE
fix: correct table of contents anchor links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@
 
 ## 📚 Table of Contents
 
-- [Overview](#overview)
-- [Available Skills](#available-skills)
-- [Quick Start](#quick-start)
-- [How to Use with Claude AI](#how-to-use-with-claude-ai)
-- [How to Use with Claude Code](#how-to-use-with-claude-code)
-- [Skill Architecture](#skill-architecture)
-- [Installation](#installation)
-- [Usage Examples](#usage-examples)
-- [Roadmap](#roadmap)
-- [Contributing](#contributing)
-- [License](#license)
-- [Author](#author)
+- [Overview](#-overview)
+- [Available Skills](#-available-skills)
+- [Quick Start](#-quick-start)
+- [How to Use with Claude AI](#-how-to-use-with-claude-ai)
+- [How to Use with Claude Code](#-how-to-use-with-claude-code)
+- [Skill Architecture](#-skill-architecture)
+- [Installation](#-installation)
+- [Usage Examples](#-usage-examples)
+- [Roadmap](#-roadmap)
+- [Contributing](#-contributing)
+- [License](#-license)
+- [Author](#-author)
 
 ---
 


### PR DESCRIPTION
@claude review and execute the PR.
Updated all TOC links to match GitHub's anchor generation for headers with emojis. Headers like "## 🎯 Overview" generate anchors like "#-overview" (with leading dash).

Changes:
- Updated 12 TOC links from #section to #-section format
- Links now properly navigate to their respective sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)