### PR TITLE
fix(ci): pass PROJECTS_TOKEN to fix automated commits + remove duplicate checkout

### DIFF
--- a/.github/workflows/pr-issue-auto-close.yml
+++ b/.github/workflows/pr-issue-auto-close.yml
@@ -29,8 +29,6 @@ jobs:
               exit 0
             fi
           fi
-      - name: Checkout repository
-        uses: actions/checkout@v4
 
       - name: Extract linked issues from PR body
         id: extract_issues

--- a/.github/workflows/sync-codex-skills.yml
+++ b/.github/workflows/sync-codex-skills.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJECTS_TOKEN }}
+>>>>>>> b6f463f (fix(ci): pass PROJECTS_TOKEN to fix automated git push and dedup checkout step)
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,6 +63,7 @@ jobs:
           file_pattern: ".codex/*"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          token: ${{ secrets.PROJECTS_TOKEN }}
 
       - name: Warn if main has drift
         if: steps.check_changes.outputs.has_changes == 'true' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Problem

Three CI workflows have been failing since ~Feb 16, 2026:

- `sync-codex-skills.yml` — **"Commit changes (dev only)"** step fails: `git-auto-commit-action` couldn't push to `dev` branch
- `smart-sync.yml` — Fails at job level: `PROJECTS_TOKEN` secret expired (created Nov 5, 2025, ~90-day expiry ≈ Feb 3)
- `pr-issue-auto-close.yml` — Duplicate `Checkout repository` step

## Fixes

### `sync-codex-skills.yml`
- Pass `token: ${{ secrets.PROJECTS_TOKEN }}` to `actions/checkout@v4` (persist write credentials)
- Pass `token: ${{ secrets.PROJECTS_TOKEN }}` to `stefanzweifel/git-auto-commit-action@v5` (explicit push token)

### `pr-issue-auto-close.yml`
- Remove duplicate `Checkout repository` step (was defined twice, second one redundant)

## Root Cause
`PROJECTS_TOKEN` secret was regenerated and updated. The token was expired, causing all workflows that depend on write access to fail.

## Testing
After merge, trigger a SKILL.md change on `dev` to verify the symlink sync commits successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
