### PR TITLE
fix: add missing 'skills' field to plugin.json for skill loading

### DIFF
--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./"
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./"
 }

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./"
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./"
 }

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./"
 }

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./"
 }


### PR DESCRIPTION
## Summary

Add missing `"skills": "./"` field to team-level plugin.json files to enable skill loading in Claude Code.

## Problem

Claude Code's plugin system requires the `"skills"` field in plugin.json to locate skill files. Without this field, skills cannot be loaded.

## Changes

Added `"skills": "./"` to 6 team-level plugin.json files:
- c-level-advisor
- engineering-team  
- marketing-skill
- product-team
- project-management
- ra-qm-team

## Testing

Verified locally that skills load correctly after adding the field.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
