### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Skills Library by nginity (Your Agentic Startup Kit)
 
+[![Run in Smithery](https://smithery.ai/badge/skills/alirezarezvani)](https://smithery.ai/skills?ns=alirezarezvani&utm_source=github&utm_medium=badge)
+
+
 **Production-Ready skill packages for Claude AI & Claude Code** - Reusable expertise bundles combining best practices, analysis tools, and strategic frameworks for marketing teams, executive leadership, product development, your web and mobile engineering teams. Many other teams will be included soon and regularly.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Add "Run in Smithery" Badge

Hi! We'd like to add a badge to your README that lets users instantly discover and try your Claude Skills in [Smithery](https://smithery.ai).

[![Run in Smithery](https://smithery.ai/badge/skills/alirezarezvani)](https://smithery.ai/skills?ns=alirezarezvani&utm_source=github&utm_medium=badge)

### What's Smithery?
Smithery is a platform for discovering and installing Claude Skills and MCP servers. Your 36 skills have been installed **7 times** by **6 users** in the last 30 days.

### Top Skills
- **content-creator** (7 activations, 6 users)

### What This PR Does
- Adds a badge to your README linking to your skills collection on Smithery
- Lets users browse and install your skills with one click
- Shows aggregate usage metrics across all your skills

### Suggested Placement
We recommend placing the badge at the top of your README, below the title or alongside other badges.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!