### PR TITLE
Merge dev into main (Codex support + conflict resolution)

### DIFF
--- a/.github/workflows/sync-codex-skills.yml
+++ b/.github/workflows/sync-codex-skills.yml
@@ -1,3 +1,4 @@
+---
 name: Sync Codex Skills Symlinks
 
 on:
@@ -13,7 +14,7 @@ on:
       dry_run:
         description: 'Dry run (no changes)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 jobs:
@@ -70,13 +71,12 @@ jobs:
             echo "**Total Skills:** $TOTAL" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Categories" >> $GITHUB_STEP_SUMMARY
-            python3 << 'PYEOF'
-import json
-with open('.codex/skills-index.json') as f:
-    data = json.load(f)
-for cat, info in data['categories'].items():
-    print(f'- **{cat}**: {info["count"]} skills')
-PYEOF
+            python3 -c "
+          import json
+          data = json.load(open('.codex/skills-index.json'))
+          for cat, info in data['categories'].items():
+              print(f'- **{cat}**: {info[\"count\"]} skills')
+          " >> $GITHUB_STEP_SUMMARY
           else
             echo "No skills index found." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,10 @@ medium-content-pro/*
 medium-content-pro 2/*
 documentation/GIST_CONTENT.md
 documentation/implementation/*__pycache__/
-medium-content-pro 2/*
 ARTICLE-FEEDBACK-AND-OPTIMIZED-VERSION.md
 CLAUDE-CODE-LOCAL-MAC-PROMPT.md
 CLAUDE-CODE-SEO-FIX-COPYPASTE.md
 GITHUB_ISSUE_RESPONSES.md
-medium-content-pro.zip
+
 # Archive folder (historical/backup files)
 archive/


### PR DESCRIPTION
## Summary

Merges dev branch into main with conflict resolution for `sync-codex-skills.yml`.

### Conflict Resolution

The workflow file had conflicts between main and dev. Resolved by keeping:
- `---` document start (required for YAML lint)
- `default: false` (proper boolean instead of string)
- Multi-line Python code (passes line-length check ≤160 chars)

### Changes Included

All Codex support changes from dev:
- `.codex/skills/` - 43 symlinks to skill folders
- `.codex/skills-index.json` - Skills manifest
- `scripts/sync-codex-skills.py` - Symlink automation
- `scripts/codex-install.sh` - Unix installer
- `scripts/codex-install.bat` - Windows installer
- `.github/workflows/sync-codex-skills.yml` - CI automation (lint-compliant)
- `.gitignore` - Updated patterns
- `INSTALLATION.md` - Codex installation docs
- `README.md` - Codex usage guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)