### PR TITLE
fix(skill): rewrite marketing-demand-acquisition with proper structure (#72)

### DIFF
--- a/marketing-skill/marketing-demand-acquisition/SKILL.md
+++ b/marketing-skill/marketing-demand-acquisition/SKILL.md
@@ -1,985 +1,310 @@
 ---
 name: marketing-demand-acquisition
-description: Multi-channel demand generation, paid media optimization, SEO strategy, and partnership programs for Series A+ startups. Includes CAC calculator, channel playbooks, HubSpot integration, and international expansion tactics. Use when planning demand generation campaigns, optimizing paid media, building SEO strategies, establishing partnerships, or when user mentions demand gen, paid ads, LinkedIn ads, Google ads, CAC, acquisition, lead generation, or pipeline generation.
-license: MIT
+description: Multi-channel demand generation, paid media optimization, SEO strategy, and partnership programs for Series A+ startups
+triggers:
+  - demand gen
+  - demand generation
+  - paid ads
+  - paid media
+  - LinkedIn ads
+  - Google ads
+  - Meta ads
+  - CAC
+  - customer acquisition cost
+  - lead generation
+  - MQL
+  - SQL
+  - pipeline generation
+  - acquisition strategy
+  - HubSpot campaigns
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   author: Alireza Rezvani
   category: marketing
   domain: demand-generation
-  updated: 2025-10-20
-  python-tools: calculate_cac.py
-  tech-stack: HubSpot, LinkedIn-Ads, Google-Ads, Meta-Ads, SEO-tools
-  target-market: B2B-SaaS, Series-A+
+  updated: 2025-01
 ---
 
 # Marketing Demand & Acquisition
 
-Expert acquisition playbook for Series A+ startups scaling internationally (EU/US/Canada) with hybrid PLG/Sales-Led motion.
+Acquisition playbook for Series A+ startups scaling internationally (EU/US/Canada) with hybrid PLG/Sales-Led motion.
 
-## Keywords
-demand generation, paid media, paid ads, LinkedIn ads, Google ads, Meta ads, CAC, customer acquisition cost, lead generation, MQL, SQL, pipeline generation, acquisition strategy, performance marketing, paid social, paid search, partnerships, affiliate marketing, SEO strategy, HubSpot campaigns, marketing automation, B2B marketing, SaaS marketing
+## Table of Contents
+
+- [Role Coverage](#role-coverage)
+- [Core KPIs](#core-kpis)
+- [Demand Generation Framework](#demand-generation-framework)
+- [Paid Media Channels](#paid-media-channels)
+- [SEO Strategy](#seo-strategy)
+- [Partnerships](#partnerships)
+- [Attribution](#attribution)
+- [Tools](#tools)
+- [References](#references)
+
+---
 
 ## Role Coverage
 
-This skill serves:
-- **Demand Generation Manager** - Multi-channel campaigns, pipeline generation
-- **Paid Media/Performance Marketer** - Paid search/social/display optimization
-- **SEO Manager** - Organic acquisition and technical SEO
-- **Affiliate/Partnerships Manager** - Co-marketing and channel partnerships
-
-## Core KPIs by Role
-
-**Demand Gen**: MQL/SQL volume, cost per opportunity, marketing-sourced pipeline $, pipeline velocity, MQL→SQL conversion rate
-
-**Paid Media**: CAC, ROAS, CPL, CPA, incrementality lift, channel efficiency ratio
-
-**SEO**: Organic sessions, non-brand traffic %, keyword rankings (P1-P3), organic-assisted conversions, technical health score
-
-**Partnerships**: Partner-sourced pipeline $, partner CAC, net new logos via partners, co-marketing ROI
-
-## Tech Stack Integration
-
-**HubSpot CRM** - Campaign tracking, lead scoring, attribution, workflows
-**Google Analytics** - Traffic analysis, conversion tracking, funnel optimization
-**Search Console** - Keyword performance, technical issues, indexing
-**LinkedIn Campaign Manager** - B2B paid social
-**Google Ads** - Search, Display, YouTube
-**Meta Ads** - Facebook, Instagram
+| Role | Focus Areas |
+|------|-------------|
+| Demand Generation Manager | Multi-channel campaigns, pipeline generation |
+| Paid Media Marketer | Paid search/social/display optimization |
+| SEO Manager | Organic acquisition, technical SEO |
+| Partnerships Manager | Co-marketing, channel partnerships |
 
 ---
 
-## 1. Demand Generation Framework
+## Core KPIs
 
-### 1.1 Full-Funnel Strategy (2025 Best Practice)
+**Demand Gen:** MQL/SQL volume, cost per opportunity, marketing-sourced pipeline $, MQL→SQL rate
 
-**TOFU (Awareness)** → **MOFU (Consideration)** → **BOFU (Decision)** → **Handoff to Sales/Product**
+**Paid Media:** CAC, ROAS, CPL, CPA, channel efficiency ratio
 
-#### TOFU Tactics
-- Paid social (LinkedIn thought leadership, Meta awareness)
-- Display advertising (programmatic, retargeting)
-- Content syndication
-- SEO (informational keywords)
-- Partnerships (co-webinars, guest content)
-- Target: Brand lift, site traffic, early-stage engagement
+**SEO:** Organic sessions, non-brand traffic %, keyword rankings, technical health score
 
-#### MOFU Tactics
-- Paid search (solution keywords)
-- Retargeting campaigns
-- Gated content (eBooks, templates, webinars)
-- Email nurture sequences
-- Comparison pages (SEO)
-- Target: MQLs, demo requests, trial signups
-
-#### BOFU Tactics
-- Paid search (brand + competitor keywords)
-- Direct outreach campaigns
-- Free trial CTAs
-- Case studies & ROI calculators
-- Intent-based retargeting
-- Target: SQLs, demos booked, pipeline $
-
-### 1.2 Campaign Planning Template
-
-**Campaign Brief** (use this for every campaign):
-
-```
-Campaign Name: [Q2-2025-LinkedIn-ABM-Enterprise]
-Objective: [Generate 50 SQLs from Enterprise accounts ($50k+ ACV)]
-Budget: [$15k/month]
-Duration: [90 days]
-Channels: [LinkedIn Ads, Retargeting, Email]
-Audience: [Director+ at SaaS companies, 500-5000 employees, EU/US]
-Offer: [Gated Industry Benchmark Report]
-Success Metrics:
-  - Primary: 50 SQLs, <$300 CPO
-  - Secondary: 500 MQLs, 10% MQL→SQL rate, 40% email open rate
-HubSpot Setup:
-  - Campaign ID: [create in HubSpot]
-  - Lead scoring: +20 for download, +30 for demo request
-  - Attribution: First-touch + Multi-touch
-Handoff Protocol:
-  - SQL criteria: Title + Company size + Budget confirmed
-  - Routing: Enterprise SDR team via HubSpot workflow
-  - SLA: 4-hour response time
-```
-
-### 1.3 HubSpot Campaign Tracking Setup
-
-**Step-by-step**:
-
-1. **Create Campaign in HubSpot**
-   - Marketing → Campaigns → Create Campaign
-   - Name: `Q2-2025-LinkedIn-ABM-Enterprise`
-   - Tag all assets (landing pages, emails, ads) with campaign ID
-
-2. **UTM Parameter Structure** (critical for attribution)
-   ```
-   utm_source={channel}       // linkedin, google, facebook
-   utm_medium={type}          // cpc, display, email, organic
-   utm_campaign={campaign-id} // q2-2025-linkedin-abm-enterprise
-   utm_content={variant}      // ad-variant-a, email-1
-   utm_term={keyword}         // [for paid search only]
-   ```
-
-3. **Lead Scoring Configuration**
-   - Navigate to: Settings → Marketing → Lead Scoring
-   - Campaign engagement: +10-30 points based on action depth
-   - Channel quality: LinkedIn +5, Google Search +10, Organic +15
-
-4. **Attribution Reports**
-   - Use HubSpot's multi-touch attribution (W-shaped for hybrid motion)
-   - First-touch: Awareness credit
-   - Multi-touch: Full journey credit
-   - Build custom report: Marketing → Reports → Attribution
-
-### 1.4 International Expansion Considerations
-
-**EU Market Entry**:
-- GDPR compliance: Double opt-in for email, explicit consent tracking in HubSpot
-- Localization: Translate landing pages, ads, emails (DE, FR, ES priority)
-- Payment: Display prices in EUR
-- Partnerships: Local co-marketing partners for credibility
-- Paid channels: LinkedIn most effective for B2B EU, Google Ads second
-
-**US/Canada Market Entry**:
-- Messaging: Direct, ROI-focused, less formal than EU
-- Paid channels: Google Ads + LinkedIn equal priority
-- Partnerships: Industry associations, review sites (G2, Capterra)
-- Content: Case studies with $ impact, not just features
-- Sales alignment: Faster sales cycles, need immediate lead follow-up
-
-**Budget Allocation** (Series A recommended):
-- EU: 40% LinkedIn, 25% Google, 20% SEO, 15% Partnerships
-- US/CA: 35% Google, 30% LinkedIn, 20% SEO, 15% Partnerships
+**Partnerships:** Partner-sourced pipeline $, partner CAC, co-marketing ROI
 
 ---
 
-## 2. Paid Media Optimization
+## Demand Generation Framework
 
-### 2.1 Channel Strategy Matrix
+### Funnel Stages
 
-| Channel | Best For | CAC Benchmark | Conversion Rate | Series A Priority |
-|---------|----------|---------------|-----------------|-------------------|
-| **LinkedIn Ads** | B2B, Enterprise, ABM | $150-$400 | 0.5-2% | ⭐⭐⭐⭐⭐ |
-| **Google Search** | High-intent, BOFU | $80-$250 | 2-5% | ⭐⭐⭐⭐⭐ |
-| **Google Display** | Retargeting, awareness | $50-$150 | 0.3-1% | ⭐⭐⭐ |
-| **Meta (FB/IG)** | SMB, consumer-like products | $60-$200 | 1-3% | ⭐⭐⭐ |
-| **YouTube** | Product demos, brand | $100-$300 | 0.5-1.5% | ⭐⭐ |
-| **Reddit/Twitter** | Technical audiences | $40-$180 | 0.5-2% | ⭐⭐ |
+| Stage | Tactics | Target |
+|-------|---------|--------|
+| TOFU | Paid social, display, content syndication, SEO | Brand awareness, traffic |
+| MOFU | Paid search, retargeting, gated content, email nurture | MQLs, demo requests |
+| BOFU | Brand search, direct outreach, case studies, trials | SQLs, pipeline $ |
 
-### 2.2 LinkedIn Ads Playbook (Primary B2B Channel)
+### Campaign Planning Workflow
 
-**Campaign Structure**:
+1. Define objective, budget, duration, audience
+2. Select channels based on funnel stage
+3. Create campaign in HubSpot with proper UTM structure
+4. Configure lead scoring and assignment rules
+5. Launch with test budget, validate tracking
+6. **Validation:** UTM parameters appear in HubSpot contact records
+
+### UTM Structure
+
 ```
-Account
-└─ Campaign Group: [Q2-2025-Enterprise-ABM]
-   ├─ Campaign 1: [Awareness - Thought Leadership]
-   │  ├─ Ad Set: [CTO/VP Eng, US, Tech Companies]
-   │  └─ Creatives: [3 carousel posts, 2 video ads]
-   ├─ Campaign 2: [Consideration - Product Education]
-   │  ├─ Ad Set: [Engaged audience, retargeting]
-   │  └─ Creatives: [2 lead gen forms, 1 landing page]
-   └─ Campaign 3: [Conversion - Demo Requests]
-      ├─ Ad Set: [Website visitors, content downloaders]
-      └─ Creatives: [Direct demo CTA, case study]
+utm_source={channel}       // linkedin, google, meta
+utm_medium={type}          // cpc, display, email
+utm_campaign={campaign-id} // q1-2025-linkedin-enterprise
+utm_content={variant}      // ad-a, email-1
+utm_term={keyword}         // [paid search only]
 ```
-
-**Targeting Best Practices**:
-- **Company Size**: 50-5000 employees (Series A sweet spot)
-- **Job Titles**: Director+, VP+, C-level (use LinkedIn's precise targeting)
-- **Industries**: Software, SaaS, Tech Services
-- **Matched Audiences**: Website retargeting (install Insight Tag), uploaded email lists
-- **Budget**: Start $50/day per campaign, scale 20% weekly if CAC < target
-
-**Creative Frameworks**:
-1. **Thought Leadership** - Industry insights, no product pitch
-2. **Social Proof** - Customer logos, testimonials, case study snippets
-3. **Problem-Solution** - Pain point + your solution in 3 seconds
-4. **Demo-First** - Show product immediately, skip fluff
-
-**LinkedIn Lead Gen Forms vs. Landing Pages**:
-- **Lead Gen Forms**: Higher conversion (2-3x), lower quality, use for TOFU/MOFU
-- **Landing Pages**: Lower conversion, higher quality, use for BOFU/demo requests
-- **HubSpot Sync**: Connect LinkedIn Lead Gen Forms via native integration
-
-### 2.3 Google Ads Playbook (High-Intent Capture)
-
-**Campaign Types Priority**:
-1. **Search - Brand** (highest priority, protect brand terms)
-2. **Search - Competitor** (steal market share)
-3. **Search - Solution** (problem-aware buyers)
-4. **Search - Product Category** (earlier stage)
-5. **Display - Retargeting** (re-engage warm traffic)
-
-**Search Campaign Structure**:
-```
-Campaign: [Search-Solution-Keywords]
-├─ Ad Group: [project management software]
-│  ├─ Keywords:
-│  │  - "project management software" [Phrase]
-│  │  - "best project management tool" [Phrase]
-│  │  - +project +management +solution [Broad Match Modifier]
-│  └─ Ads: [3 responsive search ads with 15 headlines, 4 descriptions]
-│
-├─ Ad Group: [team collaboration tools]
-   ├─ Keywords: [5-10 tightly themed keywords]
-   └─ Ads: [3 responsive search ads]
-```
-
-**Keyword Strategy**:
-- **Brand Terms**: Exact match, bid high, protect brand
-- **Competitor Terms**: "[Competitor] alternative", "[Competitor] vs [You]"
-- **Solution Terms**: "best [category] software", "top [category] tools"
-- **Problem Terms**: "how to [solve problem]"
-- **Negative Keywords**: Maintain list of 100+ (free, cheap, jobs, career, reviews)
-
-**Bid Strategy** (2025 best practice):
-- New campaigns: Start Manual CPC for control
-- After 50+ conversions: Switch to Target CPA
-- After 100+ conversions: Test Maximize Conversions with tCPA
-- EU markets: Bid 15-20% higher for same quality
-
-**Ad Copy Framework** (Responsive Search Ads):
-```
-Headlines (15 required):
-- H1-3: Value props (Save 10 hours/week, Trusted by 500+ teams)
-- H4-6: Features (AI-powered, Real-time sync, Mobile app)
-- H7-9: Social proof (4.8★ G2 rating, Used by Microsoft)
-- H10-12: CTAs (Start free trial, Book demo, See pricing)
-- H13-15: Keywords pinned (Dynamic insertion)
-
-Descriptions (4 required):
-- D1: Primary value prop + CTA (30-60 chars)
-- D2: Feature list + differentiator (60-90 chars)
-- D3: Social proof + urgency (45-90 chars)
-- D4: Backup generic (60-90 chars)
-```
-
-### 2.4 Meta Ads Playbook (SMB/Lower ACV)
-
-**When to Use Meta**:
-- ✅ Product ACV <$10k
-- ✅ Visual product (UI, consumer-facing)
-- ✅ SMB/prosumer audience
-- ✅ Broader awareness campaigns
-- ❌ Enterprise/high ACV (use LinkedIn)
-
-**Campaign Setup**:
-```
-Campaign Objective: [Conversions]
-├─ Ad Set 1: [Lookalike - 1% of converters]
-│  └─ Placement: [Feed + Stories, Auto]
-├─ Ad Set 2: [Interest - Business Software]
-│  └─ Placement: [Feed only]
-└─ Ad Set 3: [Retargeting - Website 30d]
-   └─ Placement: [All placements]
-```
-
-**Audience Strategy**:
-1. **Core Audiences**: Interests (business tools, productivity, startups)
-2. **Lookalike**: 1% of purchasers/high-value leads
-3. **Retargeting**: 30-day website visitors, video viewers (75%+)
-
-**Creative Best Practices**:
-- Use video (1:1 or 9:16 for Stories)
-- First 3 seconds = hook (problem or result)
-- Show product UI in action
-- Add captions (85% watch muted)
-- Test 3-5 creative variants per campaign
-
-### 2.5 Budget Allocation & Scaling
-
-**Initial Budget** (Series A, $30k-50k/month total):
-```
-Channel            Budget    Expected Results
-─────────────────────────────────────────────
-LinkedIn Ads       $15k      50 MQLs, 10 SQLs, $1.5k CAC
-Google Search      $12k      80 MQLs, 20 SQLs, $600 CAC
-Google Display     $5k       120 MQLs, 5 SQLs, $1k CAC
-Meta Ads           $5k       100 MQLs, 8 SQLs, $625 CAC
-Partnerships       $3k       20 MQLs, 5 SQLs, $600 CAC
-─────────────────────────────────────────────
-TOTAL              $40k      370 MQLs, 48 SQLs, $833 avg CAC
-```
-
-**Scaling Rules**:
-1. If CAC <target → Increase budget 20% weekly
-2. If CAC >target → Pause, optimize, relaunch
-3. If conversion rate drops >20% → Check landing page, offer fatigue
-4. Scale winners, kill losers fast (2-week test minimum)
-
-**HubSpot ROI Dashboard**:
-- Marketing → Reports → Create Custom Report
-- Metrics: Spend, Leads, MQLs, SQLs, CAC, ROAS, Pipeline $
-- Dimensions: Campaign, Channel, Region
-- Frequency: Daily review, weekly optimization
 
 ---
 
-## 3. SEO Strategy
+## Paid Media Channels
 
-### 3.1 Technical SEO Foundation (Must-Have)
+### Channel Selection Matrix
 
-**Pre-Launch Checklist**:
+| Channel | Best For | CAC Range | Series A Priority |
+|---------|----------|-----------|-------------------|
+| LinkedIn Ads | B2B, Enterprise, ABM | $150-400 | High |
+| Google Search | High-intent, BOFU | $80-250 | High |
+| Google Display | Retargeting | $50-150 | Medium |
+| Meta Ads | SMB, visual products | $60-200 | Medium |
+
+### LinkedIn Ads Setup
+
+1. Create campaign group for initiative
+2. Structure: Awareness → Consideration → Conversion campaigns
+3. Target: Director+, 50-5000 employees, relevant industries
+4. Start $50/day per campaign
+5. Scale 20% weekly if CAC < target
+6. **Validation:** LinkedIn Insight Tag firing on all pages
+
+### Google Ads Setup
+
+1. Prioritize: Brand → Competitor → Solution → Category keywords
+2. Structure ad groups with 5-10 tightly themed keywords
+3. Create 3 responsive search ads per ad group (15 headlines, 4 descriptions)
+4. Maintain negative keyword list (100+)
+5. Start Manual CPC, switch to Target CPA after 50+ conversions
+6. **Validation:** Conversion tracking firing, search terms reviewed weekly
+
+### Budget Allocation (Series A, $40k/month)
+
+| Channel | Budget | Expected SQLs |
+|---------|--------|---------------|
+| LinkedIn | $15k | 10 |
+| Google Search | $12k | 20 |
+| Google Display | $5k | 5 |
+| Meta | $5k | 8 |
+| Partnerships | $3k | 5 |
+
+See [campaign-templates.md](references/campaign-templates.md) for detailed structures.
+
+---
+
+## SEO Strategy
+
+### Technical Foundation Checklist
+
 - [ ] XML sitemap submitted to Search Console
-- [ ] Robots.txt configured (allow crawling)
-- [ ] HTTPS enabled (SSL certificate)
-- [ ] Page speed >90 mobile (Google PageSpeed Insights)
-- [ ] Core Web Vitals passing (LCP, FID, CLS)
-- [ ] Structured data (Organization, Product, FAQ schema)
+- [ ] Robots.txt configured correctly
+- [ ] HTTPS enabled
+- [ ] Page speed >90 mobile
+- [ ] Core Web Vitals passing
+- [ ] Structured data implemented
 - [ ] Canonical tags on all pages
-- [ ] Hreflang tags for international (en-US, en-GB, de-DE, etc.)
+- [ ] Hreflang tags for international
+- **Validation:** Run Screaming Frog crawl, zero critical errors
 
-**Technical Audit** (quarterly):
-```
-1. Crawl site with Screaming Frog
-2. Check for:
-   - 404 errors (fix or redirect)
-   - Redirect chains (consolidate)
-   - Duplicate content (canonicalize)
-   - Missing meta descriptions
-   - Slow pages (>3s load time)
-   - Mobile usability issues
-3. Fix issues in priority order: Critical → High → Medium
-```
+### Keyword Strategy
 
-### 3.2 Keyword Strategy Framework
+| Tier | Type | Volume | Priority |
+|------|------|--------|----------|
+| 1 | High-intent BOFU | 100-1k | First |
+| 2 | Solution-aware MOFU | 500-5k | Second |
+| 3 | Problem-aware TOFU | 1k-10k | Third |
 
-**Keyword Research Process**:
-1. **Seed Keywords** - Your product category (e.g., "project management software")
-2. **Use Tools** - Ahrefs, SEMrush, or free: Google Keyword Planner + Search Console
-3. **Analyze** - Volume, difficulty, intent, SERP features
-4. **Prioritize** - Quick wins (low difficulty, high intent)
+### On-Page Optimization
 
-**Keyword Tiers**:
+1. URL: Include primary keyword, 3-5 words
+2. Title tag: Primary keyword + brand (60 chars)
+3. Meta description: CTA + value prop (155 chars)
+4. H1: Match search intent (one per page)
+5. Content: 2000-3000 words for comprehensive topics
+6. Internal links: 3-5 relevant pages
+7. **Validation:** Google Search Console shows page indexed, no errors
 
-**Tier 1: High-Intent BOFU** (target first)
-- "best [product category]"
-- "[product category] for [use case]"
-- "[competitor] alternative"
-- Volume: 100-1k/mo, Difficulty: Medium, Intent: Commercial
+### Link Building Priorities
 
-**Tier 2: Solution-Aware MOFU**
-- "how to [solve problem]"
-- "[problem] solution"
-- "[use case] tools"
-- Volume: 500-5k/mo, Difficulty: Medium-High, Intent: Informational-Commercial
-
-**Tier 3: Problem-Aware TOFU**
-- "what is [concept]"
-- "[problem] examples"
-- "[industry] challenges"
-- Volume: 1k-10k/mo, Difficulty: High, Intent: Informational
-
-**International Keyword Research**:
-- Use Ahrefs/SEMrush with language filters
-- Translate keywords, don't just localize (cultural nuances matter)
-- EU: Higher trust in localized content (domain.de > domain.com/de)
-- UK: Use British spelling (optimise vs. optimize)
-
-### 3.3 On-Page SEO Template
-
-**Page Optimization Checklist**:
-```
-URL: [/best-project-management-software]
-Title Tag (60 chars): [Best Project Management Software 2025 | YourBrand]
-Meta Description (155 chars): [Compare top 10 PM tools. Features, pricing, reviews. Find the perfect fit for your team. Free trials available.]
-
-H1 (60 chars): [Best Project Management Software in 2025]
-H2s (structure):
-  - What is Project Management Software?
-  - Top 10 PM Tools Compared
-  - Key Features to Look For
-  - Pricing & Plans
-  - How to Choose
-  - FAQ
-
-Content:
-  - Length: 2000-3000 words (comprehensive)
-  - Keyword density: 1-2% (natural)
-  - Internal links: 3-5 relevant pages
-  - External links: 2-3 authoritative sources
-  - Images: 3-5 with alt text
-  - Schema: Product, FAQ, HowTo
-
-CTA:
-  - Above fold: [Start Free Trial]
-  - Mid-content: [Compare Plans]
-  - End: [Book Demo]
-```
-
-**Content Refresh Schedule**:
-- Tier 1 pages: Update quarterly (rankings, pricing, features)
-- Tier 2 pages: Update semi-annually
-- Tier 3 pages: Update annually
-- All pages: Monitor Search Console for ranking drops, refresh immediately
-
-### 3.4 Link Building Strategy (2025 Best Practices)
-
-**Link Acquisition Tactics** (in priority order):
-
-**1. Digital PR** (highest ROI)
-- Publish original research/data
-- Create industry reports
-- Pitch journalists (use HARO, Terkel, Featured)
-- Target: Industry blogs, tech publications
-
-**2. Guest Posting** (quality over quantity)
-- Target: Domain Authority (DA) 40+ sites
-- Avoid: Link farms, PBNs, paid links (Google penalty risk)
-- Anchor text: Branded (70%), topical (20%), exact match (10%)
-
-**3. Partnerships & Co-Marketing**
-- Partner with complementary SaaS tools
-- Create co-branded content
-- Exchange homepage links (footer or partner section)
-
-**4. Community Engagement**
-- Answer questions on Reddit, Quora
-- Participate in industry forums
-- Create tools/calculators → natural backlinks
-
-**5. Broken Link Building**
-- Find broken links on competitor sites
-- Offer your content as replacement
-- Tools: Ahrefs' Broken Backlinks report
-
-**Link Velocity** (avoid penalties):
-- Natural: 5-10 links/month for new sites
-- Aggressive: 20-30 links/month after 6 months
-- Monitor: Google Search Console for manual actions
-
-### 3.5 Content Strategy for SEO
-
-**Content Types by Funnel Stage**:
-
-**TOFU (Awareness)**:
-- Blog posts: "Ultimate Guide to [Topic]"
-- Listicles: "Top 10 [Category]"
-- Industry reports: "[Industry] State of 2025"
-- Target: Broad keywords, thought leadership
-
-**MOFU (Consideration)**:
-- Comparison pages: "[Your Product] vs [Competitor]"
-- Best of lists: "Best [Category] for [Use Case]"
-- How-to guides: "How to [Solve Problem] with [Product]"
-- Target: Solution keywords, product education
-
-**BOFU (Decision)**:
-- Product pages: "[Product] Features & Pricing"
-- Case studies: "How [Customer] Achieved [Result]"
-- Landing pages: "Start Free Trial"
-- Target: Brand keywords, high-intent searches
-
-**Content Calendar** (Series A minimum):
-- TOFU: 4 posts/month (1 per week)
-- MOFU: 2 posts/month
-- BOFU: 1 post/month
-- Refresh: 2 existing posts/month
-
-### 3.6 Local SEO (For Regional Offices)
-
-**Google Business Profile Setup** (per location):
-- Complete all fields: Name, address, phone, hours, category
-- Upload photos: Office, team, product (10+ images)
-- Collect reviews: Ask customers, automate via HubSpot workflow
-- Post updates: Weekly posts about company news, events
-
-**Local Citations** (US/Canada/EU):
-- Submit to: Yelp, Yellow Pages, local directories
-- NAP consistency: Name, Address, Phone identical everywhere
-- Industry directories: Software review sites (G2, Capterra)
+1. Digital PR (original research, industry reports)
+2. Guest posting (DA 40+ sites only)
+3. Partner co-marketing (complementary SaaS)
+4. Community engagement (Reddit, Quora)
 
 ---
 
-## 4. Partnerships & Affiliate Programs
+## Partnerships
 
-### 4.1 Partnership Types & Strategy
+### Partnership Tiers
 
-**Partnership Tiers**:
+| Tier | Type | Effort | ROI |
+|------|------|--------|-----|
+| 1 | Strategic integrations | High | Very high |
+| 2 | Affiliate partners | Medium | Medium-high |
+| 3 | Customer referrals | Low | Medium |
+| 4 | Marketplace listings | Medium | Low-medium |
 
-**Tier 1: Strategic Partnerships** (high impact, low volume)
-- Target: Complementary SaaS tools with overlapping ICPs
-- Structure: Co-marketing, product integrations, revenue share
-- Examples: Slack ↔ Asana, Shopify ↔ Klaviyo
-- Effort: High (6-12 months to establish)
-- ROI: Very high (100+ leads/month after ramp)
+### Partnership Workflow
 
-**Tier 2: Affiliate Partners** (scalable)
-- Target: Bloggers, review sites, industry influencers
-- Structure: Commission per sale (10-30% first year)
-- Platform: Use PartnerStack, Impact, or Rewardful
-- Effort: Medium (setup once, ongoing management)
-- ROI: Medium-High (depends on partner quality)
+1. Identify partners with overlapping ICP, no competition
+2. Outreach with specific integration/co-marketing proposal
+3. Define success metrics, revenue model, term
+4. Create co-branded assets and partner tracking
+5. Enable partner sales team with demo training
+6. **Validation:** Partner UTM tracking functional, leads routing correctly
 
-**Tier 3: Referral Partners** (customer-driven)
-- Target: Your existing customers
-- Structure: Referral bonus ($500-$1k per SQL)
-- Platform: Built into HubSpot or standalone (Friendbuy)
-- Effort: Low (automate via workflows)
-- ROI: Medium (5-10% of customers refer)
+### Affiliate Program Setup
 
-**Tier 4: Marketplace Listings** (distribution)
-- Target: Shopify App Store, Salesforce AppExchange, HubSpot Marketplace
-- Structure: Free listing + revenue share
-- Effort: Medium (initial listing, ongoing updates)
-- ROI: Low-Medium (brand visibility + discovery)
+1. Select platform (PartnerStack, Impact, Rewardful)
+2. Configure commission structure (20-30% recurring)
+3. Create affiliate enablement kit (assets, links, content)
+4. Recruit through outbound, inbound, events
+5. **Validation:** Test affiliate link tracks through to conversion
 
-### 4.2 Partnership Playbook
-
-**Step 1: Identify Partners**
-```
-Criteria:
-- Similar ICP (overlapping audience, no direct competition)
-- Product fit (complementary, not substitute)
-- Scale (similar company size, funding stage)
-- Values alignment (culture, brand positioning)
-
-Research:
-- Tools: BuiltWith, SimilarWeb, LinkedIn Sales Nav
-- Look for: Integration pages, partner pages, co-marketing history
-```
-
-**Step 2: Outreach Template**
-```
-Subject: [YourBrand] ↔ [TheirBrand] Partnership Idea
-
-Hi [Name],
-
-I'm [Your Name] at [YourBrand] - we help [ICP] with [value prop].
-
-I noticed [TheirBrand] serves a similar audience, and I think our customers would benefit from an integration between [YourProduct] and [TheirProduct].
-
-Would you be open to exploring a partnership? I'm thinking:
-- Product integration (bi-directional sync)
-- Co-marketing (joint webinar, case study)
-- Revenue share (referral fees)
-
-Let me know if you'd like to chat. Happy to send more details.
-
-Best,
-[Your Name]
-```
-
-**Step 3: Partnership Agreement**
-- Define scope (integration depth, marketing commitment)
-- Revenue model (rev share %, referral fees, co-selling)
-- Success metrics (leads, pipeline, revenue)
-- Term (12-24 months, with renewal)
-- Exit clause (90-day notice)
-
-**Step 4: Activation & Enablement**
-- Create co-branded assets (landing page, webinar deck, one-pager)
-- Train partner sales team (product demo, pitch deck, objection handling)
-- Set up tracking (UTM parameters, partner portal in HubSpot)
-
-**Step 5: Ongoing Management**
-- Quarterly business reviews (QBRs)
-- Monthly check-ins (pipeline, blockers)
-- Co-marketing calendar (1-2 activities/quarter)
-- Reporting (HubSpot dashboard for partner-sourced pipeline)
-
-### 4.3 Affiliate Program Setup
-
-**Platform Selection**:
-- **PartnerStack** - Best for B2B SaaS, native integrations
-- **Impact** - Enterprise-grade, high control
-- **Rewardful** - Lightweight, Stripe integration
-- **FirstPromoter** - Budget-friendly, good analytics
-
-**Commission Structure** (Series A typical):
-```
-Tier 1: Influencers/Publishers
-- 30% recurring for 12 months
-- Or: $500 flat per SQL
-- Bonus: $1k for 10+ referrals/quarter
-
-Tier 2: Bloggers/Content Creators
-- 20% recurring for 12 months
-- Or: $300 flat per SQL
-
-Tier 3: Customers (Referral Program)
-- $500 per closed deal
-- Or: 1 month free for both referrer + referee
-```
-
-**Recruitment Strategy**:
-1. **Outbound**: Find industry bloggers, YouTubers, newsletter writers
-2. **Inbound**: "Become an Affiliate" page, promote in product
-3. **Events**: Recruit at conferences, meetups
-4. **Communities**: Reddit, LinkedIn groups, Slack communities
-
-**Affiliate Enablement Kit**:
-- Brand assets (logos, product screenshots)
-- Pre-written content (blog post templates, social posts)
-- Tracking links (unique UTM codes per affiliate)
-- Sales collateral (one-pagers, case studies, demo videos)
-
-### 4.4 Co-Marketing Campaigns
-
-**Joint Webinar Playbook**:
-```
-Planning (6 weeks out):
-- Define topic (audience pain point, not product pitch)
-- Assign roles (host, co-host, Q&A moderator)
-- Create landing page (co-branded, dual logos)
-- Design promo assets (social graphics, email templates)
-
-Promotion (4 weeks out):
-- Email: 3 sends (announcement, reminder, last chance)
-- Social: 8-10 posts per partner (LinkedIn, Twitter)
-- Paid: $2k budget for LinkedIn ads → landing page
-- Partners: Cross-promote to each other's audiences
-
-Execution (day of):
-- 60-min format: 5min intro, 40min content, 15min Q&A
-- Record for on-demand
-- Polls/CTAs: Mid-webinar poll, end with demo CTA
-
-Follow-up (1 week after):
-- Send recording to all registrants
-- Nurture sequence: 3 emails over 2 weeks
-- Split leads: Each partner owns their referred leads
-- Report: Attendees, pipeline generated, next steps
-```
-
-**Other Co-Marketing Tactics**:
-- **Co-branded Content**: eBook, report, guide
-- **Case Study**: Joint customer success story
-- **Bundle Offer**: "Buy [YourProduct] + [TheirProduct], save 20%"
-- **Cross-promotion**: Feature each other in newsletters
-- **Social Media Takeover**: Guest post on each other's channels
-
-### 4.5 HubSpot Partner Tracking
-
-**Setup**:
-1. **Create Partner Property**
-   - Settings → Properties → Create "Partner Source" dropdown
-   - Values: Partner A, Partner B, Affiliate Network, etc.
-
-2. **UTM Tracking**
-   - Partner links: `?utm_source=partner-name&utm_medium=referral`
-   - HubSpot auto-captures UTM parameters
-
-3. **Lead Assignment**
-   - Workflow: If "Partner Source" is set → Assign to Partner Manager
-   - Notification: Slack alert when partner lead arrives
-
-4. **Reporting**
-   - Dashboard: Partner-sourced leads, pipeline, revenue
-   - Report to partners: Monthly performance summary
+See [international-playbooks.md](references/international-playbooks.md) for regional tactics.
 
 ---
 
-## 5. Attribution & Reporting
+## Attribution
 
-### 5.1 Attribution Models (HubSpot Native)
+### Model Selection
 
-**Model Selection** (use multi-touch for hybrid motion):
+| Model | Use Case |
+|-------|----------|
+| First-Touch | Awareness campaigns |
+| Last-Touch | Direct response |
+| W-Shaped (40-20-40) | Hybrid PLG/Sales (recommended) |
 
-**First-Touch** - Credit to first interaction
-- Use case: Awareness campaigns, brand building
-- Pro: Shows what drives discovery
-- Con: Ignores nurturing influence
+### HubSpot Attribution Setup
 
-**Last-Touch** - Credit to last interaction before conversion
-- Use case: Direct response, BOFU campaigns
-- Pro: Shows what closes deals
-- Con: Ignores earlier touchpoints
+1. Navigate to Marketing → Reports → Attribution
+2. Select W-Shaped model for hybrid motion
+3. Define conversion event (deal created)
+4. Set 90-day lookback window
+5. **Validation:** Run report for past 90 days, all channels show data
 
-**Multi-Touch (W-Shaped)** - Credit to first, last, and middle (40-20-40 split)
-- Use case: Hybrid PLG/Sales-Led (recommended for Series A)
-- Pro: Full-funnel view
-- Con: More complex to explain to stakeholders
+### Weekly Metrics Dashboard
 
-**HubSpot Setup**:
-- Marketing → Reports → Attribution → Select Model
-- Default: Use Multi-Touch for holistic view
-- Compare: Run reports side-by-side to see differences
+| Metric | Target |
+|--------|--------|
+| MQLs | Weekly target |
+| SQLs | Weekly target |
+| MQL→SQL Rate | >15% |
+| Blended CAC | <$300 |
+| Pipeline Velocity | <60 days |
 
-### 5.2 Reporting Dashboard (HubSpot)
-
-**Weekly Performance Dashboard**:
-```
-Metrics to Track:
-1. Traffic: Visits, unique visitors, bounce rate
-2. Leads: MQLs, SQLs, conversion rates
-3. Pipeline: Opportunities created, value, velocity
-4. CAC: Spend ÷ customers acquired
-5. Channel Mix: % of leads by source
-
-Dimensions:
-- By Channel: Organic, Paid, Email, Social, Referral
-- By Campaign: Individual campaign performance
-- By Region: US, CA, EU breakdown
-- By Stage: TOFU, MOFU, BOFU metrics
-```
-
-**Monthly Executive Dashboard**:
-```
-KPIs:
-1. Marketing-Sourced Pipeline: $[X]M (target: $[Y]M)
-2. Marketing-Sourced Revenue: $[X]k (target: $[Y]k)
-3. Blended CAC: $[X] (target: $[Y])
-4. MQL→SQL Rate: [X]% (target: [Y]%)
-5. Pipeline Velocity: [X] days (target: [Y] days)
-6. ROMI: [X]:1 (target: 3:1+)
-
-Insights:
-- Top performing campaigns
-- Underperforming channels (kill or optimize)
-- New experiments to test next month
-- Budget reallocation recommendations
-```
-
-### 5.3 Google Analytics Setup
-
-**Events to Track** (GA4):
-```
-Engagement:
-- page_view (auto-tracked)
-- scroll (75% depth)
-- video_play (product demos)
-- file_download (whitepapers, eBooks)
-
-Conversions:
-- sign_up (free trial, account created)
-- demo_request (calendar booking)
-- contact_form (inbound interest)
-- pricing_view (pricing page visit)
-
-E-commerce (if applicable):
-- add_to_cart
-- begin_checkout
-- purchase
-```
-
-**Custom Dimensions**:
-- User Type: Free vs. Paid
-- Plan Type: Starter, Pro, Enterprise
-- HubSpot Lead Status: MQL, SQL, Customer
-- Campaign: HubSpot Campaign ID
-
-**Integration with HubSpot**:
-- Use HubSpot tracking code (includes GA4 by default)
-- Or: Google Tag Manager for advanced tracking
-- Sync: GA4 audiences → HubSpot lists for retargeting
+See [attribution-guide.md](references/attribution-guide.md) for detailed setup.
 
 ---
 
-## 6. Experimentation Framework
-
-### 6.1 A/B Testing Prioritization (ICE Score)
-
-**Formula**: ICE = (Impact × Confidence × Ease) ÷ 3
-
-Rate each factor 1-10:
-- **Impact**: How much will this move the needle?
-- **Confidence**: How sure are you it will work?
-- **Ease**: How easy is it to implement?
-
-**Example Tests** (sorted by ICE score):
-
-| Test | Impact | Confidence | Ease | ICE | Priority |
-|------|--------|------------|------|-----|----------|
-| CTA button color (red vs. green) | 3 | 8 | 10 | 7.0 | Low |
-| Landing page headline rewrite | 8 | 7 | 8 | 7.7 | Medium |
-| Pricing page redesign | 9 | 6 | 4 | 6.3 | Medium |
-| New lead magnet offer | 9 | 8 | 7 | 8.0 | High |
-| Add live chat to pricing page | 7 | 9 | 8 | 8.0 | High |
-
-### 6.2 Test Design & Execution
-
-**Test Template**:
-```
-Hypothesis: [Adding a case study carousel to the pricing page will increase demo requests by 20% because users need social proof before committing]
-
-Metric: [Demo requests from /pricing page]
-Sample Size: [1000 visitors per variant]
-Duration: [2 weeks or until significance]
-Success Criteria: [20% lift, 95% confidence]
-
-Variant A (Control): [Current pricing page]
-Variant B (Treatment): [Pricing page + case study carousel]
-
-Tools: [HubSpot A/B test, or Google Optimize]
-```
-
-**Statistical Significance**:
-- Minimum: 95% confidence, 1000 visitors/variant
-- Use calculator: Optimizely Sample Size Calculator
-- Don't stop tests early (false positives)
-
-**Test Velocity** (Series A target):
-- 4-6 tests/month across channels
-- 70% win rate not realistic (aim for 30-40%)
-- Document losers (learnings matter)
-
-### 6.3 Common Experiments
-
-**Landing Page Tests**:
-- Headline variations (problem-focused vs. solution-focused)
-- CTA copy ("Start Free Trial" vs. "Get Started" vs. "Try Now")
-- Form length (5 fields vs. 2 fields)
-- Social proof placement (above vs. below fold)
-- Hero image (product screenshot vs. people vs. abstract)
-
-**Ad Tests**:
-- Creative format (static vs. video vs. carousel)
-- Messaging angle (feature-led vs. benefit-led vs. outcome-led)
-- Audience targeting (broad vs. narrow)
-- Landing page destination (homepage vs. dedicated LP)
-
-**Email Tests**:
-- Subject line length (short vs. long)
-- Personalization (generic vs. first name vs. company name)
-- Send time (morning vs. afternoon vs. evening)
-- CTA placement (top vs. middle vs. bottom)
-
----
-
-## 7. Handoff Protocols
-
-### 7.1 MQL → SQL Handoff (Marketing → Sales)
-
-**SQL Definition Criteria** (customize for your ICP):
-```
-Required:
-✅ Job title: Director+ (or Budget Authority confirmed)
-✅ Company size: 50-5000 employees
-✅ Budget: $10k+ annual (or Qualified Need confirmed)
-✅ Timeline: Buying within 90 days
-✅ Engagement: Demo requested OR High intent action
-
-Optional:
-✅ Industry: Target verticals
-✅ Geography: US/CA/EU
-✅ Use case: Matches product capabilities
-```
-
-**HubSpot Workflow**:
-1. Lead reaches MQL threshold (lead score >75)
-2. Trigger: Automated email to SDR
-3. SDR qualification call (BANT: Budget, Authority, Need, Timeline)
-4. If qualified → Mark as SQL, assign to AE
-5. If not qualified → Recycle to nurture, adjust lead score
-
-**SLA** (Service Level Agreement):
-- SDR responds to MQL: 4 hours
-- AE books demo with SQL: 24 hours
-- First demo: Within 3 business days of SQL status
-
-### 7.2 SQL → Opportunity Handoff (Sales → RevOps)
-
-**Opportunity Creation**:
-- AE creates opportunity in HubSpot after first demo
-- Required fields: Company, Deal value, Close date, Stage
-- Pipeline stages: Discovery → Demo → Proposal → Negotiation → Closed Won/Lost
-
-**Marketing Support Post-SQL**:
-- Retargeting ads to target accounts (ABM)
-- Send case studies, ROI calculator
-- Invite to customer webinar
-- Executive briefing (for Enterprise deals)
-
-### 7.3 Lost Opportunity Handoff (Sales → Marketing)
-
-**Recycle to Nurture**:
-- Reason: No budget, bad timing, wrong fit
-- Action: Move to "Nurture" list in HubSpot
-- Sequence: Quarterly check-in emails, invite to webinars
-- Re-engage: After 6-12 months, SDR re-qualification
-
-**Closed Lost Reasons** (track in HubSpot):
-- Price too high
-- Missing features
-- Chose competitor
-- No budget
-- Bad timing
-- Champion left company
-
-**Use lost reasons to inform**:
-- Product roadmap
-- Pricing changes
-- Competitive positioning
-- Messaging adjustments
-
----
-
-## 8. Quick Reference
-
-### 8.1 Channel-Specific Benchmarks (B2B SaaS Series A)
-
-| Metric | LinkedIn | Google Search | SEO | Email | Partnerships |
-|--------|----------|---------------|-----|-------|--------------|
-| CTR | 0.4-0.9% | 2-5% | 1-3% | 15-25% | N/A |
-| CVR | 1-3% | 3-7% | 2-5% | 2-5% | 5-10% |
-| CAC | $150-400 | $80-250 | $50-150 | $20-80 | $100-300 |
-| MQL→SQL | 10-20% | 15-25% | 12-22% | 8-15% | 20-35% |
-
-### 8.2 Budget Allocation (Recommended)
-
-**Series A ($40k-60k/month)**:
-- 40% Paid Acquisition (LinkedIn + Google)
-- 25% Content/SEO
-- 20% Partnerships
-- 10% Tools/Automation
-- 5% Experiments/Testing
-
-### 8.3 Team Handoff Quick Guide
-
-**Demand Gen → Sales**:
-- Deliver: SQLs with BANT qualification
-- Frequency: Real-time via HubSpot
-- SLA: 4-hour response time
-
-**Demand Gen → Product Marketing**:
-- Request: Product positioning, competitive intel, case studies
-- Frequency: Monthly sync
-- Deliverables: Updated messaging, new collateral
-
-**Demand Gen → Marketing Ops**:
-- Request: Campaign tracking setup, attribution reports, data cleaning
-- Frequency: Weekly check-in
-- SLA: 48-hour turnaround for new campaigns
-
-**Paid Media → Creative/Brand**:
-- Request: Ad creative (10-20 variants/month)
-- Format: Specs sheet with dimensions, copy length, brand guidelines
-- SLA: 5 business days per request
-
-**SEO → Content**:
-- Request: Content based on keyword research
-- Deliverables: Content brief with target keywords, structure, length
-- Frequency: Monthly editorial calendar
-
-**Partnerships → Sales**:
-- Deliver: Partner-sourced leads with partner context
-- Co-selling: Joint calls for strategic deals
-- Frequency: Weekly partner pipeline review
-
----
-
-## Resources
-
-### references/
-
-- **hubspot-workflows.md** - Pre-built HubSpot workflow templates for lead scoring, nurture, assignment
-- **campaign-templates.md** - Ready-to-use campaign briefs for LinkedIn, Google, SEO
-- **international-playbooks.md** - Market-specific tactics for EU, US, Canada expansion
-- **attribution-guide.md** - Deep dive on multi-touch attribution setup and analysis
+## Tools
 
 ### scripts/
 
-- **calculate_cac.py** - Calculate blended and channel-specific CAC
-- **experiment_calculator.py** - A/B test sample size and significance calculator
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `calculate_cac.py` | Calculate blended and channel CAC | `python scripts/calculate_cac.py --spend 40000 --customers 50` |
 
-### assets/
+### HubSpot Integration
 
-- **campaign-brief-template.docx** - Editable campaign planning document
-- **dashboard-template.xlsx** - Pre-configured performance dashboard
+- Campaign tracking with UTM parameters
+- Lead scoring and MQL/SQL workflows
+- Attribution reporting (multi-touch)
+- Partner lead routing
+
+See [hubspot-workflows.md](references/hubspot-workflows.md) for workflow templates.
 
 ---
 
-**Last Updated**: October 2025 | **Version**: 1.0
+## References
+
+| File | Content |
+|------|---------|
+| [hubspot-workflows.md](references/hubspot-workflows.md) | Lead scoring, nurture, assignment workflows |
+| [campaign-templates.md](references/campaign-templates.md) | LinkedIn, Google, Meta campaign structures |
+| [international-playbooks.md](references/international-playbooks.md) | EU, US, Canada market tactics |
+| [attribution-guide.md](references/attribution-guide.md) | Multi-touch attribution, dashboards, A/B testing |
+
+---
+
+## Channel Benchmarks (B2B SaaS Series A)
+
+| Metric | LinkedIn | Google Search | SEO | Email |
+|--------|----------|---------------|-----|-------|
+| CTR | 0.4-0.9% | 2-5% | 1-3% | 15-25% |
+| CVR | 1-3% | 3-7% | 2-5% | 2-5% |
+| CAC | $150-400 | $80-250 | $50-150 | $20-80 |
+| MQL→SQL | 10-20% | 15-25% | 12-22% | 8-15% |
+
+---
+
+## MQL→SQL Handoff
+
+### SQL Criteria
+
+```
+Required:
+✅ Job title: Director+ or budget authority
+✅ Company size: 50-5000 employees
+✅ Budget: $10k+ annual
+✅ Timeline: Buying within 90 days
+✅ Engagement: Demo requested or high-intent action
+```
+
+### SLA
+
+| Handoff | Target |
+|---------|--------|
+| SDR responds to MQL | 4 hours |
+| AE books demo with SQL | 24 hours |
+| First demo scheduled | 3 business days |
+
+**Validation:** Test lead through workflow, verify notifications and routing.

--- a/marketing-skill/marketing-demand-acquisition/references/attribution-guide.md
+++ b/marketing-skill/marketing-demand-acquisition/references/attribution-guide.md
@@ -1,0 +1,217 @@
+# Attribution Guide
+
+Multi-touch attribution setup, analysis, and reporting.
+
+---
+
+## Table of Contents
+
+- [Attribution Models](#attribution-models)
+- [HubSpot Attribution Setup](#hubspot-attribution-setup)
+- [Google Analytics Configuration](#google-analytics-configuration)
+- [Reporting Dashboards](#reporting-dashboards)
+- [A/B Testing Framework](#ab-testing-framework)
+
+---
+
+## Attribution Models
+
+### Model Comparison
+
+| Model | Credit Distribution | Best For |
+|-------|---------------------|----------|
+| First-Touch | 100% to first interaction | Awareness campaigns |
+| Last-Touch | 100% to last interaction | Direct response, BOFU |
+| Linear | Equal across all touchpoints | Simple full-funnel view |
+| Time Decay | More credit to recent touches | Long sales cycles |
+| W-Shaped | 40% first, 20% middle, 40% last | Hybrid PLG/Sales-Led |
+
+### Recommended Model: W-Shaped
+
+For Series A hybrid motion:
+- 40% credit to first touch (awareness)
+- 20% distributed across middle touches
+- 40% credit to last touch (conversion)
+
+**Rationale:** Balances discovery and closing influence.
+
+---
+
+## HubSpot Attribution Setup
+
+### Enable Attribution Reports
+
+1. Navigate to Marketing → Reports → Attribution
+2. Select attribution model (W-Shaped recommended)
+3. Define conversion event (deal created, SQL stage)
+4. Set lookback window (90 days typical)
+
+### Attribution Report Types
+
+| Report | Purpose | Frequency |
+|--------|---------|-----------|
+| Revenue Attribution | Credit revenue to channels | Monthly |
+| Content Attribution | Credit to content assets | Weekly |
+| Campaign Attribution | Credit to campaigns | Per campaign |
+
+### Custom Attribution Report
+
+Create: Marketing → Reports → Create Report
+
+**Metrics:**
+- Marketing-sourced pipeline $
+- Marketing-influenced revenue
+- CAC by channel
+- ROAS by campaign
+
+**Dimensions:**
+- Channel (Organic, Paid, Email, Social, Referral)
+- Campaign
+- Region (US, EU, Canada)
+- Funnel stage (TOFU, MOFU, BOFU)
+
+**Validation:** Run report for past 90 days. Verify all channels appear with data.
+
+---
+
+## Google Analytics Configuration
+
+### GA4 Events to Track
+
+**Engagement Events:**
+```
+page_view        (auto-tracked)
+scroll           (75% depth)
+video_play       (product demos)
+file_download    (whitepapers, eBooks)
+```
+
+**Conversion Events:**
+```
+sign_up          (free trial, account)
+demo_request     (calendar booking)
+contact_form     (inbound interest)
+pricing_view     (pricing page visit)
+```
+
+### Custom Dimensions
+
+| Dimension | Source | Purpose |
+|-----------|--------|---------|
+| User Type | CRM sync | Free vs Paid |
+| Plan Type | CRM sync | Starter, Pro, Enterprise |
+| Lead Status | HubSpot | MQL, SQL, Customer |
+| Campaign ID | UTM | HubSpot campaign |
+
+### GA4 + HubSpot Integration
+
+1. Install HubSpot tracking code (includes GA4)
+2. Or use Google Tag Manager for advanced tracking
+3. Sync GA4 audiences → HubSpot lists for retargeting
+4. Import GA4 conversions to Google Ads
+
+**Validation:** Real-time report shows events firing. Conversion events marked correctly.
+
+---
+
+## Reporting Dashboards
+
+### Weekly Performance Dashboard
+
+| Metric | Purpose | Target |
+|--------|---------|--------|
+| Visits | Traffic volume | +10% WoW |
+| Unique visitors | Reach | +5% WoW |
+| Bounce rate | Engagement | <50% |
+| MQLs | Lead volume | Weekly target |
+| SQLs | Pipeline | Weekly target |
+| Conversion rate | Efficiency | >2% |
+
+### Monthly Executive Dashboard
+
+| KPI | Formula | Target |
+|-----|---------|--------|
+| Marketing-Sourced Pipeline | Sum of new pipeline $ | $X/month |
+| Marketing-Sourced Revenue | Closed-won from marketing | $Y/month |
+| Blended CAC | Total spend / customers | <$Z |
+| MQL→SQL Rate | SQLs / MQLs | >15% |
+| Pipeline Velocity | Avg days in pipeline | <60 days |
+| ROMI | Revenue / Marketing spend | >3:1 |
+
+### Dashboard Build Process
+
+1. Define KPIs with leadership
+2. Create data sources in HubSpot
+3. Build visualizations (charts, tables)
+4. Set up automated refresh
+5. Schedule weekly/monthly distribution
+
+**Validation:** Dashboard shows last 7 days data. All metrics calculating correctly.
+
+---
+
+## A/B Testing Framework
+
+### ICE Prioritization
+
+**Formula:** ICE = (Impact × Confidence × Ease) ÷ 3
+
+| Factor | Rating | Description |
+|--------|--------|-------------|
+| Impact | 1-10 | Effect on primary metric |
+| Confidence | 1-10 | Certainty of success |
+| Ease | 1-10 | Implementation difficulty |
+
+### Test Template
+
+```
+Hypothesis: [Adding a case study carousel to pricing will
+            increase demo requests by 20%]
+
+Metric: [Demo requests from /pricing page]
+Sample Size: [1000 visitors per variant]
+Duration: [2 weeks or until significance]
+Success Criteria: [20% lift, 95% confidence]
+
+Variant A (Control): [Current pricing page]
+Variant B (Treatment): [Pricing page + case study carousel]
+
+Tools: [HubSpot A/B test or Google Optimize]
+```
+
+### Statistical Requirements
+
+- Minimum confidence: 95%
+- Minimum sample: 1000 visitors per variant
+- Minimum duration: 2 weeks
+- Do not stop tests early (false positives)
+
+### Common Test Categories
+
+**Landing Page:**
+- Headline variations
+- CTA copy and color
+- Form length
+- Social proof placement
+- Hero image type
+
+**Ad Creative:**
+- Format (static vs video)
+- Messaging angle
+- Audience targeting
+- Landing page destination
+
+**Email:**
+- Subject line length
+- Personalization depth
+- Send time
+- CTA placement
+
+### Test Velocity Target
+
+Series A: 4-6 tests per month
+- Realistic win rate: 30-40%
+- Document all results (wins and losses)
+- Build testing knowledge base
+
+**Validation:** Test reaches statistical significance before declaring winner.

--- a/marketing-skill/marketing-demand-acquisition/references/campaign-templates.md
+++ b/marketing-skill/marketing-demand-acquisition/references/campaign-templates.md
@@ -1,0 +1,221 @@
+# Campaign Templates
+
+Ready-to-use campaign briefs and structures for LinkedIn, Google, and Meta.
+
+---
+
+## Table of Contents
+
+- [Campaign Brief Template](#campaign-brief-template)
+- [LinkedIn Ads Structure](#linkedin-ads-structure)
+- [Google Ads Structure](#google-ads-structure)
+- [Meta Ads Structure](#meta-ads-structure)
+- [Ad Copy Frameworks](#ad-copy-frameworks)
+
+---
+
+## Campaign Brief Template
+
+Use for every campaign:
+
+```
+Campaign Name: [Q2-2025-LinkedIn-ABM-Enterprise]
+Objective: [Generate 50 SQLs from Enterprise accounts ($50k+ ACV)]
+Budget: [$15k/month]
+Duration: [90 days]
+Channels: [LinkedIn Ads, Retargeting, Email]
+Audience: [Director+ at SaaS companies, 500-5000 employees, EU/US]
+Offer: [Gated Industry Benchmark Report]
+
+Success Metrics:
+  - Primary: 50 SQLs, <$300 CPO
+  - Secondary: 500 MQLs, 10% MQL→SQL rate, 40% email open rate
+
+HubSpot Setup:
+  - Campaign ID: [create in HubSpot]
+  - Lead scoring: +20 for download, +30 for demo request
+  - Attribution: First-touch + Multi-touch
+
+Handoff Protocol:
+  - SQL criteria: Title + Company size + Budget confirmed
+  - Routing: Enterprise SDR team via HubSpot workflow
+  - SLA: 4-hour response time
+```
+
+**Validation:** Campaign appears in HubSpot with all assets tagged.
+
+---
+
+## LinkedIn Ads Structure
+
+### Account Hierarchy
+
+```
+Account
+└─ Campaign Group: [Q2-2025-Enterprise-ABM]
+   ├─ Campaign 1: [Awareness - Thought Leadership]
+   │  ├─ Ad Set: [CTO/VP Eng, US, Tech Companies]
+   │  └─ Creatives: [3 carousel posts, 2 video ads]
+   ├─ Campaign 2: [Consideration - Product Education]
+   │  ├─ Ad Set: [Engaged audience, retargeting]
+   │  └─ Creatives: [2 lead gen forms, 1 landing page]
+   └─ Campaign 3: [Conversion - Demo Requests]
+      ├─ Ad Set: [Website visitors, content downloaders]
+      └─ Creatives: [Direct demo CTA, case study]
+```
+
+### Targeting Settings
+
+| Parameter | Series A Sweet Spot |
+|-----------|---------------------|
+| Company Size | 50-5000 employees |
+| Job Titles | Director+, VP+, C-level |
+| Industries | Software, SaaS, Tech Services |
+| Budget | Start $50/day per campaign |
+
+### Scaling Rules
+
+- CAC < target → Increase budget 20% weekly
+- CAC > target → Pause, optimize, relaunch
+- Scale 20% weekly maximum to maintain performance
+
+### Lead Gen Forms vs Landing Pages
+
+| Type | Conversion | Quality | Use Case |
+|------|------------|---------|----------|
+| Lead Gen Forms | 2-3x higher | Lower | TOFU/MOFU |
+| Landing Pages | Lower | Higher | BOFU/demos |
+
+**Validation:** LinkedIn Insight Tag firing. Matched audiences syncing.
+
+---
+
+## Google Ads Structure
+
+### Campaign Priority
+
+1. **Search - Brand** (highest priority, protect brand terms)
+2. **Search - Competitor** (steal market share)
+3. **Search - Solution** (problem-aware buyers)
+4. **Search - Product Category** (earlier stage)
+5. **Display - Retargeting** (re-engage warm traffic)
+
+### Search Campaign Template
+
+```
+Campaign: [Search-Solution-Keywords]
+├─ Ad Group: [project management software]
+│  ├─ Keywords:
+│  │  - "project management software" [Phrase]
+│  │  - "best project management tool" [Phrase]
+│  │  - +project +management +solution [Broad Match Modifier]
+│  └─ Ads: [3 responsive search ads]
+│
+└─ Ad Group: [team collaboration tools]
+   ├─ Keywords: [5-10 tightly themed keywords]
+   └─ Ads: [3 responsive search ads]
+```
+
+### Keyword Strategy
+
+| Type | Match | Bid Priority |
+|------|-------|--------------|
+| Brand Terms | Exact | High - protect brand |
+| Competitor Terms | Phrase | Medium - comparison |
+| Solution Terms | Phrase | Medium - category |
+| Problem Terms | Broad | Lower - education |
+
+### Negative Keywords (Maintain 100+)
+
+```
+free, cheap, jobs, career, reviews, salary, login, support,
+download, tutorial, course, certification, example, template
+```
+
+### Bid Strategy Progression
+
+1. New campaigns: Manual CPC (control)
+2. After 50+ conversions: Target CPA
+3. After 100+ conversions: Maximize Conversions with tCPA
+4. EU markets: Bid 15-20% higher for same quality
+
+**Validation:** Conversion tracking firing. Search terms report reviewed weekly.
+
+---
+
+## Meta Ads Structure
+
+### When to Use Meta
+
+| Scenario | Meta | LinkedIn |
+|----------|------|----------|
+| ACV <$10k | ✅ | ❌ |
+| Visual product | ✅ | ❌ |
+| SMB audience | ✅ | ❌ |
+| Enterprise | ❌ | ✅ |
+
+### Campaign Template
+
+```
+Campaign Objective: [Conversions]
+├─ Ad Set 1: [Lookalike - 1% of converters]
+│  └─ Placement: [Feed + Stories, Auto]
+├─ Ad Set 2: [Interest - Business Software]
+│  └─ Placement: [Feed only]
+└─ Ad Set 3: [Retargeting - Website 30d]
+   └─ Placement: [All placements]
+```
+
+### Creative Best Practices
+
+- Video format: 1:1 or 9:16 for Stories
+- First 3 seconds: Hook with problem or result
+- Show product UI in action
+- Add captions (85% watch muted)
+- Test 3-5 variants per campaign
+
+**Validation:** Meta Pixel events firing. Conversion values passing correctly.
+
+---
+
+## Ad Copy Frameworks
+
+### LinkedIn Thought Leadership
+
+```
+[Industry insight or contrarian take]
+
+[Supporting data point or experience]
+
+[Call to discuss or engage]
+
+#RelevantHashtag #Industry
+```
+
+### LinkedIn Social Proof
+
+```
+[Customer result with specific numbers]
+
+"[Customer quote]"
+- [Name, Title, Company]
+
+[Soft CTA: See how →]
+```
+
+### Google Responsive Search Ads
+
+**Headlines (15 required):**
+- H1-3: Value props (Save 10 hours/week, Trusted by 500+ teams)
+- H4-6: Features (AI-powered, Real-time sync, Mobile app)
+- H7-9: Social proof (4.8★ G2 rating, Used by Microsoft)
+- H10-12: CTAs (Start free trial, Book demo, See pricing)
+- H13-15: Dynamic keyword insertion
+
+**Descriptions (4 required):**
+- D1: Primary value prop + CTA (30-60 chars)
+- D2: Feature list + differentiator (60-90 chars)
+- D3: Social proof + urgency (45-90 chars)
+- D4: Backup generic (60-90 chars)
+
+**Validation:** Ad strength score of "Excellent" before launch.

--- a/marketing-skill/marketing-demand-acquisition/references/hubspot-workflows.md
+++ b/marketing-skill/marketing-demand-acquisition/references/hubspot-workflows.md
@@ -1,0 +1,168 @@
+# HubSpot Workflow Templates
+
+Pre-built workflow configurations for lead scoring, nurturing, and assignment.
+
+---
+
+## Table of Contents
+
+- [Campaign Tracking Setup](#campaign-tracking-setup)
+- [Lead Scoring Configuration](#lead-scoring-configuration)
+- [MQL to SQL Workflow](#mql-to-sql-workflow)
+- [Partner Lead Tracking](#partner-lead-tracking)
+- [Nurture Sequences](#nurture-sequences)
+
+---
+
+## Campaign Tracking Setup
+
+### Create Campaign in HubSpot
+
+1. Navigate to Marketing → Campaigns → Create Campaign
+2. Name using convention: `Q[N]-[YEAR]-[CHANNEL]-[CAMPAIGN-TYPE]`
+   - Example: `Q2-2025-LinkedIn-ABM-Enterprise`
+3. Tag all assets (landing pages, emails, ads) with campaign ID
+
+### UTM Parameter Structure
+
+```
+utm_source={channel}       // linkedin, google, facebook
+utm_medium={type}          // cpc, display, email, organic
+utm_campaign={campaign-id} // q2-2025-linkedin-abm-enterprise
+utm_content={variant}      // ad-variant-a, email-1
+utm_term={keyword}         // [for paid search only]
+```
+
+**Validation:** Verify UTM parameters appear in HubSpot contact records after test submission.
+
+---
+
+## Lead Scoring Configuration
+
+### Navigate to Configuration
+
+Settings → Marketing → Lead Scoring
+
+### Scoring Rules
+
+| Action | Points | Rationale |
+|--------|--------|-----------|
+| Content download | +10 to +20 | Based on content depth |
+| Demo request | +30 | High intent signal |
+| Pricing page visit | +15 | Commercial intent |
+| Webinar attendance | +20 | Engaged prospect |
+| Email open | +2 | Basic engagement |
+| Email click | +5 | Active interest |
+
+### Channel Quality Modifiers
+
+| Source | Points | Rationale |
+|--------|--------|-----------|
+| LinkedIn | +5 | Professional context |
+| Google Search | +10 | Active search intent |
+| Organic | +15 | Self-discovery |
+| Referral | +20 | Pre-qualified |
+
+**Validation:** Test lead scoring by creating a test contact and triggering each action.
+
+---
+
+## MQL to SQL Workflow
+
+### SQL Definition Criteria
+
+```
+Required (all must be true):
+✅ Job title: Director+ (or Budget Authority confirmed)
+✅ Company size: 50-5000 employees
+✅ Budget: $10k+ annual
+✅ Timeline: Buying within 90 days
+✅ Engagement: Demo requested OR High intent action
+```
+
+### Workflow Configuration
+
+1. **Trigger:** Lead score reaches MQL threshold (>75 points)
+2. **Action 1:** Send automated email to SDR with lead details
+3. **Action 2:** Create task for SDR qualification call
+4. **Branch Logic:**
+   - If qualified → Update lifecycle stage to SQL, assign to AE
+   - If not qualified → Move to nurture list, reduce lead score by 30
+
+### SLA Configuration
+
+| Handoff | Target | Escalation |
+|---------|--------|------------|
+| SDR responds to MQL | 4 hours | Manager notification |
+| AE books demo with SQL | 24 hours | Director notification |
+| First demo scheduled | 3 business days | VP notification |
+
+**Validation:** Test workflow with a sample lead. Verify notifications trigger correctly.
+
+---
+
+## Partner Lead Tracking
+
+### Create Partner Property
+
+1. Settings → Properties → Create Property
+2. Property name: `Partner Source`
+3. Type: Dropdown select
+4. Values: Partner A, Partner B, Affiliate Network, Direct
+
+### Partner UTM Configuration
+
+```
+Partner links: ?utm_source=partner-name&utm_medium=referral
+```
+
+### Lead Assignment Workflow
+
+1. **Trigger:** Contact property `Partner Source` is set
+2. **Action:** Assign to Partner Manager
+3. **Notification:** Slack alert when partner lead arrives
+
+### Partner Reporting Dashboard
+
+Create custom report: Marketing → Reports → Create Report
+- Metrics: Leads, Pipeline, Revenue by Partner Source
+- Dimensions: Partner Name, Time Period
+
+**Validation:** Submit test lead with partner UTM. Verify property populates and routing works.
+
+---
+
+## Nurture Sequences
+
+### Lost Opportunity Recycle
+
+**Trigger:** Deal stage = Closed Lost
+
+**Sequence:**
+1. Day 0: Add to nurture list, remove from active campaigns
+2. Day 30: Educational content email
+3. Day 60: Industry insights email
+4. Day 90: Re-engagement offer email
+5. Month 6: SDR re-qualification task
+
+### TOFU to MOFU Progression
+
+**Trigger:** Contact downloads 2+ content pieces
+
+**Sequence:**
+1. Day 0: Thank you email with related content
+2. Day 3: Case study email
+3. Day 7: Webinar invitation
+4. Day 14: Demo offer (soft CTA)
+
+### Closed Lost Reason Tracking
+
+Configure deal properties to capture:
+- Price too high
+- Missing features
+- Chose competitor
+- No budget
+- Bad timing
+- Champion left company
+
+**Use data to inform:** Product roadmap, pricing adjustments, competitive positioning.

--- a/marketing-skill/marketing-demand-acquisition/references/international-playbooks.md
+++ b/marketing-skill/marketing-demand-acquisition/references/international-playbooks.md
@@ -1,0 +1,200 @@
+# International Market Playbooks
+
+Market-specific tactics for EU, US, and Canada expansion.
+
+---
+
+## Table of Contents
+
+- [EU Market Entry](#eu-market-entry)
+- [US Market Entry](#us-market-entry)
+- [Canada Market Entry](#canada-market-entry)
+- [Budget Allocation by Region](#budget-allocation-by-region)
+- [Localization Checklist](#localization-checklist)
+
+---
+
+## EU Market Entry
+
+### Compliance Requirements
+
+| Requirement | Implementation |
+|-------------|----------------|
+| GDPR consent | Double opt-in for email |
+| Cookie consent | Explicit consent banner |
+| Data storage | EU data center option |
+| Privacy policy | EU-specific language |
+
+**HubSpot Configuration:**
+- Enable double opt-in in Forms settings
+- Configure consent tracking properties
+- Set up GDPR deletion workflows
+
+### Localization Priority
+
+| Language | Market Priority | Revenue Potential |
+|----------|-----------------|-------------------|
+| German (DE) | High | Largest EU economy |
+| French (FR) | High | Second largest EU |
+| Spanish (ES) | Medium | Growing tech sector |
+| Dutch (NL) | Medium | English proficiency |
+| Italian (IT) | Lower | Later expansion |
+
+### Channel Mix (EU)
+
+| Channel | Budget % | Rationale |
+|---------|----------|-----------|
+| LinkedIn | 40% | Primary B2B channel |
+| Google Ads | 25% | High intent capture |
+| SEO | 20% | Long-term investment |
+| Partnerships | 15% | Local credibility |
+
+### EU Messaging Adjustments
+
+- More formal tone than US
+- Focus on data security and compliance
+- Emphasize local customer references
+- Include EU headquarters or presence
+- Display prices in EUR
+
+**Validation:** Test landing pages with EU VPN. Verify consent flows work correctly.
+
+---
+
+## US Market Entry
+
+### Market Characteristics
+
+| Aspect | US Approach |
+|--------|-------------|
+| Messaging | Direct, ROI-focused |
+| Tone | Less formal than EU |
+| Sales cycle | Faster decision-making |
+| Proof points | Dollar impact, not features |
+
+### Channel Mix (US)
+
+| Channel | Budget % | Rationale |
+|---------|----------|-----------|
+| Google Ads | 35% | High commercial intent |
+| LinkedIn | 30% | B2B targeting |
+| SEO | 20% | Competitive necessity |
+| Partnerships | 15% | Industry associations |
+
+### Partner Ecosystem
+
+| Partner Type | Examples |
+|--------------|----------|
+| Review sites | G2, Capterra, TrustRadius |
+| Industry associations | SaaStr, ProductLed |
+| Integration partners | Salesforce, HubSpot |
+| Channel partners | VARs, consultants |
+
+### Content Adjustments
+
+- Case studies with $ impact metrics
+- Faster, more aggressive CTAs
+- Video testimonials with customers
+- Comparison pages (vs. competitors)
+
+**Validation:** US-based speed test. Payment processing in USD functional.
+
+---
+
+## Canada Market Entry
+
+### Market Characteristics
+
+| Aspect | Canada Approach |
+|--------|-----------------|
+| Language | English + French (Quebec) |
+| Regulation | PIPEDA compliance |
+| Messaging | Mix of US and EU styles |
+| Pricing | CAD display preferred |
+
+### Regional Considerations
+
+| Region | Language | Focus |
+|--------|----------|-------|
+| Ontario | English | Tech hub, Toronto |
+| British Columbia | English | Vancouver tech scene |
+| Quebec | French | Requires localization |
+| Alberta | English | Energy sector |
+
+### Channel Mix (Canada)
+
+| Channel | Budget % | Rationale |
+|---------|----------|-----------|
+| Google Ads | 35% | Primary acquisition |
+| LinkedIn | 30% | Professional targeting |
+| SEO | 20% | Local content |
+| Partnerships | 15% | Local associations |
+
+**Validation:** French Quebec landing page tested. CAD pricing displays correctly.
+
+---
+
+## Budget Allocation by Region
+
+### Series A Recommended Split
+
+| Region | Budget % | Expected CAC |
+|--------|----------|--------------|
+| US | 50% | $150-300 |
+| EU | 35% | $200-400 |
+| Canada | 15% | $175-350 |
+
+### Channel by Region Matrix
+
+| Channel | US | EU | Canada |
+|---------|----|----|--------|
+| LinkedIn | 30% | 40% | 30% |
+| Google | 35% | 25% | 35% |
+| SEO | 20% | 20% | 20% |
+| Partners | 15% | 15% | 15% |
+
+### Scaling Criteria
+
+Expand regional budget when:
+- CAC < 80% of target for 4 consecutive weeks
+- MQL→SQL rate > regional benchmark
+- Sales team has regional capacity
+
+---
+
+## Localization Checklist
+
+### Website Localization
+
+- [ ] Translate navigation and UI elements
+- [ ] Localize pricing (currency, formatting)
+- [ ] Adapt case studies to regional references
+- [ ] Update screenshots with localized UI
+- [ ] Configure hreflang tags correctly
+- [ ] Submit to regional search consoles
+
+### Content Localization
+
+- [ ] Translate (don't just localize) key pages
+- [ ] Adapt idioms and cultural references
+- [ ] Update date formats (DD/MM/YYYY vs MM/DD/YYYY)
+- [ ] Adjust number formatting (1,000 vs 1.000)
+- [ ] Use regional spelling (optimise vs optimize)
+
+### Campaign Localization
+
+- [ ] Translate ad copy (not just translate, adapt)
+- [ ] Create regional landing pages
+- [ ] Set up regional tracking parameters
+- [ ] Configure regional lead routing
+- [ ] Align with regional sales hours
+
+### Legal Localization
+
+- [ ] GDPR compliance (EU)
+- [ ] PIPEDA compliance (Canada)
+- [ ] Cookie consent mechanisms
+- [ ] Privacy policy translations
+- [ ] Terms of service updates
+
+**Validation:** Native speaker review of all localized content before launch.


### PR DESCRIPTION
## Summary

Rewrites the marketing-demand-acquisition skill based on AI Agent Skills Benchmark feedback (score 77/100).

## Changes

- **SKILL.md reduced from 986 to 310 lines** - Moved detailed content to references
- **Added trigger phrases** in frontmatter: demand gen, paid ads, LinkedIn ads, CAC, MQL, SQL, etc.
- **Added Table of Contents** for navigation
- **Removed marketing language** ("Expert acquisition playbook", "2025 Best Practice")
- **Used imperative voice** consistently throughout
- **Added validation steps** after each workflow procedure
- **Created 4 missing reference files:**
  - `hubspot-workflows.md` - Lead scoring, nurture sequences, assignment rules
  - `campaign-templates.md` - LinkedIn, Google, Meta campaign structures
  - `international-playbooks.md` - EU, US, Canada market tactics
  - `attribution-guide.md` - Multi-touch attribution, dashboards, A/B testing

## Architecture Fix

The original skill referenced 4 files that didn't exist. This PR creates those files with proper content extracted from the bloated SKILL.md, implementing proper Progressive Disclosure Architecture.

| Before | After |
|--------|-------|
| SKILL.md: 986 lines | SKILL.md: 310 lines |
| Referenced files: 0 | Reference files: 4 |
| No validation steps | Validation after each workflow |

Closes #72

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)