### PR TITLE
fix(skill): normalize senior-fullstack frontmatter to inline format

### DIFF
--- a/engineering-team/senior-fullstack/SKILL.md
+++ b/engineering-team/senior-fullstack/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: senior-fullstack
-description: >
-  Generates fullstack project boilerplate for Next.js, FastAPI, MERN, and Django
-  stacks, runs static code quality analysis with security and complexity scoring,
-  and guides stack selection decisions. Use when the user asks to "scaffold a
-  project", "create a new app", "set up a starter template", "analyze code
-  quality", "audit my codebase", "what stack should I use", or mentions
-  fullstack boilerplate, project setup, code review, or tech stack comparison.
+description: Fullstack development toolkit with project scaffolding for Next.js, FastAPI, MERN, and Django stacks, code quality analysis with security and complexity scoring, and stack selection guidance. Use when the user asks to "scaffold a new project", "create a Next.js app", "set up FastAPI with React", "analyze code quality", "audit my codebase", "what stack should I use", "generate project boilerplate", or mentions fullstack development, project setup, or tech stack comparison.
 ---
 
 # Senior Fullstack


### PR DESCRIPTION
## Summary

Follow-up to PR #216 — fixes consistency issues found during audit:

- **Normalized YAML frontmatter** from block scalar (`>`) to inline single-line format, matching all other 50+ skills in the repo
- **Aligned trigger phrases** in frontmatter with the body's `## Trigger Phrases` section to eliminate partial duplication
- Kept the improved description content (stack names, trigger actions) from the original PR

## Test plan

- [ ] Verify YAML frontmatter parses correctly
- [ ] Confirm description is single-line inline format
- [ ] Check trigger phrases match between frontmatter and body section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
