### PR TITLE
Add python-venv skill

### DIFF
--- a/.codex/skills/python-venv/SKILL.md
+++ b/.codex/skills/python-venv/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: python-venv
+description: "Before running Python scripts or installing packages, you MUST use a virtual environment in the current working directory. This applies to: running .py files, using pip/uv pip install, or any task requiring third-party packages. Exceptions: simple one-liners using only Python standard library."
+---
+
+# Python Virtual Environment Requirement
+
+## Core Rule
+
+**Use virtual environment when installing packages or running scripts that require third-party dependencies.**
+
+## When Virtual Environment is REQUIRED
+
+| Scenario | Required? | Reason |
+|----------|-----------|--------|
+| `pip install` / `uv pip install` | ✅ YES | Installing packages |
+| Running `.py` files with third-party imports | ✅ YES | Needs dependencies |
+| `python script.py` with `requirements.txt` | ✅ YES | Project dependencies |
+| Multi-file Python projects | ✅ YES | Isolation needed |
+
+## When Virtual Environment is NOT Required
+
+| Scenario | Required? | Example |
+|----------|-----------|---------|
+| Simple one-liner with stdlib only | ❌ NO | `python3 -c "print('hello')"` |
+| Quick math/string operations | ❌ NO | `python3 -c "print(2**10)"` |
+| Using only built-in modules | ❌ NO | `python3 -c "import json; ..."` |
+| Checking Python version | ❌ NO | `python3 --version` |
+
+### Python Standard Library (No venv needed)
+
+These modules are built-in and don't require virtual environment:
+```
+os, sys, json, re, math, datetime, pathlib, subprocess, 
+collections, itertools, functools, argparse, logging,
+urllib, http, socket, threading, multiprocessing, etc.
+```
+
+## Workflow (When venv IS Required)
+
+```
+1. Check if virtual environment exists (.venv, venv, env, .env) → If YES, activate and reuse it
+2. If NOT exists → Create with uv (if available) or python3 -m venv
+3. Activate, then proceed with Python commands
+```
+
+## Detecting Existing Virtual Environment
+
+Check in this order (first match wins):
+```bash
+# Common virtual environment directory names
+.venv/  →  Most common (preferred)
+venv/   →  Also common
+env/    →  Sometimes used
+.env/   →  Less common (be careful: may conflict with dotenv files)
+```
+
+## Setup Methods
+
+### Option 1: uv (Recommended - Faster)
+
+```bash
+# Create virtual environment
+uv venv
+
+# Activate (Linux/macOS)
+source .venv/bin/activate
+
+# Activate (Windows PowerShell)
+.venv\Scripts\Activate.ps1
+
+# Activate (Windows CMD)
+.venv\Scripts\activate.bat
+
+# Install packages
+uv pip install <package>
+```
+
+### Option 2: Standard venv (Fallback if uv not installed)
+
+```bash
+# Create virtual environment
+python3 -m venv .venv
+
+# Activate (Linux/macOS)
+source .venv/bin/activate
+
+# Activate (Windows PowerShell)
+.venv\Scripts\Activate.ps1
+
+# Activate (Windows CMD)
+.venv\Scripts\activate.bat
+
+# Install packages
+pip install <package>
+```
+
+### Option 3: Conda/Mamba
+
+```bash
+# Create environment
+conda create -n myenv python=3.11
+
+# Activate
+conda activate myenv
+
+# Install packages
+conda install <package>
+# or
+pip install <package>
+```
+
+## Workflow Checklist
+
+Before Python operations requiring venv:
+
+1. [ ] Check for existing virtual environment (in order): `.venv/`, `venv/`, `env/`, `.env/`
+2. [ ] Also check for conda: `conda info --envs` or check if `CONDA_PREFIX` is set
+3. [ ] If exists → **Reuse it** (activate the found environment)
+4. [ ] If not exists → Create: `uv venv` (preferred) or `python3 -m venv .venv` (fallback)
+5. [ ] Activate and proceed
+
+**Priority: Always reuse existing virtual environment to preserve installed packages.**
+
+## Quick Reference
+
+| Task | Linux/macOS | Windows |
+|------|-------------|---------|
+| Create venv (uv) | `uv venv` | `uv venv` |
+| Create venv (standard) | `python3 -m venv .venv` | `python -m venv .venv` |
+| Activate | `source .venv/bin/activate` | `.venv\Scripts\activate` |
+| Install package (uv) | `uv pip install <pkg>` | `uv pip install <pkg>` |
+| Install package (pip) | `pip install <pkg>` | `pip install <pkg>` |
+| Install from requirements | `uv pip install -r requirements.txt` | `uv pip install -r requirements.txt` |
+| Install from pyproject.toml | `uv pip install -e .` | `uv pip install -e .` |
+| Deactivate | `deactivate` | `deactivate` |
+| Conda activate | `conda activate <env>` | `conda activate <env>` |
+
+## Common Patterns
+
+### Standard Pattern (Linux/macOS) - Reuse or Create with Fallback
+```bash
+# Find existing venv or create new one (uv with fallback to venv)
+if [ -d .venv ]; then
+    source .venv/bin/activate
+elif [ -d venv ]; then
+    source venv/bin/activate
+elif [ -d env ]; then
+    source env/bin/activate
+elif command -v uv &> /dev/null; then
+    uv venv && source .venv/bin/activate
+else
+    python3 -m venv .venv && source .venv/bin/activate
+fi
+```
+
+### One-liner (Linux/macOS)
+```bash
+# Quick version: check .venv, fallback to create
+[ -d .venv ] && source .venv/bin/activate || { command -v uv &>/dev/null && uv venv || python3 -m venv .venv; source .venv/bin/activate; }
+```
+
+### Windows PowerShell
+```powershell
+# Find existing venv or create new one
+if (Test-Path .venv) { .\.venv\Scripts\Activate.ps1 }
+elseif (Test-Path venv) { .\venv\Scripts\Activate.ps1 }
+elseif (Get-Command uv -ErrorAction SilentlyContinue) { uv venv; .\.venv\Scripts\Activate.ps1 }
+else { python -m venv .venv; .\.venv\Scripts\Activate.ps1 }
+```
+
+### Running a Python Script
+```bash
+# Activate existing or create new
+[ -d .venv ] && source .venv/bin/activate || { command -v uv &>/dev/null && uv venv || python3 -m venv .venv; source .venv/bin/activate; }
+
+# Install dependencies (check both requirements.txt and pyproject.toml)
+[ -f requirements.txt ] && pip install -r requirements.txt
+[ -f pyproject.toml ] && pip install -e .
+
+# Run script
+python script.py
+```
+
+### Check if venv is Active
+```bash
+# Should show path containing .venv, venv, or env
+which python
+
+# Or check VIRTUAL_ENV environment variable
+echo $VIRTUAL_ENV
+```
+
+### Check if Conda Environment is Active
+```bash
+# Check CONDA_PREFIX
+echo $CONDA_PREFIX
+
+# List all conda environments
+conda info --envs
+```
+
+## Forbidden Actions
+
+- Using `pip install` with system Python (always use venv)
+- Installing packages globally
+- Assuming third-party packages are available without explicit installation
+- Overwriting existing virtual environment without checking first
+
+## Allowed Without venv
+
+- `python3 -c "print('hello')"`
+- `python3 -c "import os; print(os.getcwd())"`
+- `python3 --version`
+- Any stdlib-only one-liner
+
+## Project Type Detection
+
+| File Present | Project Type | Install Command |
+|--------------|--------------|-----------------|
+| `requirements.txt` | Traditional | `pip install -r requirements.txt` |
+| `pyproject.toml` | Modern (PEP 517/518) | `pip install -e .` or `uv pip install -e .` |
+| `pyproject.toml` + `poetry.lock` | Poetry | `poetry install` |
+| `pyproject.toml` + `uv.lock` | uv native | `uv sync` |
+| `setup.py` | Legacy | `pip install -e .` |
+| `Pipfile` | Pipenv | `pipenv install` |
+| `environment.yml` | Conda | `conda env create -f environment.yml` |
+
+## Troubleshooting
+
+### Corrupted Virtual Environment
+
+If venv is broken (import errors, missing packages after install):
+
+```bash
+# Remove and recreate
+rm -rf .venv
+uv venv && source .venv/bin/activate
+# or
+python3 -m venv .venv && source .venv/bin/activate
+```
+
+### Wrong Python Version
+
+```bash
+# Specify Python version with uv
+uv venv --python 3.11
+
+# Or with standard venv
+python3.11 -m venv .venv
+```
+
+### Permission Denied on Windows
+
+Run PowerShell as Administrator, or:
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+### WSL (Windows Subsystem for Linux)
+
+Use Linux commands in WSL:
+```bash
+# Same as Linux/macOS
+source .venv/bin/activate
+```
+
+Note: Don't mix Windows venv with WSL. Create separate venv for each environment.

--- a/.codex/skills/python-venv/references/README.md
+++ b/.codex/skills/python-venv/references/README.md
@@ -1,0 +1,79 @@
+# Skill: Python Virtual Environment
+
+Enforce virtual environment usage for Python projects that require third-party packages.
+
+Works with: **OpenCode**, **Claude Code**, **Cursor**, **Cline**, and other AI coding assistants.
+
+[中文说明](README_CN.md)
+
+## Features
+
+- ✅ Require venv when installing packages or using third-party dependencies
+- ✅ Reuse existing virtual environment (`.venv`, `venv`, `env`, `.env`)
+- ✅ Auto-create if not exists
+- ✅ Support `uv` (recommended) with fallback to standard `venv`
+- ✅ Support Conda/Mamba environments
+- ✅ Cross-platform (Linux, macOS, Windows)
+- ✅ **Skip venv for simple stdlib-only commands**
+
+## When venv is Required
+
+| Scenario | Required? |
+|----------|-----------|
+| `pip install` / `uv pip install` | ✅ YES |
+| Running scripts with third-party imports | ✅ YES |
+| Projects with `requirements.txt` / `pyproject.toml` | ✅ YES |
+
+## When venv is NOT Required
+
+| Scenario | Example |
+|----------|---------|
+| Simple stdlib one-liner | `python3 -c "print('hello')"` |
+| Built-in modules only | `python3 -c "import json; ..."` |
+| Version check | `python3 --version` |
+
+## Installation
+
+### OpenCode
+```bash
+cd ~/.config/opencode/skills
+git clone https://github.com/cikichen/skill-python-venv.git python-venv
+```
+
+### Claude Code
+```bash
+cd ~/.claude/skills
+git clone https://github.com/cikichen/skill-python-venv.git python-venv
+```
+
+### Other AI Assistants
+Copy `SKILL.md` to your assistant's custom instructions or skills directory.
+
+## Quick Reference
+
+### Linux/macOS
+```bash
+# Reuse existing or create new (with uv fallback to venv)
+[ -d .venv ] && source .venv/bin/activate || { command -v uv &>/dev/null && uv venv || python3 -m venv .venv; source .venv/bin/activate; }
+```
+
+### Windows PowerShell
+```powershell
+if (Test-Path .venv) { .\.venv\Scripts\Activate.ps1 }
+elseif (Get-Command uv -ErrorAction SilentlyContinue) { uv venv; .\.venv\Scripts\Activate.ps1 }
+else { python -m venv .venv; .\.venv\Scripts\Activate.ps1 }
+```
+
+## Project Type Detection
+
+| File | Install Command |
+|------|-----------------|
+| `requirements.txt` | `pip install -r requirements.txt` |
+| `pyproject.toml` | `pip install -e .` |
+| `pyproject.toml` + `poetry.lock` | `poetry install` |
+| `pyproject.toml` + `uv.lock` | `uv sync` |
+| `environment.yml` | `conda env create -f environment.yml` |
+
+## License
+
+MIT

--- a/.codex/skills/python-venv/references/README_CN.md
+++ b/.codex/skills/python-venv/references/README_CN.md
@@ -1,0 +1,79 @@
+# Skill: Python 虚拟环境
+
+为需要第三方包的 Python 项目强制使用虚拟环境。
+
+适用于：**OpenCode**、**Claude Code**、**Cursor**、**Cline** 及其他 AI 编程助手。
+
+[English](README.md)
+
+## 功能
+
+- ✅ 安装包或使用第三方依赖时必须使用 venv
+- ✅ 复用现有虚拟环境（`.venv`、`venv`、`env`、`.env`）
+- ✅ 不存在时自动创建
+- ✅ 支持 `uv`（推荐），自动 fallback 到标准 `venv`
+- ✅ 支持 Conda/Mamba 环境
+- ✅ 跨平台（Linux、macOS、Windows）
+- ✅ **简单的标准库命令可跳过 venv**
+
+## 何时需要 venv
+
+| 场景 | 需要? |
+|------|-------|
+| `pip install` / `uv pip install` | ✅ 是 |
+| 运行使用第三方库的脚本 | ✅ 是 |
+| 有 `requirements.txt` / `pyproject.toml` 的项目 | ✅ 是 |
+
+## 何时不需要 venv
+
+| 场景 | 示例 |
+|------|------|
+| 简单的标准库单行命令 | `python3 -c "print('hello')"` |
+| 仅使用内置模块 | `python3 -c "import json; ..."` |
+| 版本检查 | `python3 --version` |
+
+## 安装
+
+### OpenCode
+```bash
+cd ~/.config/opencode/skills
+git clone https://github.com/cikichen/skill-python-venv.git python-venv
+```
+
+### Claude Code
+```bash
+cd ~/.claude/skills
+git clone https://github.com/cikichen/skill-python-venv.git python-venv
+```
+
+### 其他 AI 助手
+将 `SKILL.md` 复制到你的助手的自定义指令或技能目录。
+
+## 快速参考
+
+### Linux/macOS
+```bash
+# 复用现有或创建新的（uv 优先，fallback 到 venv）
+[ -d .venv ] && source .venv/bin/activate || { command -v uv &>/dev/null && uv venv || python3 -m venv .venv; source .venv/bin/activate; }
+```
+
+### Windows PowerShell
+```powershell
+if (Test-Path .venv) { .\.venv\Scripts\Activate.ps1 }
+elseif (Get-Command uv -ErrorAction SilentlyContinue) { uv venv; .\.venv\Scripts\Activate.ps1 }
+else { python -m venv .venv; .\.venv\Scripts\Activate.ps1 }
+```
+
+## 项目类型检测
+
+| 文件 | 安装命令 |
+|------|----------|
+| `requirements.txt` | `pip install -r requirements.txt` |
+| `pyproject.toml` | `pip install -e .` |
+| `pyproject.toml` + `poetry.lock` | `poetry install` |
+| `pyproject.toml` + `uv.lock` | `uv sync` |
+| `environment.yml` | `conda env create -f environment.yml` |
+
+## 许可证
+
+MIT


### PR DESCRIPTION
Add python-venv skill

Skill that enforces Python virtual environment usage when working with third-party packages. Developed as an engineering specialization following the repository's contribution guidelines.

Solves real-world problems of dependency isolation, code reproducibility, and package management best practices for Python developers.

Key features:
- Auto-detection of existing venvs (.venv, venv, env, .env)
- Smart reuse instead of creating duplicate environments
- uv priority with fallback to python3 -m venv
- Cross-platform support (Linux, macOS, Windows, WSL)
- Conda/Mamba environment detection
- Project file detection (Poetry, Pipfile, pyproject.toml, requirements.txt)
- Comprehensive troubleshooting guide
- Safe enforcement (only for third-party packages, skips stdlib)

Example use cases:
- "Run script.py that uses pandas" → Automatically creates/activates venv
- "Install requests" → Installs within venv
- "Print hello" → Skips venv (stdlib only)

Inspired by Python packaging best practices and virtual environment enforcement in production environments.

Original skill repository: https://github.com/cikichen/skill-python-venv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
