### PR TITLE
Add oiloil-ui-ux-guide skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,23 @@ Visual design systems and component architecture for consistent user interfaces.
 
 ---
 
+#### 🎨 OilOil UI/UX Guide (Community)
+**Status:** ✅ Production Ready | **Source:** [oil-oil/oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide)
+
+Modern, clean UI/UX guidance and review skill with actionable recommendations.
+
+**What's Included:**
+- **Guide Mode** - Actionable do/don't rules for modern clean UI/UX
+- **Review Mode** - Prioritized P0/P1/P2 fix lists with design psychology diagnosis
+- **Design Principles** - CRAP, task-first UX, cognitive load, HCI laws (Fitts/Hick/Miller)
+- **Modern Minimal Style** - Clean, spacious, typography-led design enforcement
+
+**Learn More:** [oiloil-ui-ux-guide/SKILL.md](oiloil-ui-ux-guide/SKILL.md)
+
+Install via: `npx skills add oil-oil/oiloil-ui-ux-guide`
+
+---
+
 ### Project Management Team Skills
 
 **6 world-class Atlassian expert skills** for project and agile delivery teams using Jira and Confluence.

--- a/oiloil-ui-ux-guide/SKILL.md
+++ b/oiloil-ui-ux-guide/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: oiloil-ui-ux-guide
+description: Modern, clean UI/UX guidance + review skill. Use when you need actionable UX/UI recommendations, design principles, or a design review checklist for new features or existing systems (web/app). Focus on CRAP (Contrast/Repetition/Alignment/Proximity) plus task-first UX, information architecture, feedback & system status, consistency, affordances, error prevention/recovery, and cognitive load. Enforce a modern minimal style (clean, spacious, typography-led), reduce unnecessary copy, forbid emoji as icons, and recommend intuitive refined icons from a consistent icon set.
+---
+
+# OilOil UI/UX Guide
+
+Modern UI/UX guidance and review skill with two modes:
+
+- `guide`: Actionable do/don't rules for modern clean UI/UX
+- `review`: Prioritized P0/P1/P2 fix lists with design psychology diagnosis
+
+Full skill with references available at: https://github.com/oil-oil/oiloil-ui-ux-guide
+
+Install via: `npx skills add oil-oil/oiloil-ui-ux-guide`


### PR DESCRIPTION
Adds [oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide) — a modern UI/UX guidance and review skill.

**What it does:**
- `guide` mode: actionable do/don't rules for modern clean UI/UX
- `review` mode: prioritized P0/P1/P2 fix lists with design psychology diagnosis

**Covers:** CRAP, task-first UX, cognitive load, HCI laws (Fitts/Hick/Miller), interaction psychology, and modern minimal style.

Full skill with all references: https://github.com/oil-oil/oiloil-ui-ux-guide
Installable via `npx skills add oil-oil/oiloil-ui-ux-guide`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
