### PR TITLE
fix(skill): rewrite marketing-strategy-pmm with proper structure (#75)

### DIFF
--- a/marketing-skill/marketing-strategy-pmm/SKILL.md
+++ b/marketing-skill/marketing-strategy-pmm/SKILL.md
@@ -1,1163 +1,378 @@
 ---
 name: marketing-strategy-pmm
-description: Product marketing, positioning, GTM strategy, and competitive intelligence. Includes ICP definition, April Dunford positioning methodology, launch playbooks, competitive battlecards, and international market entry guides. Use when developing positioning, planning product launches, creating messaging, analyzing competitors, entering new markets, enabling sales, or when user mentions product marketing, positioning, GTM, go-to-market, competitive analysis, market entry, or sales enablement.
-license: MIT
-metadata:
-  version: 1.0.0
-  author: Alireza Rezvani
-  category: marketing
-  domain: product-marketing
-  updated: 2025-10-20
-  frameworks: April-Dunford-positioning, ICP-definition, messaging-hierarchy
-  target-market: B2B-SaaS, international-expansion, Series-A+
+description: Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry.
+triggers:
+  - product marketing
+  - PMM
+  - positioning
+  - GTM strategy
+  - go-to-market
+  - competitive analysis
+  - battlecard
+  - product launch
+  - market entry
+  - sales enablement
+  - win loss analysis
 ---
 
-# Marketing Strategy & Product Marketing
+# Marketing Strategy & PMM
 
-Expert Product Marketing playbook for Series A+ startups expanding internationally with hybrid PLG/Sales-Led motion.
-
-## Keywords
-product marketing, positioning, GTM, go-to-market strategy, competitive analysis, competitive intelligence, battlecards, ICP, ideal customer profile, messaging, value proposition, product launch, market entry, international expansion, sales enablement, win loss analysis, PMM, product marketing manager, market positioning, competitive landscape, sales training
-
-## Role Coverage
-
-This skill serves:
-- **Product Marketing Manager (PMM)** - Positioning, messaging, competitive intel, launches
-- **Head of Marketing** - Strategy, budget, org design, pipeline targets
-- **Head of Growth** - Experimentation, activation, retention, growth loops
-- **CMO/VP Marketing** - Executive strategy, board reporting, team leadership
-
-## Core KPIs by Role
-
-**PMM**: Product adoption rate, win rate vs. competitors, sales velocity, launch impact metrics, competitive win rate, deal size growth
-
-**Head of Marketing**: Marketing-sourced pipeline $, CAC/LTV ratio, ROMI (3:1+ target), brand awareness lift, market share growth
-
-**Head of Growth**: Activation rate, WAU/MAU, conversion rates across funnel, payback period, viral coefficient (PLG)
-
-**CMO**: Revenue growth %, pipeline coverage (3-4x), team productivity, budget efficiency, NPS/brand health
-
-## Tech Stack Integration
-
-**HubSpot** - CRM, deal tracking, competitive loss analysis, sales enablement content
-**Google Analytics** - Product usage, activation funnels, feature adoption
-**Gong/Chorus** - Sales call analysis, competitive intelligence, objection tracking
-**Productboard** - Feature requests, customer feedback, roadmap prioritization
-**Notion/Confluence** - Internal wiki, positioning docs, competitive battlecards
+Product marketing patterns for positioning, GTM strategy, and competitive intelligence.
 
 ---
 
-## 1. Strategic Foundation
+## Table of Contents
 
-### 1.1 Company Strategy Framework (Series A Context)
+- [ICP Definition Workflow](#icp-definition-workflow)
+- [Positioning Development](#positioning-development)
+- [Competitive Intelligence](#competitive-intelligence)
+- [Product Launch Planning](#product-launch-planning)
+- [Sales Enablement](#sales-enablement)
+- [International Expansion](#international-expansion)
+- [Reference Documentation](#reference-documentation)
 
-**Current State Analysis**:
-```
-Stage: Series A
-Funding: $5-15M raised
-Team Size: 20-50 people
-Revenue: $1-5M ARR
-Market Position: Challenger/Niche leader
-Growth Rate Target: 3-5x YoY
+---
 
-Key Challenges:
-- Prove product-market fit at scale
-- Expand from early adopters → mainstream
-- Enter new markets (EU/US/Canada)
-- Compete against incumbents
-- Build repeatable sales motion
-```
+## ICP Definition Workflow
 
-**Strategic Priorities** (in order):
-1. **Nail positioning** - Clear, differentiated value prop
-2. **Scale acquisition** - Repeatable, efficient channels
-3. **Prove retention** - Product stickiness, expansion revenue
-4. **Expand markets** - Geographic + vertical expansion
-5. **Build brand** - Awareness, trust, category leadership
+Define ideal customer profile for targeting:
 
-### 1.2 ICP (Ideal Customer Profile) Definition
+1. Analyze existing customers (top 20% by LTV)
+2. Identify common firmographics (size, industry, revenue)
+3. Map technographics (tools, maturity, integrations)
+4. Document psychographics (pain level, motivation, risk tolerance)
+5. Define 3-5 buyer personas (economic, technical, user)
+6. Validate against sales cycle and churn data
+7. Score prospects A/B/C/D based on ICP fit
+8. **Validation:** A-fit customers have lowest churn and fastest close
 
-**B2B SaaS ICP Framework**:
+### Firmographics Template
 
-**Firmographics**:
-- Company size: 50-5000 employees (Series A sweet spot)
-- Industry: SaaS, Tech, Professional Services
-- Geography: US, Canada, UK, Germany, France (prioritize by TAM)
-- Revenue: $5M-$500M annual
-- Funding stage: Seed to Growth (avoid pre-product)
+| Dimension | Target Range | Rationale |
+|-----------|--------------|-----------|
+| Employees | 50-5000 | Series A sweet spot |
+| Revenue | $5M-$500M | Budget available |
+| Industry | SaaS, Tech, Services | Product fit |
+| Geography | US, UK, DACH | Market priority |
+| Funding | Seed to Growth | Willing to adopt |
 
-**Technographics**:
-- Tech stack: Modern (cloud-first, API-driven)
-- Maturity: Growing fast, willing to adopt new tools
-- Existing tools: [List competitors + complementary products]
-- Integration needs: Must integrate with [Salesforce, Slack, etc.]
+### Buyer Personas
 
-**Psychographics**:
-- Pain level: 7-10/10 (acute pain, not nice-to-have)
-- Buyer motivation: Efficiency, cost savings, revenue growth
-- Decision process: 2-6 month sales cycle
-- Risk tolerance: Early majority (not bleeding edge)
-
-**Buyer Personas** (3-5 personas max):
-
-**Primary: Economic Buyer** (signs contract)
+**Economic Buyer** (signs contract):
 - Title: VP, Director, Head of [Department]
 - Goals: ROI, team productivity, cost reduction
-- Fears: Implementation failure, team resistance, budget waste
 - Messaging: Business outcomes, ROI, case studies
 
-**Secondary: Technical Buyer** (evaluates product)
-- Title: Senior Engineer, Architect, Tech Lead
-- Goals: Solves technical problem, easy integration
-- Fears: Technical debt, vendor lock-in, poor support
-- Messaging: Technical capabilities, architecture, security
+**Technical Buyer** (evaluates product):
+- Title: Engineer, Architect, Tech Lead
+- Goals: Technical fit, easy integration
+- Messaging: Architecture, security, documentation
 
-**User/Champion** (advocates internally)
+**User/Champion** (advocates internally):
 - Title: Manager, Team Lead, Power User
-- Goals: Makes their job easier, team loves it
-- Fears: Learning curve, change management
-- Messaging: UX, ease of use, quick wins
+- Goals: Makes job easier, quick wins
+- Messaging: UX, ease of use, time savings
 
-**ICP Validation Checklist**:
+### ICP Validation Checklist
+
 - [ ] 5+ paying customers match this profile
-- [ ] Fastest sales cycles (< median time to close)
-- [ ] Highest LTV (> median customer value)
+- [ ] Fastest sales cycles (< median)
+- [ ] Highest LTV (> median)
 - [ ] Lowest churn (< 5% annual)
-- [ ] Strong product engagement (daily/weekly usage)
-- [ ] Referenceable (NPS 9-10, willing to do case studies)
-
-**HubSpot ICP Tracking**:
-- Create "ICP Fit" property: A (perfect), B (good), C (okay), D (poor)
-- Score based on firmographics, engagement, product usage
-- Report: Win rate by ICP score, pipeline by ICP score
-- Action: Focus acquisition on ICP A/B, nurture C, disqualify D
-
-### 1.3 Market Segmentation Strategy
-
-**Segmentation Dimensions**:
-
-**By Company Size** (recommend starting with one):
-- **SMB** (10-200 employees) - Self-serve PLG, low touch, $100-$2k ACV
-- **Mid-Market** (200-2000 employees) - Hybrid, inside sales, $2k-$50k ACV
-- **Enterprise** (2000+ employees) - Sales-led, field sales, $50k+ ACV
-
-**By Vertical** (choose 2-3 focus verticals):
-- Horizontal: Broad appeal (e.g., project management for any industry)
-- Vertical: Industry-specific (e.g., healthcare CRM, fintech compliance)
-- Approach: Start horizontal, add verticals as you scale
-
-**By Use Case** (messaging varies):
-- Use Case A: [e.g., Team collaboration]
-- Use Case B: [e.g., Client management]
-- Use Case C: [e.g., Project tracking]
-- Each use case = different landing page, messaging, case studies
-
-**By Geography** (Series A focus):
-- **US/Canada**: Largest TAM, fastest sales cycles, highest willingness to pay
-- **UK**: English-speaking, gateway to EU, similar buying behavior to US
-- **Germany**: Largest EU economy, high data privacy standards (GDPR leader)
-- **France**: Second largest EU market, localization critical
-- **Nordics**: High tech adoption, English proficiency, smaller markets
-
-**Segmentation Priority Matrix**:
-```
-Segment: US Mid-Market SaaS Companies (200-2000 employees)
-Priority: 1 (Highest)
-Rationale:
-  - Largest TAM ($5B)
-  - Fastest sales cycle (60 days avg)
-  - Highest win rate (35%)
-  - Strong product fit (use cases align)
-  - Existing customer base (50% of customers)
-Budget Allocation: 50% of marketing spend
-```
+- [ ] Strong product engagement
+- [ ] Willing to do case studies
 
 ---
 
-## 2. Positioning & Messaging
+## Positioning Development
 
-### 2.1 Positioning Framework (April Dunford Method)
+Develop positioning using April Dunford methodology:
 
-**Step 1: List Your True Competitive Alternatives**
+1. List competitive alternatives (direct, adjacent, status quo)
+2. Isolate unique attributes (features only you have)
+3. Map attributes to customer value (why it matters)
+4. Define best-fit customers (who cares most)
+5. Choose market category (head-to-head, niche, new category)
+6. Layer on relevant trends (timing justification)
+7. Test with 10+ customer interviews
+8. **Validation:** 7+ customers describe value unprompted
 
-Not just direct competitors - what would customers do if your product didn't exist?
-
-```
-Alternatives:
-1. Competitor A (direct)
-2. Competitor B (direct)
-3. Spreadsheets + email (status quo)
-4. Build in-house (DIY)
-5. Do nothing (ignore problem)
-```
-
-**Step 2: Isolate Your Unique Attributes**
-
-What do you have that alternatives don't?
+### Positioning Statement Template
 
 ```
-Unique Attributes:
-1. [Feature X that no one else has]
-2. [Integration Y that's exclusive]
-3. [Approach Z that's differentiated]
-4. [Performance metric better than all]
+FOR [target customer]
+WHO [statement of need]
+THE [product] IS A [category]
+THAT [key benefit]
+UNLIKE [competitive alternative]
+OUR PRODUCT [primary differentiation]
 ```
 
-**Step 3: Map Attributes to Value**
-
-What value do these attributes provide to customers?
-
-```
-Attribute: [Real-time collaboration]
-→ Value: Teams can work together simultaneously
-→ Outcome: 50% faster project completion
-
-Attribute: [AI-powered automation]
-→ Value: Eliminates manual data entry
-→ Outcome: Save 10 hours/week per user
-```
-
-**Step 4: Define Your Best-Fit Customers**
-
-Who cares most about this value?
-
-```
-Best-Fit: Mid-market SaaS companies (200-1000 employees)
-Why: They have distributed teams, need real-time collaboration
-Evidence: Fastest sales cycles, lowest churn, highest NPS
-```
-
-**Step 5: Nail Your Market Category**
-
-What market do you dominate?
-
-```
-Options:
-- Head-to-head: Compete in existing category (e.g., "CRM")
-- Big fish, small pond: Own a niche (e.g., "CRM for agencies")
-- Create new: Define new category (risky, expensive)
-
-Decision: [Choose based on competitive strength and budget]
-```
-
-**Step 6: Layer on Trends**
-
-What trends make this the right time to buy?
-
-```
-Trends:
-- Remote work explosion (2020-2025)
-- AI/ML adoption in enterprise (2024-2025)
-- Data privacy regulations (GDPR, CCPA)
-```
-
-### 2.2 Messaging Architecture
-
-**Value Proposition (One-Liner)**:
+### Value Proposition Formula
 
 Template: `[Product] helps [Target Customer] [Achieve Goal] by [Unique Approach]`
 
 Example: "Acme helps mid-market SaaS teams ship 2x faster by automating project workflows with AI"
 
-**Messaging Hierarchy**:
+### Messaging Hierarchy
 
-```
-LEVEL 1: Value Proposition (one-liner)
-[Your one-liner here]
-
-LEVEL 2: Key Benefits (3-5 bullet points)
-- Benefit 1: [Speed] → Ship products 2x faster
-- Benefit 2: [Quality] → Reduce bugs by 50%
-- Benefit 3: [Collaboration] → Align teams in real-time
-- Benefit 4: [Cost] → Save $100k/year on tools
-
-LEVEL 3: Features (supporting evidence)
-- Feature → Benefit → Outcome
-- AI automation → Eliminates manual work → Save 10 hrs/week
-- Real-time sync → No version conflicts → 50% fewer errors
-- Integrations → Connect existing tools → 80% faster onboarding
-
-LEVEL 4: Proof Points
-- Customer logos: [Microsoft, Shopify, Stripe]
-- Stats: Used by 10,000+ teams, 4.8/5 G2 rating
-- Case studies: How [Customer] achieved [Outcome]
-```
-
-**Messaging by Persona**:
-
-**Economic Buyer** (VP/Director):
-- Primary concern: ROI, business outcomes
-- Tone: Professional, data-driven, results-focused
-- Key message: "Increase revenue by 25% while reducing costs by $200k/year"
-- Proof: ROI calculator, case studies with $ impact
-
-**Technical Buyer** (Engineer/Architect):
-- Primary concern: Technical fit, security, scalability
-- Tone: Technical, detailed, objective
-- Key message: "Enterprise-grade architecture with 99.99% uptime and SOC 2 compliance"
-- Proof: Technical docs, security whitepaper, architecture diagram
-
-**End User** (Manager/Individual Contributor):
-- Primary concern: Ease of use, daily workflow
-- Tone: Friendly, empathetic, practical
-- Key message: "Spend less time on busywork, more time on what matters"
-- Proof: Product demo, free trial, customer testimonials
-
-### 2.3 Messaging Testing & Iteration
-
-**Message Testing Framework**:
-
-1. **Qualitative** (customer interviews):
-   - Ask 10-15 target customers:
-   - "How would you describe [Product] to a colleague?"
-   - "What's the main benefit you get from [Product]?"
-   - "Why did you choose us over [Competitor]?"
-
-2. **Quantitative** (A/B testing):
-   - Test messaging variations on:
-   - Landing page headlines
-   - Ad copy (LinkedIn, Google)
-   - Email subject lines
-   - Measure: CTR, conversion rate, demo requests
-
-3. **Sales Feedback** (win/loss analysis):
-   - Ask sales team monthly:
-   - "Which message resonates most with prospects?"
-   - "What objections are we hearing?"
-   - "How do we compare to [Competitor] in customer's eyes?"
-
-**Iteration Cycle**:
-- Test new messaging: 2-4 weeks
-- Analyze results: 1 week
-- Update messaging docs: 1 week
-- Train sales team: 1 week
-- Repeat quarterly
+| Level | Content | Example |
+|-------|---------|---------|
+| Headline | 5-7 words | "Ship faster with AI automation" |
+| Subhead | 1 sentence | "Automate workflows so teams focus on what matters" |
+| Benefits | 3-4 bullets | Speed, quality, collaboration, cost |
+| Features | Supporting evidence | AI automation → 10 hrs/week saved |
+| Proof | Social proof | Customer logos, stats, case studies |
 
 ---
 
-## 3. Competitive Intelligence
+## Competitive Intelligence
 
-### 3.1 Competitive Analysis Framework
+Build competitive knowledge base:
 
-**Tier 1: Direct Competitors** (head-to-head, same category)
-- [Competitor A]: Market leader, $100M+ ARR
-- [Competitor B]: Fast-growing challenger, Series B
-- [Competitor C]: Open-source alternative
+1. Identify tier 1 (direct), tier 2 (adjacent), tier 3 (status quo)
+2. Sign up for competitor products (hands-on evaluation)
+3. Monitor competitor websites, pricing, messaging
+4. Analyze sales call recordings for competitor mentions
+5. Read G2/Capterra reviews (pros and cons)
+6. Track competitor job postings (roadmap signals)
+7. Update battlecards monthly
+8. **Validation:** Sales team uses battlecards in 80%+ competitive deals
 
-**Tier 2: Indirect Competitors** (adjacent solutions)
-- [Alt Solution D]: Different approach, overlapping use case
-- [Alt Solution E]: Broader platform, includes your feature
+### Competitive Tier Structure
 
-**Tier 3: Status Quo** (what customers do today)
-- Spreadsheets + email
-- Build in-house
-- Do nothing
+| Tier | Definition | Examples |
+|------|------------|----------|
+| 1 | Direct competitor, same category | [Competitor A, B] |
+| 2 | Adjacent solution, overlapping use case | [Alt Solution C, D] |
+| 3 | Status quo (what they do today) | Spreadsheets, manual, in-house |
 
-**Competitive Intelligence Sources**:
-1. **Product trials**: Sign up for competitor products, use actively
-2. **Website monitoring**: Track changes to pricing, messaging, features
-3. **Customer interviews**: Ask "What alternatives did you consider?"
-4. **Sales call recordings** (Gong/Chorus): Listen for competitor mentions
-5. **Review sites** (G2, Capterra): Read competitor reviews (pros/cons)
-6. **Job postings**: Competitor hiring = roadmap insights
-7. **Financial filings** (if public): Revenue, growth, strategy
-8. **Social media**: Follow competitor execs, product teams
-9. **Partner channels**: Talk to shared implementation partners
-10. **Industry reports**: Gartner, Forrester, IDC
-
-### 3.2 Competitive Battlecards
-
-**Battlecard Template** (create one per competitor):
+### Battlecard Template
 
 ```
-COMPETITOR: [Competitor A]
-
-OVERVIEW:
-- Founded: 2015
-- Funding: Series C, $75M raised
-- HQ: San Francisco
-- Size: 200 employees
-- Customers: 5,000+ companies
-- Pricing: $50-$500/user/month
+COMPETITOR: [Name]
+OVERVIEW: Founded [year], Funding [stage], Size [employees]
 
 POSITIONING:
-- They say: "All-in-one platform for modern teams"
-- Reality: Broad but shallow, not deep in any use case
+- They say: "[Their claim]"
+- Reality: [Your assessment]
 
-KEY STRENGTHS (What They Do Well):
-1. Strong brand recognition (category leader)
-2. Large feature set (breadth over depth)
-3. Extensive integrations (2,000+ apps)
+STRENGTHS:
+1. [What they do well]
+2. [What they do well]
 
-KEY WEAKNESSES (Where They Fall Short):
-1. Complex UI (steep learning curve)
-2. Expensive (2x our price at scale)
-3. Poor support (low NPS in reviews)
-4. Legacy architecture (slow performance)
+WEAKNESSES:
+1. [Where they fall short]
+2. [Where they fall short]
 
 OUR ADVANTAGES:
-1. 10x easier to use (time-to-value in minutes vs. days)
-2. 50% lower cost at 100+ users
-3. Superior performance (2x faster load times)
-4. White-glove onboarding (dedicated CSM)
+1. [Your advantage + evidence]
+2. [Your advantage + evidence]
 
-WHEN TO WIN:
-- Customer values ease of use over features
-- Budget-conscious (not enterprise)
-- Need fast time-to-value (<1 week)
-- Poor experience with competitor (switching)
+WHEN WE WIN:
+- [Scenario where you win]
 
-WHEN TO LOSE:
-- Enterprise (>5000 employees) with complex requirements
-- Need feature X that we don't have yet
-- Deep integration with competitor's ecosystem
-- Already invested heavily in competitor (sunk cost)
+WHEN WE LOSE:
+- [Scenario where they win]
 
-TALK TRACKS:
-
-Objection: "We're already using [Competitor A]"
-Response: "That's great - many of our customers came from [Competitor A]. What prompted you to explore alternatives? [Listen for pain points] Typically teams switch to us because [ease of use / cost / performance]. Would it be helpful to see a side-by-side comparison?"
-
-Objection: "[Competitor A] has more features"
-Response: "You're right - they've been around longer and have a broader feature set. Here's what we found: most teams only use 20% of those features. Our customers love that we focus on doing [core use case] exceptionally well rather than trying to do everything. What features are most critical for your team?"
-
-PROOF POINTS:
-- Case study: "[Customer] switched from [Competitor A], reduced costs by 60%"
-- Review comparison: "[4.8 vs. 4.2 G2 rating in 'Ease of Use']"
-- Win rate: "35% win rate in competitive deals"
-
-COMPETITIVE LANDSCAPE:
-[Link to competitive positioning map]
-[Link to feature comparison matrix]
+TALK TRACK:
+Objection: "[Common objection]"
+Response: "[Your response]"
 ```
 
-**Battlecard Distribution**:
-- Store in: Notion, Confluence, or sales enablement platform
-- Update frequency: Monthly (or when competitor launches major feature)
-- Access: Sales, CS, Product, Marketing teams
-- Training: Monthly competitive update calls with sales
+### Win/Loss Analysis
 
-### 3.3 Win/Loss Analysis
-
-**Win/Loss Interview Process**:
-
-**Goals**:
-- Understand why you won/lost
-- Validate positioning and messaging
-- Identify product gaps
-- Track competitive trends
-
-**Process**:
-1. **Identify deals** (closed won or lost in last 30 days)
-2. **Request interview** (email or HubSpot workflow)
-3. **Conduct interview** (30-45 min, record with permission)
-4. **Analyze data** (themes, patterns, trends)
-5. **Share insights** (monthly report to product, sales, marketing)
-
-**Interview Questions** (pick 8-10):
-
-**For Wins**:
-- What problem were you trying to solve?
-- What alternatives did you evaluate?
-- Why did you choose us over [Competitor]?
-- What almost made you choose someone else?
-- What could we improve?
-
-**For Losses**:
-- What problem were you trying to solve?
-- Who did you choose instead? Why?
-- What did we do well in the sales process?
-- What could we have done differently?
-- Would you consider us in the future? When?
-
-**Data Tracking** (in HubSpot or spreadsheet):
-
-| Deal | Outcome | Reason | Competitor | Price Factor | Product Gap | Messaging Issue |
-|------|---------|--------|------------|--------------|-------------|-----------------|
-| Acme Corp | Won | Best product fit | Competitor A | No | No | No |
-| Beta Inc | Lost | Price | Competitor B | Yes | No | No |
-| Gamma LLC | Lost | Missing feature X | Built in-house | No | Yes | No |
-
-**Monthly Insights Report**:
-```
-Win/Loss Summary (March 2025):
-- Total deals analyzed: 20 (12 wins, 8 losses)
-- Win rate: 60%
-- Top win reasons:
-  1. Ease of use (8 mentions)
-  2. Better support (6 mentions)
-  3. Price (4 mentions)
-- Top loss reasons:
-  1. Missing feature X (4 mentions)
-  2. Price (3 mentions)
-  3. Competitor relationship (2 mentions)
-
-Action Items:
-- Product: Prioritize feature X (lost 4 deals)
-- Sales: Update battlecard for Competitor A (won 5 competitive deals)
-- Marketing: Create case study on "ease of use" theme
-```
+Track monthly:
+- Win rate by competitor
+- Top win reasons (product fit, ease of use, price)
+- Top loss reasons (missing feature, price, relationship)
+- Action items for product, sales, marketing
 
 ---
 
-## 4. Go-To-Market (GTM) Strategy
+## Product Launch Planning
 
-### 4.1 GTM Motion Types
+Plan launches by tier:
 
-**PLG (Product-Led Growth)**:
-- Entry: Free trial or freemium
-- Buyer: End user → Manager → VP
-- Sales: Low touch or self-serve
-- ACV: <$10k
-- Example: Slack, Notion, Figma
+| Tier | Scope | Prep Time | Budget |
+|------|-------|-----------|--------|
+| 1 | New product, major feature | 6-8 weeks | $50-100k |
+| 2 | Significant feature, integration | 3-4 weeks | $10-25k |
+| 3 | Small improvement | 1 week | <$5k |
 
-**Sales-Led Growth**:
-- Entry: Demo request → Sales qualification
-- Buyer: VP → C-level
-- Sales: High touch, consultative
-- ACV: $25k+
-- Example: Salesforce, Workday, SAP
+### Tier 1 Launch Workflow
 
-**Hybrid (PLG + Sales)**:
-- Entry: Free trial for SMB, demo for Enterprise
-- Buyer: End user (PLG) or Executive (Sales-Led)
-- Sales: Self-serve → Assisted → Enterprise
-- ACV: $5k-$100k
-- Example: HubSpot, Atlassian, Zoom
+Execute major product launch:
 
-**Series A Recommendation**: Start with **Hybrid**
-- Reason: Faster learning, broader TAM, efficient scaling
-- Approach:
-  - Bottom-up (PLG): Free trial → Paid team plan → Upgrade to Enterprise
-  - Top-down (Sales): Outbound to Enterprise → Demo → POC → Close
+1. Kickoff meeting with Product, Marketing, Sales, CS
+2. Define goals (pipeline $, MQLs, press coverage)
+3. Develop positioning and messaging
+4. Create sales enablement (deck, demo, battlecard)
+5. Build campaign assets (landing page, emails, ads)
+6. Train sales and CS teams
+7. Execute launch day (press, email, ads, outbound)
+8. Monitor and optimize for 30 days
+9. **Validation:** Pipeline on track to goal by week 2
 
-### 4.2 GTM Launch Playbook (90-Day Plan)
+### Launch Day Checklist
 
-**Pre-Launch (Days -90 to -30)**:
-
-Week 1-4: Foundation
-- [ ] Define ICP and buyer personas
-- [ ] Develop positioning and messaging
-- [ ] Create competitive battlecards
-- [ ] Set success metrics (pipeline $, MQLs, win rate)
-
-Week 5-8: Content & Enablement
-- [ ] Build website pages (homepage, product, pricing)
-- [ ] Create sales deck and demo script
-- [ ] Produce launch assets (one-pager, case studies, FAQs)
-- [ ] Develop email nurture sequences
-- [ ] Train sales team on positioning and talk tracks
-
-Week 9-12: Channel Setup
-- [ ] Launch paid campaigns (LinkedIn, Google)
-- [ ] Set up HubSpot tracking and attribution
-- [ ] Publish SEO content (blog posts, guides)
-- [ ] Activate partnerships (co-marketing plans)
-- [ ] Test conversion funnels (landing page → signup)
-
-**Launch (Days 1-30)**:
-
-Week 1: Awareness
-- [ ] Press release distribution
-- [ ] Email announcement to existing database
-- [ ] Social media campaign (LinkedIn, Twitter)
-- [ ] Paid ads go live (awareness campaigns)
-- [ ] Outbound sales blitz (top 100 accounts)
-
-Week 2-4: Activation
-- [ ] Monitor conversion rates (daily)
-- [ ] A/B test landing pages and ad copy
-- [ ] Sales follow-up on inbound leads (<4 hour SLA)
-- [ ] Customer interviews (feedback on positioning)
-- [ ] Adjust messaging based on early signals
-
-**Post-Launch (Days 31-90)**:
-
-Week 5-8: Optimization
-- [ ] Analyze win/loss data (why did we win/lose?)
-- [ ] Optimize underperforming channels (pause or pivot)
-- [ ] Scale winning channels (20% weekly budget increase)
-- [ ] Publish post-launch case studies
-- [ ] Expand content (SEO, demand gen)
-
-Week 9-12: Scale
-- [ ] Enter new market segments (vertical or geo)
-- [ ] Launch partnerships (co-marketing campaigns)
-- [ ] Build PLG loops (referral program, viral features)
-- [ ] Sales team expansion (hire based on pipeline)
-- [ ] Iterate positioning (quarterly messaging refresh)
-
-### 4.3 International Market Entry (EU/US/Canada)
-
-**Market Entry Priority** (Series A recommended order):
-
-**Phase 1: US Market** (Months 1-6)
-- Why: Largest TAM, fastest sales cycles, highest ACV
-- Entry strategy:
-  - Hire US-based SDRs/AEs (or partner with US sales agency)
-  - Localize website (USD pricing, US phone number)
-  - Paid ads (Google + LinkedIn) targeting US companies
-  - Partnerships with US-based tech companies
-- Budget: 50% of total marketing spend
-- Target: $1M ARR from US by Month 6
-
-**Phase 2: UK Market** (Months 4-9)
-- Why: English-speaking, gateway to EU, similar to US
-- Entry strategy:
-  - Hire UK sales rep or partner with UK agency
-  - Localize pricing (GBP), GDPR compliance
-  - Content localization (British spelling, cultural nuances)
-  - UK partnerships (local SaaS companies)
-- Budget: 20% of marketing spend
-- Target: $500k ARR from UK by Month 9
-
-**Phase 3: DACH (Germany/Austria/Switzerland)** (Months 7-12)
-- Why: Largest EU economy, high data privacy standards
-- Entry strategy:
-  - Translate website and product (German)
-  - Hire German-speaking sales rep
-  - GDPR compliance (critical for German market)
-  - Partnerships with German tech companies
-  - Local case studies and testimonials
-- Budget: 15% of marketing spend
-- Target: $300k ARR from DACH by Month 12
-
-**Phase 4: France** (Months 10-15)
-- Why: Second largest EU market, localization critical
-- Entry strategy:
-  - Full French translation (website, product, support)
-  - Hire French-speaking sales and support
-  - French partnerships and case studies
-  - Comply with French data regulations
-- Budget: 10% of marketing spend
-- Target: $200k ARR from France by Month 15
-
-**Phase 5: Canada** (Months 7-12)
-- Why: Similar to US, easier entry, smaller market
-- Entry strategy:
-  - Minimal localization (CAD pricing)
-  - Leverage US sales team (similar buying behavior)
-  - Canadian partnerships
-- Budget: 5% of marketing spend
-- Target: $100k ARR from Canada by Month 12
-
-**Localization Checklist (per market)**:
-
-- [ ] **Website**: Translate, localize currency, phone number
-- [ ] **Product**: UI translation (if needed for that market)
-- [ ] **Pricing**: Local currency, VAT/taxes displayed
-- [ ] **Support**: Local business hours, language support
-- [ ] **Legal**: Data privacy compliance (GDPR, CCPA)
-- [ ] **Sales**: Hire local reps or partner with local agency
-- [ ] **Marketing**: Localized ads, content, case studies
-- [ ] **Payments**: Local payment methods (SEPA, iDEAL, etc.)
-
-**Budget Allocation** (international expansion):
-```
-Year 1 (Series A):
-- US: 50% ($200k)
-- UK: 20% ($80k)
-- DACH: 15% ($60k)
-- France: 10% ($40k)
-- Canada: 5% ($20k)
-
-Total: $400k marketing spend (international)
-Expected ROI: 3:1 (marketing-sourced pipeline : spend)
-```
-
----
-
-## 5. Product Launch Framework
-
-### 5.1 Launch Tiers (Effort vs. Impact)
-
-**Tier 1: Major Launch** (quarterly, high impact)
-- Scope: New product, major feature, platform expansion
-- Audience: Existing customers + new prospects + press
-- Effort: 6-8 weeks prep, full cross-functional launch
-- Budget: $50k-$100k (Series A)
-- Activities: Press release, webinar, email series, paid ads, sales blitz
-
-**Tier 2: Standard Launch** (monthly, medium impact)
-- Scope: Significant feature, integration, improvement
-- Audience: Existing customers + select prospects
-- Effort: 3-4 weeks prep, core team involvement
-- Budget: $10k-$25k
-- Activities: Blog post, email announcement, product update, sales enablement
-
-**Tier 3: Minor Launch** (weekly, low impact)
-- Scope: Small feature, bug fix, optimization
-- Audience: Existing customers only
-- Effort: 1 week prep, product + marketing only
-- Budget: <$5k
-- Activities: In-app notification, changelog, support docs
-
-### 5.2 Major Launch Playbook (Tier 1)
-
-**8 Weeks Before Launch**:
-
-Week -8:
-- [ ] Kickoff meeting (Product, Marketing, Sales, CS)
-- [ ] Define launch goals (pipeline $, MQLs, press coverage)
-- [ ] Identify target audience (ICP, personas)
-- [ ] Create positioning and messaging
-- [ ] Assign roles and responsibilities
-
-Week -7:
-- [ ] Develop GTM strategy (channels, tactics, budget)
-- [ ] Create sales enablement (deck, demo script, FAQs)
-- [ ] Plan content (blog posts, case studies, videos)
-- [ ] Design creative assets (ads, social graphics, emails)
-
-Week -6:
-- [ ] Build landing pages (product page, demo request)
-- [ ] Set up HubSpot campaigns and tracking
-- [ ] Write press release and pitch media
-- [ ] Create email nurture sequences
-- [ ] Produce demo video
-
-Week -5:
-- [ ] Beta test with select customers (feedback)
-- [ ] Train sales team (positioning, demo, objection handling)
-- [ ] Train CS team (onboarding, support docs)
-- [ ] Finalize launch timeline and channel mix
-- [ ] Prepare customer case studies
-
-**4 Weeks Before Launch**:
-
-Week -4:
-- [ ] Launch paid ad campaigns (LinkedIn, Google)
-- [ ] Publish teaser content (blog, social)
-- [ ] Send pre-launch email to customer base
-- [ ] Pitch press and influencers
-- [ ] Set up webinar registration
-
-Week -3:
-- [ ] A/B test landing pages and ad copy
-- [ ] Ramp up content production (blog posts, videos)
-- [ ] Sales prospecting (outbound to target accounts)
-- [ ] Finalize webinar content and speakers
-- [ ] Prepare launch day checklist
-
-Week -2:
-- [ ] Send reminder emails (webinar, launch countdown)
-- [ ] Increase paid ad spend (ramp up)
-- [ ] Sales follow-up on warmed leads
-- [ ] Dry run: Test all systems (website, forms, CRM)
-- [ ] Prepare launch day assets (social posts, emails)
-
-Week -1:
-- [ ] Final review: All assets approved
-- [ ] Pre-launch email to VIP customers and partners
-- [ ] Sales team ready (trained, motivated, quotas set)
-- [ ] CS team ready (docs updated, chat support staffed)
-- [ ] Press embargo lifts (if applicable)
-
-**Launch Week**:
-
-Day 1 (Launch Day):
-- [ ] Press release goes live (distribute to media)
-- [ ] Email announcement to full database
-- [ ] Social media blitz (LinkedIn, Twitter, Facebook)
+- [ ] Press release distributed
+- [ ] Email announcement sent
+- [ ] Social media posts live
 - [ ] Paid ads at full budget
-- [ ] Sales outbound campaign (top 500 accounts)
-- [ ] Product update in-app (notify existing users)
-- [ ] Monitor metrics (signups, demos, press pickup)
+- [ ] Sales outbound blitz launched
+- [ ] In-app notification active
+- [ ] Metrics monitored every 2 hours
 
-Days 2-5:
-- [ ] Daily monitoring (conversion rates, funnel drop-offs)
-- [ ] A/B test optimizations (headlines, CTAs)
-- [ ] Sales follow-up (4-hour SLA on inbound leads)
-- [ ] Respond to press inquiries
-- [ ] Post customer testimonials and early wins
-- [ ] Webinar (Day 3 or 4)
+### Launch Metrics
 
-Week 2:
-- [ ] Analyze launch results (vs. goals)
-- [ ] Publish post-launch content (case studies, how-to guides)
-- [ ] Sales continue outbound (sustained momentum)
-- [ ] Optimize underperforming channels
-- [ ] Scale winning channels (increase budget)
-
-Week 3-4:
-- [ ] Post-launch report (metrics, learnings, next steps)
-- [ ] Customer feedback interviews (product improvements)
-- [ ] Win/loss analysis (why did we win/lose deals?)
-- [ ] Adjust messaging and positioning (based on feedback)
-- [ ] Plan next launch (apply learnings)
-
-### 5.3 Launch Metrics Dashboard
-
-**Leading Indicators** (track daily):
-- Landing page visitors
-- Demo requests
-- Free trial signups
-- MQLs generated
-- Sales pipeline created ($)
-
-**Lagging Indicators** (track weekly/monthly):
-- SQLs generated
-- Deals closed (count + $)
-- Win rate (vs. pre-launch)
-- Customer adoption rate (% of customers using feature)
-- NPS score (feature-specific)
-
-**HubSpot Dashboard**:
-```
-Launch Campaign: [Q2-2025-Product-X-Launch]
-
-WEEK 1 RESULTS:
-Traffic: 10,000 visitors (goal: 8,000) ✅
-MQLs: 250 (goal: 200) ✅
-SQLs: 40 (goal: 50) ⚠️
-Pipeline: $800k (goal: $1M) ⚠️
-Demos: 80 (goal: 100) ⚠️
-
-TOP CHANNELS:
-1. LinkedIn Ads: 120 MQLs, $150 CPL
-2. Email: 80 MQLs, $25 CPL
-3. Organic: 40 MQLs, $0 CPL
-
-UNDERPERFORMING:
-- Google Search: 10 MQLs, $400 CPL (pause and optimize)
-- Webinar: 50 registrants, 20% show rate (improve email reminders)
-
-NEXT ACTIONS:
-- Increase LinkedIn Ads budget by 30%
-- A/B test new landing page headline
-- Sales follow-up blitz on 40 SQLs
-```
+| Metric | Leading (Daily) | Lagging (Weekly) |
+|--------|-----------------|------------------|
+| Traffic | Landing page visitors | - |
+| Engagement | Demo requests, signups | Feature adoption % |
+| Pipeline | MQLs generated | SQLs, pipeline $ |
+| Revenue | - | Deals closed, revenue |
 
 ---
 
-## 6. Sales Enablement & Collaboration
+## Sales Enablement
 
-### 6.1 Sales Enablement Assets (Must-Have)
+Equip sales team with PMM assets:
 
-**Core Assets**:
+1. Create sales deck (15-20 slides, visual-first)
+2. Build one-pagers (product, competitive, case study)
+3. Develop demo script (30-45 min with discovery)
+4. Write email templates (outreach, follow-up, closing)
+5. Create ROI calculator (input costs, output savings)
+6. Conduct monthly enablement calls
+7. Deliver quarterly training (positioning, competitive)
+8. **Validation:** Sales uses assets in 80%+ of opportunities
 
-**1. Sales Deck** (15-20 slides)
+### Sales Deck Structure
+
+| Slide | Content |
+|-------|---------|
+| 1-2 | Title, agenda |
+| 3-4 | Company intro, problem statement |
+| 5-7 | Solution, key benefits, demo |
+| 8-10 | Differentiation, case study, pricing |
+| 11-12 | Implementation, support, next steps |
+
+### Demo Flow
+
 ```
-Slide 1: Title slide (logo, tagline)
-Slide 2: Agenda
-Slide 3: Company intro (mission, vision, traction)
-Slide 4: Problem statement (customer pain points)
-Slide 5: Solution overview (your product)
-Slide 6: Key benefits (3-5 bullets)
-Slide 7: Product demo (screenshots or video)
-Slide 8: Differentiation (vs. competitors)
-Slide 9: Customer logos (social proof)
-Slide 10: Case study (results-focused)
-Slide 11: Pricing and plans
-Slide 12: Implementation timeline
-Slide 13: Support and success
-Slide 14: Next steps (CTA)
-Slide 15: Q&A
-
-Guidelines:
-- Visual-first (minimal text, large images)
-- Customer-centric (benefits > features)
-- Modular (easy to skip/reorder slides)
-- Updated quarterly (or after major product changes)
-```
-
-**2. One-Pagers** (1-page PDF)
-- Product overview (what it is, who it's for, key features)
-- Competitive comparison (vs. Competitor A, B, C)
-- Case study (customer story with metrics)
-- Pricing sheet (plans, features, add-ons)
-
-**3. Battlecards** (per competitor)
-- See Section 3.2 for detailed battlecard template
-
-**4. Demo Script** (30-45 min)
-```
-Demo Flow:
-1. Intro (2 min) - Who we are, what we'll cover
-2. Discovery (5 min) - Ask about their needs, pain points
-3. Demo (20 min) - Show product (focus on their use case)
-4. Q&A (10 min) - Address objections, questions
-5. Next steps (3 min) - Define trial or POC plan
-
-Demo Tips:
-- Show, don't tell (product in action > slides)
-- Use customer data (not "Company XYZ" examples)
-- Focus on outcomes (not features)
-- Address objections proactively (price, competition)
-- Always drive to next step (trial, POC, proposal)
+1. Intro (2 min): Who we are, agenda
+2. Discovery (5 min): Their needs, pain points
+3. Demo (20 min): Product focused on their use case
+4. Q&A (10 min): Objection handling
+5. Next steps (3 min): Trial, POC, proposal
 ```
 
-**5. Email Templates** (HubSpot sequences)
-- Cold outreach (prospecting)
-- Demo follow-up
-- Trial conversion
-- Proposal sent
-- Closing sequence
+### Sales-Marketing Handoff
 
-**6. ROI Calculator** (spreadsheet or web tool)
-- Input: Customer's current costs, time spent, team size
-- Output: Savings with your product, payback period, 3-year ROI
-- Example: "Save $150k/year, 6-month payback, 500% ROI"
-
-### 6.2 Sales Training Program
-
-**Monthly Sales Enablement Call** (60 min):
-- Product updates (new features, roadmap)
-- Competitive landscape (new competitors, battlecard updates)
-- Win/loss insights (why we're winning/losing)
-- Best practices (top performer shares tips)
-- Q&A (open forum for questions)
-
-**Quarterly Sales Training** (half-day workshop):
-- Deep dive: Positioning and messaging refresh
-- Role-playing: Objection handling, competitive demos
-- Product training: New features, advanced use cases
-- Customer panel: Hear directly from customers (why they bought)
-
-**Sales Onboarding** (new hires):
-- Week 1: Company, product, market overview
-- Week 2: ICP, personas, messaging
-- Week 3: Competitive intelligence, battlecards
-- Week 4: Demo certification (must pass to sell)
-
-### 6.3 Marketing ↔ Sales Handoffs
-
-**MQL → SQL Handoff** (see marketing-demand-acquisition skill for details)
-
-**Product Marketing → Sales**:
-
-**Weekly Sync** (30 min):
-- Review: Win/loss insights, competitive updates
-- Share: New assets (battlecards, case studies, one-pagers)
-- Feedback: What's working, what's not
-- Request: Sales asks for specific assets (e.g., "Need competitor X battlecard")
-
-**Quarterly Business Review** (QBR):
-- Results: Pipeline, win rate, deal size, sales velocity
-- Insights: Top win/loss reasons, competitive trends
-- Action items: Product gaps, messaging updates, enablement needs
-
-**Communication Channels**:
-- Slack: #sales-enablement (daily questions, quick updates)
-- HubSpot: Centralized asset library (decks, one-pagers, videos)
-- Notion: Internal wiki (positioning, messaging, competitive intel)
+| Handoff | Frequency | Content |
+|---------|-----------|---------|
+| Weekly sync | 30 min | Win/loss, competitive, new assets |
+| Monthly enablement | 60 min | Product updates, training |
+| Quarterly review | Half-day | Results, strategy, planning |
 
 ---
 
-## 7. Metrics & Analytics
+## International Expansion
 
-### 7.1 PMM KPIs (Track Monthly)
+Enter new markets systematically:
 
-**Product Adoption**:
-- % of customers using new feature (within 30 days of launch)
-- Target: >40% adoption within 90 days
+1. Validate market demand (inbound leads, TAM analysis)
+2. Localize website, pricing, legal
+3. Establish sales coverage (hire or agency)
+4. Adapt messaging for cultural fit
+5. Build local partnerships and references
+6. Launch localized campaigns
+7. Monitor CAC and conversion by market
+8. **Validation:** 3+ paying customers from market in first 90 days
 
-**Sales Velocity**:
-- Days from SQL to closed won
-- Target: Decrease by 20% YoY
+### Market Priority (Series A)
 
-**Win Rate**:
-- % of opportunities won (vs. competitors)
-- Target: >30% win rate (competitive deals)
+| Market | Timeline | Budget % | Target ARR |
+|--------|----------|----------|------------|
+| US | Months 1-6 | 50% | $1M |
+| UK | Months 4-9 | 20% | $500k |
+| DACH | Months 7-12 | 15% | $300k |
+| France | Months 10-15 | 10% | $200k |
+| Canada | Months 7-12 | 5% | $100k |
 
-**Deal Size**:
-- Average contract value (ACV)
-- Target: Increase by 25% YoY
+### Localization Checklist
 
-**Launch Impact**:
-- Pipeline $ generated from launch campaigns
-- Target: 3:1 ROMI (pipeline $ : marketing spend)
-
-**Competitive Win Rate**:
-- % of deals won against Competitor A, B, C
-- Target: >35% win rate vs. top competitor
-
-### 7.2 HubSpot Reporting
-
-**Custom Reports**:
-
-**1. Product Launch Impact**
-```
-Metrics: Leads, MQLs, SQLs, Pipeline $, Closed Won $
-Dimensions: Campaign, Channel, Region
-Filters: Campaign = "Q2-2025-Product-X-Launch"
-Time period: 90 days post-launch
-```
-
-**2. Competitive Win Rate**
-```
-Metrics: Opportunities, Closed Won, Win Rate %
-Dimensions: Competitor (property)
-Filters: Deal stage = Closed Won or Closed Lost
-Segment by: Competitor A, B, C, Other
-```
-
-**3. Sales Enablement Usage**
-```
-Metrics: Asset downloads, views, shares
-Dimensions: Asset type (deck, battlecard, case study)
-Filters: User = Sales team
-Insight: Which assets are most used by sales
-```
-
-### 7.3 Quarterly Business Review (QBR)
-
-**QBR Template** (present to executive team):
-
-**Slide 1: Executive Summary**
-```
-Q2 2025 Highlights:
-- Launched Product X (pipeline: $2M, 500 MQLs)
-- Entered UK market (20 new customers, $400k ARR)
-- Improved win rate by 15% (competitive positioning)
-- Published 3 case studies (2x sales usage vs. Q1)
-```
-
-**Slide 2: Metrics Dashboard**
-```
-KPI             Q2 Target   Q2 Actual   Status
-─────────────────────────────────────────────
-MQLs            800         950         ✅ +19%
-SQLs            150         140         ⚠️ -7%
-Pipeline $      $4M         $3.8M       ⚠️ -5%
-Win Rate        30%         35%         ✅ +17%
-Deal Size       $45k        $52k        ✅ +16%
-Sales Velocity  75 days     68 days     ✅ -9%
-```
-
-**Slide 3: Key Insights**
-```
-What Worked:
-1. Product X launch exceeded MQL target by 19%
-2. Improved competitive positioning → 35% win rate
-3. UK market entry on track ($400k ARR in 3 months)
-
-What Didn't Work:
-1. SQL conversion rate dropped from 20% to 15%
-2. Google Ads underperformed (paused and optimizing)
-3. Competitor A launched aggressive pricing (5 lost deals)
-
-Action Items:
-1. Improve SQL qualification criteria (work with sales)
-2. Update battlecard for Competitor A (new pricing)
-3. Double down on UK market (hire local AE)
-```
-
-**Slide 4: Next Quarter Plan**
-```
-Q3 2025 Priorities:
-1. Launch Product Y (pipeline target: $3M)
-2. Enter DACH market (Germany, Austria, Switzerland)
-3. Refresh messaging and website (new positioning)
-4. Scale partnerships (3 new strategic partners)
-5. Build customer advocacy program (10 case studies)
-
-Budget: $150k (up from $120k in Q2)
-Headcount: +1 PMM, +1 Content Marketer
-```
+- [ ] Website translation (professional, not machine)
+- [ ] Currency and pricing localized
+- [ ] Local phone number and address
+- [ ] Legal compliance (GDPR, PIPEDA)
+- [ ] Local payment methods
+- [ ] Sales coverage during local hours
+- [ ] Local case studies and references
 
 ---
 
-## 8. Quick Reference
+## Reference Documentation
 
-### 8.1 PMM Monthly Checklist
+### Positioning Frameworks
 
-**Week 1** (Strategy & Planning):
-- [ ] Review previous month metrics (win rate, deal size, pipeline)
-- [ ] Analyze win/loss interviews (competitive trends)
-- [ ] Update competitive battlecards (if needed)
-- [ ] Plan next month campaigns and content
+`references/positioning-frameworks.md` contains:
 
-**Week 2** (Content & Enablement):
-- [ ] Create new sales assets (1-pager, case study, deck update)
-- [ ] Publish content (blog post, video, webinar)
-- [ ] Train sales on new positioning or product updates
-- [ ] Review sales asset usage (what's working?)
+- April Dunford 5-step positioning process
+- Geoffrey Moore positioning statement template
+- Positioning validation interview protocol
+- Competitive positioning map construction
 
-**Week 3** (Launches & Campaigns):
-- [ ] Support product launches (if any)
-- [ ] Monitor campaign performance (MQLs, SQLs, pipeline)
-- [ ] Optimize underperforming channels
-- [ ] Customer interviews (feedback on positioning)
+### Launch Checklists
 
-**Week 4** (Reporting & Iteration):
-- [ ] Monthly metrics report (for exec team)
-- [ ] Sales enablement call (updates, Q&A)
-- [ ] Win/loss analysis (themes, trends)
-- [ ] Plan next quarter launches and strategy
+`references/launch-checklists.md` contains:
 
-### 8.2 Positioning Development Timeline
+- Tier 1/2/3 launch checklists
+- Week-by-week launch timeline
+- Launch day runbook
+- Post-launch metrics dashboard
 
-**Week 1**: Research
-- Customer interviews (10-15)
-- Competitive analysis
-- Market trends
+### International GTM
 
-**Week 2**: Framework
-- April Dunford positioning exercise
-- Define unique value
-- Identify best-fit customers
+`references/international-gtm.md` contains:
 
-**Week 3**: Messaging
-- Craft value proposition
-- Build messaging hierarchy
-- Create persona-specific messaging
+- US, UK, DACH, France, Canada playbooks
+- Market-specific channel mix and messaging
+- Localization requirements per market
+- Entry timeline and budget allocation
 
-**Week 4**: Validation
-- Test with sales team
-- A/B test on landing pages
-- Customer feedback
+### Messaging Templates
 
-**Week 5-6**: Rollout
-- Update website, sales decks
-- Train sales and CS teams
-- Launch campaigns with new messaging
+`references/messaging-templates.md` contains:
 
-### 8.3 Team Handoff Protocols
-
-**PMM → Demand Gen**:
-- Deliver: Positioning, messaging, competitive intel, launch plans
-- Frequency: Monthly sync + ad-hoc for launches
-- SLA: 2-week lead time for major campaigns
-
-**PMM → Sales**:
-- Deliver: Battlecards, sales decks, demo scripts, objection handling
-- Frequency: Monthly enablement call + weekly Slack updates
-- SLA: 48 hours for urgent competitive questions
-
-**PMM → Product**:
-- Deliver: Customer feedback, competitive feature gaps, win/loss insights
-- Frequency: Weekly product sync
-- SLA: Quarterly roadmap input (feature prioritization)
-
-**PMM → Customer Success**:
-- Deliver: Product positioning, adoption tactics, customer education content
-- Frequency: Monthly sync
-- SLA: 1 week for new product launch enablement
+- Value proposition formulas
+- Persona-specific messaging
+- Competitive response scripts
+- Objection handling templates
+- Channel-specific copy (landing pages, emails, ads)
 
 ---
 
-## Resources
+## PMM KPIs
 
-### references/
-
-- **positioning-frameworks.md** - Detailed guide on April Dunford, Geoffrey Moore positioning methods
-- **launch-checklists.md** - Tier 1/2/3 launch checklists and templates
-- **international-gtm.md** - Market-by-market expansion playbooks (US, UK, DACH, France, Canada)
-- **messaging-templates.md** - Ready-to-use messaging frameworks for different personas
-
-### scripts/
-
-- **competitor_tracker.py** - Track competitor website/pricing changes
-- **win_loss_analyzer.py** - Analyze win/loss interview data for trends
-
-### assets/
-
-- **sales-deck-template.pptx** - Editable master sales deck
-- **battlecard-template.docx** - Competitive battlecard template
-- **one-pager-template.pptx** - Product one-pager design template
-- **roi-calculator.xlsx** - ROI calculator spreadsheet
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Product adoption | >40% in 90 days | Feature usage after launch |
+| Win rate | >30% competitive | Deals won vs. competitors |
+| Sales velocity | -20% YoY | Days from SQL to close |
+| Deal size | +25% YoY | Average contract value |
+| Launch pipeline | 3:1 ROMI | Pipeline $ : marketing spend |
 
 ---
 
-**Last Updated**: October 2025 | **Version**: 1.0
+## Quick Reference
+
+### PMM Monthly Rhythm
+
+| Week | Focus |
+|------|-------|
+| 1 | Review metrics, update battlecards |
+| 2 | Create assets, publish content |
+| 3 | Support launches, optimize campaigns |
+| 4 | Monthly report, plan next month |

--- a/marketing-skill/marketing-strategy-pmm/references/international-gtm.md
+++ b/marketing-skill/marketing-strategy-pmm/references/international-gtm.md
@@ -1,0 +1,401 @@
+# International GTM Playbooks
+
+Market-by-market expansion guides for US, UK, DACH, France, and Canada.
+
+---
+
+## Table of Contents
+
+- [Market Prioritization](#market-prioritization)
+- [US Market Entry](#us-market-entry)
+- [UK Market Entry](#uk-market-entry)
+- [DACH Market Entry](#dach-market-entry)
+- [France Market Entry](#france-market-entry)
+- [Canada Market Entry](#canada-market-entry)
+- [Localization Checklist](#localization-checklist)
+
+---
+
+## Market Prioritization
+
+### Expansion Sequence (Series A)
+
+| Phase | Market | Timeline | Budget % | Target ARR |
+|-------|--------|----------|----------|------------|
+| 1 | US | Months 1-6 | 50% | $1M |
+| 2 | UK | Months 4-9 | 20% | $500k |
+| 3 | DACH | Months 7-12 | 15% | $300k |
+| 4 | France | Months 10-15 | 10% | $200k |
+| 5 | Canada | Months 7-12 | 5% | $100k |
+
+### Market Readiness Checklist
+
+Enter market when ALL true:
+
+- [ ] Product ready for market (localization if needed)
+- [ ] Legal/compliance requirements met
+- [ ] Pricing localized (currency, taxes)
+- [ ] Sales capacity available (hire or agency)
+- [ ] Marketing budget allocated
+- [ ] Support coverage during local hours
+- [ ] **Validation:** 3+ inbound leads from market in last 90 days
+
+---
+
+## US Market Entry
+
+### Market Characteristics
+
+| Factor | US Approach |
+|--------|-------------|
+| Buying cycle | Fast (30-60 days average) |
+| Decision process | Individual empowerment, less consensus |
+| Pricing sensitivity | Value-focused, willing to pay premium |
+| Communication | Direct, results-oriented |
+| Relationship | Transaction > relationship (initially) |
+
+### Entry Strategy
+
+**Months 1-2: Foundation**
+
+1. Establish US presence:
+   - US phone number (toll-free)
+   - US address (virtual office acceptable)
+   - USD pricing on website
+   - US case studies (even if from beta users)
+
+2. Hire US sales:
+   - Option A: US-based SDR/AE (expensive but effective)
+   - Option B: US sales agency (lower risk, shared commission)
+   - Option C: Remote sales trained on US hours
+
+3. Launch paid campaigns:
+   - Google Ads (high-intent keywords)
+   - LinkedIn (B2B targeting)
+   - Budget: 50% of marketing spend
+
+**Months 3-6: Scale**
+
+1. Optimize channels based on CAC data
+2. Build US partner ecosystem:
+   - Integration partners (Salesforce, HubSpot)
+   - Resellers/VARs (for Enterprise)
+   - Industry associations
+3. Attend US conferences (SaaStr, industry events)
+4. **Validation:** $1M pipeline from US sources
+
+### US Channel Mix
+
+| Channel | Budget % | Expected CPL | Notes |
+|---------|----------|--------------|-------|
+| Google Ads | 35% | $100-200 | High intent, competitive |
+| LinkedIn | 30% | $150-250 | B2B targeting |
+| SEO/Content | 20% | $50 (long-term) | Invest early |
+| Partnerships | 15% | Variable | Co-marketing |
+
+### US Messaging
+
+- Lead with ROI and business outcomes
+- Use $ impact metrics prominently
+- Reference US customers (logos matter)
+- Emphasize speed and efficiency
+- Include G2/Capterra ratings
+
+---
+
+## UK Market Entry
+
+### Market Characteristics
+
+| Factor | UK Approach |
+|--------|-------------|
+| Buying cycle | Medium (45-90 days) |
+| Decision process | Committee involvement |
+| Pricing sensitivity | Value-conscious, compare options |
+| Communication | Professional, less aggressive than US |
+| Relationship | Balance transaction and relationship |
+
+### Entry Strategy
+
+**Months 4-6: Setup**
+
+1. Localization:
+   - GBP pricing
+   - UK spellings (colour, organisation)
+   - UK phone number
+   - GDPR compliance (essential)
+
+2. Sales coverage:
+   - Hire UK-based rep OR
+   - Partner with UK sales agency
+   - Ensure coverage during GMT hours
+
+3. Content localization:
+   - UK case studies
+   - UK-relevant industry references
+   - Local competitor positioning
+
+**Months 7-9: Growth**
+
+1. Build UK partnerships:
+   - UK tech community (TechNation, etc.)
+   - London-based VCs and accelerators
+   - UK industry associations
+
+2. Attend UK events:
+   - London Tech Week
+   - Industry-specific conferences
+
+3. **Validation:** $500k pipeline from UK sources
+
+### UK Channel Mix
+
+| Channel | Budget % | Expected CPL | Notes |
+|---------|----------|--------------|-------|
+| LinkedIn | 35% | $120-200 | Strong B2B presence |
+| Google UK | 30% | $80-150 | Less competitive than US |
+| SEO/Content | 20% | $40 | UK-targeted keywords |
+| Partnerships | 15% | Variable | Local credibility |
+
+### UK Messaging
+
+- More formal than US (avoid hyperbole)
+- Emphasize data security and GDPR
+- Reference UK/EU customers
+- Understated claims (prove with data)
+- Acknowledge local presence/support
+
+---
+
+## DACH Market Entry
+
+### Market Characteristics
+
+| Factor | DACH Approach |
+|--------|---------------|
+| Buying cycle | Long (90-180 days) |
+| Decision process | Consensus-driven, thorough evaluation |
+| Pricing sensitivity | Quality over price, long-term view |
+| Communication | Formal, detailed, precise |
+| Relationship | Trust built over time, essential |
+
+### Entry Strategy
+
+**Months 7-9: Foundation**
+
+1. Full localization:
+   - German translation (website, product UI)
+   - EUR pricing with German VAT handling
+   - German phone number and address
+   - GDPR compliance (strict enforcement)
+   - Data residency option (EU data centers)
+
+2. German-speaking sales:
+   - Hire German-speaking sales rep
+   - Native speaker critical (not just fluent)
+   - Based in Germany preferred
+
+3. Content in German:
+   - Translate key pages and materials
+   - Create German case studies
+   - German blog content
+
+**Months 10-12: Growth**
+
+1. Build local credibility:
+   - German customer testimonials
+   - German partner ecosystem
+   - Industry certifications (ISO, etc.)
+
+2. Attend German events:
+   - CeBIT/Hannover Messe
+   - Industry conferences
+
+3. **Validation:** $300k pipeline from DACH sources
+
+### DACH Channel Mix
+
+| Channel | Budget % | Expected CPL | Notes |
+|---------|----------|--------------|-------|
+| LinkedIn | 40% | $150-250 | Strong professional network |
+| Google DE | 25% | $100-180 | German keywords |
+| SEO (German) | 20% | $60 | Long-term investment |
+| Partnerships | 15% | Variable | Critical for trust |
+
+### DACH Messaging
+
+- Formal tone (Sie, not du)
+- Emphasize security, compliance, privacy
+- Detailed specifications and documentation
+- Reference German/EU customers
+- Include certifications (ISO, SOC 2)
+- Show long-term commitment to market
+
+---
+
+## France Market Entry
+
+### Market Characteristics
+
+| Factor | France Approach |
+|--------|-----------------|
+| Buying cycle | Long (90-180 days) |
+| Decision process | Hierarchical, formal process |
+| Pricing sensitivity | Value-focused, negotiation expected |
+| Communication | Formal, relationship-focused |
+| Relationship | Critical, business built on trust |
+
+### Entry Strategy
+
+**Months 10-12: Foundation**
+
+1. Full French localization:
+   - French translation (professional, not machine)
+   - EUR pricing with French VAT
+   - French phone number
+   - GDPR + French regulations
+
+2. French-speaking team:
+   - Native French speaker for sales
+   - French support coverage
+   - Paris presence (even virtual)
+
+**Months 13-15: Growth**
+
+1. Build local ecosystem:
+   - French tech community (La French Tech)
+   - French partners and integrators
+   - Industry associations
+
+2. Attend French events:
+   - VivaTech (Paris)
+   - Industry conferences
+
+3. **Validation:** $200k pipeline from France
+
+### France Channel Mix
+
+| Channel | Budget % | Expected CPL | Notes |
+|---------|----------|--------------|-------|
+| LinkedIn | 35% | $130-220 | Professional network |
+| Google FR | 30% | $90-160 | French keywords |
+| SEO (French) | 20% | $50 | French content strategy |
+| Partnerships | 15% | Variable | Local partners essential |
+
+### France Messaging
+
+- Formal and professional
+- French language throughout (no English fallback)
+- Reference French/EU customers
+- Emphasize local support and presence
+- Highlight innovation and modernity
+- Respect cultural nuances
+
+---
+
+## Canada Market Entry
+
+### Market Characteristics
+
+| Factor | Canada Approach |
+|--------|-----------------|
+| Buying cycle | Medium (45-75 days) |
+| Decision process | Similar to US, slightly more conservative |
+| Pricing sensitivity | Value-conscious, compare to US prices |
+| Communication | Professional, friendly, less aggressive |
+| Language | English (except Quebec - French required) |
+
+### Entry Strategy
+
+**Months 7-9: Foundation**
+
+1. Minimal localization:
+   - CAD pricing
+   - Canadian phone number (optional)
+   - PIPEDA compliance
+
+2. Sales coverage:
+   - Leverage US sales team (similar hours)
+   - Consider Toronto-based rep for growth
+
+3. Quebec consideration:
+   - French required for Quebec market
+   - Can delay or skip initially
+
+**Months 10-12: Growth**
+
+1. Canadian partnerships:
+   - Canadian tech community
+   - Toronto/Vancouver startup ecosystem
+   - Industry associations
+
+2. **Validation:** $100k pipeline from Canada
+
+### Canada Channel Mix
+
+| Channel | Budget % | Expected CPL | Notes |
+|---------|----------|--------------|-------|
+| Google CA | 35% | $80-150 | Canadian targeting |
+| LinkedIn | 30% | $100-180 | B2B focus |
+| SEO | 20% | $40 | Canadian content |
+| Partnerships | 15% | Variable | Local credibility |
+
+---
+
+## Localization Checklist
+
+### Per-Market Checklist
+
+**Website**
+
+- [ ] Language translation (professional, not machine)
+- [ ] Currency localization (display + checkout)
+- [ ] Phone number (local format)
+- [ ] Address (local presence)
+- [ ] Legal pages (privacy, terms in local language)
+- [ ] hreflang tags configured correctly
+
+**Product**
+
+- [ ] UI translation (if required for market)
+- [ ] Date/time format (DD/MM/YYYY vs MM/DD/YYYY)
+- [ ] Number format (1,000 vs 1.000)
+- [ ] Currency in product
+
+**Payment**
+
+- [ ] Local currency accepted
+- [ ] VAT/tax handling
+- [ ] Local payment methods (SEPA, iDEAL, etc.)
+- [ ] Invoicing in local format
+
+**Legal**
+
+- [ ] GDPR compliance (EU markets)
+- [ ] PIPEDA compliance (Canada)
+- [ ] Local data protection laws
+- [ ] Terms of service localized
+- [ ] Privacy policy localized
+
+**Sales**
+
+- [ ] Local sales coverage (rep or agency)
+- [ ] Localized sales materials
+- [ ] Local pricing and quoting
+- [ ] Local references and case studies
+
+**Support**
+
+- [ ] Coverage during local business hours
+- [ ] Language support (phone, chat, email)
+- [ ] Localized documentation
+- [ ] Local SLA commitments
+
+**Marketing**
+
+- [ ] Localized campaigns
+- [ ] Local content (blog, guides)
+- [ ] Local social media presence
+- [ ] Local event participation
+
+**Validation:** Native speaker review of ALL localized content before launch

--- a/marketing-skill/marketing-strategy-pmm/references/launch-checklists.md
+++ b/marketing-skill/marketing-strategy-pmm/references/launch-checklists.md
@@ -1,0 +1,333 @@
+# Launch Checklists
+
+GTM launch playbooks for Tier 1, 2, and 3 product releases.
+
+---
+
+## Table of Contents
+
+- [Launch Tier Definitions](#launch-tier-definitions)
+- [Tier 1 Major Launch](#tier-1-major-launch)
+- [Tier 2 Standard Launch](#tier-2-standard-launch)
+- [Tier 3 Minor Launch](#tier-3-minor-launch)
+- [Launch Metrics Dashboard](#launch-metrics-dashboard)
+
+---
+
+## Launch Tier Definitions
+
+| Tier | Scope | Prep Time | Budget | Audience |
+|------|-------|-----------|--------|----------|
+| 1 | New product, major feature | 6-8 weeks | $50-100k | All prospects + press |
+| 2 | Significant feature, integration | 3-4 weeks | $10-25k | Customers + select prospects |
+| 3 | Small feature, improvement | 1 week | <$5k | Existing customers |
+
+**Tier Selection Criteria:**
+
+```
+Tier 1 if ANY true:
+- [ ] Net-new product line
+- [ ] Revenue impact > $500k pipeline
+- [ ] Press coverage expected
+- [ ] Competitive response anticipated
+
+Tier 2 if ANY true:
+- [ ] Major feature request (top 10 customer ask)
+- [ ] New integration with strategic partner
+- [ ] Pricing or packaging change
+
+Tier 3 otherwise:
+- [ ] Bug fixes
+- [ ] UI improvements
+- [ ] Minor enhancements
+```
+
+---
+
+## Tier 1 Major Launch
+
+### Phase 1: Foundation (Weeks -8 to -5)
+
+**Week -8: Kickoff**
+
+- [ ] Schedule kickoff meeting (Product, Marketing, Sales, CS)
+- [ ] Define launch goals:
+  - Pipeline target: $______
+  - MQL target: ______
+  - Press hits target: ______
+  - Adoption target: ______% in 90 days
+- [ ] Assign roles (RACI matrix):
+  - PMM: Launch lead, positioning, messaging
+  - Product: Feature readiness, demo environment
+  - Demand Gen: Campaigns, paid ads, email
+  - Content: Blog posts, case studies, videos
+  - Sales: Enablement, outbound campaign
+- [ ] Create project timeline in Asana/Monday/Notion
+- [ ] **Validation:** All stakeholders confirm goals and timeline
+
+**Week -7: Strategy**
+
+- [ ] Develop positioning and messaging (see positioning-frameworks.md)
+- [ ] Create GTM channel plan:
+  - Owned: Email, blog, social, webinar
+  - Paid: LinkedIn ads, Google ads
+  - Earned: Press, influencers, partners
+- [ ] Define target segments (ICP, personas)
+- [ ] Allocate budget by channel
+- [ ] Draft press release (embargo date set)
+
+**Week -6: Content**
+
+- [ ] Build landing page (product page, demo request form)
+- [ ] Write blog post announcement
+- [ ] Create sales deck updates (5-10 new slides)
+- [ ] Design social media graphics (5+ variants)
+- [ ] Produce demo video (3-5 minutes)
+- [ ] Draft email sequences (announcement, nurture)
+
+**Week -5: Enablement**
+
+- [ ] Create sales battlecard (competitive positioning)
+- [ ] Write demo script (new feature walkthrough)
+- [ ] Build FAQ document (top 20 questions)
+- [ ] Develop objection handling guide
+- [ ] Schedule sales training session
+- [ ] Recruit beta customers for testimonials
+- [ ] **Validation:** Sales team can demo feature confidently
+
+### Phase 2: Preparation (Weeks -4 to -1)
+
+**Week -4: Launch Prep**
+
+- [ ] Set up HubSpot campaign (UTMs, attribution)
+- [ ] Launch teaser campaign (social, email hints)
+- [ ] Pitch press and analysts (NDA briefings)
+- [ ] Create webinar registration page
+- [ ] Finalize partner co-marketing plans
+- [ ] QA all landing pages and forms
+
+**Week -3: Ramp Up**
+
+- [ ] Activate paid ads (LinkedIn, Google) at 50% budget
+- [ ] A/B test landing page headlines
+- [ ] Send pre-launch email to VIP customers
+- [ ] Conduct sales training (2-hour session)
+- [ ] Confirm webinar speakers and content
+- [ ] Prepare launch day runbook
+
+**Week -2: Final Prep**
+
+- [ ] Increase paid ad spend to 75%
+- [ ] Send webinar reminder emails
+- [ ] Finalize press embargo lift time
+- [ ] Complete dry run (website, forms, CRM workflow)
+- [ ] Create launch day social posts (scheduled)
+- [ ] Brief customer success team
+
+**Week -1: Pre-Launch**
+
+- [ ] Final approval on all assets
+- [ ] Send VIP preview to top 10 customers
+- [ ] Confirm press embargo release
+- [ ] Sales team ready (trained, quotas set)
+- [ ] CS team ready (docs updated, chat staffed)
+- [ ] Test all systems one final time
+- [ ] **Validation:** All checklist items green
+
+### Phase 3: Launch (Weeks 1-4)
+
+**Launch Day**
+
+- [ ] Press release distribution (wire + direct pitch)
+- [ ] Email blast to full database
+- [ ] Social media posts (LinkedIn, Twitter, Facebook)
+- [ ] Paid ads at 100% budget
+- [ ] Sales outbound blitz (top 100 accounts)
+- [ ] In-app announcement to existing users
+- [ ] Monitor metrics every 2 hours:
+  - Traffic, signups, demo requests
+  - Press pickup, social engagement
+  - Sales pipeline created
+
+**Days 2-7**
+
+- [ ] Daily metrics review (conversion rates, funnel)
+- [ ] A/B test optimizations based on data
+- [ ] Sales follow-up (<4 hour SLA on leads)
+- [ ] Respond to press and analyst inquiries
+- [ ] Host webinar (Day 3 or 4)
+- [ ] Post customer testimonials
+- [ ] Adjust paid ads (pause underperformers)
+
+**Week 2-4**
+
+- [ ] Publish post-launch blog content
+- [ ] Create customer case study from early adopters
+- [ ] Conduct win/loss interviews (5+ deals)
+- [ ] Optimize converting channels (+20% budget)
+- [ ] Pause non-converting channels
+- [ ] Weekly launch status report to executives
+- [ ] **Validation:** Pipeline on track to goal
+
+### Phase 4: Post-Launch (Weeks 5-12)
+
+**Month 2**
+
+- [ ] Launch retrospective meeting
+- [ ] Document learnings (what worked, what didn't)
+- [ ] Scale winning channels
+- [ ] Expand to new segments if successful
+- [ ] Update positioning based on customer feedback
+- [ ] Plan sustaining campaigns
+
+**Month 3**
+
+- [ ] Final launch report (vs. goals)
+- [ ] Calculate ROI (pipeline / spend)
+- [ ] Publish additional case studies
+- [ ] Integrate learnings into next launch plan
+- [ ] Archive launch assets for reuse
+
+---
+
+## Tier 2 Standard Launch
+
+### Timeline: 4 Weeks
+
+**Week -4 to -3: Preparation**
+
+- [ ] Define feature and target audience
+- [ ] Create positioning and key messages
+- [ ] Build landing page or product page update
+- [ ] Write blog post announcement
+- [ ] Update sales deck (2-3 slides)
+- [ ] Create email announcement
+- [ ] Brief sales team (30-min call)
+
+**Week -2 to -1: Setup**
+
+- [ ] Set up HubSpot campaign tracking
+- [ ] Schedule social posts
+- [ ] Set up paid ads (limited budget)
+- [ ] QA landing pages and forms
+- [ ] Notify customer success team
+
+**Launch Week**
+
+- [ ] Send email announcement
+- [ ] Publish blog post
+- [ ] Post on social media
+- [ ] In-app notification to users
+- [ ] Sales mention in active deals
+- [ ] Monitor initial metrics
+
+**Week +1 to +2: Follow-up**
+
+- [ ] Analyze launch metrics
+- [ ] Optimize based on data
+- [ ] Collect customer feedback
+- [ ] Document learnings
+
+---
+
+## Tier 3 Minor Launch
+
+### Timeline: 1 Week
+
+**Day -5 to -3: Prep**
+
+- [ ] Write changelog entry
+- [ ] Update support documentation
+- [ ] Create in-app notification copy
+- [ ] Brief CS team
+
+**Day -2 to -1: Review**
+
+- [ ] QA feature in staging
+- [ ] Approve changelog copy
+- [ ] Schedule in-app notification
+
+**Launch Day**
+
+- [ ] Deploy feature
+- [ ] Trigger in-app notification
+- [ ] Publish changelog
+- [ ] Update support docs (if needed)
+
+**Day +1 to +3: Monitor**
+
+- [ ] Check for support tickets
+- [ ] Monitor feature adoption
+- [ ] Address any issues
+
+---
+
+## Launch Metrics Dashboard
+
+### Leading Indicators (Track Daily)
+
+| Metric | Target | Day 1 | Day 3 | Day 7 |
+|--------|--------|-------|-------|-------|
+| Landing page visitors | 5,000 | | | |
+| Demo requests | 100 | | | |
+| Free trial signups | 200 | | | |
+| MQLs generated | 150 | | | |
+| Pipeline created ($) | $500k | | | |
+
+### Lagging Indicators (Track Weekly)
+
+| Metric | Target | Week 1 | Week 2 | Week 4 |
+|--------|--------|--------|--------|--------|
+| SQLs generated | 30 | | | |
+| Demos completed | 50 | | | |
+| Deals closed (#) | 5 | | | |
+| Revenue ($) | $100k | | | |
+| Feature adoption (%) | 40% | | | |
+
+### Channel Performance
+
+| Channel | Spend | MQLs | CPL | Pipeline | ROI |
+|---------|-------|------|-----|----------|-----|
+| LinkedIn Ads | $10k | | | | |
+| Google Ads | $5k | | | | |
+| Email | $0 | | | | |
+| Organic | $0 | | | | |
+| Webinar | $2k | | | | |
+| **Total** | **$17k** | | | | |
+
+### Post-Launch Report Template
+
+```
+LAUNCH: [Product/Feature Name]
+DATE: [Launch Date]
+OWNER: [PMM Name]
+
+EXECUTIVE SUMMARY:
+- Goal: $500k pipeline in 30 days
+- Actual: $[X] pipeline (X% of goal)
+- Status: ✅ On Track / ⚠️ Behind / ❌ Missed
+
+KEY RESULTS:
+| Metric       | Goal    | Actual  | % of Goal |
+|--------------|---------|---------|-----------|
+| MQLs         | 150     |         |           |
+| SQLs         | 30      |         |           |
+| Pipeline     | $500k   |         |           |
+| Feature Adoption | 40% |         |           |
+
+TOP PERFORMING:
+1. [Channel/Tactic] - [Result]
+2. [Channel/Tactic] - [Result]
+
+UNDERPERFORMING:
+1. [Channel/Tactic] - [Result] - [Action taken]
+
+LEARNINGS:
+1. [What worked and why]
+2. [What didn't work and why]
+3. [What we'd do differently]
+
+NEXT STEPS:
+1. [Action item] - Owner - Due date
+2. [Action item] - Owner - Due date
+```

--- a/marketing-skill/marketing-strategy-pmm/references/messaging-templates.md
+++ b/marketing-skill/marketing-strategy-pmm/references/messaging-templates.md
@@ -1,0 +1,446 @@
+# Messaging Templates
+
+Ready-to-use messaging frameworks for different personas and contexts.
+
+---
+
+## Table of Contents
+
+- [Value Proposition Templates](#value-proposition-templates)
+- [Persona-Specific Messaging](#persona-specific-messaging)
+- [Competitive Messaging](#competitive-messaging)
+- [Channel-Specific Copy](#channel-specific-copy)
+- [Objection Handling Scripts](#objection-handling-scripts)
+
+---
+
+## Value Proposition Templates
+
+### One-Liner Formula
+
+Template: `[Product] helps [Target Customer] [Achieve Goal] by [Unique Approach]`
+
+**Examples:**
+
+```
+B2B SaaS:
+"Acme helps mid-market SaaS teams ship 2x faster by automating
+project workflows with AI."
+
+Enterprise:
+"Acme helps Fortune 500 companies reduce operational costs by 40%
+through intelligent process automation."
+
+SMB:
+"Acme helps small businesses save 10 hours per week by automating
+their daily tasks."
+```
+
+### Elevator Pitch (30 Seconds)
+
+Template:
+```
+You know how [target customer] struggles with [pain point]?
+
+[Product] is a [category] that [key differentiator].
+
+Unlike [alternatives], we [unique value].
+
+Our customers see [specific outcome] within [timeframe].
+```
+
+**Example:**
+
+```
+You know how engineering teams struggle with slow code reviews
+that delay releases?
+
+Acme is an AI code review platform that catches bugs before
+they reach production.
+
+Unlike manual reviews, we analyze every PR in under 2 minutes
+with 95% accuracy.
+
+Our customers ship 40% faster within their first month.
+```
+
+### Messaging Hierarchy
+
+```
+LEVEL 1: HEADLINE (5-7 words)
+"Ship faster with AI-powered automation"
+
+LEVEL 2: SUBHEAD (1 sentence)
+"Acme automates your workflows so your team can focus on what matters."
+
+LEVEL 3: KEY BENEFITS (3-4 bullets)
+• Save 10+ hours per week on manual tasks
+• Reduce errors by 80% with AI validation
+• Deploy changes 3x faster with automated testing
+• Scale operations without adding headcount
+
+LEVEL 4: FEATURES → VALUE
+• AI Automation → Eliminates repetitive work → Save $50k/year
+• Real-time Sync → No version conflicts → 50% fewer errors
+• Integrations → Connect existing tools → 2-hour setup
+```
+
+---
+
+## Persona-Specific Messaging
+
+### Economic Buyer (VP/Director/C-Level)
+
+**Primary concerns:** ROI, business outcomes, risk mitigation
+
+**Messaging principles:**
+- Lead with business impact ($, %, time)
+- Show ROI within 6-12 months
+- Reference similar companies
+- Address risk (security, implementation)
+
+**Template:**
+
+```
+HEADLINE: [Business outcome] in [timeframe]
+
+OPENING:
+"[Role at similar company] was spending [hours/dollars] on [problem].
+After implementing [Product], they achieved [specific result]."
+
+KEY POINTS:
+• [Metric] improvement in [area] (e.g., "40% reduction in manual work")
+• ROI: [X]x return within [timeframe]
+• Implementation: [timeframe] with [level] of effort
+• Risk: [How you mitigate concerns]
+
+CTA: "See how [similar company] achieved [result] →"
+```
+
+**Example email:**
+
+```
+Subject: How Stripe reduced deployment time by 60%
+
+Hi [Name],
+
+The VP of Engineering at a company similar to yours was spending
+40 hours per week on code review bottlenecks.
+
+After implementing Acme, they:
+• Reduced review time by 60%
+• Caught 3x more bugs before production
+• Shipped new features 2 weeks faster
+
+Would a 15-minute call to explore if similar results are possible
+for [Company] make sense?
+```
+
+### Technical Buyer (Engineer/Architect)
+
+**Primary concerns:** Technical fit, security, integration, vendor lock-in
+
+**Messaging principles:**
+- Lead with technical capabilities
+- Show architecture and security details
+- Demonstrate easy integration
+- Provide technical documentation
+
+**Template:**
+
+```
+HEADLINE: [Technical capability] for [their stack]
+
+OPENING:
+"Built for [their technology environment] with [key technical feature]."
+
+KEY POINTS:
+• Architecture: [how it works technically]
+• Security: [certifications, compliance, encryption]
+• Integration: [specific integrations with their tools]
+• Performance: [benchmarks, latency, uptime]
+
+CTA: "Read the technical whitepaper →" or "See the API docs →"
+```
+
+**Example:**
+
+```
+Subject: SOC 2 Type II compliant with 99.99% uptime
+
+Hi [Name],
+
+I noticed [Company] uses Kubernetes for container orchestration.
+
+Acme integrates natively with K8s with:
+• Single-line Helm chart deployment
+• mTLS encryption for all traffic
+• SOC 2 Type II + GDPR compliant
+• 99.99% uptime SLA with $10k credit guarantee
+
+Here's our architecture diagram: [link]
+
+Worth a quick technical review?
+```
+
+### End User (Manager/Individual Contributor)
+
+**Primary concerns:** Ease of use, daily workflow, learning curve
+
+**Messaging principles:**
+- Lead with time savings
+- Show product in action (demo, screenshots)
+- Emphasize simplicity
+- Include peer testimonials
+
+**Template:**
+
+```
+HEADLINE: [Daily benefit] in [time to value]
+
+OPENING:
+"Imagine [desired outcome] without [pain point]."
+
+KEY POINTS:
+• Get started in [timeframe] (no training required)
+• Save [hours] every [timeframe]
+• [Feature] makes [task] effortless
+• Loved by [peer companies/roles]
+
+CTA: "Try free for 14 days →"
+```
+
+**Example:**
+
+```
+Subject: Spend less time in meetings, more time building
+
+Hi [Name],
+
+What if your weekly status meetings could run themselves?
+
+Acme automatically:
+• Collects updates from your team (no nagging)
+• Creates visual progress reports (no spreadsheets)
+• Flags blockers before they become problems
+
+Teams like [Company A] and [Company B] love it.
+
+Start your free trial: [link]
+```
+
+---
+
+## Competitive Messaging
+
+### "Why Us vs. Competitor A" Framework
+
+```
+OPENING (acknowledge competition):
+"Both [Product] and [Competitor A] help teams with [general category].
+Here's what sets us apart:"
+
+DIFFERENTIATORS (3-4 key points):
+
+1. [Your advantage] vs. [Their limitation]
+   "Our AI catches 95% of bugs vs. their rule-based 60% coverage"
+
+2. [Your advantage] vs. [Their limitation]
+   "Get started in 2 hours vs. their 2-week implementation"
+
+3. [Your advantage] vs. [Their limitation]
+   "$50/user vs. their $150/user at scale"
+
+PROOF POINT:
+"[Customer] switched from [Competitor A] to us and saw [result]"
+
+CTA:
+"See a side-by-side comparison →"
+```
+
+### Competitive Positioning Statements
+
+**When they're the market leader:**
+
+```
+"[Competitor] built the category, but it was designed for [old paradigm].
+[Product] is purpose-built for [new reality] with [key differentiators]."
+```
+
+**When they're cheaper:**
+
+```
+"[Competitor] costs less upfront, but teams spend [X hours] working
+around limitations. [Product] pays for itself in [timeframe] through
+[specific efficiency gains]."
+```
+
+**When they have more features:**
+
+```
+"[Competitor] tries to do everything. [Product] focuses on doing
+[core use case] exceptionally well. Our customers tell us they only
+use 20% of [Competitor's] features anyway."
+```
+
+---
+
+## Channel-Specific Copy
+
+### Landing Page
+
+**Above the fold:**
+```
+[HEADLINE - 5-7 words, benefit-focused]
+Ship faster with AI-powered automation
+
+[SUBHEAD - 1 sentence expanding on value]
+Acme automates your workflows so your team can focus on what matters.
+
+[CTA - Action-oriented]
+Start Free Trial     |     Book Demo
+```
+
+**Social proof bar:**
+```
+Trusted by 5,000+ teams including [Logo] [Logo] [Logo] [Logo]
+```
+
+### Email Subject Lines
+
+**High performers:**
+- "How [Similar Company] achieved [result]"
+- "[Name], quick question about [their challenge]"
+- "Re: [topic they care about]" (for follow-ups)
+- "[Specific number]% improvement in [metric]"
+
+**Avoid:**
+- "Quick sync?"
+- "Following up..."
+- "Just checking in"
+- ALL CAPS or excessive punctuation!!!
+
+### LinkedIn Ads
+
+**Format: Single image or carousel**
+
+```
+HEADLINE (70 chars max):
+"Cut code review time by 60%"
+
+BODY (150 chars recommended):
+"AI-powered code reviews that catch bugs before production.
+Trusted by engineering teams at Stripe and Shopify.
+Try free →"
+
+CTA: Learn More / Try Free / Get Demo
+```
+
+### Google Ads
+
+**Search ad format:**
+
+```
+Headline 1 (30 chars): AI Code Review Platform
+Headline 2 (30 chars): Ship 40% Faster
+Headline 3 (30 chars): Free 14-Day Trial
+
+Description (90 chars):
+Catch bugs before production. Trusted by 5,000+ teams.
+Start your free trial today.
+```
+
+---
+
+## Objection Handling Scripts
+
+### Price Objection
+
+**"It's too expensive"**
+
+```
+ACKNOWLEDGE: "I understand budget is a concern."
+
+REFRAME: "Let me share how our customers think about it...
+[Customer] was spending [X hours/dollars] on [problem] every month.
+After implementing [Product], they saved [Y hours/dollars], paying
+for the solution in [timeframe]."
+
+QUESTION: "What would it be worth to your team to [achieve outcome]?"
+
+ALTERNATIVE: "We also offer [smaller plan/annual discount] that might
+work for your current budget. Would that help?"
+```
+
+### Competitor Objection
+
+**"We're looking at [Competitor A] too"**
+
+```
+ACKNOWLEDGE: "That's smart to evaluate options. [Competitor A] is
+a solid product."
+
+DIFFERENTIATE: "The main differences customers tell us about:
+1. [Your advantage] - [Competitor] doesn't offer this
+2. [Your advantage] - Their approach is [different/older]
+3. [Price/support/speed] - We're typically [X] better here"
+
+PROOF: "[Customer] evaluated both and chose us because [reason]."
+
+QUESTION: "What are the 2-3 things that matter most to you in
+this decision?"
+```
+
+### Timing Objection
+
+**"Not the right time"**
+
+```
+ACKNOWLEDGE: "I completely understand. Timing is everything."
+
+EXPLORE: "Out of curiosity, what would need to change for this
+to become a priority?"
+
+FUTURE: "Would it make sense to schedule a brief call in [timeframe]
+to revisit? I can share relevant updates without any pressure."
+
+VALUE ADD: "In the meantime, I'll send over [relevant content] that
+might be useful for when you're ready."
+```
+
+### Authority Objection
+
+**"I need to check with my team/boss"**
+
+```
+ACKNOWLEDGE: "Of course, that makes sense."
+
+SUPPORT: "What information would be most helpful for that conversation?
+I can put together a one-pager with key points."
+
+OFFER: "Would it help if I joined a brief call with [stakeholder]
+to answer any technical/business questions directly?"
+
+TIMELINE: "When do you think you'll have that conversation?
+I can follow up with any additional materials beforehand."
+```
+
+### Technical Objection
+
+**"Will this integrate with our stack?"**
+
+```
+ACKNOWLEDGE: "Great question - integration is critical."
+
+CONFIRM: "What are the main tools you need to connect with?
+[Listen and take notes]"
+
+ANSWER: "We have native integrations with [tools]. For [tool],
+we use [API/webhook/Zapier]. Here's our integration docs: [link]"
+
+PROOF: "[Similar company] uses a similar stack and got integrated
+in [timeframe]."
+
+DEMO: "Want me to show you exactly how the integration works
+in a quick demo?"
+```

--- a/marketing-skill/marketing-strategy-pmm/references/positioning-frameworks.md
+++ b/marketing-skill/marketing-strategy-pmm/references/positioning-frameworks.md
@@ -1,0 +1,279 @@
+# Positioning Frameworks
+
+Strategic positioning methodologies for B2B SaaS products.
+
+---
+
+## Table of Contents
+
+- [April Dunford Positioning](#april-dunford-positioning)
+- [Geoffrey Moore Positioning](#geoffrey-moore-positioning)
+- [Positioning Validation](#positioning-validation)
+- [Competitive Positioning Map](#competitive-positioning-map)
+
+---
+
+## April Dunford Positioning
+
+### The 5-Step Process
+
+Execute positioning using April Dunford's "Obviously Awesome" methodology:
+
+1. List competitive alternatives (what customers would use instead)
+2. Isolate unique attributes (features only you have)
+3. Map attributes to value (why each attribute matters)
+4. Define best-fit customers (who cares most about this value)
+5. Choose market category (where you compete)
+6. **Validation:** Best-fit customers articulate your value unprompted
+
+### Step 1: Competitive Alternatives
+
+Document what customers do without your product:
+
+| Alternative Type | Examples | How They Solve It |
+|------------------|----------|-------------------|
+| Direct competitor | Competitor A, B | Same category, different approach |
+| Adjacent solution | Spreadsheets, email | Manual workaround |
+| Build in-house | Custom development | Internal solution |
+| Do nothing | Ignore problem | Accept status quo |
+
+**Interview Questions:**
+- "Before using us, how did you handle this?"
+- "What alternatives did you evaluate?"
+- "What would you switch to if we disappeared?"
+
+### Step 2: Unique Attributes
+
+Identify capabilities competitors lack:
+
+```
+Attribute Audit:
+1. Feature: [Real-time collaboration]
+   - Competitor A: No (async only)
+   - Competitor B: Partial (limited to 5 users)
+   - You: Yes (unlimited users, 50ms sync)
+   → Unique: Yes
+
+2. Feature: [AI automation]
+   - Competitor A: No
+   - Competitor B: No
+   - You: Yes (3 AI models)
+   → Unique: Yes
+
+3. Feature: [Integrations]
+   - Competitor A: 500+
+   - Competitor B: 200+
+   - You: 100
+   → Unique: No (table stakes)
+```
+
+### Step 3: Attribute-Value Mapping
+
+Connect features to business outcomes:
+
+| Attribute | Value Enabled | Customer Outcome |
+|-----------|--------------|------------------|
+| Real-time sync | No version conflicts | 50% fewer errors |
+| AI automation | Eliminates manual work | Save 10 hrs/week |
+| One-click deploy | Faster releases | Ship 2x faster |
+
+**Value Statement Formula:**
+`[Feature] enables [Value] so customers achieve [Outcome]`
+
+### Step 4: Best-Fit Customers
+
+Define who values your unique attributes most:
+
+```
+Best-Fit Profile:
+- Company size: 200-2000 employees
+- Industry: SaaS, Professional Services
+- Pain: Distributed teams, collaboration bottlenecks
+- Evidence:
+  - Fastest sales cycles (45 days vs. 75 avg)
+  - Lowest churn (3% vs. 8% avg)
+  - Highest NPS (65 vs. 45 avg)
+```
+
+### Step 5: Market Category
+
+Choose competitive frame:
+
+| Strategy | When to Use | Risk Level |
+|----------|-------------|------------|
+| Head-to-head | Strong product, big budget | Medium |
+| Niche domination | Unique for segment | Low |
+| Category creation | True innovation, deep pockets | High |
+
+**Decision Framework:**
+- Can you win head-to-head? → Head-to-head
+- Can you dominate a niche? → Niche
+- Is the market undefined? → Category creation
+
+---
+
+## Geoffrey Moore Positioning
+
+### Crossing the Chasm Framework
+
+Position for technology adoption lifecycle:
+
+```
+Technology Adoption Curve:
+Innovators (2.5%) → Early Adopters (13.5%) → Early Majority (34%)
+                              ↑
+                         THE CHASM
+```
+
+### Positioning Statement Template
+
+```
+FOR [target customer]
+WHO [statement of need or opportunity]
+THE [product name] IS A [product category]
+THAT [key benefit/reason to buy]
+UNLIKE [primary competitive alternative]
+OUR PRODUCT [primary differentiation]
+```
+
+**Example:**
+```
+FOR mid-market SaaS companies with distributed engineering teams
+WHO struggle with coordination across time zones
+THE Acme Platform IS A real-time collaboration workspace
+THAT eliminates version conflicts and communication delays
+UNLIKE Slack and email which create information silos
+OUR PRODUCT provides unified project context with AI-powered summaries
+```
+
+### Whole Product Concept
+
+Define complete solution for target segment:
+
+| Layer | Components | Your Coverage |
+|-------|------------|---------------|
+| Generic | Core product | 100% |
+| Expected | Basic integrations, support | 90% |
+| Augmented | Training, consulting, custom work | 60% |
+| Potential | Future roadmap, ecosystem | 30% |
+
+**Gap Analysis:**
+- What's missing for complete solution?
+- Which partners can fill gaps?
+- What must you build vs. buy vs. partner?
+
+---
+
+## Positioning Validation
+
+### Customer Interview Protocol
+
+Validate positioning with target customers:
+
+1. Schedule 15-20 minute calls with 10+ target customers
+2. Ask open-ended questions (no leading)
+3. Document exact language used
+4. Look for patterns across interviews
+5. **Validation:** 7+ of 10 describe value similarly
+
+**Interview Script:**
+
+```
+Opening (2 min):
+"Thanks for your time. I want to understand how you think about
+[product category] and your experience with our product."
+
+Questions (10 min):
+1. "How would you describe [Product] to a colleague?"
+2. "What problem does [Product] solve for you?"
+3. "What alternatives did you consider?"
+4. "Why did you choose us over [alternative]?"
+5. "What would make you stop using us?"
+
+Closing (3 min):
+"Is there anything else you'd like to share?"
+```
+
+### Quantitative Validation
+
+Test messaging through A/B experiments:
+
+| Test | Control | Variant | Winner Criteria |
+|------|---------|---------|-----------------|
+| Landing page headline | Old positioning | New positioning | +20% conversion |
+| Ad copy | Feature-focused | Value-focused | +15% CTR |
+| Email subject | Generic | Personalized | +25% open rate |
+
+**Sample Size Calculator:**
+- Baseline conversion: 3%
+- Minimum detectable effect: 20% relative lift
+- Statistical power: 80%
+- Required sample: ~2,500 per variant
+
+---
+
+## Competitive Positioning Map
+
+### 2x2 Matrix Construction
+
+Create visual positioning map:
+
+```
+                    HIGH PRICE
+                        │
+    Enterprise          │         Premium
+    (Salesforce)        │         (You?)
+                        │
+    ────────────────────┼──────────────────
+    LOW                 │              HIGH
+    EASE OF USE         │         EASE OF USE
+                        │
+    Legacy              │         Self-Serve
+    (Oracle)            │         (Notion)
+                        │
+                    LOW PRICE
+```
+
+### Axis Selection
+
+Choose dimensions that highlight your advantage:
+
+| Good Axes | Why |
+|-----------|-----|
+| Ease of use vs. Power | If you're easiest to use |
+| Speed vs. Accuracy | If you're fastest |
+| Price vs. Features | If you're best value |
+| Specialization vs. Breadth | If you own a niche |
+
+| Bad Axes | Why |
+|----------|-----|
+| Quality vs. Price | Everyone claims quality |
+| Innovation vs. Stability | Subjective, hard to prove |
+| Customer vs. Product focus | Not differentiating |
+
+### Positioning Map Template
+
+```
+Market Category: [Your Category]
+Date: [Month Year]
+
+Axes:
+- X-axis: [Dimension 1] (Low → High)
+- Y-axis: [Dimension 2] (Low → High)
+
+Quadrants:
+- Top-left: [Quadrant description]
+- Top-right: [Quadrant description] ← Your target
+- Bottom-left: [Quadrant description]
+- Bottom-right: [Quadrant description]
+
+Competitors:
+1. [Competitor A]: Position (X, Y), Why
+2. [Competitor B]: Position (X, Y), Why
+3. [You]: Position (X, Y), Why you win
+
+Strategic Implications:
+- Attack: [How to position against Competitor A]
+- Defend: [How to protect against Competitor B]
+- Differentiate: [Your unique positioning claim]
+```


### PR DESCRIPTION
## Summary

- Create 4 missing reference files (1,344 lines of real PMM content)
- Rewrite SKILL.md from 1164 to 379 lines (67% reduction)
- Add proper trigger phrases, TOC, and numbered workflows

## Changes

**New Reference Files:**
- `positioning-frameworks.md`: April Dunford 5-step process, Geoffrey Moore template, validation protocol, competitive mapping
- `launch-checklists.md`: Tier 1/2/3 launch playbooks with week-by-week checklists, metrics dashboards
- `international-gtm.md`: US, UK, DACH, France, Canada market entry playbooks with localization checklists
- `messaging-templates.md`: Value proposition formulas, persona messaging, competitive scripts, objection handling

**SKILL.md Improvements:**
- Added 11 trigger phrases for discoverability
- Added Table of Contents
- Added 6 numbered workflows with validation checkpoints
- Converted to imperative voice (removed "This skill serves...")
- Standardized terminology to "PMM"
- Removed marketing language

## Fixes

Closes #75

## Test plan

- [ ] Verify all 4 reference files exist and have real content
- [ ] Confirm trigger phrases in frontmatter
- [ ] Check all workflows have validation steps
- [ ] Verify no explanatory voice ("This skill...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)