### PR TITLE
fix(plugin): update marketplace manifest with correct counts and missing domains

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,18 @@
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
   },
-  "description": "Production-ready skill packages for Claude AI - 48 expert skills across marketing, engineering, product, C-level advisory, project management, and regulatory compliance",
+  "description": "Production-ready skill packages for Claude AI - 53 expert skills across marketing, engineering, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
   "homepage": "https://github.com/alirezarezvani/claude-skills",
   "repository": "https://github.com/alirezarezvani/claude-skills",
+  "metadata": {
+    "description": "53 production-ready skill packages across 8 domains: marketing, engineering, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
+    "version": "1.0.0"
+  },
   "plugins": [
     {
       "name": "marketing-skills",
       "source": "./marketing-skill",
-      "description": "5 marketing skills: content creator, demand generation, product marketing, ASO, social media analytics",
+      "description": "6 marketing skills: content creator, demand generation, product marketing, ASO, social media analytics, campaign analytics",
       "version": "1.0.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -73,6 +77,28 @@
       },
       "keywords": ["regulatory", "quality", "compliance", "iso-13485", "mdr", "fda", "gdpr", "medtech"],
       "category": "compliance"
+    },
+    {
+      "name": "business-growth-skills",
+      "source": "./business-growth",
+      "description": "3 business & growth skills: customer success manager, sales engineer, revenue operations",
+      "version": "1.0.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": ["customer-success", "sales-engineering", "revenue-operations", "business-growth"],
+      "category": "business-growth"
+    },
+    {
+      "name": "finance-skills",
+      "source": "./finance",
+      "description": "1 finance skill: financial analyst with ratio analysis, DCF valuation, budgeting, and forecasting",
+      "version": "1.0.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": ["finance", "dcf", "valuation", "budgeting", "forecasting"],
+      "category": "finance"
     },
     {
       "name": "content-creator",


### PR DESCRIPTION
## Summary

- **Skill count**: 48 → 53 in top-level description
- **Added business-growth plugin**: 3 skills (customer-success-manager, sales-engineer, revenue-operations)
- **Added finance plugin**: 1 skill (financial-analyst)
- **Fixed marketing count**: 5 → 6 (added campaign analytics)
- **Added `metadata` block**: clears `claude plugin validate` warning

## Test plan

- [ ] Run `claude plugin validate` — should pass with no warnings
- [ ] Verify all 14 plugin entries have valid `source` paths
- [ ] Test install: `/plugin install scrum-master@claude-code-skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
