### PR TITLE
feat: add Claude Code plugin manifest for engineering/ directory

### DIFF
--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "engineering-advanced-skills",
+  "description": "11 advanced engineering skills covering tech debt tracking, API design review, database design, dependency auditing, release management, RAG architecture, agent design, migration planning, observability, interview system design, and skill testing",
+  "version": "1.0.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": "./"
+}


### PR DESCRIPTION
The 11 skills in `engineering/` (batch 2) were missing a `.claude-plugin/plugin.json` manifest, making them invisible to Claude Code's plugin discovery.

This adds the manifest so all 11 advanced engineering skills are properly discoverable as Claude Code plugins, matching the existing `engineering-team/.claude-plugin/plugin.json` pattern.

Skills covered: tech-debt-tracker, api-design-reviewer, interview-system-designer, migration-architect, observability-designer, dependency-auditor, release-manager, database-designer, rag-architect, agent-designer, skill-tester
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
