### PR TITLE
fix(ci): remove stray merge conflict marker in sync-codex-skills.yml

### DIFF
--- a/.github/workflows/sync-codex-skills.yml
+++ b/.github/workflows/sync-codex-skills.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PROJECTS_TOKEN }}
->>>>>>> b6f463f (fix(ci): pass PROJECTS_TOKEN to fix automated git push and dedup checkout step)
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Problem
PR #220 left a stray `>>>>>>>` git conflict marker at line 32 of `.github/workflows/sync-codex-skills.yml`. This caused the yamllint step in the CI Quality Gate to fail with:

```
32:2 syntax error: expected chomping or indentation indicators, but found '>'
```

## Fix
Deleted the single offending line. No logic changes — the `token: ${{ secrets.PROJECTS_TOKEN }}` line above it was already correct and complete.

## Test
CI Quality Gate should pass after this merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
