### PR TITLE
docs: rewrite CHANGELOG.md with v2.0.0 release (65 skills, 9 domains)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,170 +1,284 @@
 {
-  "name": "claude-code-skills",
-  "owner": {
-    "name": "Alireza Rezvani",
-    "url": "https://alirezarezvani.com"
-  },
-  "description": "Production-ready skill packages for Claude AI - 65 expert skills across marketing, engineering, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
-  "homepage": "https://github.com/alirezarezvani/claude-skills",
-  "repository": "https://github.com/alirezarezvani/claude-skills",
-  "metadata": {
-    "description": "65 production-ready skill packages across 8 domains: marketing, engineering, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
-    "version": "1.0.0"
-  },
-  "plugins": [
-    {
-      "name": "marketing-skills",
-      "source": "./marketing-skill",
-      "description": "6 marketing skills: content creator, demand generation, product marketing, ASO, social media analytics, campaign analytics",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["marketing", "content", "seo", "demand-gen", "social-media"],
-      "category": "marketing"
+    "name": "claude-code-skills",
+    "owner": {
+        "name": "Alireza Rezvani",
+        "url": "https://alirezarezvani.com"
     },
-    {
-      "name": "engineering-skills",
-      "source": "./engineering-team",
-      "description": "30 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["engineering", "architecture", "frontend", "backend", "devops", "security", "ai", "ml", "data"],
-      "category": "development"
+    "description": "Production-ready skill packages for Claude AI - 85 expert skills across marketing, engineering, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
+    "homepage": "https://github.com/alirezarezvani/claude-skills",
+    "repository": "https://github.com/alirezarezvani/claude-skills",
+    "metadata": {
+        "description": "85 production-ready skill packages across 9 domains: marketing, engineering, engineering-advanced, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
+        "version": "2.0.0"
     },
-    {
-      "name": "product-skills",
-      "source": "./product-team",
-      "description": "5 product skills: product manager toolkit, agile product owner, product strategist, UX researcher, UI design system",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["product", "pm", "agile", "ux", "design-system"],
-      "category": "product"
-    },
-    {
-      "name": "c-level-skills",
-      "source": "./c-level-advisor",
-      "description": "2 C-level advisory skills: CEO advisor, CTO advisor",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["ceo", "cto", "executive", "strategy", "leadership"],
-      "category": "leadership"
-    },
-    {
-      "name": "pm-skills",
-      "source": "./project-management",
-      "description": "6 project management skills: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["project-management", "scrum", "agile", "jira", "confluence", "atlassian"],
-      "category": "project-management"
-    },
-    {
-      "name": "ra-qm-skills",
-      "source": "./ra-qm-team",
-      "description": "12 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485, MDR, FDA, GDPR, ISO 27001 compliance",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["regulatory", "quality", "compliance", "iso-13485", "mdr", "fda", "gdpr", "medtech"],
-      "category": "compliance"
-    },
-    {
-      "name": "business-growth-skills",
-      "source": "./business-growth",
-      "description": "3 business & growth skills: customer success manager, sales engineer, revenue operations",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["customer-success", "sales-engineering", "revenue-operations", "business-growth"],
-      "category": "business-growth"
-    },
-    {
-      "name": "finance-skills",
-      "source": "./finance",
-      "description": "1 finance skill: financial analyst with ratio analysis, DCF valuation, budgeting, and forecasting",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["finance", "dcf", "valuation", "budgeting", "forecasting"],
-      "category": "finance"
-    },
-    {
-      "name": "content-creator",
-      "source": "./marketing-skill/content-creator",
-      "description": "Brand voice analysis, SEO optimization, content frameworks for marketing content creation",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["content", "seo", "brand-voice", "marketing"],
-      "category": "marketing"
-    },
-    {
-      "name": "demand-gen",
-      "source": "./marketing-skill/marketing-demand-acquisition",
-      "description": "Demand generation, paid media, SEO, partnerships for Series A+ startups",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["demand-gen", "paid-media", "acquisition", "marketing"],
-      "category": "marketing"
-    },
-    {
-      "name": "fullstack-engineer",
-      "source": "./engineering-team/senior-fullstack",
-      "description": "End-to-end application development with Next.js, GraphQL, PostgreSQL",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["fullstack", "nextjs", "graphql", "postgresql"],
-      "category": "development"
-    },
-    {
-      "name": "aws-architect",
-      "source": "./engineering-team/aws-solution-architect",
-      "description": "AWS solution architecture with serverless, cost optimization, and security best practices",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["aws", "cloud", "serverless", "architecture"],
-      "category": "development"
-    },
-    {
-      "name": "product-manager",
-      "source": "./product-team/product-manager-toolkit",
-      "description": "RICE prioritization, customer interview analysis, PRD templates for product managers",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["product-management", "rice", "prd", "prioritization"],
-      "category": "product"
-    },
-    {
-      "name": "scrum-master",
-      "source": "./project-management/scrum-master",
-      "description": "Agile facilitation, sprint planning, retrospectives for Scrum teams",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alireza Rezvani"
-      },
-      "keywords": ["scrum", "agile", "sprint", "retrospective"],
-      "category": "project-management"
-    }
-  ]
+    "plugins": [
+        {
+            "name": "marketing-skills",
+            "source": "./marketing-skill",
+            "description": "6 marketing skills: content creator, demand generation, product marketing, ASO, social media analytics, campaign analytics",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "marketing",
+                "content",
+                "seo",
+                "demand-gen",
+                "social-media"
+            ],
+            "category": "marketing"
+        },
+        {
+            "name": "engineering-skills",
+            "source": "./engineering-team",
+            "description": "21 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "engineering",
+                "architecture",
+                "frontend",
+                "backend",
+                "devops",
+                "security",
+                "ai",
+                "ml",
+                "data"
+            ],
+            "category": "development"
+        },
+        {
+            "name": "engineering-advanced-skills",
+            "source": "./engineering",
+            "description": "24 POWERFUL-tier engineering skills: agent designer, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, and more",
+            "version": "2.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "powerful",
+                "agent-design",
+                "rag",
+                "database",
+                "migration",
+                "observability",
+                "dependency-audit",
+                "release",
+                "api-review",
+                "ci-cd",
+                "mcp",
+                "monorepo",
+                "performance",
+                "runbook",
+                "changelog",
+                "onboarding",
+                "worktree"
+            ],
+            "category": "development"
+        },
+        {
+            "name": "product-skills",
+            "source": "./product-team",
+            "description": "8 product skills: product manager toolkit, agile product owner, product strategist, UX researcher, UI design system, and 3 more",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "product",
+                "pm",
+                "agile",
+                "ux",
+                "design-system"
+            ],
+            "category": "product"
+        },
+        {
+            "name": "c-level-skills",
+            "source": "./c-level-advisor",
+            "description": "2 C-level advisory skills: CEO advisor, CTO advisor",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "ceo",
+                "cto",
+                "executive",
+                "strategy",
+                "leadership"
+            ],
+            "category": "leadership"
+        },
+        {
+            "name": "pm-skills",
+            "source": "./project-management",
+            "description": "6 project management skills: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "project-management",
+                "scrum",
+                "agile",
+                "jira",
+                "confluence",
+                "atlassian"
+            ],
+            "category": "project-management"
+        },
+        {
+            "name": "ra-qm-skills",
+            "source": "./ra-qm-team",
+            "description": "12 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485, MDR, FDA, GDPR, ISO 27001 compliance",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "regulatory",
+                "quality",
+                "compliance",
+                "iso-13485",
+                "mdr",
+                "fda",
+                "gdpr",
+                "medtech"
+            ],
+            "category": "compliance"
+        },
+        {
+            "name": "business-growth-skills",
+            "source": "./business-growth",
+            "description": "4 business & growth skills: customer success manager, sales engineer, revenue operations, and more",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "customer-success",
+                "sales-engineering",
+                "revenue-operations",
+                "business-growth"
+            ],
+            "category": "business-growth"
+        },
+        {
+            "name": "finance-skills",
+            "source": "./finance",
+            "description": "1 finance skill: financial analyst with ratio analysis, DCF valuation, budgeting, and forecasting",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "finance",
+                "dcf",
+                "valuation",
+                "budgeting",
+                "forecasting"
+            ],
+            "category": "finance"
+        },
+        {
+            "name": "content-creator",
+            "source": "./marketing-skill/content-creator",
+            "description": "Brand voice analysis, SEO optimization, content frameworks for marketing content creation",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "content",
+                "seo",
+                "brand-voice",
+                "marketing"
+            ],
+            "category": "marketing"
+        },
+        {
+            "name": "demand-gen",
+            "source": "./marketing-skill/marketing-demand-acquisition",
+            "description": "Demand generation, paid media, SEO, partnerships for Series A+ startups",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "demand-gen",
+                "paid-media",
+                "acquisition",
+                "marketing"
+            ],
+            "category": "marketing"
+        },
+        {
+            "name": "fullstack-engineer",
+            "source": "./engineering-team/senior-fullstack",
+            "description": "End-to-end application development with Next.js, GraphQL, PostgreSQL",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "fullstack",
+                "nextjs",
+                "graphql",
+                "postgresql"
+            ],
+            "category": "development"
+        },
+        {
+            "name": "aws-architect",
+            "source": "./engineering-team/aws-solution-architect",
+            "description": "AWS solution architecture with serverless, cost optimization, and security best practices",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "aws",
+                "cloud",
+                "serverless",
+                "architecture"
+            ],
+            "category": "development"
+        },
+        {
+            "name": "product-manager",
+            "source": "./product-team/product-manager-toolkit",
+            "description": "RICE prioritization, customer interview analysis, PRD templates for product managers",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "product-management",
+                "rice",
+                "prd",
+                "prioritization"
+            ],
+            "category": "product"
+        },
+        {
+            "name": "scrum-master",
+            "source": "./project-management/scrum-master",
+            "description": "Agile facilitation, sprint planning, retrospectives for Scrum teams",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "scrum",
+                "agile",
+                "sprint",
+                "retrospective"
+            ],
+            "category": "project-management"
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2026-02-16
 
-### ⚡ POWERFUL Tier — 12 New Skills
+### ⚡ POWERFUL Tier — 25 New Skills
 
 A new tier of advanced, deeply-engineered skills with comprehensive tooling:
 
@@ -32,6 +32,19 @@ A new tier of advanced, deeply-engineered skills with comprehensive tooling:
 - **rag-architect** — RAG pipeline builder, chunking optimizer, and retrieval evaluator
 - **agent-designer** — Multi-agent architect, tool schema generator, and agent performance evaluator
 - **skill-tester** — Meta-skill validator, script tester, and quality scorer
+- **agent-workflow-designer** — Multi-agent orchestration system designer with sequential, parallel, router, orchestrator, and evaluator patterns
+- **api-test-suite-builder** — API route scanner and test suite generator across frameworks (Next.js, Express, FastAPI, Django REST)
+- **changelog-generator** — Conventional commit parser, semantic version bumper, and structured changelog generator
+- **ci-cd-pipeline-builder** — Stack-aware CI/CD pipeline generator for GitHub Actions, GitLab CI, and more
+- **codebase-onboarding** — Codebase analyzer and onboarding documentation generator for new team members
+- **database-schema-designer** — Database schema design and modeling tool with migration support
+- **env-secrets-manager** — Environment and secrets management across dev/staging/prod lifecycle
+- **git-worktree-manager** — Systematic Git worktree management for parallel development workflows
+- **mcp-server-builder** — MCP (Model Context Protocol) server scaffolder and implementation guide
+- **monorepo-navigator** — Monorepo management for Turborepo, Nx, pnpm workspaces, and Lerna
+- **performance-profiler** — Systematic performance profiling for Node.js, Python, and Go applications
+- **pr-review-expert** — Structured code review for GitHub PRs and GitLab MRs with systematic analysis
+- **runbook-generator** — Production-grade operational runbook generator with stack detection
 
 ### 🆕 New Domains & Skills
 
@@ -86,10 +99,10 @@ Major rewrite of existing skills following Anthropic's agent skills specificatio
 - **Codex skills sync** — Automated symlink workflow for Codex integration
 
 ### 📊 Stats
-- **65 total skills** across 9 domains (up from 42 across 6)
+- **85 total skills** across 9 domains (up from 42 across 6)
 - **92+ Python automation tools** (up from 20+)
-- **17 POWERFUL-tier tools** with advanced capabilities
-- **37/42 skills refactored** to Anthropic best practices
+- **25 POWERFUL-tier skills** in new `engineering/` domain
+- **37/42 original skills refactored** to Anthropic best practices
 
 ### Fixed
 - CI workflows (`smart-sync.yml`, `pr-issue-auto-close.yml`) — PR #193
@@ -237,7 +250,7 @@ Major rewrite of existing skills following Anthropic's agent skills specificatio
 
 | Version | Date | Skills | Domains | Key Changes |
 |---------|------|--------|---------|-------------|
-| 2.0.0 | 2026-02-16 | 65 | 9 | 12 POWERFUL-tier skills, 37 refactored, Codex support, 2 new domains |
+| 2.0.0 | 2026-02-16 | 85 | 9 | 25 POWERFUL-tier skills, 37 refactored, Codex support, 3 new domains |
 | 1.1.0 | 2025-10-21 | 42 | 6 | Anthropic best practices refactoring (5 skills) |
 | 1.0.2 | 2025-10-21 | 42 | 6 | GitHub repository pages (LICENSE, CONTRIBUTING, etc.) |
 | 1.0.1 | 2025-10-21 | 42 | 6 | Star History, link fixes |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Claude Skills Library (Your Agentic Startup Kit)
 
-**86 Production-Ready skill packages for Claude AI & Claude Code** - Reusable expertise bundles combining best practices, analysis tools, and strategic frameworks for marketing teams, executive leadership, product development, your web and mobile engineering teams. Many other teams will be included soon and regularly.
+**85 Production-Ready skill packages for Claude AI & Claude Code** - Reusable expertise bundles combining best practices, analysis tools, and strategic frameworks for marketing teams, executive leadership, product development, your web and mobile engineering teams. Many other teams will be included soon and regularly.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude AI](https://img.shields.io/badge/Claude-AI-blue.svg)](https://claude.ai)
 [![Claude Code](https://img.shields.io/badge/Claude-Code-purple.svg)](https://claude.ai/code)
 [![Multi-Agent Compatible](https://img.shields.io/badge/Multi--Agent-Compatible-green.svg)](https://github.com/skillcreatorai/Ai-Agent-Skills)
-[![86 Skills](https://img.shields.io/badge/Skills-86-brightgreen.svg)](#-available-skills)
+[![85 Skills](https://img.shields.io/badge/Skills-85-brightgreen.svg)](#-available-skills)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1)](https://getskillcheck.com)
 
 ---
@@ -25,7 +25,8 @@ Use Claude Code's built-in plugin system for native integration:
 
 # Then install skill bundles:
 /plugin install marketing-skills@claude-code-skills     # 7 marketing skills
-/plugin install engineering-skills@claude-code-skills   # 24 engineering skills
+/plugin install engineering-skills@claude-code-skills   # 21 core engineering skills
+/plugin install engineering-advanced-skills@claude-code-skills  # 24 POWERFUL-tier engineering skills
 /plugin install product-skills@claude-code-skills       # 8 product skills
 /plugin install c-level-skills@claude-code-skills       # 2 C-level advisory skills
 /plugin install pm-skills@claude-code-skills            # 6 project management skills
@@ -77,7 +78,7 @@ cd claude-skills
 
 ### Method 3: OpenClaw Installation
 
-For [OpenClaw](https://openclaw.ai) users — skills use the same `SKILL.md` format, so all 86 skills work out of the box.
+For [OpenClaw](https://openclaw.ai) users — skills use the same `SKILL.md` format, so all 85 skills work out of the box.
 
 ```bash
 # Clone the repo
@@ -112,7 +113,7 @@ Or preview first with `--dry-run`:
 Install to Claude Code, Cursor, VS Code, Amp, Goose, and more - all with one command:
 
 ```bash
-# Install all 53 skills to all supported agents
+# Install all 85 skills to all supported agents
 npx agent-skills-cli add alirezarezvani/claude-skills
 
 # Install to specific agent (Claude Code)
@@ -173,7 +174,7 @@ npx agent-skills-cli add alirezarezvani/claude-skills --dry-run
 This repository provides **modular, self-contained skill packages** designed to augment Claude AI with specialized domain expertise. Each skill includes:
 
 - **📖 Comprehensive documentation** - Workflows, best practices, and strategic frameworks
-- **🛠️ Python analysis tools** - 87+ CLI utilities for automated analysis and optimization
+- **🛠️ Python analysis tools** - 92+ CLI utilities for automated analysis and optimization
 - **📚 Knowledge bases** - Curated reference materials and guidelines
 - **📋 Ready-to-use templates** - Customizable assets for immediate deployment
 
@@ -566,7 +567,7 @@ Template and file creation/modification specialist.
 
 ### Engineering Team Skills
 
-**Complete engineering skills suite with 19 specialized roles** covering architecture, development, testing, security, operations, cloud infrastructure, and enterprise systems.
+**Complete engineering skills suite with 45 specialized roles** covering architecture, development, testing, security, operations, cloud infrastructure, enterprise systems, and 24 POWERFUL-tier advanced engineering skills.
 
 #### 🏗️ Senior Software Architect
 **Status:** ✅ Production Ready | **Version:** 1.0
@@ -1842,7 +1843,7 @@ Once installed, skills are available at `~/.codex/skills/`. Each skill contains:
 
 ### 🆕 New Skills (March 2026)
 
-**20 practical skills** designed for everyday professional use and commercial distribution.
+**24 POWERFUL-tier skills** designed for everyday professional use — all in the `engineering/` domain.
 
 #### Developer Workflow
 | Skill | What It Does |
@@ -2173,7 +2174,7 @@ Explore our complete ecosystem of Claude Code augmentation tools and utilities:
 - ⚡ **Rapid Prototyping** - Create custom skills in minutes, not hours
 
 **Perfect For:**
-- Building custom skills beyond the 53 provided in this library
+- Building custom skills beyond the 85 provided in this library
 - Generating domain-specific agents for your organization
 - Scaling AI customization across teams
 - Rapid prototyping of specialized workflows
@@ -2212,7 +2213,7 @@ Explore our complete ecosystem of Claude Code augmentation tools and utilities:
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  Claude Skills Library (This Repository)                │
-│  53 Domain Expert Skills - Marketing to Engineering     │
+│  85 Domain Expert Skills - Marketing to Engineering     │
 │  Use for: Domain expertise, frameworks, best practices  │
 └────────────────┬────────────────────────────────────────┘
                  │
@@ -2233,12 +2234,12 @@ Explore our complete ecosystem of Claude Code augmentation tools and utilities:
 ```
 
 **Workflow:**
-1. **Start here** (Skills Library) - Get 53 production-ready expert skills
+1. **Start here** (Skills Library) - Get 85 production-ready expert skills
 2. **Expand** (Skill Factory) - Generate custom skills for your specific needs
 3. **Supercharge** (Tresor) - Use skills + agents + commands in Claude Code development
 
 **Together they provide:**
-- ✅ 53 ready-to-use expert skills (this repo)
+- ✅ 85 ready-to-use expert skills (this repo)
 - ✅ Unlimited custom skill generation (Factory)
 - ✅ Complete development workflow automation (Tresor)
 - ✅ Cross-platform compatibility (Claude.ai, Claude Code, API)
@@ -2251,7 +2252,7 @@ Explore our complete ecosystem of Claude Code augmentation tools and utilities:
 
 ### Current Status (Q4 2025)
 
-**✅ Phase 1: Complete - 53 Production-Ready Skills**
+**✅ Phase 1: Complete - 85 Production-Ready Skills**
 
 **Marketing Skills (6):**
 - Content Creator - Brand voice analysis, SEO optimization, social media frameworks
@@ -2347,7 +2348,7 @@ Explore our complete ecosystem of Claude Code augmentation tools and utilities:
 
 | Metric | Current | Target (Q3 2026) |
 |--------|---------|------------------|
-| Available Skills | 53 | 55+ |
+| Available Skills | 85 | 55+ |
 | Skill Categories | 8 | 9 |
 | Python Tools | 87+ | 110+ |
 | Time Savings | 70% | 85% |
@@ -2356,7 +2357,7 @@ Explore our complete ecosystem of Claude Code augmentation tools and utilities:
 | Organizations | 25 | 250+ |
 | Industries Covered | Tech, HealthTech | Tech, Health, Finance, Manufacturing |
 
-### ROI Metrics (Current - 53 Skills)
+### ROI Metrics (Current - 85 Skills)
 
 **Time Savings Per Organization:**
 - Marketing teams: 310 hours/month (Content + Demand Gen + PMM + ASO + Social Media)


### PR DESCRIPTION
## Summary

Consolidates 191 commits since v1.0.2 into a proper **v2.0.0** release entry.

### What changed
- **12 POWERFUL-tier skills** documented (incident-commander through skill-tester)
- **5 new domain skills** (business-growth, finance, marketing)
- **37/42 skills refactored** to Anthropic best practices
- **2 skills elevated** to POWERFUL tier (scrum-master, senior-pm)
- **Platform support** documented (Codex, Claude Code marketplace)
- **7 bug fixes** catalogued
- **Version history table** updated (42→65 skills, 6→9 domains)
- **`[Unreleased]`** cleaned to only remaining planned work

### Why v2.0.0
- 55% increase in skills (42→65)
- 50% increase in domains (6→9)
- 88% of skills rewritten
- New platform support (Codex)
- This is unambiguously a major release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
