### PR TITLE
add playwright skill

### DIFF
--- a/engineering-team/playwright skill/LICENSE
+++ b/engineering-team/playwright skill/LICENSE
@@ -1,0 +1,22 @@
+
+MIT License
+
+Copyright (c) 2026 TestDino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/engineering-team/playwright skill/README.md
+++ b/engineering-team/playwright skill/README.md
@@ -1,0 +1,354 @@
+<!-- Playwright Skill by TestDino -->
+
+<div align="center">
+  <h1>Playwright Skill</h1>
+  <p>Production-tested guides that help AI coding agents generate better Playwright tests.</p>
+</div>
+
+<div align="center">
+  <a href="https://github.com/testdino-hq/playwright-skill/stargazers">
+    <img src="https://img.shields.io/github/stars/testdino-hq/playwright-skill?style=social" alt="GitHub Stars">
+  </a>
+  <a href="LICENSE">
+    <img src="https://img.shields.io/github/license/testdino-hq/playwright-skill" alt="License">
+  </a>
+  <img src="https://img.shields.io/badge/guides-70%2B-blue" alt="70+ Guides">
+  <img src="https://img.shields.io/badge/TypeScript%20%7C%20JavaScript-supported-yellow" alt="TS & JS">
+  <img src="https://img.shields.io/badge/Playwright-v1.40%2B-45ba4b?logo=playwright&logoColor=white" alt="Playwright v1.40+">
+</div>
+
+---
+
+Give your AI agent — Cursor, Claude, GitHub Copilot, Windsurf, or any AI coding tool — the knowledge to write reliable, maintainable Playwright tests on the first try. These aren't generic docs. They're battle-tested patterns used every day at [TestDino](https://testdino.com) to generate E2E tests for real-world applications.
+
+> **70+ guides** covering E2E, API, component, visual, accessibility, and security testing, plus CI/CD and CLI automation — with TypeScript and JavaScript examples throughout.
+
+---
+
+## Table of Contents
+
+- [Who Is This For?](#who-is-this-for)
+- [Why These Skills?](#why-these-skills)
+- [Quick Start](#quick-start)
+- [What's Inside](#whats-inside)
+- [Core Skills](#core-skills)
+- [CI/CD Skills](#cicd-skills)
+- [Playwright CLI Skills](#playwright-cli-skills)
+- [Migration Skills](#migration-skills)
+- [Page Object Model Skills](#page-object-model-skills)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Who Is This For?
+
+- **Developers using AI coding agents** who want better Playwright test generation out of the box
+- **QA engineers** looking for a comprehensive, well-organized Playwright reference
+- **Teams migrating** from Cypress or Selenium to Playwright
+- **Anyone tired of AI-generated tests** that break on the first run
+
+---
+
+## Why These Skills?
+
+AI agents generate Playwright tests that _look_ right but fail in CI. Wrong selectors, missing waits, no auth handling, flaky assertions — the same problems, over and over.
+
+These guides document every pattern that actually works in production. No guesswork, no boilerplate — just the decisions that matter: which locator to use, when to mock, how to handle auth, why your test is flaky.
+
+They're used internally at [TestDino](https://testdino.com) to generate E2E tests for real applications. The guides encode that hard-won knowledge so your AI agent gets it right on the first try.
+
+---
+
+## Quick Start
+
+The `skills` CLI copies guide content into your project so AI coding agents like Cursor, Claude, and Copilot can reference these patterns when generating tests.
+
+Add all skill packs to your project at once:
+
+```bash
+npx skills add testdino-hq/playwright-skill
+```
+
+Or install only the packs you need:
+
+```bash
+npx skills add testdino-hq/playwright-skill/core          # Locators, assertions, fixtures, auth, API testing, and more
+npx skills add testdino-hq/playwright-skill/ci             # GitHub Actions, GitLab CI, Docker, sharding
+npx skills add testdino-hq/playwright-skill/pom            # Page Object Model patterns
+npx skills add testdino-hq/playwright-skill/migration      # Migrate from Cypress or Selenium
+npx skills add testdino-hq/playwright-skill/playwright-cli # CLI browser automation
+```
+
+---
+
+## What's Inside
+
+| Skill Pack | Guides | What's Covered |
+| --- | :---: | --- |
+| **[core](#core-skills)** | 46 | Locators, assertions, fixtures, auth, API testing, network mocking, visual regression, accessibility, debugging, framework recipes |
+| **[ci](#cicd-skills)** | 9 | GitHub Actions, GitLab CI, CircleCI, Azure DevOps, Jenkins, Docker, sharding, reporting, coverage |
+| **[pom](#page-object-model-skills)** | 2 | Page Object Model patterns, POM vs fixtures vs helpers |
+| **[migration](#migration-skills)** | 2 | Migrating from Cypress, migrating from Selenium |
+| **[playwright-cli](#playwright-cli-skills)** | 11 | CLI browser automation, screenshots, tracing, session management, device emulation |
+
+---
+
+## Core Skills
+
+The foundation of Playwright testing. Start here if you're new to Playwright, or use these as a reference when your AI agent needs to handle a specific pattern.
+
+> **New to Playwright?** Follow this path:
+> [locators.md](core/locators.md) → [assertions-and-waiting.md](core/assertions-and-waiting.md) → [fixtures-and-hooks.md](core/fixtures-and-hooks.md)
+
+### Writing Tests
+
+| Guide | Description |
+| --- | --- |
+| [locators.md](core/locators.md) | Selector strategies — `getByRole`, `getByText`, `getByTestId` |
+| [assertions-and-waiting.md](core/assertions-and-waiting.md) | Web-first assertions, auto-retry, waiting patterns |
+| [fixtures-and-hooks.md](core/fixtures-and-hooks.md) | `test.extend()`, setup/teardown, worker-scoped fixtures |
+| [configuration.md](core/configuration.md) | `playwright.config.ts` — projects, timeouts, reporters, web server |
+| [test-organization.md](core/test-organization.md) | File structure, tagging, `test.describe`, test filtering |
+| [test-data-management.md](core/test-data-management.md) | Factories, seeding, cleanup strategies |
+| [authentication.md](core/authentication.md) | Storage state reuse, multi-role auth, session management |
+| [auth-flows.md](core/auth-flows.md) | Login, signup, logout, OAuth, and SSO flow recipes |
+| [api-testing.md](core/api-testing.md) | REST and GraphQL testing with the `request` fixture |
+| [network-mocking.md](core/network-mocking.md) | Route interception, HAR replay, response modification |
+| [when-to-mock.md](core/when-to-mock.md) | Mock third-party boundaries, never your own app |
+| [forms-and-validation.md](core/forms-and-validation.md) | Form fills, validation, error states, multi-step wizards |
+| [visual-regression.md](core/visual-regression.md) | Screenshot comparison, thresholds, masking dynamic content |
+| [accessibility.md](core/accessibility.md) | axe-core integration, ARIA assertions, a11y auditing |
+| [component-testing.md](core/component-testing.md) | Mount React/Vue/Svelte components in isolation |
+| [mobile-and-responsive.md](core/mobile-and-responsive.md) | Device emulation, viewport testing, touch interactions |
+| [file-operations.md](core/file-operations.md) | File uploads, downloads, drag-and-drop file interactions |
+| [file-upload-download.md](core/file-upload-download.md) | Upload and download recipes — single, multiple, progress |
+| [error-and-edge-cases.md](core/error-and-edge-cases.md) | Error states, boundary conditions, unhappy path testing |
+| [crud-testing.md](core/crud-testing.md) | Create, read, update, delete test patterns for any resource |
+| [drag-and-drop.md](core/drag-and-drop.md) | Sortable lists, kanban boards, file drop zones |
+| [search-and-filter.md](core/search-and-filter.md) | Search inputs, filters, autocomplete, no-results states |
+
+### Debugging & Fixing
+
+| Guide | Description |
+| --- | --- |
+| [debugging.md](core/debugging.md) | Trace viewer, `PWDEBUG`, UI mode, headed + slow-mo |
+| [error-index.md](core/error-index.md) | Common error messages and how to fix them |
+| [flaky-tests.md](core/flaky-tests.md) | Root causes, retry strategies, stabilization patterns |
+| [common-pitfalls.md](core/common-pitfalls.md) | Top beginner mistakes and how to avoid them |
+
+### Framework Recipes
+
+| Guide | Description |
+| --- | --- |
+| [nextjs.md](core/nextjs.md) | App Router + Pages Router testing |
+| [react.md](core/react.md) | CRA, Vite, component testing |
+| [vue.md](core/vue.md) | Vue 3 / Nuxt testing |
+| [angular.md](core/angular.md) | Angular testing patterns |
+
+### Specialized Topics
+
+| Guide | Description |
+| --- | --- |
+| [browser-apis.md](core/browser-apis.md) | Geolocation, clipboard, permissions |
+| [iframes-and-shadow-dom.md](core/iframes-and-shadow-dom.md) | Cross-frame testing, Shadow DOM piercing |
+| [multi-context-and-popups.md](core/multi-context-and-popups.md) | Multi-tab, popups, new windows |
+| [websockets-and-realtime.md](core/websockets-and-realtime.md) | WebSocket testing, real-time UI |
+| [canvas-and-webgl.md](core/canvas-and-webgl.md) | Canvas testing, visual comparison |
+| [electron-testing.md](core/electron-testing.md) | Desktop app testing with Electron |
+| [security-testing.md](core/security-testing.md) | XSS, CSRF, header validation |
+| [performance-testing.md](core/performance-testing.md) | Core Web Vitals, Lighthouse, benchmarks |
+| [clock-and-time-mocking.md](core/clock-and-time-mocking.md) | Fake timers, date mocking |
+| [service-workers-and-pwa.md](core/service-workers-and-pwa.md) | PWA testing, offline mode |
+| [browser-extensions.md](core/browser-extensions.md) | Extension testing patterns |
+| [i18n-and-localization.md](core/i18n-and-localization.md) | Multi-language, RTL, locale testing |
+| [multi-user-and-collaboration.md](core/multi-user-and-collaboration.md) | Real-time collaboration, multi-user workflows, shared state |
+| [third-party-integrations.md](core/third-party-integrations.md) | OAuth providers, payment gateways, analytics, CAPTCHAs |
+
+### Architecture Decisions
+
+Not sure which approach to take? These guides answer the "which option?" questions before you write a line of code.
+
+| Question | Guide |
+| --- | --- |
+| Which locator strategy should I use? | [locator-strategy.md](core/locator-strategy.md) |
+| E2E vs component vs API — what kind of test? | [test-architecture.md](core/test-architecture.md) |
+| Should I mock this service or hit it for real? | [when-to-mock.md](core/when-to-mock.md) |
+| POM vs fixtures vs helpers — what's right here? | [pom-vs-fixtures-vs-helpers.md](pom/pom-vs-fixtures-vs-helpers.md) |
+
+---
+
+## CI/CD Skills
+
+| Guide | Description |
+| --- | --- |
+| [ci-github-actions.md](ci/ci-github-actions.md) | Workflows, caching, artifact uploads |
+| [ci-gitlab.md](ci/ci-gitlab.md) | GitLab CI pipelines |
+| [ci-other.md](ci/ci-other.md) | CircleCI, Azure DevOps, Jenkins |
+| [parallel-and-sharding.md](ci/parallel-and-sharding.md) | Sharding across CI runners |
+| [docker-and-containers.md](ci/docker-and-containers.md) | Containerized test execution |
+| [reporting-and-artifacts.md](ci/reporting-and-artifacts.md) | HTML reports, traces, screenshots |
+| [test-coverage.md](ci/test-coverage.md) | Code coverage collection |
+| [global-setup-teardown.md](ci/global-setup-teardown.md) | One-time setup/teardown |
+| [projects-and-dependencies.md](ci/projects-and-dependencies.md) | Multi-project config, dependencies |
+
+---
+
+## Playwright CLI Skills
+
+| Guide | Description |
+| --- | --- |
+| [SKILL.md](playwright-cli/SKILL.md) | CLI overview — when and how to use browser automation from the CLI |
+| [core-commands.md](playwright-cli/core-commands.md) | Open, navigate, click, fill, keyboard, mouse |
+| [request-mocking.md](playwright-cli/request-mocking.md) | Route interception, conditional mocks, HAR replay |
+| [running-custom-code.md](playwright-cli/running-custom-code.md) | Full Playwright API via `run-code` |
+| [session-management.md](playwright-cli/session-management.md) | Named sessions, isolation, persistent profiles |
+| [storage-and-auth.md](playwright-cli/storage-and-auth.md) | Cookies, localStorage, auth state save/restore |
+| [test-generation.md](playwright-cli/test-generation.md) | Auto-generate test code from CLI interactions |
+| [tracing-and-debugging.md](playwright-cli/tracing-and-debugging.md) | Traces, console/network monitoring |
+| [screenshots-and-media.md](playwright-cli/screenshots-and-media.md) | Screenshots, video recording, PDF export |
+| [device-emulation.md](playwright-cli/device-emulation.md) | Viewport, geolocation, locale, dark mode |
+| [advanced-workflows.md](playwright-cli/advanced-workflows.md) | Popups, scraping, accessibility auditing |
+
+---
+
+## Migration Skills
+
+| Guide | Description |
+| --- | --- |
+| [from-cypress.md](migration/from-cypress.md) | Cypress to Playwright — API mapping, config translation, common gotchas |
+| [from-selenium.md](migration/from-selenium.md) | Selenium/WebDriver to Playwright — locator strategies, wait model, parallel execution |
+
+---
+
+## Page Object Model Skills
+
+| Guide | Description |
+| --- | --- |
+| [page-object-model.md](pom/page-object-model.md) | POM patterns for Playwright |
+| [pom-vs-fixtures-vs-helpers.md](pom/pom-vs-fixtures-vs-helpers.md) | When to use POM vs fixtures vs helpers |
+
+---
+
+## Beginner Guide
+
+Not sure where to start? Pick your goal and follow the path.
+
+```mermaid
+flowchart LR
+    S([Start here]) --> Q{What is your goal?}
+    Q -->|New to Playwright| A[A · Learn E2E Testing]
+    Q -->|Terminal automation| B[B · CLI Automation]
+    Q -->|Coming from Cypress or Selenium| C[C · Migration]
+    Q -->|Structured test code| D[D · Page Object Model]
+```
+
+---
+
+### Path A · Learn Playwright Testing *(recommended for beginners)*
+
+```bash
+npx skills add testdino-hq/playwright-skill/core
+```
+
+**Read these four guides first, in order:**
+
+1. [locators.md](core/locators.md) — how to find elements on the page
+2. [assertions-and-waiting.md](core/assertions-and-waiting.md) — how to verify and wait correctly
+3. [fixtures-and-hooks.md](core/fixtures-and-hooks.md) — how to share setup across tests
+4. [configuration.md](core/configuration.md) — how to configure Playwright for your project
+
+**Then add only what your app needs:**
+
+| Your app has... | Read this |
+| --- | --- |
+| Login or auth | [authentication.md](core/authentication.md) · [auth-flows.md](core/auth-flows.md) |
+| Forms | [forms-and-validation.md](core/forms-and-validation.md) |
+| API calls | [api-testing.md](core/api-testing.md) |
+| Network mocking | [when-to-mock.md](core/when-to-mock.md) · [network-mocking.md](core/network-mocking.md) |
+| Visual checks | [visual-regression.md](core/visual-regression.md) |
+| Accessibility | [accessibility.md](core/accessibility.md) |
+| CRUD screens | [crud-testing.md](core/crud-testing.md) |
+| Search or filters | [search-and-filter.md](core/search-and-filter.md) |
+| File upload/download | [file-operations.md](core/file-operations.md) · [file-upload-download.md](core/file-upload-download.md) |
+| Test data setup | [test-data-management.md](core/test-data-management.md) |
+
+**When something breaks:**
+
+[debugging.md](core/debugging.md) → [error-index.md](core/error-index.md) → [common-pitfalls.md](core/common-pitfalls.md) → [flaky-tests.md](core/flaky-tests.md)
+
+**When you're ready to scale:**
+
+[test-architecture.md](core/test-architecture.md) · [locator-strategy.md](core/locator-strategy.md) · [pom-vs-fixtures-vs-helpers.md](pom/pom-vs-fixtures-vs-helpers.md)
+
+**When local tests are stable, move to CI:**
+
+```bash
+npx skills add testdino-hq/playwright-skill/ci
+```
+
+1. [ci-github-actions.md](ci/ci-github-actions.md) or [ci-gitlab.md](ci/ci-gitlab.md) — pick your platform
+2. [reporting-and-artifacts.md](ci/reporting-and-artifacts.md) — HTML reports and traces
+3. [parallel-and-sharding.md](ci/parallel-and-sharding.md) — speed up your pipeline
+4. [docker-and-containers.md](ci/docker-and-containers.md) *(only if using Docker)*
+5. [test-coverage.md](ci/test-coverage.md) *(only if you need coverage)*
+
+**Advanced — only when your app requires it:**
+
+[iframes-and-shadow-dom.md](core/iframes-and-shadow-dom.md) · [multi-context-and-popups.md](core/multi-context-and-popups.md) · [websockets-and-realtime.md](core/websockets-and-realtime.md) · [service-workers-and-pwa.md](core/service-workers-and-pwa.md) · [i18n-and-localization.md](core/i18n-and-localization.md) · [third-party-integrations.md](core/third-party-integrations.md) · [security-testing.md](core/security-testing.md) · [performance-testing.md](core/performance-testing.md)
+
+---
+
+### Path B · CLI Browser Automation
+
+```bash
+npx skills add testdino-hq/playwright-skill/playwright-cli
+```
+
+1. [SKILL.md](playwright-cli/SKILL.md) — start here for an overview
+2. [core-commands.md](playwright-cli/core-commands.md)
+3. [session-management.md](playwright-cli/session-management.md)
+4. [storage-and-auth.md](playwright-cli/storage-and-auth.md)
+5. [tracing-and-debugging.md](playwright-cli/tracing-and-debugging.md)
+6. [screenshots-and-media.md](playwright-cli/screenshots-and-media.md)
+
+---
+
+### Path C · Migrating from Another Tool
+
+```bash
+npx skills add testdino-hq/playwright-skill/migration
+```
+
+| Coming from | Read this |
+| --- | --- |
+| Cypress | [from-cypress.md](migration/from-cypress.md) — API mapping, config translation, common gotchas |
+| Selenium / WebDriver | [from-selenium.md](migration/from-selenium.md) — locator strategies, wait model, parallel execution |
+
+---
+
+### Path D · Page Object Model Structure
+
+```bash
+npx skills add testdino-hq/playwright-skill/pom
+```
+
+1. [page-object-model.md](pom/page-object-model.md) — POM patterns for Playwright
+2. [pom-vs-fixtures-vs-helpers.md](pom/pom-vs-fixtures-vs-helpers.md) — when to use each approach
+
+
+## Contributing
+
+Found a bug or a missing pattern? [Open an issue](https://github.com/testdino-hq/playwright-skill/issues) or submit a PR.
+
+---
+
+## License
+
+[MIT](LICENSE)
+
+---
+
+<div align="center">
+  Built by <a href="https://testdino.com">TestDino</a> — production Playwright test generation
+</div>

--- a/engineering-team/playwright skill/SKILL.md
+++ b/engineering-team/playwright skill/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: playwright-skill
+description: Battle-tested Playwright patterns for E2E, API, component, visual, accessibility, and security testing. Covers locators, fixtures, POM, network mocking, auth flows, debugging, CI/CD (GitHub Actions, GitLab, CircleCI, Azure, Jenkins), framework recipes (React, Next.js, Vue, Angular), and migration guides from Cypress/Selenium. TypeScript and JavaScript.
+---
+
+# Playwright Skill
+
+> Opinionated, production-tested Playwright guidance — every pattern includes when (and when *not*) to use it.
+
+**50+ reference guides** covering the full Playwright surface: selectors, assertions, fixtures, page objects, network mocking, auth, visual regression, accessibility, API testing, CI/CD, debugging, and more — with TypeScript and JavaScript examples throughout.
+
+## Golden Rules
+
+1. **`getByRole()` over CSS/XPath** — resilient to markup changes, mirrors how users see the page
+2. **Never `page.waitForTimeout()`** — use `expect(locator).toBeVisible()` or `page.waitForURL()`
+3. **Web-first assertions** — `expect(locator)` auto-retries; `expect(await locator.textContent())` does not
+4. **Isolate every test** — no shared state, no execution-order dependencies
+5. **`baseURL` in config** — zero hardcoded URLs in tests
+6. **Retries: `2` in CI, `0` locally** — surface flakiness where it matters
+7. **Traces: `'on-first-retry'`** — rich debugging artifacts without CI slowdown
+8. **Fixtures over globals** — share state via `test.extend()`, not module-level variables
+9. **One behavior per test** — multiple related `expect()` calls are fine
+10. **Mock external services only** — never mock your own app; mock third-party APIs, payment gateways, email
+
+## Guide Index
+
+### Writing Tests
+
+| What you're doing | Guide | Deep dive |
+|---|---|---|
+| Choosing selectors | [locators.md](core/locators.md) | [locator-strategy.md](core/locator-strategy.md) |
+| Assertions & waiting | [assertions-and-waiting.md](core/assertions-and-waiting.md) | |
+| Organizing test suites | [test-organization.md](core/test-organization.md) | [test-architecture.md](core/test-architecture.md) |
+| Playwright config | [configuration.md](core/configuration.md) | |
+| Page objects | [page-object-model.md](pom/page-object-model.md) | [pom-vs-fixtures-vs-helpers.md](pom/pom-vs-fixtures-vs-helpers.md) |
+| Fixtures & hooks | [fixtures-and-hooks.md](core/fixtures-and-hooks.md) | |
+| Test data | [test-data-management.md](core/test-data-management.md) | |
+| Auth & login | [authentication.md](core/authentication.md) | [auth-flows.md](core/auth-flows.md) |
+| API testing (REST/GraphQL) | [api-testing.md](core/api-testing.md) | |
+| Visual regression | [visual-regression.md](core/visual-regression.md) | |
+| Accessibility | [accessibility.md](core/accessibility.md) | |
+| Mobile & responsive | [mobile-and-responsive.md](core/mobile-and-responsive.md) | |
+| Component testing | [component-testing.md](core/component-testing.md) | |
+| Network mocking | [network-mocking.md](core/network-mocking.md) | [when-to-mock.md](core/when-to-mock.md) |
+| Forms & validation | [forms-and-validation.md](core/forms-and-validation.md) | |
+| File uploads/downloads | [file-operations.md](core/file-operations.md) | [file-upload-download.md](core/file-upload-download.md) |
+| Error & edge cases | [error-and-edge-cases.md](core/error-and-edge-cases.md) | |
+| CRUD flows | [crud-testing.md](core/crud-testing.md) | |
+| Drag and drop | [drag-and-drop.md](core/drag-and-drop.md) | |
+| Search & filter UI | [search-and-filter.md](core/search-and-filter.md) | |
+
+### Debugging & Fixing
+
+| Problem | Guide |
+|---|---|
+| General debugging workflow | [debugging.md](core/debugging.md) |
+| Specific error message | [error-index.md](core/error-index.md) |
+| Flaky / intermittent tests | [flaky-tests.md](core/flaky-tests.md) |
+| Common beginner mistakes | [common-pitfalls.md](core/common-pitfalls.md) |
+
+### Framework Recipes
+
+| Framework | Guide |
+|---|---|
+| Next.js (App Router + Pages Router) | [nextjs.md](core/nextjs.md) |
+| React (CRA, Vite) | [react.md](core/react.md) |
+| Vue 3 / Nuxt | [vue.md](core/vue.md) |
+| Angular | [angular.md](core/angular.md) |
+
+### Migration Guides
+
+| From | Guide |
+|---|---|
+| Cypress | [from-cypress.md](migration/from-cypress.md) |
+| Selenium / WebDriver | [from-selenium.md](migration/from-selenium.md) |
+
+### Architecture Decisions
+
+| Question | Guide |
+|---|---|
+| Which locator strategy? | [locator-strategy.md](core/locator-strategy.md) |
+| E2E vs component vs API? | [test-architecture.md](core/test-architecture.md) |
+| Mock vs real services? | [when-to-mock.md](core/when-to-mock.md) |
+| POM vs fixtures vs helpers? | [pom-vs-fixtures-vs-helpers.md](pom/pom-vs-fixtures-vs-helpers.md) |
+
+### CI/CD & Infrastructure
+
+| Topic | Guide |
+|---|---|
+| GitHub Actions | [ci-github-actions.md](ci/ci-github-actions.md) |
+| GitLab CI | [ci-gitlab.md](ci/ci-gitlab.md) |
+| CircleCI / Azure DevOps / Jenkins | [ci-other.md](ci/ci-other.md) |
+| Parallel execution & sharding | [parallel-and-sharding.md](ci/parallel-and-sharding.md) |
+| Docker & containers | [docker-and-containers.md](ci/docker-and-containers.md) |
+| Reports & artifacts | [reporting-and-artifacts.md](ci/reporting-and-artifacts.md) |
+| Code coverage | [test-coverage.md](ci/test-coverage.md) |
+| Global setup/teardown | [global-setup-teardown.md](ci/global-setup-teardown.md) |
+| Multi-project config | [projects-and-dependencies.md](ci/projects-and-dependencies.md) |
+
+### Specialized Topics
+
+| Topic | Guide |
+|---|---|
+| Multi-user & collaboration | [multi-user-and-collaboration.md](core/multi-user-and-collaboration.md) |
+| WebSockets & real-time | [websockets-and-realtime.md](core/websockets-and-realtime.md) |
+| Browser APIs (geo, clipboard, permissions) | [browser-apis.md](core/browser-apis.md) |
+| iframes & Shadow DOM | [iframes-and-shadow-dom.md](core/iframes-and-shadow-dom.md) |
+| Canvas & WebGL | [canvas-and-webgl.md](core/canvas-and-webgl.md) |
+| Service workers & PWA | [service-workers-and-pwa.md](core/service-workers-and-pwa.md) |
+| Electron apps | [electron-testing.md](core/electron-testing.md) |
+| Browser extensions | [browser-extensions.md](core/browser-extensions.md) |
+| Security testing | [security-testing.md](core/security-testing.md) |
+| Performance & benchmarks | [performance-testing.md](core/performance-testing.md) |
+| i18n & localization | [i18n-and-localization.md](core/i18n-and-localization.md) |
+| Multi-tab & popups | [multi-context-and-popups.md](core/multi-context-and-popups.md) |
+| Clock & time mocking | [clock-and-time-mocking.md](core/clock-and-time-mocking.md) |
+| Third-party integrations | [third-party-integrations.md](core/third-party-integrations.md) |
+
+### CLI Browser Automation
+
+| What you're doing | Guide |
+|---|---|
+| CLI browser interaction | [playwright-cli/SKILL.md](playwright-cli/SKILL.md) |
+| Core commands (open, click, fill, navigate) | [core-commands.md](playwright-cli/core-commands.md) |
+| Network mocking & interception | [request-mocking.md](playwright-cli/request-mocking.md) |
+| Running custom Playwright code | [running-custom-code.md](playwright-cli/running-custom-code.md) |
+| Multi-session browser management | [session-management.md](playwright-cli/session-management.md) |
+| Cookies, localStorage, auth state | [storage-and-auth.md](playwright-cli/storage-and-auth.md) |
+| Test code generation from CLI | [test-generation.md](playwright-cli/test-generation.md) |
+| Tracing and debugging | [tracing-and-debugging.md](playwright-cli/tracing-and-debugging.md) |
+| Screenshots, video, PDF | [screenshots-and-media.md](playwright-cli/screenshots-and-media.md) |
+| Device & environment emulation | [device-emulation.md](playwright-cli/device-emulation.md) |
+| Complex multi-step workflows | [advanced-workflows.md](playwright-cli/advanced-workflows.md) |
+
+## Language Note
+
+All guides include TypeScript and JavaScript examples. When the project uses `.js` files or has no `tsconfig.json`, examples are adapted to plain JavaScript.

--- a/engineering-team/playwright skill/core/SKILL.md
+++ b/engineering-team/playwright skill/core/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: playwright-core
+description: Battle-tested Playwright patterns for E2E, API, component, visual, accessibility, and security testing. Covers locators, assertions, fixtures, network mocking, auth flows, debugging, and framework recipes for React, Next.js, Vue, and Angular. TypeScript and JavaScript.
+---
+
+# Playwright Core Testing
+
+> Opinionated, production-tested Playwright guidance — every pattern includes when (and when *not*) to use it.
+
+**46 reference guides** covering the full Playwright testing surface: selectors, assertions, fixtures, network mocking, auth, visual regression, accessibility, API testing, debugging, and more — with TypeScript and JavaScript examples throughout.
+
+## Golden Rules
+
+1. **`getByRole()` over CSS/XPath** — resilient to markup changes, mirrors how users see the page
+2. **Never `page.waitForTimeout()`** — use `expect(locator).toBeVisible()` or `page.waitForURL()`
+3. **Web-first assertions** — `expect(locator)` auto-retries; `expect(await locator.textContent())` does not
+4. **Isolate every test** — no shared state, no execution-order dependencies
+5. **`baseURL` in config** — zero hardcoded URLs in tests
+6. **Retries: `2` in CI, `0` locally** — surface flakiness where it matters
+7. **Traces: `'on-first-retry'`** — rich debugging artifacts without CI slowdown
+8. **Fixtures over globals** — share state via `test.extend()`, not module-level variables
+9. **One behavior per test** — multiple related `expect()` calls are fine
+10. **Mock external services only** — never mock your own app; mock third-party APIs, payment gateways, email
+
+## Guide Index
+
+### Writing Tests
+
+| What you're doing | Guide | Deep dive |
+|---|---|---|
+| Choosing selectors | [locators.md](locators.md) | [locator-strategy.md](locator-strategy.md) |
+| Assertions & waiting | [assertions-and-waiting.md](assertions-and-waiting.md) | |
+| Organizing test suites | [test-organization.md](test-organization.md) | [test-architecture.md](test-architecture.md) |
+| Playwright config | [configuration.md](configuration.md) | |
+| Fixtures & hooks | [fixtures-and-hooks.md](fixtures-and-hooks.md) | |
+| Test data | [test-data-management.md](test-data-management.md) | |
+| Auth & login | [authentication.md](authentication.md) | [auth-flows.md](auth-flows.md) |
+| API testing (REST/GraphQL) | [api-testing.md](api-testing.md) | |
+| Visual regression | [visual-regression.md](visual-regression.md) | |
+| Accessibility | [accessibility.md](accessibility.md) | |
+| Mobile & responsive | [mobile-and-responsive.md](mobile-and-responsive.md) | |
+| Component testing | [component-testing.md](component-testing.md) | |
+| Network mocking | [network-mocking.md](network-mocking.md) | [when-to-mock.md](when-to-mock.md) |
+| Forms & validation | [forms-and-validation.md](forms-and-validation.md) | |
+| File uploads/downloads | [file-operations.md](file-operations.md) | [file-upload-download.md](file-upload-download.md) |
+| Error & edge cases | [error-and-edge-cases.md](error-and-edge-cases.md) | |
+| CRUD flows | [crud-testing.md](crud-testing.md) | |
+| Drag and drop | [drag-and-drop.md](drag-and-drop.md) | |
+| Search & filter UI | [search-and-filter.md](search-and-filter.md) | |
+
+### Debugging & Fixing
+
+| Problem | Guide |
+|---|---|
+| General debugging workflow | [debugging.md](debugging.md) |
+| Specific error message | [error-index.md](error-index.md) |
+| Flaky / intermittent tests | [flaky-tests.md](flaky-tests.md) |
+| Common beginner mistakes | [common-pitfalls.md](common-pitfalls.md) |
+
+### Framework Recipes
+
+| Framework | Guide |
+|---|---|
+| Next.js (App Router + Pages Router) | [nextjs.md](nextjs.md) |
+| React (CRA, Vite) | [react.md](react.md) |
+| Vue 3 / Nuxt | [vue.md](vue.md) |
+| Angular | [angular.md](angular.md) |
+
+### Specialized Topics
+
+| Topic | Guide |
+|---|---|
+| Multi-user & collaboration | [multi-user-and-collaboration.md](multi-user-and-collaboration.md) |
+| WebSockets & real-time | [websockets-and-realtime.md](websockets-and-realtime.md) |
+| Browser APIs (geo, clipboard, permissions) | [browser-apis.md](browser-apis.md) |
+| iframes & Shadow DOM | [iframes-and-shadow-dom.md](iframes-and-shadow-dom.md) |
+| Canvas & WebGL | [canvas-and-webgl.md](canvas-and-webgl.md) |
+| Service workers & PWA | [service-workers-and-pwa.md](service-workers-and-pwa.md) |
+| Electron apps | [electron-testing.md](electron-testing.md) |
+| Browser extensions | [browser-extensions.md](browser-extensions.md) |
+| Security testing | [security-testing.md](security-testing.md) |
+| Performance & benchmarks | [performance-testing.md](performance-testing.md) |
+| i18n & localization | [i18n-and-localization.md](i18n-and-localization.md) |
+| Multi-tab & popups | [multi-context-and-popups.md](multi-context-and-popups.md) |
+| Clock & time mocking | [clock-and-time-mocking.md](clock-and-time-mocking.md) |
+| Third-party integrations | [third-party-integrations.md](third-party-integrations.md) |
+
+### Architecture Decisions
+
+| Question | Guide |
+|---|---|
+| Which locator strategy? | [locator-strategy.md](locator-strategy.md) |
+| E2E vs component vs API? | [test-architecture.md](test-architecture.md) |
+| Mock vs real services? | [when-to-mock.md](when-to-mock.md) |

--- a/engineering-team/playwright skill/core/accessibility.md
+++ b/engineering-team/playwright skill/core/accessibility.md
@@ -1,0 +1,1410 @@
+# Accessibility Testing
+
+> **When to use**: Every project. Accessibility is not a feature — it is a quality baseline. Integrate automated checks (axe-core) into every test suite and supplement with manual keyboard/screen-reader verification for critical flows.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```typescript
+// Install: npm install -D @axe-core/playwright
+import AxeBuilder from '@axe-core/playwright';
+
+// Full page scan
+const results = await new AxeBuilder({ page }).analyze();
+expect(results.violations).toEqual([]);
+
+// Scoped scan — only the main content area
+const results = await new AxeBuilder({ page }).include('#main-content').analyze();
+
+// WCAG AA only
+const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+
+// Exclude known issues during migration
+const results = await new AxeBuilder({ page }).disableRules(['color-contrast']).analyze();
+```
+
+## Patterns
+
+### axe-core/playwright Integration
+
+**Use when**: You want automated WCAG violation detection on any page or component. This is your first line of defense and should run in every test suite.
+**Avoid when**: You need to verify subjective UX quality (reading order, cognitive load, plain language). axe-core catches structural violations, not usability problems.
+
+axe-core detects roughly 30-40% of WCAG issues automatically. That 30-40% includes the most common and egregious violations: missing alt text, broken label associations, invalid ARIA, and contrast failures. Catching these automatically frees you to spend manual effort on the harder problems.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('accessibility', () => {
+  test('home page has no accessibility violations', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('dashboard has no accessibility violations after login', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+
+    // Scan after the page is fully interactive
+    const results = await new AxeBuilder({ page }).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('report violations with helpful details on failure', async ({ page }) => {
+    await page.goto('/products');
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    // Format violations for readable test output
+    const violationSummary = results.violations.map((v) => ({
+      rule: v.id,
+      impact: v.impact,
+      description: v.description,
+      nodes: v.nodes.length,
+      help: v.helpUrl,
+    }));
+
+    expect(results.violations, JSON.stringify(violationSummary, null, 2)).toEqual([]);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+test.describe('accessibility', () => {
+  test('home page has no accessibility violations', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('report violations with helpful details on failure', async ({ page }) => {
+    await page.goto('/products');
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    const violationSummary = results.violations.map((v) => ({
+      rule: v.id,
+      impact: v.impact,
+      description: v.description,
+      nodes: v.nodes.length,
+      help: v.helpUrl,
+    }));
+
+    expect(results.violations, JSON.stringify(violationSummary, null, 2)).toEqual([]);
+  });
+});
+```
+
+### Scanning Specific Regions
+
+**Use when**: You want to focus axe-core on a specific component (new feature, redesigned section) or exclude areas you do not control (third-party widgets, ads, embedded iframes).
+**Avoid when**: You want a full-page baseline. Scan everything first, then narrow down.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('scoped accessibility scans', () => {
+  test('scan only the checkout form', async ({ page }) => {
+    await page.goto('/checkout');
+
+    const results = await new AxeBuilder({ page })
+      .include('#checkout-form')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('scan page excluding third-party chat widget', async ({ page }) => {
+    await page.goto('/support');
+
+    const results = await new AxeBuilder({ page })
+      .exclude('#intercom-widget')
+      .exclude('.third-party-ads')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('scan multiple specific regions', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // Include multiple areas — each is scanned independently
+    const results = await new AxeBuilder({ page })
+      .include('#navigation')
+      .include('#main-content')
+      .include('#footer')
+      .exclude('.ad-banner')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('scan a modal after it opens', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: 'Delete account' }).click();
+
+    // Wait for the modal to be fully rendered
+    await expect(page.getByRole('dialog', { name: 'Confirm deletion' })).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .include('[role="dialog"]')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+test.describe('scoped accessibility scans', () => {
+  test('scan only the checkout form', async ({ page }) => {
+    await page.goto('/checkout');
+
+    const results = await new AxeBuilder({ page })
+      .include('#checkout-form')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('scan page excluding third-party chat widget', async ({ page }) => {
+    await page.goto('/support');
+
+    const results = await new AxeBuilder({ page })
+      .exclude('#intercom-widget')
+      .exclude('.third-party-ads')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('scan a modal after it opens', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: 'Delete account' }).click();
+    await expect(page.getByRole('dialog', { name: 'Confirm deletion' })).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .include('[role="dialog"]')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});
+```
+
+### WCAG Compliance Levels
+
+**Use when**: Your project targets a specific WCAG compliance level (most target AA). Use tags to limit axe-core to the rules that matter for your compliance requirement.
+**Avoid when**: You want the broadest possible scan. Omitting `withTags()` runs all rules, including best practices beyond WCAG.
+
+Tag reference:
+- `wcag2a` — WCAG 2.0 Level A (minimum)
+- `wcag2aa` — WCAG 2.0 Level AA (standard target for most organizations)
+- `wcag2aaa` — WCAG 2.0 Level AAA (strict; rarely required)
+- `wcag21a`, `wcag21aa`, `wcag21aaa` — WCAG 2.1 additions
+- `wcag22aa` — WCAG 2.2 additions
+- `best-practice` — not WCAG, but recommended patterns
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('WCAG compliance levels', () => {
+  test('meets WCAG 2.1 AA (standard compliance target)', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('meets WCAG 2.2 AA (latest standard)', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('meets WCAG AAA (strict — use for government or healthcare)', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag2aaa', 'wcag21a', 'wcag21aa', 'wcag21aaa'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('best practices beyond WCAG', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['best-practice'])
+      .analyze();
+
+    // Use soft assertion — best practices are advisory, not blocking
+    expect.soft(results.violations).toEqual([]);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+test.describe('WCAG compliance levels', () => {
+  test('meets WCAG 2.1 AA (standard compliance target)', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('meets WCAG 2.2 AA (latest standard)', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});
+```
+
+### Disabling Specific Rules
+
+**Use when**: Migrating a legacy app to accessibility compliance incrementally. You have known violations documented in a tracking system and want the test suite to catch new regressions without failing on existing known issues.
+**Avoid when**: Hiding violations you do not intend to fix. Every disabled rule should have a tracking ticket.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// Centralize known exceptions — makes them visible and trackable
+const KNOWN_ISSUES = {
+  // JIRA-1234: Legacy header component, scheduled for redesign Q2
+  rules: ['color-contrast'],
+  // JIRA-1235: Third-party date picker has no label association
+  selectors: ['#legacy-datepicker'],
+};
+
+test.describe('accessibility with known exceptions', () => {
+  test('no new violations (excluding tracked known issues)', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const results = await new AxeBuilder({ page })
+      .disableRules(KNOWN_ISSUES.rules)
+      .exclude(KNOWN_ISSUES.selectors[0])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('verify known issues still exist (remove when fixed)', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // Scan ONLY for the known issues to confirm they still exist
+    // When this test fails (violations disappear), remove the exception
+    const results = await new AxeBuilder({ page })
+      .withRules(KNOWN_ISSUES.rules)
+      .analyze();
+
+    if (results.violations.length === 0) {
+      console.warn(
+        'Known accessibility issues appear to be fixed. ' +
+        'Remove exceptions from KNOWN_ISSUES and close tracking tickets.'
+      );
+    }
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+const KNOWN_ISSUES = {
+  rules: ['color-contrast'],
+  selectors: ['#legacy-datepicker'],
+};
+
+test.describe('accessibility with known exceptions', () => {
+  test('no new violations (excluding tracked known issues)', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const results = await new AxeBuilder({ page })
+      .disableRules(KNOWN_ISSUES.rules)
+      .exclude(KNOWN_ISSUES.selectors[0])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('verify known issues still exist (remove when fixed)', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const results = await new AxeBuilder({ page })
+      .withRules(KNOWN_ISSUES.rules)
+      .analyze();
+
+    if (results.violations.length === 0) {
+      console.warn(
+        'Known accessibility issues appear to be fixed. ' +
+        'Remove exceptions from KNOWN_ISSUES and close tracking tickets.'
+      );
+    }
+  });
+});
+```
+
+### Keyboard Navigation Testing
+
+**Use when**: Verifying that all interactive elements are reachable and operable via keyboard alone. This is critical for motor-impaired users and power users who navigate without a mouse.
+**Avoid when**: Never skip this. Automated tools cannot fully verify keyboard navigation — this requires behavioral tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('keyboard navigation', () => {
+  test('tab order follows logical reading order', async ({ page }) => {
+    await page.goto('/login');
+
+    // Tab through interactive elements and verify focus order
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Email')).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Password')).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('link', { name: 'Forgot password?' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeFocused();
+
+    // Verify Enter activates the focused button
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).focus();
+    await page.keyboard.press('Enter');
+    await page.waitForURL('/dashboard');
+  });
+
+  test('skip navigation link moves focus to main content', async ({ page }) => {
+    await page.goto('/');
+
+    // First Tab should land on the skip link (visually hidden until focused)
+    await page.keyboard.press('Tab');
+    const skipLink = page.getByRole('link', { name: 'Skip to main content' });
+    await expect(skipLink).toBeFocused();
+
+    // Activating the skip link moves focus past the nav
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#main-content')).toBeFocused();
+  });
+
+  test('dropdown menu operates with keyboard', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const menuButton = page.getByRole('button', { name: 'User menu' });
+    await menuButton.focus();
+
+    // Open menu with Enter or Space
+    await page.keyboard.press('Enter');
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    // Arrow keys navigate menu items
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Profile' })).toBeFocused();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Settings' })).toBeFocused();
+
+    // Escape closes the menu and returns focus to the trigger
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(menuButton).toBeFocused();
+  });
+
+  test('keyboard shortcuts work correctly', async ({ page }) => {
+    await page.goto('/editor');
+
+    // Ctrl+S / Cmd+S triggers save
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    const saveResponse = page.waitForResponse('**/api/save');
+    await page.keyboard.press(`${modifier}+s`);
+    await saveResponse;
+
+    await expect(page.getByText('Saved')).toBeVisible();
+  });
+
+  test('no keyboard traps in form navigation', async ({ page }) => {
+    await page.goto('/complex-form');
+
+    // Tab through every field — focus should never get stuck
+    const interactiveElements = page.locator(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const count = await interactiveElements.count();
+
+    for (let i = 0; i < count; i++) {
+      await page.keyboard.press('Tab');
+      // Verify something is focused (focus did not get trapped or lost)
+      const focused = page.locator(':focus');
+      await expect(focused).toBeAttached();
+    }
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('keyboard navigation', () => {
+  test('tab order follows logical reading order', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Email')).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Password')).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('link', { name: 'Forgot password?' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeFocused();
+  });
+
+  test('dropdown menu operates with keyboard', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const menuButton = page.getByRole('button', { name: 'User menu' });
+    await menuButton.focus();
+
+    await page.keyboard.press('Enter');
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Profile' })).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(menuButton).toBeFocused();
+  });
+
+  test('no keyboard traps in form navigation', async ({ page }) => {
+    await page.goto('/complex-form');
+
+    const interactiveElements = page.locator(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const count = await interactiveElements.count();
+
+    for (let i = 0; i < count; i++) {
+      await page.keyboard.press('Tab');
+      const focused = page.locator(':focus');
+      await expect(focused).toBeAttached();
+    }
+  });
+});
+```
+
+### Screen Reader Testing Patterns
+
+**Use when**: Verifying that ARIA attributes, live regions, and roles produce the correct accessible experience. You cannot run a real screen reader in CI, but you can verify the semantic structure that screen readers depend on.
+**Avoid when**: You want to test actual screen reader output (use manual testing with NVDA/VoiceOver for that).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('screen reader semantics', () => {
+  test('ARIA labels provide meaningful context', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // Navigation landmarks must have distinct labels
+    const mainNav = page.getByRole('navigation', { name: 'Main' });
+    const footerNav = page.getByRole('navigation', { name: 'Footer' });
+    await expect(mainNav).toBeVisible();
+    await expect(footerNav).toBeVisible();
+
+    // Regions should have accessible names
+    const mainRegion = page.getByRole('main');
+    await expect(mainRegion).toBeAttached();
+
+    // Buttons with icons must have accessible names
+    const closeButton = page.getByRole('button', { name: 'Close' });
+    await expect(closeButton).toBeAttached();
+
+    // Images must have alt text (getByRole('img') only matches with accessible name)
+    const logo = page.getByRole('img', { name: 'Company logo' });
+    await expect(logo).toBeVisible();
+  });
+
+  test('live regions announce dynamic content changes', async ({ page }) => {
+    await page.goto('/notifications');
+
+    // Verify the live region exists before triggering content
+    const statusRegion = page.locator('[aria-live="polite"]');
+    await expect(statusRegion).toBeAttached();
+
+    // Trigger an action that updates the live region
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Verify the live region received the update
+    await expect(statusRegion).toHaveText('Changes saved successfully');
+  });
+
+  test('alert live region announces errors immediately', async ({ page }) => {
+    await page.goto('/checkout');
+
+    // aria-live="assertive" or role="alert" interrupts the screen reader
+    await page.getByRole('button', { name: 'Place order' }).click();
+
+    const alert = page.getByRole('alert');
+    await expect(alert).toBeVisible();
+    await expect(alert).toHaveText('Payment method is required');
+  });
+
+  test('expandable sections announce their state', async ({ page }) => {
+    await page.goto('/faq');
+
+    const faqButton = page.getByRole('button', { name: 'How do I reset my password?' });
+
+    // aria-expanded should reflect the current state
+    await expect(faqButton).toHaveAttribute('aria-expanded', 'false');
+
+    await faqButton.click();
+    await expect(faqButton).toHaveAttribute('aria-expanded', 'true');
+
+    // The controlled panel should be visible
+    const panel = page.locator(`#${await faqButton.getAttribute('aria-controls')}`);
+    await expect(panel).toBeVisible();
+  });
+
+  test('page headings form a logical hierarchy', async ({ page }) => {
+    await page.goto('/about');
+
+    // There should be exactly one h1
+    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
+
+    // Heading levels should not skip (h1 -> h3 without h2 is a violation)
+    const headings = page.getByRole('heading');
+    const count = await headings.count();
+    let previousLevel = 0;
+
+    for (let i = 0; i < count; i++) {
+      const heading = headings.nth(i);
+      const tagName = await heading.evaluate((el) => el.tagName.toLowerCase());
+      const level = parseInt(tagName.replace('h', ''), 10);
+
+      // Level can go up by 1 or drop to any lower level, but never skip forward
+      if (level > previousLevel + 1 && previousLevel !== 0) {
+        throw new Error(
+          `Heading hierarchy skipped from h${previousLevel} to h${level}: "${await heading.textContent()}"`
+        );
+      }
+      previousLevel = level;
+    }
+  });
+
+  test('table has proper headers and caption', async ({ page }) => {
+    await page.goto('/reports');
+
+    const table = page.getByRole('table', { name: 'Monthly revenue' });
+    await expect(table).toBeVisible();
+
+    // Column headers
+    const columnHeaders = table.getByRole('columnheader');
+    await expect(columnHeaders).toHaveCount(4);
+    await expect(columnHeaders.first()).toHaveText('Month');
+
+    // Row headers (if applicable)
+    const rowHeaders = table.getByRole('rowheader');
+    await expect(rowHeaders.first()).toHaveText('January');
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('screen reader semantics', () => {
+  test('ARIA labels provide meaningful context', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const mainNav = page.getByRole('navigation', { name: 'Main' });
+    const footerNav = page.getByRole('navigation', { name: 'Footer' });
+    await expect(mainNav).toBeVisible();
+    await expect(footerNav).toBeVisible();
+
+    const closeButton = page.getByRole('button', { name: 'Close' });
+    await expect(closeButton).toBeAttached();
+
+    const logo = page.getByRole('img', { name: 'Company logo' });
+    await expect(logo).toBeVisible();
+  });
+
+  test('live regions announce dynamic content changes', async ({ page }) => {
+    await page.goto('/notifications');
+
+    const statusRegion = page.locator('[aria-live="polite"]');
+    await expect(statusRegion).toBeAttached();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(statusRegion).toHaveText('Changes saved successfully');
+  });
+
+  test('expandable sections announce their state', async ({ page }) => {
+    await page.goto('/faq');
+
+    const faqButton = page.getByRole('button', { name: 'How do I reset my password?' });
+    await expect(faqButton).toHaveAttribute('aria-expanded', 'false');
+
+    await faqButton.click();
+    await expect(faqButton).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+```
+
+### Color Contrast Verification
+
+**Use when**: Ensuring text and UI components meet WCAG contrast ratio requirements. axe-core checks contrast automatically, but you may need explicit checks for dynamic themes, dark mode, or brand color changes.
+**Avoid when**: axe-core's built-in contrast rule covers your use case. Only add explicit checks for dynamic color changes axe cannot observe in a single scan.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('color contrast', () => {
+  test('light theme meets contrast requirements', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('dark theme meets contrast requirements', async ({ page }) => {
+    await page.goto('/');
+
+    // Activate dark mode
+    await page.getByRole('button', { name: 'Toggle dark mode' }).click();
+
+    // Wait for theme transition to complete
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('high contrast mode meets AAA contrast requirements', async ({ page }) => {
+    await page.goto('/settings/display');
+    await page.getByRole('checkbox', { name: 'High contrast' }).check();
+
+    // AAA requires 7:1 for normal text, 4.5:1 for large text
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2aaa'])
+      .withRules(['color-contrast'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('focus indicators are visible', async ({ page }) => {
+    await page.goto('/');
+
+    // Tab to an element and verify focus outline has sufficient contrast
+    await page.keyboard.press('Tab');
+    const focusedElement = page.locator(':focus');
+
+    // Verify the outline is not transparent or zero-width
+    const outline = await focusedElement.evaluate((el) => {
+      const styles = window.getComputedStyle(el);
+      return {
+        outlineStyle: styles.outlineStyle,
+        outlineWidth: styles.outlineWidth,
+        outlineColor: styles.outlineColor,
+        boxShadow: styles.boxShadow,
+      };
+    });
+
+    // Focus must be visible — either outline or box-shadow
+    const hasVisibleFocus =
+      (outline.outlineStyle !== 'none' && outline.outlineWidth !== '0px') ||
+      outline.boxShadow !== 'none';
+
+    expect(hasVisibleFocus, 'Focused element must have a visible focus indicator').toBe(true);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+test.describe('color contrast', () => {
+  test('light theme meets contrast requirements', async ({ page }) => {
+    await page.goto('/');
+
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('dark theme meets contrast requirements', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Toggle dark mode' }).click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('focus indicators are visible', async ({ page }) => {
+    await page.goto('/');
+    await page.keyboard.press('Tab');
+    const focusedElement = page.locator(':focus');
+
+    const outline = await focusedElement.evaluate((el) => {
+      const styles = window.getComputedStyle(el);
+      return {
+        outlineStyle: styles.outlineStyle,
+        outlineWidth: styles.outlineWidth,
+        boxShadow: styles.boxShadow,
+      };
+    });
+
+    const hasVisibleFocus =
+      (outline.outlineStyle !== 'none' && outline.outlineWidth !== '0px') ||
+      outline.boxShadow !== 'none';
+
+    expect(hasVisibleFocus, 'Focused element must have a visible focus indicator').toBe(true);
+  });
+});
+```
+
+### Focus Trap Testing
+
+**Use when**: Testing modals, dialogs, dropdown menus, slide-over panels, and any overlay that must trap focus within itself to prevent users from accidentally interacting with background content.
+**Avoid when**: The component does not overlay content (inline expandable sections do not need focus traps).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('focus trap', () => {
+  test('modal traps focus within itself', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Open the modal
+    await page.getByRole('button', { name: 'Delete account' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(dialog).toBeVisible();
+
+    // Focus should move into the dialog automatically
+    const firstFocusable = dialog.getByRole('button', { name: 'Cancel' });
+    await expect(firstFocusable).toBeFocused();
+
+    // Tab should cycle within the dialog
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Delete' })).toBeFocused();
+
+    // Tab again wraps back to the first focusable element
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeFocused();
+
+    // Shift+Tab wraps to the last focusable element
+    await page.keyboard.press('Shift+Tab');
+    await expect(dialog.getByRole('button', { name: 'Delete' })).toBeFocused();
+
+    // Escape closes the dialog
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+
+    // Focus returns to the trigger element
+    await expect(page.getByRole('button', { name: 'Delete account' })).toBeFocused();
+  });
+
+  test('dropdown menu traps focus and returns it on close', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const trigger = page.getByRole('button', { name: 'Actions' });
+    await trigger.click();
+
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    // First menu item receives focus
+    await expect(page.getByRole('menuitem').first()).toBeFocused();
+
+    // ArrowDown moves through items
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem').nth(1)).toBeFocused();
+
+    // Escape closes and returns focus
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+  });
+
+  test('background content is inert when modal is open', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: 'Delete account' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Background content should have aria-hidden="true" or be inert
+    const mainContent = page.locator('main');
+    const isHidden = await mainContent.evaluate((el) => {
+      return el.getAttribute('aria-hidden') === 'true' || el.hasAttribute('inert');
+    });
+
+    expect(isHidden, 'Background content must be hidden from assistive technology').toBe(true);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('focus trap', () => {
+  test('modal traps focus within itself', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: 'Delete account' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(dialog).toBeVisible();
+
+    const firstFocusable = dialog.getByRole('button', { name: 'Cancel' });
+    await expect(firstFocusable).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Delete' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete account' })).toBeFocused();
+  });
+
+  test('background content is inert when modal is open', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: 'Delete account' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const mainContent = page.locator('main');
+    const isHidden = await mainContent.evaluate((el) => {
+      return el.getAttribute('aria-hidden') === 'true' || el.hasAttribute('inert');
+    });
+
+    expect(isHidden, 'Background content must be hidden from assistive technology').toBe(true);
+  });
+});
+```
+
+### Accessible Forms
+
+**Use when**: Testing that forms are usable by assistive technology. Every form field must have an associated label, error messages must be programmatically linked, and required fields must be announced.
+**Avoid when**: Never skip this for any form.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('accessible forms', () => {
+  test('all form fields have associated labels', async ({ page }) => {
+    await page.goto('/register');
+
+    // Every input should be reachable via getByLabel (proves label association)
+    await expect(page.getByLabel('First name')).toBeVisible();
+    await expect(page.getByLabel('Last name')).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+
+    // Run axe to catch any we missed
+    const results = await new AxeBuilder({ page })
+      .include('form')
+      .withRules(['label', 'label-title-only'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('required fields are announced to screen readers', async ({ page }) => {
+    await page.goto('/register');
+
+    // Required fields must have aria-required="true" or the required attribute
+    const emailField = page.getByLabel('Email');
+    const hasRequired = await emailField.evaluate((el) => {
+      return el.hasAttribute('required') || el.getAttribute('aria-required') === 'true';
+    });
+
+    expect(hasRequired, 'Email field must be marked as required').toBe(true);
+  });
+
+  test('error messages are linked to their fields via aria-describedby', async ({ page }) => {
+    await page.goto('/register');
+
+    // Submit empty form to trigger validation
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    // The error message should be visible
+    const errorMessage = page.getByText('Email is required');
+    await expect(errorMessage).toBeVisible();
+
+    // The error must be linked to the field via aria-describedby
+    const emailField = page.getByLabel('Email');
+    const describedBy = await emailField.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    // The id of the error message matches the aria-describedby value
+    const errorId = await errorMessage.getAttribute('id');
+    expect(describedBy).toContain(errorId);
+
+    // The field should also indicate invalid state
+    await expect(emailField).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  test('form error summary is announced and links to fields', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    // Error summary should appear with role="alert" for immediate announcement
+    const errorSummary = page.getByRole('alert');
+    await expect(errorSummary).toBeVisible();
+    await expect(errorSummary).toContainText('Please fix the following errors');
+
+    // Error summary links should move focus to the corresponding field
+    await errorSummary.getByRole('link', { name: 'Email is required' }).click();
+    await expect(page.getByLabel('Email')).toBeFocused();
+  });
+
+  test('autocomplete attributes are set for common fields', async ({ page }) => {
+    await page.goto('/checkout');
+
+    // Autocomplete helps password managers and assistive tech fill forms
+    await expect(page.getByLabel('Full name')).toHaveAttribute('autocomplete', 'name');
+    await expect(page.getByLabel('Email')).toHaveAttribute('autocomplete', 'email');
+    await expect(page.getByLabel('Street address')).toHaveAttribute('autocomplete', 'street-address');
+    await expect(page.getByLabel('Postal code')).toHaveAttribute('autocomplete', 'postal-code');
+  });
+
+  test('fieldsets group related fields with legends', async ({ page }) => {
+    await page.goto('/checkout');
+
+    // Related fields should be grouped in fieldsets with legends
+    const shippingGroup = page.getByRole('group', { name: 'Shipping address' });
+    await expect(shippingGroup).toBeVisible();
+    await expect(shippingGroup.getByLabel('Street address')).toBeVisible();
+
+    const billingGroup = page.getByRole('group', { name: 'Billing address' });
+    await expect(billingGroup).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+test.describe('accessible forms', () => {
+  test('all form fields have associated labels', async ({ page }) => {
+    await page.goto('/register');
+
+    await expect(page.getByLabel('First name')).toBeVisible();
+    await expect(page.getByLabel('Last name')).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .include('form')
+      .withRules(['label', 'label-title-only'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('error messages are linked to their fields via aria-describedby', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    const errorMessage = page.getByText('Email is required');
+    await expect(errorMessage).toBeVisible();
+
+    const emailField = page.getByLabel('Email');
+    const describedBy = await emailField.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const errorId = await errorMessage.getAttribute('id');
+    expect(describedBy).toContain(errorId);
+
+    await expect(emailField).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  test('autocomplete attributes are set for common fields', async ({ page }) => {
+    await page.goto('/checkout');
+
+    await expect(page.getByLabel('Full name')).toHaveAttribute('autocomplete', 'name');
+    await expect(page.getByLabel('Email')).toHaveAttribute('autocomplete', 'email');
+    await expect(page.getByLabel('Street address')).toHaveAttribute('autocomplete', 'street-address');
+  });
+});
+```
+
+### Accessibility in CI
+
+**Use when**: You want accessibility violations to fail builds, preventing regressions from reaching production. Every team should gate their CI pipeline on accessibility.
+**Avoid when**: Never. If you only run accessibility checks locally, they will be skipped.
+
+**TypeScript**
+```typescript
+// playwright.config.ts — dedicated accessibility project
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'accessibility',
+      testMatch: '**/*.a11y.spec.ts',
+      use: {
+        browserName: 'chromium', // axe-core works best with Chromium
+      },
+    },
+    {
+      name: 'e2e-chromium',
+      testMatch: '**/*.spec.ts',
+      testIgnore: '**/*.a11y.spec.ts',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});
+```
+
+```typescript
+// tests/pages.a11y.spec.ts — scan all critical pages
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const PAGES_TO_SCAN = [
+  { name: 'Home', path: '/' },
+  { name: 'Login', path: '/login' },
+  { name: 'Register', path: '/register' },
+  { name: 'Dashboard', path: '/dashboard' },
+  { name: 'Products', path: '/products' },
+  { name: 'Checkout', path: '/checkout' },
+  { name: 'Contact', path: '/contact' },
+];
+
+for (const { name, path } of PAGES_TO_SCAN) {
+  test(`${name} page (${path}) has no WCAG AA violations`, async ({ page }) => {
+    await page.goto(path);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    // Attach violation details to the test report
+    await test.info().attach('accessibility-scan-results', {
+      body: JSON.stringify(results.violations, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(results.violations).toEqual([]);
+  });
+}
+```
+
+```typescript
+// tests/helpers/a11y-fixture.ts — reusable axe-core fixture
+import { test as base, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+type A11yFixtures = {
+  makeAxeBuilder: () => AxeBuilder;
+};
+
+export const test = base.extend<A11yFixtures>({
+  makeAxeBuilder: async ({ page }, use) => {
+    const makeAxeBuilder = () =>
+      new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
+    await use(makeAxeBuilder);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// tests/dashboard.a11y.spec.ts — using the fixture
+import { test, expect } from './helpers/a11y-fixture';
+
+test('dashboard has no violations after data loads', async ({ page, makeAxeBuilder }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  const results = await makeAxeBuilder().analyze();
+
+  await test.info().attach('a11y-results', {
+    body: JSON.stringify(results.violations, null, 2),
+    contentType: 'application/json',
+  });
+
+  expect(results.violations).toEqual([]);
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    {
+      name: 'accessibility',
+      testMatch: '**/*.a11y.spec.js',
+      use: { browserName: 'chromium' },
+    },
+    {
+      name: 'e2e-chromium',
+      testMatch: '**/*.spec.js',
+      testIgnore: '**/*.a11y.spec.js',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});
+```
+
+```javascript
+// tests/pages.a11y.spec.js
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+const PAGES_TO_SCAN = [
+  { name: 'Home', path: '/' },
+  { name: 'Login', path: '/login' },
+  { name: 'Dashboard', path: '/dashboard' },
+  { name: 'Products', path: '/products' },
+];
+
+for (const { name, path } of PAGES_TO_SCAN) {
+  test(`${name} page (${path}) has no WCAG AA violations`, async ({ page }) => {
+    await page.goto(path);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    await test.info().attach('accessibility-scan-results', {
+      body: JSON.stringify(results.violations, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(results.violations).toEqual([]);
+  });
+}
+```
+
+**GitHub Actions integration:**
+
+```yaml
+# .github/workflows/accessibility.yml
+name: Accessibility Tests
+on: [push, pull_request]
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+
+      - name: Run accessibility tests
+        run: npx playwright test --project=accessibility
+
+      - name: Upload accessibility report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: accessibility-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+## Decision Guide
+
+| What to Check | Automated (axe-core) | Manual (Keyboard/Screen Reader) | Why |
+|---|---|---|---|
+| Missing alt text | Yes | No | axe-core detects this reliably |
+| Color contrast ratios | Yes | No | Computed automatically from CSS |
+| Missing form labels | Yes | No | Detects missing `<label>` and aria associations |
+| Invalid ARIA attributes | Yes | No | Validates against WAI-ARIA spec |
+| Duplicate IDs | Yes | No | DOM analysis |
+| Tab order / logical flow | No | Yes | Requires understanding of page layout and user intent |
+| Focus management in modals | Partial (axe checks `aria-hidden`) | Yes | Focus trapping behavior requires behavioral testing |
+| Screen reader UX quality | No | Yes | Whether announcements are helpful is subjective |
+| Cognitive load / readability | No | Yes | Cannot be automated — requires human judgment |
+| Touch target size (mobile) | Yes (WCAG 2.2) | Yes | axe checks minimum size; real-device feel needs manual testing |
+| Dynamic content announcements | No | Yes | Live region behavior depends on timing and screen reader |
+| Keyboard shortcut conflicts | No | Yes | Requires knowing OS/browser/AT shortcuts |
+| Reading order vs visual order | No | Yes | CSS reordering (flexbox `order`, grid) can break this |
+| Error recovery flow | No | Yes | Whether error guidance is understandable requires human judgment |
+| Video captions / audio descriptions | Partial (checks `<track>`) | Yes | Quality of captions must be verified manually |
+
+**Rule of thumb**: Automate everything axe-core can catch (run it in CI on every page), then spend your manual testing budget on keyboard navigation, focus management, and screen reader announcements for your most critical user flows.
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Only test with axe-core | Catches ~30-40% of WCAG issues. Misses keyboard navigation, focus management, reading order, and UX quality. | Combine axe-core with keyboard navigation tests and periodic manual screen reader audits |
+| Ignore keyboard navigation | ~8% of users rely on keyboard-only navigation. Inaccessible keyboard UX blocks real users. | Test Tab order, Enter/Space activation, Escape to close, and arrow key navigation for every interactive component |
+| Skip focus management in modals | Users Tab into background content behind the modal, lose context, or cannot close the dialog. | Test focus trap, Escape to close, and focus return to trigger element |
+| Test accessibility once | Regressions creep in with every PR. A passing audit today means nothing next sprint. | Run axe-core in CI on every build; schedule quarterly manual audits |
+| Use `tabindex` > 0 | Overrides natural tab order, creating unpredictable navigation. Extremely difficult to maintain. | Use `tabindex="0"` to make elements focusable and `tabindex="-1"` for programmatic focus; never use positive values |
+| Rely on `title` attribute for accessibility | Screen readers handle `title` inconsistently — many ignore it. | Use `aria-label`, `aria-labelledby`, or visible text labels |
+| Add `role="button"` to `<div>` without keyboard support | Creates a "button" that only works with a mouse. Screen reader announces it as a button, but Enter/Space does nothing. | Use `<button>` elements. If you must use a `<div>`, add `tabindex="0"`, `role="button"`, and `keydown` handlers for Enter and Space |
+| Hide content with `display: none` and expect screen readers to read it | `display: none` hides content from everyone, including assistive technology. | Use `.sr-only` / visually-hidden CSS pattern to hide visually while keeping content accessible |
+| Use `aria-label` on non-interactive `<div>` or `<span>` | `aria-label` is ignored on elements without a role. Screen readers will not announce it. | Add an appropriate role (`role="region"`) or use `aria-labelledby` pointing to a visible heading |
+| Test only the happy path | Missing error states, empty states, and loading states that may have different accessibility characteristics. | Test forms with validation errors, empty search results, loading skeletons, and timeout states |
+| Disable `color-contrast` rule permanently | Users with low vision cannot read your content. | Fix the contrast. If migrating, track exceptions with tickets and set a deadline |
+
+## Troubleshooting
+
+### axe-core reports no violations but screen reader experience is poor
+
+**Cause**: axe-core tests the structural HTML/ARIA correctness, not the quality of the user experience. An element can have a technically valid `aria-label` that is unhelpful ("button", "click here", "x").
+
+**Fix**: Audit your most critical flows with a real screen reader (VoiceOver on macOS: Cmd+F5; NVDA on Windows: free download). Listen to the announcements and ask: would a user who cannot see the screen understand what to do?
+
+### "color-contrast" violation on elements that look fine
+
+**Cause**: axe-core computes contrast against the actual background, which may involve overlapping elements, gradients, or background images. The computed background may differ from what you see.
+
+**Fix**:
+- Inspect the element in DevTools: check the computed background color including any overlapping elements.
+- For text on images/gradients, add a semi-transparent background behind the text.
+- If axe reports a false positive (rare), verify with a manual contrast checker and use `disableRules` with a documented justification.
+
+### Focus is lost after a dynamic content change
+
+**Cause**: When an element is removed from the DOM (closing a modal, deleting a list item, navigating a SPA), focus falls back to `<body>`, leaving keyboard users stranded.
+
+**Fix**:
+```typescript
+// After closing a modal, return focus to the trigger
+await page.getByRole('button', { name: 'Close' }).click();
+await expect(page.getByRole('button', { name: 'Open modal' })).toBeFocused();
+
+// After deleting an item, move focus to the next item or a logical landmark
+await page.getByRole('button', { name: 'Delete item 3' }).click();
+await expect(page.getByRole('listitem').nth(2)).toBeFocused(); // next item
+```
+
+### axe-core scan returns incomplete results (not violations)
+
+**Cause**: `results.incomplete` contains checks axe could not determine automatically. These are not failures — they are items that need manual review. Common for color contrast on complex backgrounds.
+
+**Fix**:
+```typescript
+const results = await new AxeBuilder({ page }).analyze();
+
+// Log incomplete checks for manual review
+if (results.incomplete.length > 0) {
+  console.log('Needs manual review:', results.incomplete.map((i) => i.id));
+}
+
+// Still fail on definite violations
+expect(results.violations).toEqual([]);
+```
+
+### Tab order test fails intermittently
+
+**Cause**: Focus behavior depends on the page being fully loaded and interactive. Animations, lazy-loaded content, or auto-focus scripts can interfere.
+
+**Fix**:
+```typescript
+// Wait for the page to be fully interactive before testing tab order
+await page.goto('/login');
+await expect(page.getByLabel('Email')).toBeVisible();
+
+// Click the body first to ensure focus starts from a known position
+await page.locator('body').click();
+
+// Now test tab order
+await page.keyboard.press('Tab');
+await expect(page.getByLabel('Email')).toBeFocused();
+```
+
+## Related
+
+- [core/locators.md](locators.md) — role-based locators align with accessibility best practices
+- [core/forms-and-validation.md](forms-and-validation.md) — form interaction patterns including accessible error handling
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) — CI setup for running accessibility tests
+- [core/i18n-and-localization.md](i18n-and-localization.md) — accessibility considerations for multilingual apps
+- [core/component-testing.md](component-testing.md) — test individual component accessibility in isolation

--- a/engineering-team/playwright skill/core/angular.md
+++ b/engineering-team/playwright skill/core/angular.md
@@ -1,0 +1,1086 @@
+# Testing Angular Apps with Playwright
+
+> **When to use**: Testing Angular applications -- reactive forms, Angular Material components, Angular Router navigation, lazy-loaded modules, signals, observables, and Zone.js-driven change detection. This guide covers E2E testing patterns specific to Angular behavior.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```bash
+# Install Playwright in an Angular project
+npm init playwright@latest
+
+# Run tests with Angular dev server managed by Playwright
+npx playwright test
+
+# Run against a production build (recommended for CI)
+npx playwright test --project=chromium
+
+# Debug a single test
+npx playwright test tests/home.spec.ts --headed --debug
+
+# Generate tests with codegen
+npx playwright codegen http://localhost:4200
+```
+
+## Setup
+
+### Playwright Config for Angular
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npx ng build && npx http-server dist/your-app/browser -p 4200 -s'
+      : 'npx ng serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000, // Angular builds can be slow
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npx ng build && npx http-server dist/your-app/browser -p 4200 -s'
+      : 'npx ng serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+### Angular CLI Integration
+
+Angular projects that previously used Protractor can adopt Playwright as a direct replacement. The test directory conventionally lives at `e2e/` in Angular projects.
+
+```
+your-angular-app/
+  src/
+  e2e/
+    tests/
+      home.spec.ts
+      auth.spec.ts
+      products.spec.ts
+    fixtures/
+      auth.fixture.ts
+  playwright.config.ts
+  angular.json
+  package.json
+```
+
+Add scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "e2e:debug": "playwright test --debug",
+    "e2e:report": "playwright show-report"
+  }
+}
+```
+
+### Environment Configuration
+
+Angular uses `environment.ts` and `environment.prod.ts` for build-time configuration. For test-specific settings, use environment variables passed through the Playwright config.
+
+**TypeScript**
+```typescript
+// playwright.config.ts (excerpt)
+webServer: {
+  command: process.env.CI
+    ? 'npx ng build --configuration=production && npx http-server dist/your-app/browser -p 4200 -s'
+    : 'npx ng serve --configuration=development',
+  url: 'http://localhost:4200',
+  reuseExistingServer: !process.env.CI,
+  timeout: 120_000,
+  env: {
+    NG_APP_API_URL: 'http://localhost:4200/api',
+  },
+},
+```
+
+## Patterns
+
+### Angular-Specific Locator Strategies
+
+**Use when**: Targeting elements in Angular templates. Angular generates specific attribute patterns (`_ngcontent-*`, `_nghost-*`, `ng-reflect-*`) that you must avoid in locators. Always use semantic locators.
+**Avoid when**: You are tempted to use `[_ngcontent-abc123]` or `[ng-reflect-model]` attributes -- they are internal and change on every build.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Angular locator strategies', () => {
+  test('prefer role-based locators over Angular internals', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // GOOD: Role-based locators work with Angular Material and native HTML
+    await page.getByRole('button', { name: 'Create project' }).click();
+    await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible();
+
+    // GOOD: Label-based for form fields
+    await page.getByLabel('Project name').fill('My Project');
+
+    // GOOD: Text-based for non-interactive content
+    await expect(page.getByText('3 projects total')).toBeVisible();
+
+    // BAD (never do this):
+    // page.locator('[_ngcontent-abc]')  -- changes every build
+    // page.locator('[ng-reflect-model]') -- debug attribute, stripped in prod
+    // page.locator('app-dashboard .mat-card') -- component selector + internal class
+  });
+
+  test('use test IDs for complex Angular components', async ({ page }) => {
+    await page.goto('/analytics');
+
+    // Angular components with no semantic role need test IDs
+    const chart = page.getByTestId('revenue-chart');
+    await expect(chart).toBeVisible();
+
+    // Configure the testIdAttribute if your team uses a different attribute
+    // In playwright.config.ts: use: { testIdAttribute: 'data-cy' }
+  });
+
+  test('scope locators within Angular component boundaries', async ({ page }) => {
+    await page.goto('/users');
+
+    // Scope within a table to find specific rows
+    const userTable = page.getByRole('table', { name: 'Users' });
+    const adminRow = userTable.getByRole('row').filter({
+      has: page.getByRole('cell', { name: 'Admin' }),
+    });
+    await adminRow.getByRole('button', { name: 'Edit' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'Edit User' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Angular locator strategies', () => {
+  test('prefer role-based locators over Angular internals', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await page.getByRole('button', { name: 'Create project' }).click();
+    await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible();
+
+    await page.getByLabel('Project name').fill('My Project');
+    await expect(page.getByText('3 projects total')).toBeVisible();
+  });
+
+  test('use test IDs for complex Angular components', async ({ page }) => {
+    await page.goto('/analytics');
+
+    const chart = page.getByTestId('revenue-chart');
+    await expect(chart).toBeVisible();
+  });
+
+  test('scope locators within Angular component boundaries', async ({ page }) => {
+    await page.goto('/users');
+
+    const userTable = page.getByRole('table', { name: 'Users' });
+    const adminRow = userTable.getByRole('row').filter({
+      has: page.getByRole('cell', { name: 'Admin' }),
+    });
+    await adminRow.getByRole('button', { name: 'Edit' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'Edit User' })).toBeVisible();
+  });
+});
+```
+
+### Testing Reactive Forms
+
+**Use when**: Testing Angular reactive forms (`FormGroup`, `FormControl`, `FormArray`). Playwright interacts with the rendered DOM, so reactive forms are transparent -- test the user experience.
+**Avoid when**: Testing form validation logic in isolation -- use Angular TestBed unit tests for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('reactive forms', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/register');
+  });
+
+  test('shows validation errors for invalid inputs', async ({ page }) => {
+    // Touch and blur each field to trigger Angular's touched + dirty validators
+    const emailInput = page.getByLabel('Email');
+    await emailInput.click();
+    await emailInput.blur();
+
+    await expect(page.getByText('Email is required')).toBeVisible();
+
+    await emailInput.fill('not-an-email');
+    await emailInput.blur();
+
+    await expect(page.getByText('Invalid email format')).toBeVisible();
+  });
+
+  test('cross-field validation (password match)', async ({ page }) => {
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('different-password');
+    await page.getByLabel('Confirm password').blur();
+
+    await expect(page.getByText('Passwords do not match')).toBeVisible();
+
+    // Fix the mismatch
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').blur();
+
+    await expect(page.getByText('Passwords do not match')).toBeHidden();
+  });
+
+  test('dynamic FormArray -- add and remove items', async ({ page }) => {
+    await page.goto('/profile/edit');
+
+    // Add a phone number (FormArray push)
+    await page.getByRole('button', { name: 'Add phone number' }).click();
+
+    const phoneInputs = page.getByLabel(/Phone number/);
+    await expect(phoneInputs).toHaveCount(2); // default + new one
+
+    await phoneInputs.nth(1).fill('+1-555-0199');
+
+    // Remove the first phone number
+    await page.getByRole('button', { name: 'Remove phone 1' }).click();
+    await expect(phoneInputs).toHaveCount(1);
+    await expect(phoneInputs.first()).toHaveValue('+1-555-0199');
+  });
+
+  test('submit button disabled when form is invalid', async ({ page }) => {
+    const submitButton = page.getByRole('button', { name: 'Create account' });
+
+    // Form starts invalid -- button should be disabled
+    await expect(submitButton).toBeDisabled();
+
+    // Fill all required fields
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('I agree to the terms').check();
+
+    // Now the form is valid -- button should be enabled
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test('async validator shows loading state', async ({ page }) => {
+    // Slow down the username availability check
+    await page.route('**/api/check-username*', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ available: true }),
+      });
+    });
+
+    await page.getByLabel('Username').fill('janedoe');
+    await page.getByLabel('Username').blur();
+
+    // Async validator fires -- shows a loading indicator
+    await expect(page.getByTestId('username-checking')).toBeVisible();
+
+    // After the check completes
+    await expect(page.getByTestId('username-checking')).toBeHidden();
+    await expect(page.getByText('Username is available')).toBeVisible();
+  });
+
+  test('form submission posts correct data', async ({ page }) => {
+    let submittedData: Record<string, unknown> = {};
+    await page.route('**/api/register', async (route) => {
+      submittedData = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1 }),
+      });
+    });
+
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('I agree to the terms').check();
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    expect(submittedData).toMatchObject({
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+    });
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('reactive forms', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/register');
+  });
+
+  test('shows validation errors for invalid inputs', async ({ page }) => {
+    const emailInput = page.getByLabel('Email');
+    await emailInput.click();
+    await emailInput.blur();
+
+    await expect(page.getByText('Email is required')).toBeVisible();
+
+    await emailInput.fill('not-an-email');
+    await emailInput.blur();
+
+    await expect(page.getByText('Invalid email format')).toBeVisible();
+  });
+
+  test('cross-field validation (password match)', async ({ page }) => {
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('different-password');
+    await page.getByLabel('Confirm password').blur();
+
+    await expect(page.getByText('Passwords do not match')).toBeVisible();
+
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').blur();
+
+    await expect(page.getByText('Passwords do not match')).toBeHidden();
+  });
+
+  test('submit button disabled when form is invalid', async ({ page }) => {
+    const submitButton = page.getByRole('button', { name: 'Create account' });
+
+    await expect(submitButton).toBeDisabled();
+
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('I agree to the terms').check();
+
+    await expect(submitButton).toBeEnabled();
+  });
+});
+```
+
+### Testing Angular Material Components
+
+**Use when**: Testing apps using Angular Material (mat-button, mat-input, mat-select, mat-dialog, mat-table, etc.). Angular Material components use proper ARIA attributes, making them accessible to role-based locators.
+**Avoid when**: Using CSS class selectors like `.mat-mdc-button` or `.mat-option` -- these change between Material versions.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Angular Material components', () => {
+  test('mat-select dropdown', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Angular Material select has role="combobox"
+    await page.getByRole('combobox', { name: 'Theme' }).click();
+
+    // Options appear in a CDK overlay (similar to a portal)
+    await page.getByRole('option', { name: 'Dark' }).click();
+
+    // Verify the selection
+    await expect(page.getByRole('combobox', { name: 'Theme' })).toContainText('Dark');
+  });
+
+  test('mat-autocomplete with type-ahead', async ({ page }) => {
+    await page.goto('/users/new');
+
+    const roleInput = page.getByRole('combobox', { name: 'Role' });
+    await roleInput.fill('adm');
+
+    // Autocomplete suggestions appear in a CDK overlay
+    await expect(page.getByRole('option', { name: 'Admin' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Administrator' })).toBeVisible();
+
+    await page.getByRole('option', { name: 'Admin' }).click();
+    await expect(roleInput).toHaveValue('Admin');
+  });
+
+  test('mat-dialog opens and closes', async ({ page }) => {
+    await page.goto('/projects');
+
+    await page.getByRole('button', { name: 'Delete project' }).first().click();
+
+    // MatDialog renders as a CDK overlay with role="dialog"
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Are you sure?')).toBeVisible();
+
+    // Cancel
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test('mat-table sorting', async ({ page }) => {
+    await page.goto('/users');
+
+    // Click the column header to sort
+    await page.getByRole('columnheader', { name: 'Name' }).click();
+
+    // Verify sort indicator
+    const header = page.getByRole('columnheader', { name: 'Name' });
+    await expect(header).toHaveAttribute('aria-sort', 'ascending');
+
+    // Verify rows are sorted
+    const names = await page.getByRole('cell').filter({
+      has: page.locator('[data-column="name"]'),
+    }).allTextContents();
+    const sortedNames = [...names].sort();
+    expect(names).toEqual(sortedNames);
+
+    // Click again for descending
+    await page.getByRole('columnheader', { name: 'Name' }).click();
+    await expect(header).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  test('mat-paginator controls table pagination', async ({ page }) => {
+    await page.goto('/users');
+
+    await expect(page.getByText('1 - 10 of 50')).toBeVisible();
+
+    // Navigate to next page
+    await page.getByRole('button', { name: 'Next page' }).click();
+    await expect(page.getByText('11 - 20 of 50')).toBeVisible();
+
+    // Change page size
+    await page.getByRole('combobox', { name: 'Items per page' }).click();
+    await page.getByRole('option', { name: '25' }).click();
+    await expect(page.getByText('1 - 25 of 50')).toBeVisible();
+  });
+
+  test('mat-snack-bar notification appears and dismisses', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Snackbar appears at the bottom of the screen
+    await expect(page.getByText('Settings saved successfully')).toBeVisible();
+
+    // Dismiss via action button
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(page.getByText('Settings saved successfully')).toBeHidden();
+  });
+
+  test('mat-stepper wizard flow', async ({ page }) => {
+    await page.goto('/onboarding');
+
+    // Step 1: Personal info
+    await expect(page.getByText('Step 1 of 3')).toBeVisible();
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Step 2: Company info
+    await expect(page.getByText('Step 2 of 3')).toBeVisible();
+    await page.getByLabel('Company').fill('Acme Corp');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Step 3: Review
+    await expect(page.getByText('Step 3 of 3')).toBeVisible();
+    await expect(page.getByText('Jane Doe')).toBeVisible();
+    await expect(page.getByText('Acme Corp')).toBeVisible();
+
+    // Go back to step 1
+    await page.getByRole('button', { name: 'Back' }).click();
+    await page.getByRole('button', { name: 'Back' }).click();
+    await expect(page.getByText('Step 1 of 3')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Angular Material components', () => {
+  test('mat-select dropdown', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('combobox', { name: 'Theme' }).click();
+    await page.getByRole('option', { name: 'Dark' }).click();
+
+    await expect(page.getByRole('combobox', { name: 'Theme' })).toContainText('Dark');
+  });
+
+  test('mat-dialog opens and closes', async ({ page }) => {
+    await page.goto('/projects');
+
+    await page.getByRole('button', { name: 'Delete project' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Are you sure?')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test('mat-table sorting', async ({ page }) => {
+    await page.goto('/users');
+
+    await page.getByRole('columnheader', { name: 'Name' }).click();
+
+    const header = page.getByRole('columnheader', { name: 'Name' });
+    await expect(header).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  test('mat-snack-bar notification appears and dismisses', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Settings saved successfully')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(page.getByText('Settings saved successfully')).toBeHidden();
+  });
+});
+```
+
+### Testing Angular Router Navigation
+
+**Use when**: Testing Angular Router navigation, lazy-loaded routes, route guards, and URL parameter handling.
+**Avoid when**: Testing router configuration in isolation -- use Angular TestBed for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Angular Router navigation', () => {
+  test('lazy-loaded module loads on navigation', async ({ page }) => {
+    await page.goto('/');
+
+    // Navigate to a lazy-loaded route
+    await page.getByRole('link', { name: 'Admin' }).click();
+    await page.waitForURL('/admin');
+
+    // The lazy module loads and renders its component
+    await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
+  });
+
+  test('route guard redirects unauthorized users', async ({ page }) => {
+    // Visit a route protected by AuthGuard (canActivate)
+    await page.goto('/admin/users');
+
+    // Guard should redirect to login
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('route resolver prefetches data before navigation', async ({ page }) => {
+    // Intercept the API call that the resolver makes
+    const resolverPromise = page.waitForResponse('**/api/products/*');
+
+    await page.goto('/products/42');
+
+    // The resolver fetches data before the component renders
+    await resolverPromise;
+
+    // Component renders with pre-fetched data (no loading spinner)
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Product');
+  });
+
+  test('nested router-outlet renders child components', async ({ page }) => {
+    await page.goto('/settings/profile');
+
+    // Parent layout (SettingsComponent with its own router-outlet)
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Settings' })).toBeVisible();
+
+    // Child route (ProfileComponent rendered inside nested router-outlet)
+    await expect(page.getByRole('heading', { name: 'Profile', level: 2 })).toBeVisible();
+
+    // Navigate to sibling child route
+    await page.getByRole('link', { name: 'Security' }).click();
+    await page.waitForURL('/settings/security');
+
+    // Parent persists, child changes
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Security', level: 2 })).toBeVisible();
+  });
+
+  test('route parameters update component state', async ({ page }) => {
+    await page.goto('/users/1');
+    await expect(page.getByRole('heading')).toContainText('User #1');
+
+    // Navigate to a different user via the URL
+    await page.goto('/users/2');
+    await expect(page.getByRole('heading')).toContainText('User #2');
+  });
+
+  test('query parameters drive filter behavior', async ({ page }) => {
+    await page.goto('/products?category=electronics&page=2');
+
+    await expect(page.getByRole('heading', { name: 'Electronics' })).toBeVisible();
+    await expect(page.getByText('Page 2')).toBeVisible();
+  });
+
+  test('browser back navigates through Angular history', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/products/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Angular Router navigation', () => {
+  test('lazy-loaded module loads on navigation', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Admin' }).click();
+    await page.waitForURL('/admin');
+
+    await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
+  });
+
+  test('route guard redirects unauthorized users', async ({ page }) => {
+    await page.goto('/admin/users');
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('nested router-outlet renders child components', async ({ page }) => {
+    await page.goto('/settings/profile');
+
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Profile', level: 2 })).toBeVisible();
+
+    await page.getByRole('link', { name: 'Security' }).click();
+    await page.waitForURL('/settings/security');
+
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Security', level: 2 })).toBeVisible();
+  });
+
+  test('browser back navigates through Angular history', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/products/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+  });
+});
+```
+
+### Testing Lazy-Loaded Modules
+
+**Use when**: Verifying that Angular lazy-loaded feature modules load correctly when the user navigates to their routes. Lazy-loaded modules introduce network requests for JavaScript chunks.
+**Avoid when**: The module is eagerly loaded -- no separate chunk to load.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('lazy-loaded modules', () => {
+  test('lazy module loads without errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+
+    // Navigate to a lazy-loaded route
+    const chunkRequest = page.waitForResponse((response) =>
+      response.url().includes('.js') && response.status() === 200
+    );
+    await page.getByRole('link', { name: 'Reports' }).click();
+    await chunkRequest;
+
+    await page.waitForURL('/reports');
+    await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible();
+
+    // No chunk loading errors
+    const chunkErrors = consoleErrors.filter(
+      (e) => e.includes('ChunkLoadError') || e.includes('Loading chunk')
+    );
+    expect(chunkErrors).toEqual([]);
+  });
+
+  test('preloaded lazy module navigates instantly', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // If preloadingStrategy is configured, the module may already be cached
+    // Navigate and verify it renders without visible delay
+    const startTime = Date.now();
+    await page.getByRole('link', { name: 'Reports' }).click();
+    await page.waitForURL('/reports');
+    await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible();
+    const loadTime = Date.now() - startTime;
+
+    // Preloaded modules should render quickly (not an exact assertion, but a sanity check)
+    expect(loadTime).toBeLessThan(3000);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('lazy-loaded modules', () => {
+  test('lazy module loads without errors', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Reports' }).click();
+    await page.waitForURL('/reports');
+    await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible();
+
+    const chunkErrors = consoleErrors.filter(
+      (e) => e.includes('ChunkLoadError') || e.includes('Loading chunk')
+    );
+    expect(chunkErrors).toEqual([]);
+  });
+});
+```
+
+### Testing Signals and Observables Indirectly
+
+**Use when**: Verifying that Angular signals (`signal()`, `computed()`, `effect()`) and RxJS observables produce correct UI updates. Playwright cannot subscribe to observables or read signals directly -- test through the rendered output.
+**Avoid when**: Testing observable transformation logic in isolation -- use Jasmine/Jest with Angular TestBed for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('signals (tested through UI)', () => {
+  test('signal-based counter updates the DOM', async ({ page }) => {
+    await page.goto('/counter');
+
+    // The counter uses signal() internally
+    await expect(page.getByTestId('count')).toHaveText('0');
+
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await expect(page.getByTestId('count')).toHaveText('1');
+
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await expect(page.getByTestId('count')).toHaveText('3');
+
+    await page.getByRole('button', { name: 'Reset' }).click();
+    await expect(page.getByTestId('count')).toHaveText('0');
+  });
+
+  test('computed signal updates derived values', async ({ page }) => {
+    await page.goto('/cart');
+
+    // Cart total is a computed() signal derived from items
+    await expect(page.getByTestId('cart-total')).toHaveText('$0.00');
+
+    // Add item (updates the items signal, which updates the computed total)
+    await page.goto('/products');
+    await page.getByRole('listitem')
+      .filter({ hasText: '$29.99' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await expect(page.getByTestId('cart-total')).toHaveText('$29.99');
+  });
+});
+
+test.describe('observables (tested through UI)', () => {
+  test('real-time data stream updates the UI', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // The component subscribes to an observable that emits stock prices
+    const priceElement = page.getByTestId('stock-price');
+    await expect(priceElement).toBeVisible();
+
+    // Get the initial value
+    const initialPrice = await priceElement.textContent();
+
+    // Wait for the observable to emit a new value
+    // Use polling assertion instead of waitForTimeout
+    await expect(priceElement).not.toHaveText(initialPrice!, { timeout: 10_000 });
+  });
+
+  test('search with debounceTime observable', async ({ page }) => {
+    await page.goto('/search');
+
+    const apiCalls: string[] = [];
+    await page.route('**/api/search*', async (route) => {
+      apiCalls.push(route.request().url());
+      await route.continue();
+    });
+
+    // Type quickly -- the observable's debounceTime should batch
+    await page.getByRole('textbox', { name: 'Search' }).pressSequentially('angular', {
+      delay: 50,
+    });
+
+    await expect(page.getByRole('listitem')).toHaveCount(5);
+
+    // debounceTime should prevent a request per keystroke
+    expect(apiCalls.length).toBeLessThanOrEqual(2);
+  });
+
+  test('switchMap cancels previous requests on new input', async ({ page }) => {
+    await page.goto('/search');
+
+    // Type one query
+    await page.getByRole('textbox', { name: 'Search' }).fill('first query');
+
+    // Immediately type a different query before results come back
+    await page.getByRole('textbox', { name: 'Search' }).fill('second query');
+
+    // Results should match the second query, not the first
+    await expect(page.getByRole('listitem').first()).toContainText(/second query/i);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('signals (tested through UI)', () => {
+  test('signal-based counter updates the DOM', async ({ page }) => {
+    await page.goto('/counter');
+
+    await expect(page.getByTestId('count')).toHaveText('0');
+
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await expect(page.getByTestId('count')).toHaveText('1');
+
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await expect(page.getByTestId('count')).toHaveText('3');
+
+    await page.getByRole('button', { name: 'Reset' }).click();
+    await expect(page.getByTestId('count')).toHaveText('0');
+  });
+});
+
+test.describe('observables (tested through UI)', () => {
+  test('search with debounceTime observable', async ({ page }) => {
+    await page.goto('/search');
+
+    const apiCalls = [];
+    await page.route('**/api/search*', async (route) => {
+      apiCalls.push(route.request().url());
+      await route.continue();
+    });
+
+    await page.getByRole('textbox', { name: 'Search' }).pressSequentially('angular', {
+      delay: 50,
+    });
+
+    await expect(page.getByRole('listitem')).toHaveCount(5);
+    expect(apiCalls.length).toBeLessThanOrEqual(2);
+  });
+});
+```
+
+## Framework-Specific Tips
+
+### Zone.js Considerations
+
+Angular uses Zone.js to detect async operations and trigger change detection. Playwright does not depend on Zone.js -- it interacts with the DOM directly. However, Zone.js can affect test behavior:
+
+1. **Change detection timing**: After user interactions (click, fill), Angular schedules change detection via Zone.js. Playwright's auto-waiting handles this -- `expect(locator).toHaveText('new value')` retries until the DOM updates.
+
+2. **Zoneless Angular (experimental)**: Angular 17+ supports zoneless change detection. Tests work identically with Playwright because Playwright waits for DOM changes, not Zone.js ticks.
+
+3. **Long-running async operations**: If your app has `setInterval` or long-running observables, Zone.js keeps Angular in a "not stable" state. This does not affect Playwright (unlike Protractor, which waited for Angular stability). Playwright simply interacts with whatever is on the screen.
+
+### Protractor to Playwright Migration Checklist
+
+| Protractor | Playwright Equivalent |
+|---|---|
+| `element(by.css('.btn'))` | `page.locator('.btn')` -- but prefer `page.getByRole('button', { name: '...' })` |
+| `element(by.id('login'))` | `page.getByTestId('login')` or `page.getByRole(...)` |
+| `element(by.buttonText('Submit'))` | `page.getByRole('button', { name: 'Submit' })` |
+| `element(by.model('user.name'))` | `page.getByLabel('Name')` -- Playwright cannot read ng-model |
+| `element(by.binding('user.name'))` | `page.getByText(expectedValue)` -- test the rendered output |
+| `element(by.repeater('item in items'))` | `page.getByRole('listitem')` or `page.getByTestId(...)` |
+| `browser.waitForAngular()` | Not needed -- Playwright auto-waits; remove all instances |
+| `browser.sleep(3000)` | `await expect(locator).toBeVisible()` -- never use arbitrary waits |
+| `browser.get('/path')` | `await page.goto('/path')` |
+| `protractor.ExpectedConditions` | `await expect(locator).toBeVisible/toBeHidden/toHaveText(...)` |
+
+### Angular Build Configurations
+
+| Scenario | Build Command | Notes |
+|---|---|---|
+| Local development | `npx ng serve` | Fast rebuild, source maps, no optimization |
+| CI (production build) | `npx ng build && npx http-server dist/your-app/browser -p 4200 -s` | Tests the real production bundle |
+| CI (SSR/Universal) | `npx ng build --ssr && node dist/your-app/server/server.mjs` | Tests server-side rendered Angular |
+| Staging environment | No `webServer` needed | Point `baseURL` to the staging URL |
+
+The `-s` flag on `http-server` enables SPA fallback (sends `index.html` for all routes), which is essential for Angular Router to work correctly.
+
+### CDK Overlay Container
+
+Angular Material and Angular CDK render overlays (dialogs, menus, selects, autocompletes) in a special container outside the component tree. Playwright sees these overlays in the document -- no special handling is needed. Use standard role-based locators:
+
+```typescript
+// CDK overlays render into <div class="cdk-overlay-container"> at the body level
+// Playwright sees them as regular DOM elements
+const dialog = page.getByRole('dialog');
+const menu = page.getByRole('menu');
+const listbox = page.getByRole('listbox');
+```
+
+### Testing with Angular SSR (Universal)
+
+If your Angular app uses server-side rendering:
+
+```typescript
+// playwright.config.ts (SSR-specific)
+webServer: {
+  command: process.env.CI
+    ? 'npx ng build --ssr && node dist/your-app/server/server.mjs'
+    : 'npx ng serve --ssr',
+  url: 'http://localhost:4200',
+  reuseExistingServer: !process.env.CI,
+  timeout: 180_000, // SSR builds are slower
+},
+```
+
+Test for hydration issues the same way as with other SSR frameworks:
+
+```typescript
+test('no hydration errors after SSR', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && msg.text().includes('hydration')) {
+      errors.push(msg.text());
+    }
+  });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Get started' }).click();
+
+  expect(errors).toEqual([]);
+});
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.locator('[_ngcontent-abc123]')` | Angular scoped style attributes are random and change every build | Use `getByRole`, `getByLabel`, `getByText`, `getByTestId` |
+| `page.locator('[ng-reflect-model="value"]')` | `ng-reflect-*` attributes only exist in dev mode; stripped in production | Test the rendered value: `expect(input).toHaveValue('value')` |
+| `page.locator('app-my-component')` | Angular component selectors are implementation details | Target the content the component renders using semantic locators |
+| `page.locator('.mat-mdc-button')` | Angular Material class names change between versions (MDC migration) | `page.getByRole('button', { name: 'Submit' })` |
+| `page.evaluate(() => (window as any).ng)` to access Angular internals | Depends on debug mode; not available in production builds | Test through the DOM; never access the Angular runtime |
+| `await page.waitForTimeout(500)` after clicking a button | Zone.js change detection timing varies; arbitrary waits are fragile | `await expect(locator).toHaveText('expected value')` auto-retries |
+| `browser.waitForAngular()` (Protractor pattern) | Does not exist in Playwright; not needed -- Playwright auto-waits | Remove entirely; use web-first assertions |
+| Test Angular services by injecting them via `page.evaluate` | Services are not accessible from the browser console in production | Test services indirectly through the UI they power; unit test with TestBed |
+| Use `ng serve` in CI | Development server is slower, includes debug code, may hide production-only bugs | Use `ng build && http-server` in CI |
+| Skip testing CDK overlay components (dialogs, selects, menus) | These are the most interactive parts of the app; bugs here are highly visible | Test overlays with role-based locators; they render in the regular DOM |
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategies for Angular Material and CDK components
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-waiting assertions that replace Protractor's waitForAngular
+- [core/forms-and-validation.md](forms-and-validation.md) -- form testing patterns for reactive and template-driven forms
+- [core/accessibility.md](accessibility.md) -- accessibility testing for Angular Material components
+- [core/authentication.md](authentication.md) -- authentication with Angular route guards
+- [migration/from-selenium.md](../migration/from-selenium.md) -- migration patterns applicable to Protractor (Protractor is built on Selenium)
+- [core/test-architecture.md](test-architecture.md) -- when to use E2E vs unit tests with Angular TestBed
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI setup with Angular build caching

--- a/engineering-team/playwright skill/core/api-testing.md
+++ b/engineering-team/playwright skill/core/api-testing.md
@@ -1,0 +1,1617 @@
+# API Testing
+
+> **When to use**: Testing REST or GraphQL APIs directly — validating endpoints, seeding test data, or verifying backend behavior without browser overhead.
+> **Prerequisites**: [core/configuration.md](configuration.md) for `baseURL` setup, [core/fixtures-and-hooks.md](fixtures-and-hooks.md) for custom fixture patterns.
+
+## Quick Reference
+
+```typescript
+// Standalone API test — no browser launched
+import { test, expect } from '@playwright/test';
+
+test('GET /api/users returns user list', async ({ request }) => {
+  const response = await request.get('/api/users');
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']).toContain('application/json');
+  const body = await response.json();
+  expect(body.users).toHaveLength(3);
+  expect(body.users[0]).toMatchObject({ id: expect.any(Number), email: expect.any(String) });
+});
+```
+
+## Patterns
+
+### APIRequestContext Basics
+
+**Use when**: Making HTTP requests in any test — GET, POST, PUT, PATCH, DELETE with headers, query params, and request bodies.
+**Avoid when**: You need to test browser-rendered responses (redirects, cookies set via `Set-Cookie` with `HttpOnly`). Use a browser test instead.
+
+The `request` fixture provides a pre-configured `APIRequestContext` that inherits `baseURL` from your config. No browser is launched.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('CRUD operations via API', async ({ request }) => {
+  // GET with query parameters
+  const listResponse = await request.get('/api/users', {
+    params: { page: 1, limit: 10, role: 'admin' },
+  });
+  expect(listResponse.ok()).toBeTruthy();
+
+  // POST with JSON body
+  const createResponse = await request.post('/api/users', {
+    data: {
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      role: 'editor',
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = await createResponse.json();
+
+  // PUT — full replacement
+  const updateResponse = await request.put(`/api/users/${created.id}`, {
+    data: {
+      name: 'Jane Smith',
+      email: 'jane.smith@example.com',
+      role: 'editor',
+    },
+  });
+  expect(updateResponse.ok()).toBeTruthy();
+
+  // PATCH — partial update
+  const patchResponse = await request.patch(`/api/users/${created.id}`, {
+    data: { role: 'admin' },
+  });
+  expect(patchResponse.ok()).toBeTruthy();
+  const patched = await patchResponse.json();
+  expect(patched.role).toBe('admin');
+
+  // DELETE
+  const deleteResponse = await request.delete(`/api/users/${created.id}`);
+  expect(deleteResponse.status()).toBe(204);
+
+  // Verify deletion
+  const getDeleted = await request.get(`/api/users/${created.id}`);
+  expect(getDeleted.status()).toBe(404);
+});
+
+test('custom headers and auth tokens', async ({ request }) => {
+  const response = await request.get('/api/protected/resource', {
+    headers: {
+      'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIs...',
+      'X-Request-ID': 'test-correlation-id-123',
+      'Accept': 'application/json',
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+});
+
+test('form-urlencoded body', async ({ request }) => {
+  const response = await request.post('/api/oauth/token', {
+    form: {
+      grant_type: 'client_credentials',
+      client_id: 'my-app',
+      client_secret: 'secret-value',
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const token = await response.json();
+  expect(token).toHaveProperty('access_token');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('CRUD operations via API', async ({ request }) => {
+  const listResponse = await request.get('/api/users', {
+    params: { page: 1, limit: 10, role: 'admin' },
+  });
+  expect(listResponse.ok()).toBeTruthy();
+
+  const createResponse = await request.post('/api/users', {
+    data: {
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      role: 'editor',
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = await createResponse.json();
+
+  const updateResponse = await request.put(`/api/users/${created.id}`, {
+    data: {
+      name: 'Jane Smith',
+      email: 'jane.smith@example.com',
+      role: 'editor',
+    },
+  });
+  expect(updateResponse.ok()).toBeTruthy();
+
+  const patchResponse = await request.patch(`/api/users/${created.id}`, {
+    data: { role: 'admin' },
+  });
+  expect(patchResponse.ok()).toBeTruthy();
+
+  const deleteResponse = await request.delete(`/api/users/${created.id}`);
+  expect(deleteResponse.status()).toBe(204);
+});
+
+test('form-urlencoded body', async ({ request }) => {
+  const response = await request.post('/api/oauth/token', {
+    form: {
+      grant_type: 'client_credentials',
+      client_id: 'my-app',
+      client_secret: 'secret-value',
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const token = await response.json();
+  expect(token).toHaveProperty('access_token');
+});
+```
+
+### API Test Structure
+
+**Use when**: Writing dedicated API test suites that do not need a browser.
+**Avoid when**: You need to assert on UI state after an API call — use a combined test with `page` and `request` fixtures.
+
+Structure API tests in their own directory with descriptive `describe` blocks per resource or domain.
+
+**TypeScript**
+```typescript
+// tests/api/users.spec.ts
+import { test, expect } from '@playwright/test';
+
+// No browser is launched — these tests use only the request fixture
+test.describe('Users API', () => {
+  test.describe('GET /api/users', () => {
+    test('returns paginated user list', async ({ request }) => {
+      const response = await request.get('/api/users', {
+        params: { page: 1, limit: 5 },
+      });
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body.users.length).toBeLessThanOrEqual(5);
+      expect(body.pagination).toMatchObject({
+        page: 1,
+        limit: 5,
+        total: expect.any(Number),
+      });
+    });
+
+    test('filters by role', async ({ request }) => {
+      const response = await request.get('/api/users', {
+        params: { role: 'admin' },
+      });
+      const body = await response.json();
+      for (const user of body.users) {
+        expect(user.role).toBe('admin');
+      }
+    });
+  });
+
+  test.describe('POST /api/users', () => {
+    test('creates a new user with valid data', async ({ request }) => {
+      const response = await request.post('/api/users', {
+        data: { name: 'Test User', email: `test-${Date.now()}@example.com` },
+      });
+      expect(response.status()).toBe(201);
+      const user = await response.json();
+      expect(user).toMatchObject({
+        id: expect.any(Number),
+        name: 'Test User',
+      });
+    });
+
+    test('rejects duplicate email', async ({ request }) => {
+      const email = `dupe-${Date.now()}@example.com`;
+      await request.post('/api/users', { data: { name: 'First', email } });
+
+      const response = await request.post('/api/users', {
+        data: { name: 'Second', email },
+      });
+      expect(response.status()).toBe(409);
+      const body = await response.json();
+      expect(body.error).toContain('already exists');
+    });
+  });
+});
+```
+
+**JavaScript**
+```javascript
+// tests/api/users.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe('Users API', () => {
+  test.describe('GET /api/users', () => {
+    test('returns paginated user list', async ({ request }) => {
+      const response = await request.get('/api/users', {
+        params: { page: 1, limit: 5 },
+      });
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body.users.length).toBeLessThanOrEqual(5);
+      expect(body.pagination).toMatchObject({
+        page: 1,
+        limit: 5,
+        total: expect.any(Number),
+      });
+    });
+  });
+
+  test.describe('POST /api/users', () => {
+    test('creates a new user with valid data', async ({ request }) => {
+      const response = await request.post('/api/users', {
+        data: { name: 'Test User', email: `test-${Date.now()}@example.com` },
+      });
+      expect(response.status()).toBe(201);
+      const user = await response.json();
+      expect(user).toMatchObject({
+        id: expect.any(Number),
+        name: 'Test User',
+      });
+    });
+  });
+});
+```
+
+**Config tip**: Use a dedicated project for API tests to avoid launching browsers.
+
+```typescript
+// playwright.config.ts — API project runs without a browser
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'api',
+      testDir: './tests/api',
+      use: {
+        baseURL: 'https://api.example.com',
+        extraHTTPHeaders: {
+          'Accept': 'application/json',
+        },
+      },
+    },
+    {
+      name: 'e2e',
+      testDir: './tests/e2e',
+      use: {
+        baseURL: 'https://app.example.com',
+        browserName: 'chromium',
+      },
+    },
+  ],
+});
+```
+
+### Request Fixtures
+
+**Use when**: Multiple tests need an authenticated API client, or you want to share request configuration (headers, base URL, auth tokens) across a test suite.
+**Avoid when**: A single test makes one-off API calls. Use the built-in `request` fixture directly.
+
+**TypeScript**
+```typescript
+// fixtures/api-fixtures.ts
+import { test as base, expect, APIRequestContext } from '@playwright/test';
+
+type ApiFixtures = {
+  authenticatedRequest: APIRequestContext;
+  adminRequest: APIRequestContext;
+};
+
+export const test = base.extend<ApiFixtures>({
+  authenticatedRequest: async ({ playwright }, use) => {
+    // Create a fresh context with auth headers
+    const context = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+      extraHTTPHeaders: {
+        'Authorization': `Bearer ${process.env.API_TOKEN}`,
+        'Accept': 'application/json',
+      },
+    });
+    await use(context);
+    await context.dispose();
+  },
+
+  adminRequest: async ({ playwright }, use) => {
+    // Login via API to get a token, then create authenticated context
+    const loginContext = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+    });
+    const loginResponse = await loginContext.post('/api/auth/login', {
+      data: {
+        email: process.env.ADMIN_EMAIL,
+        password: process.env.ADMIN_PASSWORD,
+      },
+    });
+    expect(loginResponse.ok()).toBeTruthy();
+    const { token } = await loginResponse.json();
+    await loginContext.dispose();
+
+    const context = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+      extraHTTPHeaders: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+      },
+    });
+    await use(context);
+    await context.dispose();
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// tests/api/admin.spec.ts
+import { test, expect } from '../../fixtures/api-fixtures';
+
+test('admin can list all users', async ({ adminRequest }) => {
+  const response = await adminRequest.get('/api/admin/users');
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.users.length).toBeGreaterThan(0);
+});
+
+test('admin can delete a user', async ({ adminRequest }) => {
+  // Create then delete
+  const createResp = await adminRequest.post('/api/users', {
+    data: { name: 'To Delete', email: `del-${Date.now()}@example.com` },
+  });
+  const { id } = await createResp.json();
+
+  const deleteResp = await adminRequest.delete(`/api/users/${id}`);
+  expect(deleteResp.status()).toBe(204);
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures/api-fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  authenticatedRequest: async ({ playwright }, use) => {
+    const context = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+      extraHTTPHeaders: {
+        'Authorization': `Bearer ${process.env.API_TOKEN}`,
+        'Accept': 'application/json',
+      },
+    });
+    await use(context);
+    await context.dispose();
+  },
+
+  adminRequest: async ({ playwright }, use) => {
+    const loginContext = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+    });
+    const loginResponse = await loginContext.post('/api/auth/login', {
+      data: {
+        email: process.env.ADMIN_EMAIL,
+        password: process.env.ADMIN_PASSWORD,
+      },
+    });
+    expect(loginResponse.ok()).toBeTruthy();
+    const { token } = await loginResponse.json();
+    await loginContext.dispose();
+
+    const context = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+      extraHTTPHeaders: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+      },
+    });
+    await use(context);
+    await context.dispose();
+  },
+});
+
+module.exports = { test, expect };
+```
+
+```javascript
+// tests/api/admin.spec.js
+const { test, expect } = require('../../fixtures/api-fixtures');
+
+test('admin can list all users', async ({ adminRequest }) => {
+  const response = await adminRequest.get('/api/admin/users');
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.users.length).toBeGreaterThan(0);
+});
+```
+
+### JSON Response Assertions
+
+**Use when**: Validating response status, headers, and body structure after every API call.
+**Avoid when**: Never skip these. Every API test should assert on status and body.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('thorough response validation', async ({ request }) => {
+  const response = await request.get('/api/users/42');
+
+  // Status code — always check first
+  expect(response.status()).toBe(200);
+
+  // Status category — ok() checks 200-299 range
+  expect(response.ok()).toBeTruthy();
+
+  // Response headers
+  expect(response.headers()['content-type']).toContain('application/json');
+  expect(response.headers()['x-request-id']).toBeDefined();
+  expect(response.headers()['cache-control']).toMatch(/max-age=\d+/);
+
+  // Full body parse and deep assertion
+  const user = await response.json();
+
+  // Exact match on known fields
+  expect(user.id).toBe(42);
+  expect(user.name).toBe('Jane Doe');
+  expect(user.email).toBe('jane@example.com');
+
+  // Partial match — ignore fields you don't care about
+  expect(user).toMatchObject({
+    id: 42,
+    name: 'Jane Doe',
+    role: expect.stringMatching(/^(admin|editor|viewer)$/),
+  });
+
+  // Type checks with expect.any()
+  expect(user).toMatchObject({
+    id: expect.any(Number),
+    name: expect.any(String),
+    createdAt: expect.any(String),
+    permissions: expect.any(Array),
+  });
+
+  // Array content
+  expect(user.permissions).toEqual(
+    expect.arrayContaining(['read', 'write'])
+  );
+  expect(user.permissions).not.toContain('delete');
+
+  // Nested object assertions
+  expect(user.profile).toMatchObject({
+    avatar: expect.stringMatching(/^https:\/\//),
+    bio: expect.any(String),
+  });
+
+  // Date format validation
+  expect(new Date(user.createdAt).toISOString()).toBe(user.createdAt);
+});
+
+test('list response structure', async ({ request }) => {
+  const response = await request.get('/api/users');
+  const body = await response.json();
+
+  // Array length
+  expect(body.users).toHaveLength(10);
+
+  // Every item in array matches shape
+  for (const user of body.users) {
+    expect(user).toMatchObject({
+      id: expect.any(Number),
+      name: expect.any(String),
+      email: expect.stringContaining('@'),
+    });
+  }
+
+  // Pagination metadata
+  expect(body.pagination).toEqual({
+    page: 1,
+    limit: 10,
+    total: expect.any(Number),
+    totalPages: expect.any(Number),
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('thorough response validation', async ({ request }) => {
+  const response = await request.get('/api/users/42');
+
+  expect(response.status()).toBe(200);
+  expect(response.ok()).toBeTruthy();
+  expect(response.headers()['content-type']).toContain('application/json');
+
+  const user = await response.json();
+
+  expect(user).toMatchObject({
+    id: 42,
+    name: 'Jane Doe',
+    role: expect.stringMatching(/^(admin|editor|viewer)$/),
+  });
+
+  expect(user).toMatchObject({
+    id: expect.any(Number),
+    name: expect.any(String),
+    createdAt: expect.any(String),
+    permissions: expect.any(Array),
+  });
+
+  expect(user.permissions).toEqual(
+    expect.arrayContaining(['read', 'write'])
+  );
+});
+
+test('list response structure', async ({ request }) => {
+  const response = await request.get('/api/users');
+  const body = await response.json();
+
+  expect(body.users).toHaveLength(10);
+  for (const user of body.users) {
+    expect(user).toMatchObject({
+      id: expect.any(Number),
+      name: expect.any(String),
+      email: expect.stringContaining('@'),
+    });
+  }
+});
+```
+
+### GraphQL Testing
+
+**Use when**: Your backend exposes a GraphQL API and you want to test queries, mutations, variables, and error handling.
+**Avoid when**: Your API is purely REST. Use the standard HTTP methods instead.
+
+All GraphQL requests go through `POST` to a single endpoint. Send `query`, `variables`, and optionally `operationName` in the JSON body.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const GRAPHQL_ENDPOINT = '/graphql';
+
+test.describe('GraphQL API', () => {
+  test('query with variables', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          query GetUser($id: ID!) {
+            user(id: $id) {
+              id
+              name
+              email
+              posts {
+                id
+                title
+              }
+            }
+          }
+        `,
+        variables: { id: '42' },
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const { data, errors } = await response.json();
+
+    // GraphQL returns 200 even on errors — always check both
+    expect(errors).toBeUndefined();
+    expect(data.user).toMatchObject({
+      id: '42',
+      name: expect.any(String),
+      email: expect.stringContaining('@'),
+    });
+    expect(data.user.posts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(String), title: expect.any(String) }),
+      ])
+    );
+  });
+
+  test('mutation creates a resource', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          mutation CreatePost($input: CreatePostInput!) {
+            createPost(input: $input) {
+              id
+              title
+              status
+              author {
+                id
+              }
+            }
+          }
+        `,
+        variables: {
+          input: {
+            title: 'API Testing with Playwright',
+            body: 'A comprehensive guide...',
+            status: 'DRAFT',
+          },
+        },
+      },
+    });
+
+    const { data, errors } = await response.json();
+    expect(errors).toBeUndefined();
+    expect(data.createPost).toMatchObject({
+      id: expect.any(String),
+      title: 'API Testing with Playwright',
+      status: 'DRAFT',
+    });
+  });
+
+  test('handles GraphQL validation errors', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          mutation CreatePost($input: CreatePostInput!) {
+            createPost(input: $input) {
+              id
+            }
+          }
+        `,
+        variables: {
+          input: { title: '' }, // invalid: empty title
+        },
+      },
+    });
+
+    // GraphQL often returns 200 even for validation errors
+    const { data, errors } = await response.json();
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain('title');
+    expect(errors[0].extensions?.code).toBe('BAD_USER_INPUT');
+  });
+
+  test('handles authorization errors', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          query AdminDashboard {
+            adminStats {
+              totalRevenue
+              activeUsers
+            }
+          }
+        `,
+      },
+      // No auth header
+    });
+
+    const { data, errors } = await response.json();
+    expect(errors).toBeDefined();
+    expect(errors[0].extensions?.code).toBe('UNAUTHORIZED');
+    expect(data?.adminStats).toBeNull();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const GRAPHQL_ENDPOINT = '/graphql';
+
+test.describe('GraphQL API', () => {
+  test('query with variables', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          query GetUser($id: ID!) {
+            user(id: $id) {
+              id
+              name
+              email
+            }
+          }
+        `,
+        variables: { id: '42' },
+      },
+    });
+
+    const { data, errors } = await response.json();
+    expect(errors).toBeUndefined();
+    expect(data.user).toMatchObject({
+      id: '42',
+      name: expect.any(String),
+      email: expect.stringContaining('@'),
+    });
+  });
+
+  test('mutation creates a resource', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          mutation CreatePost($input: CreatePostInput!) {
+            createPost(input: $input) {
+              id
+              title
+              status
+            }
+          }
+        `,
+        variables: {
+          input: {
+            title: 'API Testing with Playwright',
+            body: 'A comprehensive guide...',
+            status: 'DRAFT',
+          },
+        },
+      },
+    });
+
+    const { data, errors } = await response.json();
+    expect(errors).toBeUndefined();
+    expect(data.createPost).toMatchObject({
+      id: expect.any(String),
+      title: 'API Testing with Playwright',
+      status: 'DRAFT',
+    });
+  });
+
+  test('handles GraphQL validation errors', async ({ request }) => {
+    const response = await request.post(GRAPHQL_ENDPOINT, {
+      data: {
+        query: `
+          mutation CreatePost($input: CreatePostInput!) {
+            createPost(input: $input) { id }
+          }
+        `,
+        variables: { input: { title: '' } },
+      },
+    });
+
+    const { data, errors } = await response.json();
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain('title');
+  });
+});
+```
+
+### API Data Seeding
+
+**Use when**: E2E tests need specific data to exist before running. API seeding is 10-100x faster than UI-based setup.
+**Avoid when**: The test specifically validates the creation flow through the UI. Seed everything *except* what you are testing.
+
+**TypeScript**
+```typescript
+import { test as base, expect, APIRequestContext } from '@playwright/test';
+
+// Fixture that seeds data via API before each test
+type SeedFixtures = {
+  seedUser: { id: number; email: string; password: string };
+  seedProject: { id: number; name: string };
+};
+
+export const test = base.extend<SeedFixtures>({
+  seedUser: async ({ request }, use) => {
+    const email = `user-${Date.now()}@example.com`;
+    const password = 'TestPass123!';
+
+    // Create via API
+    const response = await request.post('/api/users', {
+      data: { name: 'Test User', email, password },
+    });
+    expect(response.ok()).toBeTruthy();
+    const user = await response.json();
+
+    // Pass to test
+    await use({ id: user.id, email, password });
+
+    // Cleanup after test — always delete what you created
+    await request.delete(`/api/users/${user.id}`);
+  },
+
+  seedProject: async ({ request, seedUser }, use) => {
+    const response = await request.post('/api/projects', {
+      data: { name: `Test Project ${Date.now()}`, ownerId: seedUser.id },
+    });
+    expect(response.ok()).toBeTruthy();
+    const project = await response.json();
+
+    await use({ id: project.id, name: project.name });
+
+    await request.delete(`/api/projects/${project.id}`);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// tests/e2e/project-dashboard.spec.ts
+import { test, expect } from '../../fixtures/seed-fixtures';
+
+test('user sees their project on dashboard', async ({ page, seedUser, seedProject }) => {
+  // Login via UI (or use storageState for speed)
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(seedUser.email);
+  await page.getByLabel('Password').fill(seedUser.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Data already exists — go straight to assertion
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: seedProject.name })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures/seed-fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  seedUser: async ({ request }, use) => {
+    const email = `user-${Date.now()}@example.com`;
+    const password = 'TestPass123!';
+
+    const response = await request.post('/api/users', {
+      data: { name: 'Test User', email, password },
+    });
+    expect(response.ok()).toBeTruthy();
+    const user = await response.json();
+
+    await use({ id: user.id, email, password });
+
+    await request.delete(`/api/users/${user.id}`);
+  },
+
+  seedProject: async ({ request, seedUser }, use) => {
+    const response = await request.post('/api/projects', {
+      data: { name: `Test Project ${Date.now()}`, ownerId: seedUser.id },
+    });
+    expect(response.ok()).toBeTruthy();
+    const project = await response.json();
+
+    await use({ id: project.id, name: project.name });
+
+    await request.delete(`/api/projects/${project.id}`);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+```javascript
+// tests/e2e/project-dashboard.spec.js
+const { test, expect } = require('../../fixtures/seed-fixtures');
+
+test('user sees their project on dashboard', async ({ page, seedUser, seedProject }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(seedUser.email);
+  await page.getByLabel('Password').fill(seedUser.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: seedProject.name })).toBeVisible();
+});
+```
+
+### Schema Validation
+
+**Use when**: Verifying that API responses match a contract — field types, required fields, value constraints. Catches backend regressions early.
+**Avoid when**: You only need to check one or two specific fields. Use `toMatchObject` instead.
+
+#### Option A: Zod (recommended for TypeScript projects)
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import { z } from 'zod';
+
+// Define schemas once, reuse across tests
+const UserSchema = z.object({
+  id: z.number().positive(),
+  name: z.string().min(1),
+  email: z.string().email(),
+  role: z.enum(['admin', 'editor', 'viewer']),
+  createdAt: z.string().datetime(),
+  profile: z.object({
+    avatar: z.string().url().nullable(),
+    bio: z.string().max(500),
+  }),
+});
+
+const PaginatedUsersSchema = z.object({
+  users: z.array(UserSchema),
+  pagination: z.object({
+    page: z.number().int().positive(),
+    limit: z.number().int().positive(),
+    total: z.number().int().nonnegative(),
+  }),
+});
+
+test('GET /api/users matches schema', async ({ request }) => {
+  const response = await request.get('/api/users');
+  expect(response.ok()).toBeTruthy();
+
+  const body = await response.json();
+  const result = PaginatedUsersSchema.safeParse(body);
+
+  if (!result.success) {
+    // Detailed error output showing exactly which fields failed
+    throw new Error(
+      `Schema validation failed:\n${result.error.issues
+        .map((i) => `  ${i.path.join('.')}: ${i.message}`)
+        .join('\n')}`
+    );
+  }
+});
+
+test('POST /api/users returns valid user', async ({ request }) => {
+  const response = await request.post('/api/users', {
+    data: { name: 'Schema Test', email: `schema-${Date.now()}@example.com` },
+  });
+
+  const body = await response.json();
+  // Throws with detailed path info if validation fails
+  UserSchema.parse(body);
+});
+```
+
+#### Option B: Manual type checks (no dependencies)
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+function assertUserShape(user: unknown): void {
+  expect(user).toBeDefined();
+  expect(user).toMatchObject({
+    id: expect.any(Number),
+    name: expect.any(String),
+    email: expect.any(String),
+    role: expect.any(String),
+    createdAt: expect.any(String),
+  });
+
+  const u = user as Record<string, unknown>;
+  // Value constraints
+  expect(['admin', 'editor', 'viewer']).toContain(u.role);
+  expect(typeof u.email === 'string' && u.email.includes('@')).toBe(true);
+  expect(new Date(u.createdAt as string).toString()).not.toBe('Invalid Date');
+}
+
+test('response matches expected shape', async ({ request }) => {
+  const response = await request.get('/api/users/1');
+  expect(response.ok()).toBeTruthy();
+
+  const body = await response.json();
+  assertUserShape(body);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+function assertUserShape(user) {
+  expect(user).toBeDefined();
+  expect(user).toMatchObject({
+    id: expect.any(Number),
+    name: expect.any(String),
+    email: expect.any(String),
+    role: expect.any(String),
+    createdAt: expect.any(String),
+  });
+  expect(['admin', 'editor', 'viewer']).toContain(user.role);
+  expect(user.email).toContain('@');
+  expect(new Date(user.createdAt).toString()).not.toBe('Invalid Date');
+}
+
+test('response matches expected shape', async ({ request }) => {
+  const response = await request.get('/api/users/1');
+  expect(response.ok()).toBeTruthy();
+
+  const body = await response.json();
+  assertUserShape(body);
+});
+```
+
+### Error Response Testing
+
+**Use when**: Every API has error paths. Test them. A missing 401 test today is a security hole tomorrow.
+**Avoid when**: Never skip error testing.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Error responses', () => {
+  test('400 — validation error with details', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      data: { name: '', email: 'not-an-email' }, // invalid
+    });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: 'Validation Error',
+      details: expect.any(Array),
+    });
+    // Check individual field errors
+    expect(body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'name', message: expect.any(String) }),
+        expect.objectContaining({ field: 'email', message: expect.any(String) }),
+      ])
+    );
+  });
+
+  test('401 — missing authentication', async ({ request }) => {
+    // Create a fresh context with NO auth headers
+    const response = await request.get('/api/protected/resource', {
+      headers: { 'Authorization': '' }, // explicitly clear
+    });
+    expect(response.status()).toBe(401);
+
+    const body = await response.json();
+    expect(body.error).toMatch(/unauthorized|unauthenticated/i);
+  });
+
+  test('403 — insufficient permissions', async ({ request }) => {
+    // Assuming `request` is authenticated as a viewer
+    const response = await request.delete('/api/admin/users/1');
+    expect(response.status()).toBe(403);
+
+    const body = await response.json();
+    expect(body.error).toMatch(/forbidden|insufficient permissions/i);
+  });
+
+  test('404 — resource not found', async ({ request }) => {
+    const response = await request.get('/api/users/999999');
+    expect(response.status()).toBe(404);
+
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: expect.stringMatching(/not found/i),
+    });
+  });
+
+  test('409 — conflict on duplicate resource', async ({ request }) => {
+    const email = `conflict-${Date.now()}@example.com`;
+    await request.post('/api/users', {
+      data: { name: 'First', email },
+    });
+
+    const response = await request.post('/api/users', {
+      data: { name: 'Duplicate', email },
+    });
+    expect(response.status()).toBe(409);
+  });
+
+  test('422 — unprocessable entity', async ({ request }) => {
+    const response = await request.post('/api/orders', {
+      data: { items: [] }, // empty cart
+    });
+    expect(response.status()).toBe(422);
+    const body = await response.json();
+    expect(body.error).toContain('at least one item');
+  });
+
+  test('429 — rate limiting', async ({ request }) => {
+    // Send rapid requests to trigger rate limit
+    const responses = await Promise.all(
+      Array.from({ length: 50 }, () =>
+        request.get('/api/search', { params: { q: 'test' } })
+      )
+    );
+    const rateLimited = responses.filter((r) => r.status() === 429);
+    expect(rateLimited.length).toBeGreaterThan(0);
+
+    // Verify rate limit headers
+    const limited = rateLimited[0];
+    expect(limited.headers()['retry-after']).toBeDefined();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Error responses', () => {
+  test('400 — validation error with details', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      data: { name: '', email: 'not-an-email' },
+    });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: 'Validation Error',
+      details: expect.any(Array),
+    });
+    expect(body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'name', message: expect.any(String) }),
+        expect.objectContaining({ field: 'email', message: expect.any(String) }),
+      ])
+    );
+  });
+
+  test('401 — missing authentication', async ({ request }) => {
+    const response = await request.get('/api/protected/resource', {
+      headers: { 'Authorization': '' },
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test('404 — resource not found', async ({ request }) => {
+    const response = await request.get('/api/users/999999');
+    expect(response.status()).toBe(404);
+  });
+
+  test('409 — conflict on duplicate resource', async ({ request }) => {
+    const email = `conflict-${Date.now()}@example.com`;
+    await request.post('/api/users', { data: { name: 'First', email } });
+
+    const response = await request.post('/api/users', {
+      data: { name: 'Duplicate', email },
+    });
+    expect(response.status()).toBe(409);
+  });
+});
+```
+
+### File Upload via API
+
+**Use when**: Testing file upload endpoints with multipart form data — document uploads, image processing, CSV imports.
+**Avoid when**: You need to test the browser file picker dialog. Use `page.setInputFiles()` in an E2E test instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+test('upload a file via multipart form data', async ({ request }) => {
+  const filePath = path.resolve('tests/fixtures/test-document.pdf');
+
+  const response = await request.post('/api/documents/upload', {
+    multipart: {
+      file: {
+        name: 'test-document.pdf',
+        mimeType: 'application/pdf',
+        buffer: fs.readFileSync(filePath),
+      },
+      description: 'Quarterly report',
+      category: 'reports',
+    },
+  });
+
+  expect(response.status()).toBe(201);
+  const body = await response.json();
+  expect(body).toMatchObject({
+    id: expect.any(String),
+    filename: 'test-document.pdf',
+    mimeType: 'application/pdf',
+    size: expect.any(Number),
+    url: expect.stringMatching(/^https:\/\//),
+  });
+});
+
+test('upload an image with metadata', async ({ request }) => {
+  const imagePath = path.resolve('tests/fixtures/avatar.png');
+
+  const response = await request.post('/api/users/42/avatar', {
+    multipart: {
+      image: {
+        name: 'avatar.png',
+        mimeType: 'image/png',
+        buffer: fs.readFileSync(imagePath),
+      },
+      crop: JSON.stringify({ x: 0, y: 0, width: 200, height: 200 }),
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+  const body = await response.json();
+  expect(body.avatarUrl).toMatch(/\.png$/);
+});
+
+test('upload multiple files', async ({ request }) => {
+  const files = ['report-q1.csv', 'report-q2.csv'].map((name) => ({
+    name,
+    mimeType: 'text/csv',
+    buffer: fs.readFileSync(path.resolve(`tests/fixtures/${name}`)),
+  }));
+
+  // Send sequential uploads when the API does not support batch
+  const results = [];
+  for (const file of files) {
+    const response = await request.post('/api/imports/csv', {
+      multipart: { file },
+    });
+    expect(response.ok()).toBeTruthy();
+    results.push(await response.json());
+  }
+  expect(results).toHaveLength(2);
+});
+
+test('rejects oversized files', async ({ request }) => {
+  // Create a buffer that exceeds the server limit
+  const largeBuffer = Buffer.alloc(11 * 1024 * 1024); // 11MB
+
+  const response = await request.post('/api/documents/upload', {
+    multipart: {
+      file: {
+        name: 'large-file.bin',
+        mimeType: 'application/octet-stream',
+        buffer: largeBuffer,
+      },
+    },
+  });
+
+  expect(response.status()).toBe(413); // Payload Too Large
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+test('upload a file via multipart form data', async ({ request }) => {
+  const filePath = path.resolve('tests/fixtures/test-document.pdf');
+
+  const response = await request.post('/api/documents/upload', {
+    multipart: {
+      file: {
+        name: 'test-document.pdf',
+        mimeType: 'application/pdf',
+        buffer: fs.readFileSync(filePath),
+      },
+      description: 'Quarterly report',
+      category: 'reports',
+    },
+  });
+
+  expect(response.status()).toBe(201);
+  const body = await response.json();
+  expect(body).toMatchObject({
+    id: expect.any(String),
+    filename: 'test-document.pdf',
+    mimeType: 'application/pdf',
+    size: expect.any(Number),
+  });
+});
+
+test('rejects oversized files', async ({ request }) => {
+  const largeBuffer = Buffer.alloc(11 * 1024 * 1024);
+
+  const response = await request.post('/api/documents/upload', {
+    multipart: {
+      file: {
+        name: 'large-file.bin',
+        mimeType: 'application/octet-stream',
+        buffer: largeBuffer,
+      },
+    },
+  });
+
+  expect(response.status()).toBe(413);
+});
+```
+
+### Chained API Calls
+
+**Use when**: Testing multi-step workflows — create, read, update, delete sequences; order flows; state machine transitions. This verifies the API's behavior as an integrated system, not just isolated endpoints.
+**Avoid when**: You can test each endpoint in isolation and the interactions are trivial.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('complete order workflow', async ({ request }) => {
+  // Step 1: Create a product
+  const productResp = await request.post('/api/products', {
+    data: { name: 'Widget', price: 29.99, stock: 100 },
+  });
+  expect(productResp.status()).toBe(201);
+  const product = await productResp.json();
+
+  // Step 2: Create a cart
+  const cartResp = await request.post('/api/carts', {
+    data: { items: [{ productId: product.id, quantity: 2 }] },
+  });
+  expect(cartResp.status()).toBe(201);
+  const cart = await cartResp.json();
+  expect(cart.total).toBe(59.98);
+
+  // Step 3: Checkout — create an order from the cart
+  const orderResp = await request.post('/api/orders', {
+    data: {
+      cartId: cart.id,
+      shippingAddress: {
+        street: '123 Test St',
+        city: 'Testville',
+        zip: '12345',
+      },
+    },
+  });
+  expect(orderResp.status()).toBe(201);
+  const order = await orderResp.json();
+  expect(order.status).toBe('pending');
+  expect(order.items).toHaveLength(1);
+  expect(order.total).toBe(59.98);
+
+  // Step 4: Verify order appears in user's order list
+  const ordersResp = await request.get('/api/orders');
+  const orders = await ordersResp.json();
+  expect(orders.items.map((o: any) => o.id)).toContain(order.id);
+
+  // Step 5: Verify product stock decreased
+  const updatedProduct = await (await request.get(`/api/products/${product.id}`)).json();
+  expect(updatedProduct.stock).toBe(98); // 100 - 2
+
+  // Cleanup
+  await request.delete(`/api/orders/${order.id}`);
+  await request.delete(`/api/products/${product.id}`);
+});
+
+test('state machine transitions — publish workflow', async ({ request }) => {
+  // Create a draft post
+  const createResp = await request.post('/api/posts', {
+    data: { title: 'Draft Post', body: 'Content here.' },
+  });
+  const post = await createResp.json();
+  expect(post.status).toBe('draft');
+
+  // Submit for review
+  const reviewResp = await request.patch(`/api/posts/${post.id}/status`, {
+    data: { status: 'in_review' },
+  });
+  expect(reviewResp.ok()).toBeTruthy();
+  expect((await reviewResp.json()).status).toBe('in_review');
+
+  // Approve (requires admin — use appropriate fixture in real tests)
+  const approveResp = await request.patch(`/api/posts/${post.id}/status`, {
+    data: { status: 'published' },
+  });
+  expect(approveResp.ok()).toBeTruthy();
+  expect((await approveResp.json()).status).toBe('published');
+
+  // Verify: cannot go back to draft from published
+  const revertResp = await request.patch(`/api/posts/${post.id}/status`, {
+    data: { status: 'draft' },
+  });
+  expect(revertResp.status()).toBe(422);
+
+  // Cleanup
+  await request.delete(`/api/posts/${post.id}`);
+});
+
+test('API + E2E hybrid — seed via API, verify in browser', async ({ request, page }) => {
+  // Seed test data via API
+  const resp = await request.post('/api/products', {
+    data: {
+      name: `Hybrid Test Product ${Date.now()}`,
+      price: 42.00,
+      published: true,
+    },
+  });
+  const product = await resp.json();
+
+  // Verify via browser
+  await page.goto('/products');
+  await expect(
+    page.getByRole('heading', { name: product.name })
+  ).toBeVisible();
+  await expect(page.getByText('$42.00')).toBeVisible();
+
+  // Cleanup via API
+  await request.delete(`/api/products/${product.id}`);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('complete order workflow', async ({ request }) => {
+  const productResp = await request.post('/api/products', {
+    data: { name: 'Widget', price: 29.99, stock: 100 },
+  });
+  expect(productResp.status()).toBe(201);
+  const product = await productResp.json();
+
+  const cartResp = await request.post('/api/carts', {
+    data: { items: [{ productId: product.id, quantity: 2 }] },
+  });
+  expect(cartResp.status()).toBe(201);
+  const cart = await cartResp.json();
+  expect(cart.total).toBe(59.98);
+
+  const orderResp = await request.post('/api/orders', {
+    data: {
+      cartId: cart.id,
+      shippingAddress: {
+        street: '123 Test St',
+        city: 'Testville',
+        zip: '12345',
+      },
+    },
+  });
+  expect(orderResp.status()).toBe(201);
+  const order = await orderResp.json();
+  expect(order.status).toBe('pending');
+
+  const ordersResp = await request.get('/api/orders');
+  const orders = await ordersResp.json();
+  expect(orders.items.map((o) => o.id)).toContain(order.id);
+
+  await request.delete(`/api/orders/${order.id}`);
+  await request.delete(`/api/products/${product.id}`);
+});
+
+test('API + E2E hybrid — seed via API, verify in browser', async ({ request, page }) => {
+  const resp = await request.post('/api/products', {
+    data: {
+      name: `Hybrid Test Product ${Date.now()}`,
+      price: 42.00,
+      published: true,
+    },
+  });
+  const product = await resp.json();
+
+  await page.goto('/products');
+  await expect(
+    page.getByRole('heading', { name: product.name })
+  ).toBeVisible();
+
+  await request.delete(`/api/products/${product.id}`);
+});
+```
+
+## Decision Guide
+
+| Scenario | Use API Tests | Use E2E Tests | Why |
+|---|---|---|---|
+| Validate response status/body/headers | Yes | No | No browser needed; 10-100x faster |
+| Test business logic (calculations, rules) | Yes | No | API tests isolate backend logic from UI |
+| Verify form submission creates correct data | Seed via API, submit via UI | Yes | UI test validates the form; API check confirms persistence |
+| Test error messages shown to user | No | Yes | Error rendering is a UI concern |
+| Validate pagination, filtering, sorting | Yes | Maybe both | API test for correctness; E2E test only if the UI logic is complex |
+| Seed test data for E2E tests | Yes (fixture) | No | API seeding is fast and reliable |
+| Test auth flows (login/logout/RBAC) | Yes for token/session logic | Yes for UI flow | Both matter: API protects resources, UI guides users |
+| Verify file upload processing | Yes | Only if testing file picker UI | API test validates backend processing |
+| Contract/schema regression testing | Yes | No | Schema tests run in milliseconds |
+| Test third-party webhook handling | Yes | No | Webhooks are API-to-API; no UI involved |
+| Verify redirect behavior after action | No | Yes | Redirects are browser/navigation concerns |
+| Test real-time updates (WebSocket + API trigger) | API triggers | E2E verifies | Seed via API, observe in browser |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Use E2E tests to validate pure API responses | Slow, flaky, launches a browser for no reason | Use `request` fixture — no browser, direct HTTP |
+| Ignore `response.status()` | A 500 with a fallback body can pass all body assertions | Always assert status first: `expect(response.status()).toBe(200)` |
+| Skip response header checks | Missing `Content-Type`, `Cache-Control`, CORS headers cause production bugs | Assert critical headers: `expect(response.headers()['content-type']).toContain('application/json')` |
+| Only test the happy path | Real users trigger 400, 401, 403, 404, 409, 422 — every one needs a test | Dedicate a `describe` block to error responses |
+| Hardcode IDs in API tests | Tests break when database is reset or IDs are reassigned | Create resources in the test, use returned IDs |
+| Share mutable state between tests | Tests that depend on execution order are flaky and cannot run in parallel | Each test creates and cleans up its own data |
+| Parse `response.text()` then `JSON.parse()` manually | Playwright's `response.json()` handles this and throws clear errors on non-JSON | Use `await response.json()` |
+| Forget cleanup after creating resources | Test pollution: subsequent tests may see stale data or hit unique constraints | Use fixtures with teardown or explicit `delete` calls |
+| Test GraphQL by checking only `response.ok()` | GraphQL returns 200 even on errors — `errors` array is the real signal | Always check both `data` and `errors` in the response body |
+| Use `page.request` when you don't need a page | `page.request` shares cookies with the browser context, which may cause auth confusion | Use the standalone `request` fixture for pure API tests |
+
+## Troubleshooting
+
+### "Request failed: connect ECONNREFUSED 127.0.0.1:3000"
+
+**Cause**: The API server is not running, or `baseURL` points to the wrong host/port.
+
+**Fix**:
+- Verify the server is running before tests: use `webServer` in `playwright.config.ts` to start it automatically.
+- Check `baseURL` in your config matches the actual server address.
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  webServer: {
+    command: 'npm run start:api',
+    url: 'http://localhost:3000/api/health',
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+```
+
+### "response.json() failed — body is not valid JSON"
+
+**Cause**: The endpoint returned HTML (error page), plain text, or an empty body instead of JSON.
+
+**Fix**:
+- Check `response.status()` first — a 500 or 302 often returns HTML.
+- Log `await response.text()` to see the actual body.
+- Verify the `Accept: application/json` header is set.
+
+```typescript
+const response = await request.get('/api/endpoint');
+if (!response.ok()) {
+  console.error(`Status: ${response.status()}, Body: ${await response.text()}`);
+}
+const body = await response.json(); // now you know what failed
+```
+
+### "401 Unauthorized" when using `request` fixture
+
+**Cause**: The built-in `request` fixture does not carry browser cookies or auth tokens automatically. It starts with a clean slate.
+
+**Fix**:
+- Set `extraHTTPHeaders` in your config or create a custom authenticated fixture.
+- If you need cookies from a browser login, use `page.request` (which shares the browser context's cookies) instead of the standalone `request` fixture.
+
+```typescript
+// Option A: config-level headers
+export default defineConfig({
+  use: {
+    extraHTTPHeaders: {
+      'Authorization': `Bearer ${process.env.API_TOKEN}`,
+    },
+  },
+});
+
+// Option B: per-request headers
+const response = await request.get('/api/resource', {
+  headers: { 'Authorization': `Bearer ${token}` },
+});
+
+// Option C: use page.request to inherit browser cookies
+test('API call with browser auth', async ({ page }) => {
+  await page.goto('/login');
+  // ... login via UI ...
+  const response = await page.request.get('/api/profile');
+  expect(response.ok()).toBeTruthy();
+});
+```
+
+### GraphQL returns 200 but data is null
+
+**Cause**: GraphQL servers return HTTP 200 even when the query has errors. The actual error is in the `errors` array.
+
+**Fix**: Always destructure and check both `data` and `errors`.
+
+```typescript
+const { data, errors } = await response.json();
+if (errors) {
+  console.error('GraphQL errors:', JSON.stringify(errors, null, 2));
+}
+expect(errors).toBeUndefined();
+expect(data.user).toBeDefined();
+```
+
+### Tests pass locally but fail in CI
+
+**Cause**: Different environments, database state, or missing environment variables.
+
+**Fix**:
+- Use `process.env` for secrets and base URLs — never hardcode them.
+- Run database seeds or migrations in `globalSetup`.
+- Use unique identifiers (timestamps, UUIDs) for test data to avoid collisions in parallel runs.
+- Check that the CI `baseURL` matches the deployed or containerized service.
+
+## Related
+
+- [core/configuration.md](configuration.md) — `baseURL`, `extraHTTPHeaders`, and `webServer` config
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) — custom fixture patterns for reusable API clients
+- [core/authentication.md](authentication.md) — auth patterns including token-based API auth
+- [core/network-mocking.md](network-mocking.md) — mocking API responses in E2E tests (opposite of this guide)
+- [core/test-architecture.md](test-architecture.md) — when to use API tests vs E2E vs component tests
+- [core/when-to-mock.md](when-to-mock.md) — when to hit real APIs vs mock them

--- a/engineering-team/playwright skill/core/assertions-and-waiting.md
+++ b/engineering-team/playwright skill/core/assertions-and-waiting.md
@@ -1,0 +1,661 @@
+# Assertions and Waiting
+
+> **When to use**: Every time you write an `expect()` call, wait for a condition, or wonder why a test is flaky due to timing.
+> **Prerequisites**: [core/locators.md](locators.md) for locator strategies used in examples.
+
+## Quick Reference
+
+```typescript
+// Web-first (auto-retry) — ALWAYS prefer these
+await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+await expect(page.getByRole('heading')).toHaveText('Dashboard');
+await expect(page.getByRole('listitem')).toHaveCount(5);
+
+// Negative — auto-retries until condition is met
+await expect(page.getByRole('dialog')).not.toBeVisible();
+
+// Soft — collect failures, don't stop test
+await expect.soft(page.getByRole('heading')).toHaveText('Title');
+
+// Polling — non-DOM async conditions
+await expect.poll(() => getUserCount()).toBe(10);
+
+// Retry a block — multiple assertions that must pass together
+await expect(async () => { /* assertions */ }).toPass();
+```
+
+## Patterns
+
+### Web-First Assertions (Auto-Retry)
+
+**Use when**: Asserting anything about a locator — visibility, text, attributes, CSS, count, values.
+**Avoid when**: Asserting on an already-resolved JavaScript value (use non-retrying assertions instead).
+
+Web-first assertions automatically retry until the condition is met or the timeout expires. They are the backbone of reliable Playwright tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('web-first assertions demo', async ({ page }) => {
+  await page.goto('/products');
+
+  // Visibility
+  await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
+
+  // Text — exact match
+  await expect(page.getByTestId('total')).toHaveText('Total: $99.00');
+
+  // Text — partial match (substring or regex)
+  await expect(page.getByTestId('total')).toContainText('$99');
+  await expect(page.getByTestId('total')).toHaveText(/Total: \$\d+\.\d{2}/);
+
+  // Element count
+  await expect(page.getByRole('listitem')).toHaveCount(5);
+
+  // Attribute
+  await expect(page.getByRole('link', { name: 'Docs' })).toHaveAttribute('href', '/docs');
+
+  // CSS property
+  await expect(page.getByTestId('alert')).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+
+  // Input value
+  await expect(page.getByLabel('Email')).toHaveValue('user@example.com');
+
+  // Class (use toHaveClass for full match, regex for partial)
+  await expect(page.getByTestId('card')).toHaveClass(/active/);
+
+  // Enabled / disabled / checked
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
+  await expect(page.getByRole('checkbox')).toBeChecked();
+
+  // Editable / focused / attached
+  await expect(page.getByLabel('Name')).toBeEditable();
+  await expect(page.getByLabel('Name')).toBeFocused();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('web-first assertions demo', async ({ page }) => {
+  await page.goto('/products');
+
+  await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
+  await expect(page.getByTestId('total')).toHaveText('Total: $99.00');
+  await expect(page.getByTestId('total')).toContainText('$99');
+  await expect(page.getByTestId('total')).toHaveText(/Total: \$\d+\.\d{2}/);
+  await expect(page.getByRole('listitem')).toHaveCount(5);
+  await expect(page.getByRole('link', { name: 'Docs' })).toHaveAttribute('href', '/docs');
+  await expect(page.getByTestId('alert')).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+  await expect(page.getByLabel('Email')).toHaveValue('user@example.com');
+  await expect(page.getByTestId('card')).toHaveClass(/active/);
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
+  await expect(page.getByRole('checkbox')).toBeChecked();
+  await expect(page.getByLabel('Name')).toBeEditable();
+  await expect(page.getByLabel('Name')).toBeFocused();
+});
+```
+
+### Non-Retrying Assertions
+
+**Use when**: The value is already resolved — a JavaScript variable, an API response body, a page title from `page.title()`, or a URL from `page.url()`.
+**Avoid when**: Asserting on anything that might change asynchronously in the DOM. Use web-first assertions instead.
+
+Non-retrying assertions run once. If they fail, they fail immediately.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('non-retrying assertions for resolved values', async ({ page }) => {
+  await page.goto('/api/health');
+
+  // Already-resolved values — no retry needed
+  const title = await page.title();
+  expect(title).toBe('Health Check');
+
+  const url = page.url();
+  expect(url).toContain('/api/health');
+
+  // API response body
+  const response = await page.request.get('/api/users');
+  const body = await response.json();
+  expect(body.users).toHaveLength(3);
+  expect(response.status()).toBe(200);
+
+  // Snapshot (value comparison, not retrying)
+  expect(body).toMatchObject({ status: 'healthy', users: expect.any(Array) });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('non-retrying assertions for resolved values', async ({ page }) => {
+  await page.goto('/api/health');
+
+  const title = await page.title();
+  expect(title).toBe('Health Check');
+
+  const url = page.url();
+  expect(url).toContain('/api/health');
+
+  const response = await page.request.get('/api/users');
+  const body = await response.json();
+  expect(body.users).toHaveLength(3);
+  expect(response.status()).toBe(200);
+
+  expect(body).toMatchObject({ status: 'healthy', users: expect.any(Array) });
+});
+```
+
+### Negative Assertions
+
+**Use when**: Verifying something has disappeared, been removed, or is not present.
+**Avoid when**: Never.
+
+Negative web-first assertions auto-retry until the condition is met. This is critical: `expect(locator).not.toBeVisible()` correctly waits for the element to disappear. It does not just check once.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('verify element disappears after action', async ({ page }) => {
+  await page.goto('/notifications');
+
+  // Dismiss a notification
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+
+  // Auto-retries until the notification is gone — correct
+  await expect(page.getByRole('alert')).not.toBeVisible();
+
+  // Verify text is not present
+  await expect(page.getByText('Error occurred')).not.toBeVisible();
+
+  // Verify element is detached from DOM entirely
+  await expect(page.getByTestId('modal')).not.toBeAttached();
+
+  // Verify count dropped to zero
+  await expect(page.getByRole('alert')).toHaveCount(0);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('verify element disappears after action', async ({ page }) => {
+  await page.goto('/notifications');
+
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+
+  await expect(page.getByRole('alert')).not.toBeVisible();
+  await expect(page.getByText('Error occurred')).not.toBeVisible();
+  await expect(page.getByTestId('modal')).not.toBeAttached();
+  await expect(page.getByRole('alert')).toHaveCount(0);
+});
+```
+
+**Gotcha**: `not.toBeVisible()` passes for elements that exist but are hidden AND for elements not in the DOM. If you specifically need to assert the element is removed from the DOM entirely (not just hidden), use `not.toBeAttached()`.
+
+### Soft Assertions
+
+**Use when**: You want to collect multiple failures in a single test without stopping at the first one. Common for form validation checks, dashboard content audits, or visual checklists.
+**Avoid when**: Subsequent assertions depend on the result of earlier ones (if the first fails, later assertions may be meaningless).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('dashboard shows all expected widgets', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // All checks run even if earlier ones fail
+  await expect.soft(page.getByTestId('revenue-widget')).toBeVisible();
+  await expect.soft(page.getByTestId('users-widget')).toBeVisible();
+  await expect.soft(page.getByTestId('orders-widget')).toBeVisible();
+  await expect.soft(page.getByTestId('revenue-widget')).toContainText('$');
+  await expect.soft(page.getByTestId('users-widget')).toContainText('active');
+
+  // Test still fails if any soft assertion failed, but you see ALL failures in the report
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('dashboard shows all expected widgets', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect.soft(page.getByTestId('revenue-widget')).toBeVisible();
+  await expect.soft(page.getByTestId('users-widget')).toBeVisible();
+  await expect.soft(page.getByTestId('orders-widget')).toBeVisible();
+  await expect.soft(page.getByTestId('revenue-widget')).toContainText('$');
+  await expect.soft(page.getByTestId('users-widget')).toContainText('active');
+});
+```
+
+**Tip**: Guard subsequent actions against soft-assertion failures when those actions would throw confusing errors.
+
+```typescript
+await expect.soft(page.getByRole('button', { name: 'Next' })).toBeVisible();
+if (test.info().errors.length > 0) return; // bail out — no point continuing
+await page.getByRole('button', { name: 'Next' }).click();
+```
+
+### Polling Assertions
+
+**Use when**: Waiting for a non-DOM, non-locator async condition: API readiness, database state, file existence, polling a service.
+**Avoid when**: The condition is about a DOM element. Use web-first assertions on locators.
+
+`expect.poll()` repeatedly calls a function until the assertion passes.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('wait for background job to complete', async ({ page }) => {
+  await page.goto('/jobs');
+  await page.getByRole('button', { name: 'Start Export' }).click();
+
+  // Poll an API endpoint until the job finishes
+  await expect.poll(async () => {
+    const response = await page.request.get('/api/jobs/latest');
+    const job = await response.json();
+    return job.status;
+  }, {
+    message: 'Expected export job to complete',
+    timeout: 30_000,
+    intervals: [1_000, 2_000, 5_000], // backoff: 1s, 2s, then every 5s
+  }).toBe('completed');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('wait for background job to complete', async ({ page }) => {
+  await page.goto('/jobs');
+  await page.getByRole('button', { name: 'Start Export' }).click();
+
+  await expect.poll(async () => {
+    const response = await page.request.get('/api/jobs/latest');
+    const job = await response.json();
+    return job.status;
+  }, {
+    message: 'Expected export job to complete',
+    timeout: 30_000,
+    intervals: [1_000, 2_000, 5_000],
+  }).toBe('completed');
+});
+```
+
+### Retrying Assertion Blocks with `toPass()`
+
+**Use when**: Multiple assertions or actions must pass together as a group, and the whole block should be retried if any part fails. Common for race conditions where data appears incrementally.
+**Avoid when**: A single web-first assertion suffices.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('search results update correctly', async ({ page }) => {
+  await page.goto('/search');
+
+  await expect(async () => {
+    await page.getByLabel('Search').fill('playwright');
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    // Both must pass together — retries the whole block
+    await expect(page.getByRole('listitem')).toHaveCount(10);
+    await expect(page.getByRole('listitem').first()).toContainText('Playwright');
+  }).toPass({
+    timeout: 15_000,
+    intervals: [1_000, 2_000, 5_000],
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('search results update correctly', async ({ page }) => {
+  await page.goto('/search');
+
+  await expect(async () => {
+    await page.getByLabel('Search').fill('playwright');
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    await expect(page.getByRole('listitem')).toHaveCount(10);
+    await expect(page.getByRole('listitem').first()).toContainText('Playwright');
+  }).toPass({
+    timeout: 15_000,
+    intervals: [1_000, 2_000, 5_000],
+  });
+});
+```
+
+### Custom Matchers
+
+**Use when**: Domain-specific assertions you repeat across many tests — valid price format, date range, accessible form, etc.
+**Avoid when**: The assertion is only used in one test. Inline it.
+
+**TypeScript**
+```typescript
+// fixtures/custom-matchers.ts
+import { expect, type Locator } from '@playwright/test';
+
+expect.extend({
+  async toHaveValidPrice(locator: Locator) {
+    const assertionName = 'toHaveValidPrice';
+    let pass: boolean;
+    let matcherResult: any;
+
+    try {
+      await expect(locator).toHaveText(/^\$\d{1,3}(,\d{3})*\.\d{2}$/);
+      pass = true;
+    } catch (e: any) {
+      matcherResult = e.matcherResult;
+      pass = false;
+    }
+
+    const message = pass
+      ? () => `${this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot })}\n\nLocator: ${locator}\nExpected: not a valid price format\nReceived: ${matcherResult?.actual || 'valid price'}`
+      : () => `${this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot })}\n\nLocator: ${locator}\nExpected: valid price format ($X,XXX.XX)\nReceived: ${matcherResult?.actual || 'no text'}`;
+
+    return { message, pass, name: assertionName, expected: 'valid price format', actual: matcherResult?.actual };
+  },
+});
+
+// Declare types for TypeScript
+export {};
+declare global {
+  namespace PlaywrightTest {
+    interface Matchers<R, T> {
+      toHaveValidPrice(): R;
+    }
+  }
+}
+```
+
+```typescript
+// tests/products.spec.ts
+import { test, expect } from '@playwright/test';
+import '../fixtures/custom-matchers';
+
+test('product prices are valid', async ({ page }) => {
+  await page.goto('/products');
+  await expect(page.getByTestId('price-tag').first()).toHaveValidPrice();
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures/custom-matchers.js
+const { expect } = require('@playwright/test');
+
+expect.extend({
+  async toHaveValidPrice(locator) {
+    const assertionName = 'toHaveValidPrice';
+    let pass;
+    let matcherResult;
+
+    try {
+      await expect(locator).toHaveText(/^\$\d{1,3}(,\d{3})*\.\d{2}$/);
+      pass = true;
+    } catch (e) {
+      matcherResult = e.matcherResult;
+      pass = false;
+    }
+
+    const message = pass
+      ? () => `Expected locator not to have valid price format`
+      : () => `Expected locator to have valid price format ($X,XXX.XX), received: ${matcherResult?.actual || 'no text'}`;
+
+    return { message, pass, name: assertionName };
+  },
+});
+```
+
+```javascript
+// tests/products.spec.js
+const { test, expect } = require('@playwright/test');
+require('../fixtures/custom-matchers');
+
+test('product prices are valid', async ({ page }) => {
+  await page.goto('/products');
+  await expect(page.getByTestId('price-tag').first()).toHaveValidPrice();
+});
+```
+
+### Auto-Waiting (Actionability)
+
+**Use when**: You don't need to "use" this — understand it. Every Playwright action (`click`, `fill`, `check`, `selectOption`, etc.) auto-waits for the target element to be actionable before proceeding.
+
+Playwright checks before acting:
+| Action | Waits for |
+|---|---|
+| `click()` | Attached, visible, stable (no animation), enabled, not obscured by another element |
+| `fill()` | Attached, visible, enabled, editable |
+| `check()` | Attached, visible, stable, enabled |
+| `selectOption()` | Attached, visible, enabled |
+| `hover()` | Attached, visible, stable |
+| `type()` | Attached, visible, enabled, editable |
+
+This means you almost never need explicit waits before actions. Do NOT write `await expect(button).toBeVisible()` before `await button.click()` — the click already waits for visibility.
+
+### Explicit Waits
+
+**Use when**: Waiting for navigation, network responses, or page load states that are not tied to a specific locator.
+**Avoid when**: A web-first assertion on a locator would suffice.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('explicit waits for non-locator conditions', async ({ page }) => {
+  await page.goto('/login');
+
+  // Wait for navigation after form submit
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.waitForURL('/dashboard');
+  // can also use glob: await page.waitForURL('**/dashboard');
+  // or regex: await page.waitForURL(/.*dashboard/);
+
+  // Wait for a specific API response
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('/api/user') && resp.status() === 200
+  );
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const response = await responsePromise;
+  const data = await response.json();
+  expect(data.name).toBe('Test User');
+
+  // Wait for a network request to be sent
+  const requestPromise = page.waitForRequest('**/api/analytics');
+  await page.getByRole('button', { name: 'Track' }).click();
+  const request = await requestPromise;
+  expect(request.method()).toBe('POST');
+
+  // Wait for load state
+  await page.waitForLoadState('networkidle'); // use sparingly — only for legacy apps
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('explicit waits for non-locator conditions', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.waitForURL('/dashboard');
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('/api/user') && resp.status() === 200
+  );
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const response = await responsePromise;
+  const data = await response.json();
+  expect(data.name).toBe('Test User');
+
+  const requestPromise = page.waitForRequest('**/api/analytics');
+  await page.getByRole('button', { name: 'Track' }).click();
+  const request = await requestPromise;
+  expect(request.method()).toBe('POST');
+
+  await page.waitForLoadState('networkidle');
+});
+```
+
+**Critical pattern**: Always set up `waitForResponse` / `waitForRequest` BEFORE the action that triggers it. Otherwise you have a race condition.
+
+```typescript
+// CORRECT — promise registered before the click
+const responsePromise = page.waitForResponse('**/api/data');
+await page.getByRole('button', { name: 'Load' }).click();
+const response = await responsePromise;
+
+// WRONG — response may already have arrived before waitForResponse is registered
+await page.getByRole('button', { name: 'Load' }).click();
+const response = await page.waitForResponse('**/api/data'); // race condition!
+```
+
+### Assertion Timeouts
+
+**Use when**: A specific assertion needs more or less time than the global default.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Per-assertion timeout
+test('slow element appears eventually', async ({ page }) => {
+  await page.goto('/slow-dashboard');
+
+  await expect(page.getByTestId('heavy-chart')).toBeVisible({
+    timeout: 30_000, // override for this one assertion
+  });
+});
+
+// Per-test timeout
+test('long-running flow', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto('/import');
+  await page.getByRole('button', { name: 'Import CSV' }).click();
+  await expect(page.getByText('Import complete')).toBeVisible({ timeout: 60_000 });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('slow element appears eventually', async ({ page }) => {
+  await page.goto('/slow-dashboard');
+
+  await expect(page.getByTestId('heavy-chart')).toBeVisible({
+    timeout: 30_000,
+  });
+});
+
+test('long-running flow', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto('/import');
+  await page.getByRole('button', { name: 'Import CSV' }).click();
+  await expect(page.getByText('Import complete')).toBeVisible({ timeout: 60_000 });
+});
+```
+
+**Global timeout** in `playwright.config.ts`:
+```typescript
+export default defineConfig({
+  expect: {
+    timeout: 10_000, // default is 5_000 — increase for slow apps
+  },
+  timeout: 30_000,   // per-test timeout (default 30_000)
+});
+```
+
+## Decision Guide
+
+| Scenario | Recommended Approach | Why |
+|---|---|---|
+| Element visible / hidden | `expect(locator).toBeVisible()` / `.not.toBeVisible()` | Auto-retries, handles timing |
+| Text content check | `expect(locator).toHaveText()` or `.toContainText()` | Auto-retries; use `toContainText` for substring |
+| Element count | `expect(locator).toHaveCount(n)` | Retries until count matches |
+| Input value | `expect(locator).toHaveValue('x')` | Auto-retries on the locator |
+| Element attribute | `expect(locator).toHaveAttribute('href', '/x')` | Auto-retries |
+| CSS property | `expect(locator).toHaveCSS('color', 'rgb(0,0,0)')` | Auto-retries; use computed RGB values |
+| Element gone from DOM | `expect(locator).not.toBeAttached()` | Distinguishes hidden vs. removed |
+| URL changed | `page.waitForURL('/path')` or `expect(page).toHaveURL('/path')` | `toHaveURL` auto-retries; `waitForURL` blocks |
+| Page title | `expect(page).toHaveTitle('Title')` | Auto-retries |
+| API response status | `expect(response.status()).toBe(200)` | Already resolved — non-retrying |
+| Background job / polling | `expect.poll(() => fetchStatus())` | Retries a function, not a locator |
+| Multiple assertions as one | `expect(async () => { ... }).toPass()` | Retries the entire block |
+| Multiple independent checks | `expect.soft(locator)` | Collects all failures |
+| Resolved JS value | `expect(value).toBe(x)` | No retry needed |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `await page.waitForTimeout(2000)` | Arbitrary delay. Too slow when fast, too short when slow. Flaky. | Use a web-first assertion: `await expect(locator).toBeVisible()` |
+| `const visible = await el.isVisible(); expect(visible).toBe(true)` | `isVisible()` resolves once — no retry. Race condition. | `await expect(el).toBeVisible()` |
+| `try { await expect(el).toBeVisible() } catch { /* ignore */ }` | Swallows real failures. Masks bugs. | Use `expect.soft()` or restructure the test |
+| `expect(locator).toBeVisible().then(...)` | Missing `await`. Assertion runs detached, test passes before it resolves. | Always `await expect(locator).toBeVisible()` |
+| `await expect(btn).toBeVisible(); await btn.click()` | Redundant. `click()` auto-waits for visibility. | Just `await btn.click()` |
+| `await page.waitForLoadState('networkidle')` before every action | `networkidle` is fragile (long-poll, analytics, websockets break it). Slows tests. | Wait for a specific element or URL instead |
+| `expect(await el.textContent()).toBe('X')` | Resolves text once — no retry. | `await expect(el).toHaveText('X')` |
+| `expect(await page.locator('.item').count()).toBe(5)` | Resolves count once — no retry. | `await expect(page.locator('.item')).toHaveCount(5)` |
+| Using `toPass()` for a single assertion | Unnecessary complexity. | Use the web-first assertion directly |
+| Huge timeout per assertion (>60s) | Hides real performance problems. Tests become unbearably slow on failure. | Fix the app or split the test. Use 10-30s max. |
+
+## Troubleshooting
+
+### "Timed out 5000ms waiting for expect(...).toBeVisible()"
+
+**Cause**: The element never appeared within the assertion timeout. Common reasons:
+1. Wrong locator — element exists but locator doesn't match.
+2. Element is behind a loading spinner or inside a collapsed section.
+3. Network request that populates the element is slow.
+
+**Fix**:
+- Run with `--ui` or `--debug` to visually inspect the page state at failure time.
+- Check the locator matches in the browser console: `playwright.$(selector)`.
+- Increase timeout for genuinely slow operations: `{ timeout: 15_000 }`.
+- Verify the locator targets the right element: `await expect(locator).toHaveCount(1)` first.
+
+### "expect.soft: Test finished with X failed assertions"
+
+**Cause**: Soft assertions collected failures but you have no immediate visibility into which ones.
+
+**Fix**: Check the HTML report (`npx playwright show-report`). Each soft failure is listed with its locator, expected value, and actual value. Group related soft assertions under `test.step()` for better readability.
+
+### "Expected '  Dashboard  ' to have text 'Dashboard'"
+
+**Cause**: `toHaveText()` performs full text match including normalization, but whitespace mismatch still trips people up when elements have unusual rendering.
+
+**Fix**:
+- Use `toContainText('Dashboard')` for a substring match that is more resilient to whitespace.
+- Use regex: `toHaveText(/Dashboard/)`.
+- Check for zero-width spaces or special Unicode characters with `--debug`.
+
+## Related
+
+- [core/locators.md](locators.md) — locator strategies used in assertion targets
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) — custom fixtures for reusable assertion setup
+- [core/debugging.md](debugging.md) — debugging assertion failures with UI mode and traces
+- [core/flaky-tests.md](flaky-tests.md) — fixing timing-related flakiness
+- [core/error-index.md](error-index.md) — specific error messages and fixes

--- a/engineering-team/playwright skill/core/auth-flows.md
+++ b/engineering-team/playwright skill/core/auth-flows.md
@@ -1,0 +1,1030 @@
+# Authentication Flow Recipes
+
+> **When to use**: You need to test login, signup, logout, session management, or any authentication-related user flow.
+
+---
+
+## Recipe 1: Basic Login
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('logs in with valid credentials', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('SecurePass123!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Wait for navigation to complete after login
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(page.getByText('Welcome, user@example.com')).toBeVisible();
+});
+
+test('shows error for invalid credentials', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('WrongPassword');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Invalid email or password');
+  // Should remain on login page
+  await expect(page).toHaveURL('/login');
+});
+
+test('shows validation errors for empty fields', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByText('Email is required')).toBeVisible();
+  await expect(page.getByText('Password is required')).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('logs in with valid credentials', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('SecurePass123!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(page.getByText('Welcome, user@example.com')).toBeVisible();
+});
+
+test('shows error for invalid credentials', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('WrongPassword');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Invalid email or password');
+  await expect(page).toHaveURL('/login');
+});
+
+test('shows validation errors for empty fields', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByText('Email is required')).toBeVisible();
+  await expect(page.getByText('Password is required')).toBeVisible();
+});
+```
+
+---
+
+## Recipe 2: Login with "Remember Me"
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect, type BrowserContext } from '@playwright/test';
+
+test('remember me persists session across browser restarts', async ({ browser }) => {
+  // First session: log in with "remember me" checked
+  const context1 = await browser.newContext();
+  const page1 = await context1.newPage();
+
+  await page1.goto('/login');
+  await page1.getByLabel('Email').fill('user@example.com');
+  await page1.getByLabel('Password').fill('SecurePass123!');
+  await page1.getByLabel('Remember me').check();
+  await page1.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page1).toHaveURL('/dashboard');
+
+  // Save storage state (cookies + localStorage)
+  const storageState = await context1.storageState();
+  await context1.close();
+
+  // Second session: restore state to simulate browser restart
+  const context2 = await browser.newContext({ storageState });
+  const page2 = await context2.newPage();
+
+  await page2.goto('/dashboard');
+
+  // Should still be logged in without re-authenticating
+  await expect(page2).toHaveURL('/dashboard');
+  await expect(page2.getByText('Welcome, user@example.com')).toBeVisible();
+
+  await context2.close();
+});
+
+test('no remember me does not persist session', async ({ browser }) => {
+  const context1 = await browser.newContext();
+  const page1 = await context1.newPage();
+
+  await page1.goto('/login');
+  await page1.getByLabel('Email').fill('user@example.com');
+  await page1.getByLabel('Password').fill('SecurePass123!');
+  // Explicitly leave "Remember me" unchecked
+  await expect(page1.getByLabel('Remember me')).not.toBeChecked();
+  await page1.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page1).toHaveURL('/dashboard');
+
+  // Capture only cookies (not sessionStorage) to simulate new tab/window
+  const cookies = await context1.cookies();
+  await context1.close();
+
+  // New context with only persistent cookies (session cookies are excluded)
+  const persistentCookies = cookies.filter(c => c.expires > 0);
+  const context2 = await browser.newContext();
+  await context2.addCookies(persistentCookies);
+  const page2 = await context2.newPage();
+
+  await page2.goto('/dashboard');
+
+  // Should redirect to login since session was not persisted
+  await expect(page2).toHaveURL(/\/login/);
+
+  await context2.close();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('remember me persists session across browser restarts', async ({ browser }) => {
+  const context1 = await browser.newContext();
+  const page1 = await context1.newPage();
+
+  await page1.goto('/login');
+  await page1.getByLabel('Email').fill('user@example.com');
+  await page1.getByLabel('Password').fill('SecurePass123!');
+  await page1.getByLabel('Remember me').check();
+  await page1.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page1).toHaveURL('/dashboard');
+
+  const storageState = await context1.storageState();
+  await context1.close();
+
+  const context2 = await browser.newContext({ storageState });
+  const page2 = await context2.newPage();
+
+  await page2.goto('/dashboard');
+
+  await expect(page2).toHaveURL('/dashboard');
+  await expect(page2.getByText('Welcome, user@example.com')).toBeVisible();
+
+  await context2.close();
+});
+```
+
+---
+
+## Recipe 3: Signup with Email Verification (Mocked)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('completes signup flow with mocked email verification', async ({ page }) => {
+  // Intercept the verification email API so we can capture the token
+  let verificationToken = '';
+  await page.route('**/api/auth/send-verification', async (route) => {
+    // Let the request go through to the server
+    const response = await route.fetch();
+    const body = await response.json();
+
+    // Capture the token from the API response (test environments expose this)
+    verificationToken = body.verificationToken;
+
+    await route.fulfill({ response });
+  });
+
+  // Step 1: Fill out signup form
+  await page.goto('/signup');
+
+  await page.getByLabel('Full name').fill('Jane Tester');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('SecurePass123!');
+  await page.getByLabel('Confirm password').fill('SecurePass123!');
+  await page.getByLabel('I agree to the Terms of Service').check();
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  // Step 2: Verify "check your email" screen appears
+  await expect(page.getByText('Check your email')).toBeVisible();
+  await expect(page.getByText('jane@example.com')).toBeVisible();
+
+  // Step 3: Navigate directly to verification URL using captured token
+  expect(verificationToken).toBeTruthy();
+  await page.goto(`/verify-email?token=${verificationToken}`);
+
+  // Step 4: Verify account is now active
+  await expect(page.getByText('Email verified successfully')).toBeVisible();
+  await expect(page).toHaveURL('/login');
+
+  // Step 5: Log in with the new account
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Password').fill('SecurePass123!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.getByText('Welcome, Jane Tester')).toBeVisible();
+});
+
+test('signup with fully mocked email API (no server dependency)', async ({ page }) => {
+  const fakeToken = 'test-verification-token-12345';
+
+  // Mock the signup API endpoint
+  await page.route('**/api/auth/signup', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        message: 'Verification email sent',
+        verificationToken: fakeToken,
+      }),
+    });
+  });
+
+  // Mock the verification endpoint
+  await page.route(`**/api/auth/verify-email?token=${fakeToken}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Email verified', redirectTo: '/login' }),
+    });
+  });
+
+  await page.goto('/signup');
+
+  await page.getByLabel('Full name').fill('Jane Tester');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('SecurePass123!');
+  await page.getByLabel('Confirm password').fill('SecurePass123!');
+  await page.getByLabel('I agree to the Terms of Service').check();
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  await expect(page.getByText('Check your email')).toBeVisible();
+
+  // Simulate clicking the verification link from the email
+  await page.goto(`/verify-email?token=${fakeToken}`);
+
+  await expect(page.getByText('Email verified successfully')).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('completes signup flow with mocked email verification', async ({ page }) => {
+  let verificationToken = '';
+  await page.route('**/api/auth/send-verification', async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    verificationToken = body.verificationToken;
+    await route.fulfill({ response });
+  });
+
+  await page.goto('/signup');
+
+  await page.getByLabel('Full name').fill('Jane Tester');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('SecurePass123!');
+  await page.getByLabel('Confirm password').fill('SecurePass123!');
+  await page.getByLabel('I agree to the Terms of Service').check();
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  await expect(page.getByText('Check your email')).toBeVisible();
+
+  expect(verificationToken).toBeTruthy();
+  await page.goto(`/verify-email?token=${verificationToken}`);
+
+  await expect(page.getByText('Email verified successfully')).toBeVisible();
+  await expect(page).toHaveURL('/login');
+});
+```
+
+---
+
+## Recipe 4: Password Reset Flow
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('completes password reset flow', async ({ page }) => {
+  let resetToken = '';
+
+  // Intercept the password reset API to capture the reset token
+  await page.route('**/api/auth/forgot-password', async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    resetToken = body.resetToken;
+    await route.fulfill({ response });
+  });
+
+  // Step 1: Request password reset
+  await page.goto('/forgot-password');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByRole('button', { name: 'Send reset link' }).click();
+
+  await expect(page.getByText('Reset link sent')).toBeVisible();
+  await expect(page.getByText('user@example.com')).toBeVisible();
+
+  // Step 2: Navigate to the reset page with token
+  expect(resetToken).toBeTruthy();
+  await page.goto(`/reset-password?token=${resetToken}`);
+
+  // Step 3: Set new password
+  await page.getByLabel('New password', { exact: true }).fill('NewSecurePass456!');
+  await page.getByLabel('Confirm new password').fill('NewSecurePass456!');
+  await page.getByRole('button', { name: 'Reset password' }).click();
+
+  await expect(page.getByText('Password reset successfully')).toBeVisible();
+
+  // Step 4: Log in with new password
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('NewSecurePass456!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page).toHaveURL('/dashboard');
+});
+
+test('password reset with expired token shows error', async ({ page }) => {
+  await page.goto('/reset-password?token=expired-token-123');
+
+  await page.getByLabel('New password', { exact: true }).fill('NewSecurePass456!');
+  await page.getByLabel('Confirm new password').fill('NewSecurePass456!');
+  await page.getByRole('button', { name: 'Reset password' }).click();
+
+  await expect(page.getByRole('alert')).toContainText(
+    /token has expired|link is no longer valid/i
+  );
+  await expect(page.getByRole('link', { name: 'Request a new reset link' })).toBeVisible();
+});
+
+test('password reset enforces password strength requirements', async ({ page }) => {
+  await page.goto('/reset-password?token=valid-token');
+
+  // Try a weak password
+  await page.getByLabel('New password', { exact: true }).fill('123');
+  await page.getByLabel('Confirm new password').fill('123');
+  await page.getByRole('button', { name: 'Reset password' }).click();
+
+  await expect(page.getByText(/at least 8 characters/i)).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('completes password reset flow', async ({ page }) => {
+  let resetToken = '';
+
+  await page.route('**/api/auth/forgot-password', async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    resetToken = body.resetToken;
+    await route.fulfill({ response });
+  });
+
+  await page.goto('/forgot-password');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByRole('button', { name: 'Send reset link' }).click();
+
+  await expect(page.getByText('Reset link sent')).toBeVisible();
+
+  expect(resetToken).toBeTruthy();
+  await page.goto(`/reset-password?token=${resetToken}`);
+
+  await page.getByLabel('New password', { exact: true }).fill('NewSecurePass456!');
+  await page.getByLabel('Confirm new password').fill('NewSecurePass456!');
+  await page.getByRole('button', { name: 'Reset password' }).click();
+
+  await expect(page.getByText('Password reset successfully')).toBeVisible();
+
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('NewSecurePass456!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page).toHaveURL('/dashboard');
+});
+```
+
+---
+
+## Recipe 5: OAuth Login (Mocked Callback)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('logs in via mocked Google OAuth callback', async ({ page }) => {
+  // Intercept the OAuth redirect to Google and simulate the callback
+  await page.route('**/accounts.google.com/**', async (route) => {
+    // Instead of actually going to Google, redirect back to our callback URL
+    // with a mock authorization code
+    const callbackUrl = new URL('/auth/callback/google', 'http://localhost:3000');
+    callbackUrl.searchParams.set('code', 'mock-auth-code-12345');
+    callbackUrl.searchParams.set('state', route.request().url().match(/state=([^&]+)/)?.[1] || '');
+
+    await route.fulfill({
+      status: 302,
+      headers: { location: callbackUrl.toString() },
+    });
+  });
+
+  // Mock the token exchange on our backend
+  await page.route('**/api/auth/callback/google**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: '1',
+          email: 'googleuser@gmail.com',
+          name: 'Google User',
+          avatar: 'https://example.com/avatar.jpg',
+        },
+        token: 'mock-jwt-token',
+      }),
+    });
+  });
+
+  await page.goto('/login');
+
+  // Click the OAuth button
+  await page.getByRole('button', { name: /Sign in with Google/i }).click();
+
+  // After the mocked OAuth flow, we should land on the dashboard
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.getByText('Google User')).toBeVisible();
+});
+
+test('handles OAuth login failure gracefully', async ({ page }) => {
+  // Simulate OAuth provider returning an error
+  await page.route('**/accounts.google.com/**', async (route) => {
+    const callbackUrl = new URL('/auth/callback/google', 'http://localhost:3000');
+    callbackUrl.searchParams.set('error', 'access_denied');
+    callbackUrl.searchParams.set('error_description', 'User denied access');
+
+    await route.fulfill({
+      status: 302,
+      headers: { location: callbackUrl.toString() },
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: /Sign in with Google/i }).click();
+
+  await expect(page.getByRole('alert')).toContainText(/authentication failed|access denied/i);
+  await expect(page).toHaveURL(/\/login/);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('logs in via mocked Google OAuth callback', async ({ page }) => {
+  await page.route('**/accounts.google.com/**', async (route) => {
+    const callbackUrl = new URL('/auth/callback/google', 'http://localhost:3000');
+    callbackUrl.searchParams.set('code', 'mock-auth-code-12345');
+    callbackUrl.searchParams.set('state', route.request().url().match(/state=([^&]+)/)?.[1] || '');
+
+    await route.fulfill({
+      status: 302,
+      headers: { location: callbackUrl.toString() },
+    });
+  });
+
+  await page.route('**/api/auth/callback/google**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: { id: '1', email: 'googleuser@gmail.com', name: 'Google User' },
+        token: 'mock-jwt-token',
+      }),
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: /Sign in with Google/i }).click();
+
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.getByText('Google User')).toBeVisible();
+});
+```
+
+---
+
+## Recipe 6: Role-Based Access Testing
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect, type Page } from '@playwright/test';
+import path from 'path';
+
+// Store auth state for each role in separate files
+const authDir = path.resolve(__dirname, '../.auth');
+
+// Setup: create auth state files for each role (run in globalSetup or auth.setup)
+// This pattern uses Playwright's storage state for efficient role switching
+const roles = ['admin', 'editor', 'viewer'] as const;
+type Role = typeof roles[number];
+
+function authFile(role: Role): string {
+  return path.join(authDir, `${role}.json`);
+}
+
+// Auth setup project — runs before all tests
+test.describe('auth setup', () => {
+  const credentials: Record<Role, { email: string; password: string }> = {
+    admin: { email: 'admin@example.com', password: 'AdminPass123!' },
+    editor: { email: 'editor@example.com', password: 'EditorPass123!' },
+    viewer: { email: 'viewer@example.com', password: 'ViewerPass123!' },
+  };
+
+  for (const role of roles) {
+    test(`authenticate as ${role}`, async ({ page }) => {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(credentials[role].email);
+      await page.getByLabel('Password').fill(credentials[role].password);
+      await page.getByRole('button', { name: 'Sign in' }).click();
+      await expect(page).toHaveURL('/dashboard');
+
+      await page.context().storageState({ path: authFile(role) });
+    });
+  }
+});
+
+// Admin tests
+test.describe('admin access', () => {
+  test.use({ storageState: authFile('admin') });
+
+  test('admin can access user management', async ({ page }) => {
+    await page.goto('/admin/users');
+    await expect(page).toHaveURL('/admin/users');
+    await expect(page.getByRole('heading', { name: 'User Management' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add user' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete' }).first()).toBeVisible();
+  });
+
+  test('admin can access system settings', async ({ page }) => {
+    await page.goto('/admin/settings');
+    await expect(page).toHaveURL('/admin/settings');
+    await expect(page.getByRole('heading', { name: 'System Settings' })).toBeVisible();
+  });
+});
+
+// Editor tests
+test.describe('editor access', () => {
+  test.use({ storageState: authFile('editor') });
+
+  test('editor can create and edit content', async ({ page }) => {
+    await page.goto('/content');
+    await expect(page.getByRole('button', { name: 'New post' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible();
+  });
+
+  test('editor cannot access admin area', async ({ page }) => {
+    await page.goto('/admin/users');
+    // Should be redirected or shown forbidden
+    await expect(page).toHaveURL(/\/(403|dashboard|login)/);
+  });
+});
+
+// Viewer tests
+test.describe('viewer access', () => {
+  test.use({ storageState: authFile('viewer') });
+
+  test('viewer can read content', async ({ page }) => {
+    await page.goto('/content');
+    await expect(page.getByRole('article').first()).toBeVisible();
+  });
+
+  test('viewer cannot create content', async ({ page }) => {
+    await page.goto('/content');
+    await expect(page.getByRole('button', { name: 'New post' })).not.toBeVisible();
+  });
+
+  test('viewer cannot access admin area', async ({ page }) => {
+    await page.goto('/admin/users');
+    await expect(page).toHaveURL(/\/(403|dashboard|login)/);
+  });
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const authDir = path.resolve(__dirname, '../.auth');
+
+function authFile(role) {
+  return path.join(authDir, `${role}.json`);
+}
+
+// Admin tests
+test.describe('admin access', () => {
+  test.use({ storageState: authFile('admin') });
+
+  test('admin can access user management', async ({ page }) => {
+    await page.goto('/admin/users');
+    await expect(page).toHaveURL('/admin/users');
+    await expect(page.getByRole('heading', { name: 'User Management' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add user' })).toBeVisible();
+  });
+
+  test('admin can access system settings', async ({ page }) => {
+    await page.goto('/admin/settings');
+    await expect(page).toHaveURL('/admin/settings');
+  });
+});
+
+// Viewer tests
+test.describe('viewer access', () => {
+  test.use({ storageState: authFile('viewer') });
+
+  test('viewer cannot create content', async ({ page }) => {
+    await page.goto('/content');
+    await expect(page.getByRole('button', { name: 'New post' })).not.toBeVisible();
+  });
+
+  test('viewer cannot access admin area', async ({ page }) => {
+    await page.goto('/admin/users');
+    await expect(page).toHaveURL(/\/(403|dashboard|login)/);
+  });
+});
+```
+
+---
+
+## Recipe 7: Session Timeout Handling
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('redirects to login after session timeout', async ({ page, context }) => {
+  // Log in first
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('SecurePass123!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL('/dashboard');
+
+  // Simulate session expiration by clearing the session cookie
+  const cookies = await context.cookies();
+  const sessionCookie = cookies.find(
+    (c) => c.name === 'session' || c.name === 'sid' || c.name === 'connect.sid'
+  );
+
+  if (sessionCookie) {
+    await context.clearCookies({ name: sessionCookie.name });
+  }
+
+  // Try to navigate to a protected page
+  await page.goto('/settings');
+
+  // Should redirect to login with a return URL
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByText(/session.*expired|please.*log in again/i)).toBeVisible();
+});
+
+test('shows session expiry warning before timeout', async ({ page }) => {
+  // Mock the session check endpoint to return "expiring soon"
+  await page.route('**/api/auth/session', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        valid: true,
+        expiresIn: 120, // 2 minutes remaining
+      }),
+    });
+  });
+
+  await page.goto('/dashboard');
+
+  // The app should show a warning when session is about to expire
+  await expect(page.getByText(/session.*expir/i)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole('button', { name: /extend|stay logged in/i })).toBeVisible();
+});
+
+test('extends session when user clicks extend', async ({ page }) => {
+  let sessionExtended = false;
+
+  await page.route('**/api/auth/session', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ valid: true, expiresIn: 120 }),
+    });
+  });
+
+  await page.route('**/api/auth/refresh', async (route) => {
+    sessionExtended = true;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ valid: true, expiresIn: 3600 }),
+    });
+  });
+
+  await page.goto('/dashboard');
+
+  await expect(page.getByRole('button', { name: /extend|stay logged in/i })).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByRole('button', { name: /extend|stay logged in/i }).click();
+
+  expect(sessionExtended).toBe(true);
+  await expect(page.getByText(/session.*expir/i)).not.toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('redirects to login after session timeout', async ({ page, context }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('SecurePass123!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL('/dashboard');
+
+  const cookies = await context.cookies();
+  const sessionCookie = cookies.find(
+    (c) => c.name === 'session' || c.name === 'sid' || c.name === 'connect.sid'
+  );
+
+  if (sessionCookie) {
+    await context.clearCookies({ name: sessionCookie.name });
+  }
+
+  await page.goto('/settings');
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByText(/session.*expired|please.*log in again/i)).toBeVisible();
+});
+```
+
+---
+
+## Recipe 8: Logout
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Use a logged-in state
+test.use({ storageState: '.auth/user.json' });
+
+test('logs out and redirects to login page', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByText('Welcome')).toBeVisible();
+
+  // Open user menu and click logout
+  await page.getByRole('button', { name: /user menu|account|profile/i }).click();
+  await page.getByRole('menuitem', { name: 'Log out' }).click();
+
+  // Should redirect to login
+  await expect(page).toHaveURL('/login');
+
+  // Verify we can no longer access protected pages
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test('logout clears all session data', async ({ page, context }) => {
+  await page.goto('/dashboard');
+
+  await page.getByRole('button', { name: /user menu|account|profile/i }).click();
+  await page.getByRole('menuitem', { name: 'Log out' }).click();
+
+  await expect(page).toHaveURL('/login');
+
+  // Verify cookies are cleared
+  const cookies = await context.cookies();
+  const sessionCookies = cookies.filter(
+    (c) => c.name === 'session' || c.name === 'sid' || c.name === 'token'
+  );
+  expect(sessionCookies).toHaveLength(0);
+
+  // Verify localStorage is cleared
+  const token = await page.evaluate(() => localStorage.getItem('authToken'));
+  expect(token).toBeNull();
+});
+
+test('logout from all devices', async ({ page }) => {
+  let logoutAllCalled = false;
+
+  await page.route('**/api/auth/logout-all', async (route) => {
+    logoutAllCalled = true;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Logged out from all devices' }),
+    });
+  });
+
+  await page.goto('/settings/security');
+
+  await page.getByRole('button', { name: 'Log out of all devices' }).click();
+
+  // Confirm the action in the dialog
+  await page.getByRole('dialog').getByRole('button', { name: 'Confirm' }).click();
+
+  expect(logoutAllCalled).toBe(true);
+  await expect(page).toHaveURL(/\/login/);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.use({ storageState: '.auth/user.json' });
+
+test('logs out and redirects to login page', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await page.getByRole('button', { name: /user menu|account|profile/i }).click();
+  await page.getByRole('menuitem', { name: 'Log out' }).click();
+
+  await expect(page).toHaveURL('/login');
+
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test('logout clears all session data', async ({ page, context }) => {
+  await page.goto('/dashboard');
+
+  await page.getByRole('button', { name: /user menu|account|profile/i }).click();
+  await page.getByRole('menuitem', { name: 'Log out' }).click();
+
+  await expect(page).toHaveURL('/login');
+
+  const cookies = await context.cookies();
+  const sessionCookies = cookies.filter(
+    (c) => c.name === 'session' || c.name === 'sid' || c.name === 'token'
+  );
+  expect(sessionCookies).toHaveLength(0);
+});
+```
+
+---
+
+## Variations
+
+### Login via API for Speed
+
+Skip the UI for login when testing non-auth features. Use `request` context to get tokens faster.
+
+**TypeScript**
+
+```typescript
+import { test as setup } from '@playwright/test';
+
+setup('authenticate via API', async ({ request }) => {
+  const response = await request.post('/api/auth/login', {
+    data: {
+      email: 'user@example.com',
+      password: 'SecurePass123!',
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+
+  // Save the auth state
+  await request.storageState({ path: '.auth/user.json' });
+});
+```
+
+### Multi-Factor Authentication
+
+```typescript
+test('logs in with MFA (TOTP)', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('mfa-user@example.com');
+  await page.getByLabel('Password').fill('SecurePass123!');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // MFA challenge screen appears
+  await expect(page.getByText('Enter verification code')).toBeVisible();
+
+  // In test environments, use a predictable TOTP code or mock the verification
+  await page.route('**/api/auth/verify-mfa', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, token: 'jwt-token' }),
+    });
+  });
+
+  await page.getByLabel('Verification code').fill('123456');
+  await page.getByRole('button', { name: 'Verify' }).click();
+
+  await expect(page).toHaveURL('/dashboard');
+});
+```
+
+### Testing Auth with Different Browser Contexts
+
+```typescript
+test('two users interact simultaneously', async ({ browser }) => {
+  const adminContext = await browser.newContext({
+    storageState: '.auth/admin.json',
+  });
+  const userContext = await browser.newContext({
+    storageState: '.auth/viewer.json',
+  });
+
+  const adminPage = await adminContext.newPage();
+  const userPage = await userContext.newPage();
+
+  // Admin bans a user
+  await adminPage.goto('/admin/users');
+  await adminPage.getByRole('row', { name: 'viewer@example.com' })
+    .getByRole('button', { name: 'Ban' }).click();
+  await adminPage.getByRole('dialog').getByRole('button', { name: 'Confirm' }).click();
+
+  // User tries to navigate and should be blocked
+  await userPage.goto('/dashboard');
+  await expect(userPage.getByText(/account.*banned|access.*revoked/i)).toBeVisible();
+
+  await adminContext.close();
+  await userContext.close();
+});
+```
+
+---
+
+## Tips
+
+1. **Use `storageState` for reusable auth**. Run login once in a setup project, save the state to a JSON file, and reuse it across all tests. This dramatically speeds up your test suite since you only log in once per role.
+
+2. **Never hard-code credentials in test files**. Use environment variables or a `.env` file loaded via `dotenv`. In `playwright.config.ts`, set `process.env` values or use the `env` option in `use`.
+
+3. **Prefer API-based login for non-auth tests**. Only test the login UI in your auth-specific tests. For everything else, authenticate via the API or by restoring `storageState`. This makes tests faster and less brittle.
+
+4. **Test the negative paths too**. Invalid credentials, expired tokens, locked accounts, rate limiting. These are the scenarios users actually encounter in production and are frequently undertested.
+
+5. **Set a shorter session timeout in your test environment**. If your app has a 30-minute session timeout, configure it to 30 seconds in the test environment so you can test timeout behavior without slow tests.
+
+---
+
+## Related
+
+- [Playwright Authentication Docs](https://playwright.dev/docs/auth)
+- `patterns/page-objects.md` -- Encapsulate login flows in page objects
+- `foundations/assertions.md` -- Assertion patterns for auth states
+- `recipes/crud-testing.md` -- Test CRUD operations once authenticated

--- a/engineering-team/playwright skill/core/authentication.md
+++ b/engineering-team/playwright skill/core/authentication.md
@@ -1,0 +1,1374 @@
+# Authentication Testing
+
+> **When to use**: Any app that has login, session management, or protected routes. Authentication is the most common source of slow test suites -- get this right and your entire suite speeds up.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+// Storage state reuse — the #1 pattern for fast auth
+await page.goto('/login');
+await page.getByLabel('Email').fill('user@test.com');
+await page.getByLabel('Password').fill('password');
+await page.getByRole('button', { name: 'Sign in' }).click();
+await page.context().storageState({ path: '.auth/user.json' });
+
+// Reuse in config — every test starts authenticated, zero login overhead
+{ use: { storageState: '.auth/user.json' } }
+
+// API login — skip the UI entirely
+const context = await browser.newContext();
+const response = await context.request.post('/api/auth/login', {
+  data: { email: 'user@test.com', password: 'password' },
+});
+await context.storageState({ path: '.auth/user.json' });
+```
+
+## Patterns
+
+### Storage State Reuse
+
+**Use when**: You need authenticated tests and want to avoid logging in before every test. This is the default pattern for nearly every project.
+**Avoid when**: Tests require completely fresh sessions with no prior state, or you are testing the login flow itself.
+
+Playwright's `storageState` serializes cookies and localStorage to a JSON file. Load it in any browser context to start authenticated instantly.
+
+**TypeScript**
+```typescript
+// scripts/save-auth-state.ts — run once to generate the state file
+import { chromium } from '@playwright/test';
+
+async function saveAuthState() {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('http://localhost:3000/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('s3cure!Pass');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Save cookies + localStorage to a file
+  await context.storageState({ path: '.auth/user.json' });
+  await browser.close();
+}
+
+saveAuthState();
+```
+
+```typescript
+// playwright.config.ts — load saved state for all tests
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: '.auth/user.json',
+  },
+});
+```
+
+```typescript
+// tests/dashboard.spec.ts — test starts already logged in
+import { test, expect } from '@playwright/test';
+
+test('authenticated user sees dashboard', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  // No login step needed — storageState handles it
+});
+```
+
+**JavaScript**
+```javascript
+// scripts/save-auth-state.js
+const { chromium } = require('@playwright/test');
+
+async function saveAuthState() {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('http://localhost:3000/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('s3cure!Pass');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  await context.storageState({ path: '.auth/user.json' });
+  await browser.close();
+}
+
+saveAuthState();
+```
+
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: '.auth/user.json',
+  },
+});
+```
+
+### Global Setup Authentication
+
+**Use when**: You want to authenticate once before the entire test suite runs, then reuse that session everywhere. The standard Playwright-recommended approach.
+**Avoid when**: Different tests need different users, or your tokens expire faster than your suite runs.
+
+Global setup runs once per `npx playwright test` invocation. It logs in, saves the state, and every test project that references that state file starts authenticated.
+
+**TypeScript**
+```typescript
+// global-setup.ts
+import { chromium, type FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  const { baseURL } = config.projects[0].use;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(`${baseURL}/login`);
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+
+  await context.storageState({ path: '.auth/user.json' });
+  await browser.close();
+}
+
+export default globalSetup;
+```
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  globalSetup: require.resolve('./global-setup'),
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: '.auth/user.json',
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// global-setup.js
+const { chromium } = require('@playwright/test');
+
+async function globalSetup(config) {
+  const { baseURL } = config.projects[0].use;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(`${baseURL}/login`);
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+
+  await context.storageState({ path: '.auth/user.json' });
+  await browser.close();
+}
+
+module.exports = globalSetup;
+```
+
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  globalSetup: require.resolve('./global-setup'),
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: '.auth/user.json',
+  },
+});
+```
+
+**Important**: Add `.auth/` to your `.gitignore`. Auth state files contain session tokens and should never be committed.
+
+### Per-Worker Authentication
+
+**Use when**: Each parallel worker needs its own authenticated session to avoid race conditions. Essential when tests modify user state (profile updates, settings changes, data mutations).
+**Avoid when**: Tests are read-only and a shared session is safe, or you only run tests serially.
+
+Worker-scoped fixtures run once per worker process, not once per test. This gives each parallel worker its own isolated session.
+
+**TypeScript**
+```typescript
+// fixtures/auth.ts
+import { test as base, type BrowserContext } from '@playwright/test';
+
+type AuthFixtures = {
+  authenticatedContext: BrowserContext;
+};
+
+export const test = base.extend<{}, AuthFixtures>({
+  authenticatedContext: [async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(`worker-${test.info().parallelIndex}@test.com`);
+    await page.getByLabel('Password').fill('password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await page.close();
+
+    await use(context);
+    await context.close();
+  }, { scope: 'worker' }],
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/profile.spec.ts
+import { test, expect } from '../fixtures/auth';
+
+test('update profile name', async ({ authenticatedContext }) => {
+  const page = await authenticatedContext.newPage();
+  await page.goto('/settings/profile');
+  await page.getByLabel('Display name').fill('Updated Name');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures/auth.js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  authenticatedContext: [async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(`worker-${test.info().parallelIndex}@test.com`);
+    await page.getByLabel('Password').fill('password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await page.close();
+
+    await use(context);
+    await context.close();
+  }, { scope: 'worker' }],
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+### Multiple Roles
+
+**Use when**: Your app has role-based access control and you need to test that admins, regular users, and viewers see different things.
+**Avoid when**: Your app has a single user role.
+
+Use separate Playwright projects with different storage states, one per role. This is cleaner than switching roles within tests.
+
+**TypeScript**
+```typescript
+// global-setup.ts — authenticate all roles
+import { chromium, type FullConfig } from '@playwright/test';
+
+const users = [
+  { role: 'admin', email: 'admin@test.com', password: process.env.ADMIN_PASSWORD! },
+  { role: 'user', email: 'user@test.com', password: process.env.USER_PASSWORD! },
+  { role: 'viewer', email: 'viewer@test.com', password: process.env.VIEWER_PASSWORD! },
+];
+
+async function globalSetup(config: FullConfig) {
+  const { baseURL } = config.projects[0].use;
+
+  for (const { role, email, password } of users) {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(`${baseURL}/login`);
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('**/dashboard');
+
+    await context.storageState({ path: `.auth/${role}.json` });
+    await browser.close();
+  }
+}
+
+export default globalSetup;
+```
+
+```typescript
+// playwright.config.ts — one project per role
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  globalSetup: require.resolve('./global-setup'),
+  projects: [
+    {
+      name: 'admin',
+      use: { storageState: '.auth/admin.json' },
+      testMatch: '**/*.admin.spec.ts',
+    },
+    {
+      name: 'user',
+      use: { storageState: '.auth/user.json' },
+      testMatch: '**/*.user.spec.ts',
+    },
+    {
+      name: 'viewer',
+      use: { storageState: '.auth/viewer.json' },
+      testMatch: '**/*.viewer.spec.ts',
+    },
+    {
+      name: 'unauthenticated',
+      use: { storageState: { cookies: [], origins: [] } },
+      testMatch: '**/*.anon.spec.ts',
+    },
+  ],
+});
+```
+
+```typescript
+// tests/admin-panel.admin.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('admin can access user management', async ({ page }) => {
+  await page.goto('/admin/users');
+  await expect(page.getByRole('heading', { name: 'User Management' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete user' })).toBeEnabled();
+});
+```
+
+```typescript
+// tests/admin-panel.viewer.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('viewer cannot access admin panel', async ({ page }) => {
+  await page.goto('/admin/users');
+  // Should redirect to forbidden or dashboard
+  await expect(page.getByText('Access denied')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// global-setup.js
+const { chromium } = require('@playwright/test');
+
+const users = [
+  { role: 'admin', email: 'admin@test.com', password: process.env.ADMIN_PASSWORD },
+  { role: 'user', email: 'user@test.com', password: process.env.USER_PASSWORD },
+  { role: 'viewer', email: 'viewer@test.com', password: process.env.VIEWER_PASSWORD },
+];
+
+async function globalSetup(config) {
+  const { baseURL } = config.projects[0].use;
+
+  for (const { role, email, password } of users) {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(`${baseURL}/login`);
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('**/dashboard');
+
+    await context.storageState({ path: `.auth/${role}.json` });
+    await browser.close();
+  }
+}
+
+module.exports = globalSetup;
+```
+
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  globalSetup: require.resolve('./global-setup'),
+  projects: [
+    {
+      name: 'admin',
+      use: { storageState: '.auth/admin.json' },
+      testMatch: '**/*.admin.spec.js',
+    },
+    {
+      name: 'user',
+      use: { storageState: '.auth/user.json' },
+      testMatch: '**/*.user.spec.js',
+    },
+    {
+      name: 'viewer',
+      use: { storageState: '.auth/viewer.json' },
+      testMatch: '**/*.viewer.spec.js',
+    },
+    {
+      name: 'unauthenticated',
+      use: { storageState: { cookies: [], origins: [] } },
+      testMatch: '**/*.anon.spec.js',
+    },
+  ],
+});
+```
+
+**Alternative**: Use a fixture that accepts a role parameter when you need role switching within a single spec file.
+
+```typescript
+// fixtures/auth.ts — role-based fixture
+import { test as base, type Page } from '@playwright/test';
+import fs from 'fs';
+
+type RoleFixtures = {
+  loginAs: (role: 'admin' | 'user' | 'viewer') => Promise<Page>;
+};
+
+export const test = base.extend<RoleFixtures>({
+  loginAs: async ({ browser }, use) => {
+    const pages: Page[] = [];
+
+    await use(async (role) => {
+      const statePath = `.auth/${role}.json`;
+      if (!fs.existsSync(statePath)) {
+        throw new Error(`Auth state for role "${role}" not found at ${statePath}. Run global setup first.`);
+      }
+      const context = await browser.newContext({ storageState: statePath });
+      const page = await context.newPage();
+      pages.push(page);
+      return page;
+    });
+
+    for (const page of pages) {
+      await page.context().close();
+    }
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/role-comparison.spec.ts
+import { test, expect } from '../fixtures/auth';
+
+test('admin sees delete button, viewer does not', async ({ loginAs }) => {
+  const adminPage = await loginAs('admin');
+  await adminPage.goto('/admin/users');
+  await expect(adminPage.getByRole('button', { name: 'Delete user' })).toBeVisible();
+
+  const viewerPage = await loginAs('viewer');
+  await viewerPage.goto('/admin/users');
+  await expect(viewerPage.getByText('Access denied')).toBeVisible();
+});
+```
+
+### OAuth/SSO Mocking
+
+**Use when**: Your app authenticates via a third-party OAuth provider (Google, GitHub, Okta, Auth0) and you cannot or should not hit the real provider in tests.
+**Avoid when**: You have a dedicated test tenant on the OAuth provider and want true end-to-end coverage of the OAuth flow.
+
+The strategy: intercept the OAuth callback route and inject a valid session directly, bypassing the provider entirely.
+
+**TypeScript**
+```typescript
+// fixtures/oauth-mock.ts
+import { test as base } from '@playwright/test';
+
+export const test = base.extend({
+  // Mock OAuth by intercepting the callback and injecting session cookies
+  page: async ({ page }, use) => {
+    // Intercept the OAuth redirect to the provider
+    await page.route('**/auth/callback**', async (route) => {
+      // Instead of going to Google/GitHub, call your own backend
+      // with a test token that your backend recognizes in test mode
+      const url = new URL(route.request().url());
+      url.searchParams.set('code', 'test-oauth-code');
+      url.searchParams.set('state', url.searchParams.get('state') || '');
+
+      await route.continue({ url: url.toString() });
+    });
+
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/oauth-login.spec.ts — approach 1: mock the callback route
+import { test, expect } from '@playwright/test';
+
+test('login via mocked OAuth flow', async ({ page }) => {
+  // Intercept the redirect to the OAuth provider
+  await page.route('https://accounts.google.com/**', async (route) => {
+    // Redirect back to your app's callback with a fake auth code
+    const callbackUrl = new URL('http://localhost:3000/auth/callback');
+    callbackUrl.searchParams.set('code', 'mock-auth-code-12345');
+    callbackUrl.searchParams.set('state', 'expected-state-value');
+    await route.fulfill({
+      status: 302,
+      headers: { location: callbackUrl.toString() },
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+
+  // Your backend must accept "mock-auth-code-12345" in test mode
+  // and exchange it for a real session
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+```typescript
+// tests/oauth-login.spec.ts — approach 2: API-based session injection
+import { test, expect } from '@playwright/test';
+
+test('bypass OAuth entirely via API session injection', async ({ page, request }) => {
+  // Call a test-only endpoint that creates a session without OAuth
+  // Your backend exposes this only when NODE_ENV=test
+  const response = await request.post('/api/test/create-session', {
+    data: {
+      email: 'oauth-user@test.com',
+      provider: 'google',
+      role: 'user',
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+
+  // The response sets session cookies; storageState captures them
+  await page.context().storageState({ path: '.auth/oauth-user.json' });
+
+  // Now navigate — already authenticated
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('login via mocked OAuth flow', async ({ page }) => {
+  await page.route('https://accounts.google.com/**', async (route) => {
+    const callbackUrl = new URL('http://localhost:3000/auth/callback');
+    callbackUrl.searchParams.set('code', 'mock-auth-code-12345');
+    callbackUrl.searchParams.set('state', 'expected-state-value');
+    await route.fulfill({
+      status: 302,
+      headers: { location: callbackUrl.toString() },
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+```javascript
+test('bypass OAuth entirely via API session injection', async ({ page, request }) => {
+  const response = await request.post('/api/test/create-session', {
+    data: {
+      email: 'oauth-user@test.com',
+      provider: 'google',
+      role: 'user',
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**Backend requirement**: Your backend must expose a test-only session creation endpoint (guarded by `NODE_ENV=test`) or accept a known test OAuth code. Never ship test auth endpoints to production.
+
+### MFA Handling
+
+**Use when**: Your app requires two-factor authentication (TOTP, SMS, email codes) and you need to handle it in tests.
+**Avoid when**: MFA is optional and you can disable it for test accounts.
+
+**Strategy 1**: Generate real TOTP codes from a shared secret. This is the most reliable approach.
+
+**TypeScript**
+```typescript
+// helpers/totp.ts
+import * as OTPAuth from 'otpauth';
+
+export function generateTOTP(secret: string): string {
+  const totp = new OTPAuth.TOTP({
+    secret: OTPAuth.Secret.fromBase32(secret),
+    digits: 6,
+    period: 30,
+    algorithm: 'SHA1',
+  });
+  return totp.generate();
+}
+```
+
+```typescript
+// tests/mfa-login.spec.ts
+import { test, expect } from '@playwright/test';
+import { generateTOTP } from '../helpers/totp';
+
+test('login with TOTP two-factor auth', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('mfa-user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // MFA challenge screen
+  await expect(page.getByText('Enter your authentication code')).toBeVisible();
+
+  // Generate a valid TOTP from the test account's secret
+  const code = generateTOTP(process.env.MFA_TOTP_SECRET!);
+  await page.getByLabel('Authentication code').fill(code);
+  await page.getByRole('button', { name: 'Verify' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// helpers/totp.js
+const OTPAuth = require('otpauth');
+
+function generateTOTP(secret) {
+  const totp = new OTPAuth.TOTP({
+    secret: OTPAuth.Secret.fromBase32(secret),
+    digits: 6,
+    period: 30,
+    algorithm: 'SHA1',
+  });
+  return totp.generate();
+}
+
+module.exports = { generateTOTP };
+```
+
+```javascript
+// tests/mfa-login.spec.js
+const { test, expect } = require('@playwright/test');
+const { generateTOTP } = require('../helpers/totp');
+
+test('login with TOTP two-factor auth', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('mfa-user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByText('Enter your authentication code')).toBeVisible();
+
+  const code = generateTOTP(process.env.MFA_TOTP_SECRET);
+  await page.getByLabel('Authentication code').fill(code);
+  await page.getByRole('button', { name: 'Verify' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**Strategy 2**: Mock MFA at the backend level. Have your backend accept a known bypass code (e.g., `000000`) when `NODE_ENV=test`.
+
+```typescript
+// Simpler but less realistic — backend accepts bypass code in test mode
+test('login with MFA bypass code', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('mfa-user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Backend accepts "000000" as a valid MFA code in test environment
+  await page.getByLabel('Authentication code').fill('000000');
+  await page.getByRole('button', { name: 'Verify' }).click();
+
+  await page.waitForURL('/dashboard');
+});
+```
+
+**Strategy 3**: Disable MFA for test accounts at the infrastructure level. Set up dedicated test users with MFA disabled. This is the simplest approach when feasible.
+
+### Session Refresh
+
+**Use when**: Your tokens expire during long test runs or your app uses short-lived JWTs that need refreshing.
+**Avoid when**: Your test suite runs in under a few minutes and tokens outlast the entire run.
+
+**TypeScript**
+```typescript
+// fixtures/auth-with-refresh.ts
+import { test as base, type BrowserContext } from '@playwright/test';
+import fs from 'fs';
+
+type AuthFixtures = {
+  authenticatedPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<AuthFixtures>({
+  authenticatedPage: async ({ browser }, use) => {
+    const statePath = '.auth/user.json';
+
+    // Check if the stored session is still valid
+    let context: BrowserContext;
+    if (fs.existsSync(statePath)) {
+      context = await browser.newContext({ storageState: statePath });
+      const page = await context.newPage();
+
+      // Quick health check — does the session still work?
+      const response = await page.request.get('/api/auth/me');
+      if (response.ok()) {
+        await use(page);
+        await context.close();
+        return;
+      }
+      // Session expired — close and re-authenticate
+      await context.close();
+    }
+
+    // Re-authenticate
+    context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
+    await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+
+    // Save refreshed state for subsequent tests
+    await context.storageState({ path: statePath });
+
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// Alternative: intercept token refresh requests to ensure they work
+import { test, expect } from '@playwright/test';
+
+test('app refreshes expired token automatically', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Simulate token expiration by clearing the access token cookie
+  await page.context().clearCookies({ name: 'access_token' });
+
+  // Next API call should trigger a token refresh via refresh_token cookie
+  const refreshPromise = page.waitForResponse('**/api/auth/refresh');
+  await page.getByRole('button', { name: 'Load data' }).click();
+  const refreshResponse = await refreshPromise;
+
+  expect(refreshResponse.status()).toBe(200);
+  await expect(page.getByTestId('data-table')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures/auth-with-refresh.js
+const { test: base } = require('@playwright/test');
+const fs = require('fs');
+
+const test = base.extend({
+  authenticatedPage: async ({ browser }, use) => {
+    const statePath = '.auth/user.json';
+
+    if (fs.existsSync(statePath)) {
+      const context = await browser.newContext({ storageState: statePath });
+      const page = await context.newPage();
+      const response = await page.request.get('/api/auth/me');
+
+      if (response.ok()) {
+        await use(page);
+        await context.close();
+        return;
+      }
+      await context.close();
+    }
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL);
+    await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await context.storageState({ path: statePath });
+
+    await use(page);
+    await context.close();
+  },
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+### Login Page Object
+
+**Use when**: Multiple test files need to log in and you want consistent, maintainable login logic with proper error handling.
+**Avoid when**: You use `storageState` everywhere and never navigate through the login UI in tests (still useful for testing the login page itself).
+
+**TypeScript**
+```typescript
+// page-objects/LoginPage.ts
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class LoginPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly signInButton: Locator;
+  readonly errorMessage: Locator;
+  readonly forgotPasswordLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.getByLabel('Email');
+    this.passwordInput = page.getByLabel('Password');
+    this.signInButton = page.getByRole('button', { name: 'Sign in' });
+    this.errorMessage = page.getByRole('alert');
+    this.forgotPasswordLink = page.getByRole('link', { name: 'Forgot password' });
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+    await expect(this.signInButton).toBeVisible();
+  }
+
+  async login(email: string, password: string) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+
+  async loginAndWaitForDashboard(email: string, password: string) {
+    await this.login(email, password);
+    await this.page.waitForURL('/dashboard');
+  }
+
+  async expectError(message: string | RegExp) {
+    await expect(this.errorMessage).toContainText(message);
+  }
+
+  async expectFieldError(field: 'email' | 'password', message: string) {
+    const input = field === 'email' ? this.emailInput : this.passwordInput;
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    // Error message associated with the field
+    const errorId = await input.getAttribute('aria-describedby');
+    if (errorId) {
+      await expect(this.page.locator(`#${errorId}`)).toContainText(message);
+    }
+  }
+}
+```
+
+```typescript
+// tests/login.spec.ts
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../page-objects/LoginPage';
+
+// These tests run WITHOUT storageState (unauthenticated)
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('login page', () => {
+  let loginPage: LoginPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await loginPage.goto();
+  });
+
+  test('successful login redirects to dashboard', async ({ page }) => {
+    await loginPage.loginAndWaitForDashboard('user@test.com', 'password');
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  });
+
+  test('wrong password shows error', async () => {
+    await loginPage.login('user@test.com', 'wrong-password');
+    await loginPage.expectError('Invalid email or password');
+  });
+
+  test('empty fields show validation errors', async () => {
+    await loginPage.signInButton.click();
+    await loginPage.expectFieldError('email', 'Email is required');
+  });
+
+  test('forgot password link navigates correctly', async ({ page }) => {
+    await loginPage.forgotPasswordLink.click();
+    await page.waitForURL('/forgot-password');
+    await expect(page.getByRole('heading', { name: 'Reset password' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+// page-objects/LoginPage.js
+const { expect } = require('@playwright/test');
+
+class LoginPage {
+  constructor(page) {
+    this.page = page;
+    this.emailInput = page.getByLabel('Email');
+    this.passwordInput = page.getByLabel('Password');
+    this.signInButton = page.getByRole('button', { name: 'Sign in' });
+    this.errorMessage = page.getByRole('alert');
+    this.forgotPasswordLink = page.getByRole('link', { name: 'Forgot password' });
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+    await expect(this.signInButton).toBeVisible();
+  }
+
+  async login(email, password) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+
+  async loginAndWaitForDashboard(email, password) {
+    await this.login(email, password);
+    await this.page.waitForURL('/dashboard');
+  }
+
+  async expectError(message) {
+    await expect(this.errorMessage).toContainText(message);
+  }
+
+  async expectFieldError(field, message) {
+    const input = field === 'email' ? this.emailInput : this.passwordInput;
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    const errorId = await input.getAttribute('aria-describedby');
+    if (errorId) {
+      await expect(this.page.locator(`#${errorId}`)).toContainText(message);
+    }
+  }
+}
+
+module.exports = { LoginPage };
+```
+
+```javascript
+// tests/login.spec.js
+const { test, expect } = require('@playwright/test');
+const { LoginPage } = require('../page-objects/LoginPage');
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('login page', () => {
+  let loginPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await loginPage.goto();
+  });
+
+  test('successful login redirects to dashboard', async ({ page }) => {
+    await loginPage.loginAndWaitForDashboard('user@test.com', 'password');
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  });
+
+  test('wrong password shows error', async () => {
+    await loginPage.login('user@test.com', 'wrong-password');
+    await loginPage.expectError('Invalid email or password');
+  });
+
+  test('empty fields show validation errors', async () => {
+    await loginPage.signInButton.click();
+    await loginPage.expectFieldError('email', 'Email is required');
+  });
+});
+```
+
+### API-Based Login
+
+**Use when**: You want the fastest possible authentication without any browser interaction. Ideal for generating `storageState` files in global setup or fixtures.
+**Avoid when**: You are specifically testing the login UI. Use the Login Page Object pattern instead.
+
+API login is typically 5-10x faster than UI login. Use `request.post()` to hit your auth endpoint directly, then capture the resulting cookies.
+
+**TypeScript**
+```typescript
+// global-setup.ts — API-based login (fastest)
+import { request, type FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  const { baseURL } = config.projects[0].use;
+
+  const requestContext = await request.newContext({ baseURL });
+
+  // Login via API — no browser needed
+  const response = await requestContext.post('/api/auth/login', {
+    data: {
+      email: process.env.TEST_USER_EMAIL!,
+      password: process.env.TEST_USER_PASSWORD!,
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`API login failed: ${response.status()} ${await response.text()}`);
+  }
+
+  // Save the session cookies from the API response
+  await requestContext.storageState({ path: '.auth/user.json' });
+  await requestContext.dispose();
+}
+
+export default globalSetup;
+```
+
+```typescript
+// fixtures/api-auth.ts — fixture version for per-test authentication
+import { test as base } from '@playwright/test';
+
+export const test = base.extend({
+  authenticatedPage: async ({ browser, playwright }, use) => {
+    // Create API context and login
+    const apiContext = await playwright.request.newContext({
+      baseURL: 'http://localhost:3000',
+    });
+
+    await apiContext.post('/api/auth/login', {
+      data: {
+        email: 'user@test.com',
+        password: 'password',
+      },
+    });
+
+    // Transfer API session to browser context
+    const state = await apiContext.storageState();
+    const context = await browser.newContext({ storageState: state });
+    const page = await context.newPage();
+
+    await use(page);
+
+    await context.close();
+    await apiContext.dispose();
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+**JavaScript**
+```javascript
+// global-setup.js — API-based login
+const { request } = require('@playwright/test');
+
+async function globalSetup(config) {
+  const { baseURL } = config.projects[0].use;
+  const requestContext = await request.newContext({ baseURL });
+
+  const response = await requestContext.post('/api/auth/login', {
+    data: {
+      email: process.env.TEST_USER_EMAIL,
+      password: process.env.TEST_USER_PASSWORD,
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`API login failed: ${response.status()} ${await response.text()}`);
+  }
+
+  await requestContext.storageState({ path: '.auth/user.json' });
+  await requestContext.dispose();
+}
+
+module.exports = globalSetup;
+```
+
+```javascript
+// fixtures/api-auth.js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  authenticatedPage: async ({ browser, playwright }, use) => {
+    const apiContext = await playwright.request.newContext({
+      baseURL: 'http://localhost:3000',
+    });
+
+    await apiContext.post('/api/auth/login', {
+      data: { email: 'user@test.com', password: 'password' },
+    });
+
+    const state = await apiContext.storageState();
+    const context = await browser.newContext({ storageState: state });
+    const page = await context.newPage();
+
+    await use(page);
+
+    await context.close();
+    await apiContext.dispose();
+  },
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+### Unauthenticated Tests
+
+**Use when**: Testing the login page, signup flow, password reset, public pages, authentication error handling, or redirect behavior for unauthenticated users.
+**Avoid when**: The test requires a logged-in user.
+
+When your config sets a default `storageState`, you must explicitly clear it for unauthenticated tests.
+
+**TypeScript**
+```typescript
+// tests/public-pages.spec.ts
+import { test, expect } from '@playwright/test';
+
+// Override storageState to empty — no cookies, no session
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('unauthenticated access', () => {
+  test('homepage is accessible without login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('protected route redirects to login', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.waitForURL('**/login**');
+    // Verify redirect preserves the intended destination
+    expect(page.url()).toContain('redirect=%2Fdashboard');
+  });
+
+  test('expired session shows re-login prompt', async ({ page, context }) => {
+    // Start with a valid session, then invalidate it
+    await page.goto('/dashboard');
+
+    // Clear all cookies to simulate session expiration
+    await context.clearCookies();
+
+    // Next navigation should detect the invalid session
+    await page.goto('/settings');
+    await page.waitForURL('**/login**');
+    await expect(page.getByText('Your session has expired')).toBeVisible();
+  });
+
+  test('login page shows social auth options', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+  });
+
+  test('signup flow creates account', async ({ page }) => {
+    await page.goto('/signup');
+    await page.getByLabel('Name').fill('New User');
+    await page.getByLabel('Email').fill(`test-${Date.now()}@test.com`);
+    await page.getByLabel('Password', { exact: true }).fill('s3cure!Pass');
+    await page.getByLabel('Confirm password').fill('s3cure!Pass');
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await page.waitForURL('/onboarding');
+    await expect(page.getByText('Welcome, New User')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+// tests/public-pages.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('unauthenticated access', () => {
+  test('homepage is accessible without login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('protected route redirects to login', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.waitForURL('**/login**');
+    expect(page.url()).toContain('redirect=%2Fdashboard');
+  });
+
+  test('signup flow creates account', async ({ page }) => {
+    await page.goto('/signup');
+    await page.getByLabel('Name').fill('New User');
+    await page.getByLabel('Email').fill(`test-${Date.now()}@test.com`);
+    await page.getByLabel('Password', { exact: true }).fill('s3cure!Pass');
+    await page.getByLabel('Confirm password').fill('s3cure!Pass');
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await page.waitForURL('/onboarding');
+    await expect(page.getByText('Welcome, New User')).toBeVisible();
+  });
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Speed | Isolation | When to Choose |
+|---|---|---|---|---|
+| Most tests need auth | Global setup + `storageState` | Fastest | Shared session | Default for nearly every project. Login happens once, all tests reuse the session file. |
+| Tests modify user state | Per-worker fixture | Fast | Per worker | Tests update profile, change settings, or mutate data that could conflict between parallel workers. |
+| Multiple user roles | Per-project `storageState` | Fastest | Per role | App has admin/user/viewer roles. Each project gets its own state file from global setup. |
+| Testing the login page | No `storageState` | N/A | Full | Use `test.use({ storageState: { cookies: [], origins: [] } })` to override defaults. |
+| OAuth/SSO provider | Mock the callback | Fast | Per test | Never hit real OAuth providers in CI. Mock the redirect or use API session injection. |
+| MFA is required | TOTP generation or bypass | Moderate | Per test | Generate real TOTP codes from a shared secret, or use a test-mode bypass code. |
+| Token expires mid-suite | Session refresh fixture | Fast | Per check | Fixture validates the session before use and re-authenticates if expired. |
+| Single test needs different user | `loginAs(role)` fixture | Moderate | Per call | Rare: prefer per-project roles. Use when a single test must compare two roles side by side. |
+| API-first app (no login UI) | API login via `request.post()` | Fastest | Per test | No browser needed for auth. Hit the API directly and capture cookies. |
+| CI with long-running suites | API login + session check | Fastest | Per worker | Combine API login speed with session refresh for reliability over long runs. |
+
+### UI Login vs API Login vs Storage State
+
+```
+Need to test the login page itself?
+├── Yes → UI login with LoginPage POM, no storageState
+└── No → Do you have a login API endpoint?
+    ├── Yes → API login in global setup, save storageState (fastest)
+    └── No → UI login in global setup, save storageState
+              └── Tokens expire quickly?
+                  ├── Yes → Add session refresh fixture
+                  └── No → Standard storageState reuse is fine
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Log in via UI before every test | Adds 2-5 seconds per test. A suite of 200 tests wastes 7-17 minutes just logging in. | Use `storageState` to skip login entirely. Log in once in global setup. |
+| Share a single auth state file across parallel workers that mutate state | Race conditions: worker A changes the password while worker B is mid-test. | Use per-worker fixtures with `{ scope: 'worker' }` or per-worker test accounts. |
+| Hardcode credentials in test files | Security risk. Credentials leak into version control and CI logs. | Use environment variables (`process.env.TEST_USER_PASSWORD`) and `.env` files. |
+| Ignore token expiration | Tests fail intermittently with 401 errors after running for a while. | Add a session validity check in your auth fixture and re-authenticate when expired. |
+| Hit real OAuth providers in CI | Flaky: provider rate limits, CAPTCHA, network issues. Slow. May violate ToS. | Mock the OAuth callback or use API session injection with a test-only endpoint. |
+| Use `page.waitForTimeout(2000)` after login | Arbitrary delay. Too slow in fast environments, too short in slow ones. | `await page.waitForURL('/dashboard')` or `await expect(heading).toBeVisible()`. |
+| Store `.auth/*.json` files in git | Tokens and cookies in version control. Security incident waiting to happen. | Add `.auth/` to `.gitignore`. Generate auth state in CI as part of the test run. |
+| Create one "god" test account with all permissions | Cannot test role-based access control. Bugs in permission checks go undetected. | Create separate accounts per role (admin, user, viewer) with appropriate permissions. |
+| Use `browser.newContext()` without `storageState` for authenticated tests | Every context starts unauthenticated. You end up re-logging in constantly. | Pass `storageState` when creating the context: `browser.newContext({ storageState: '.auth/user.json' })`. |
+| Test MFA by disabling it everywhere | You never test the MFA flow. Real users hit MFA bugs you never catch. | Use TOTP generation from a shared secret for at least one test. Bypass MFA for the rest. |
+
+## Troubleshooting
+
+### Global setup fails with "Target page, context or browser has been closed"
+
+**Cause**: The login page redirected unexpectedly, or the browser closed before `storageState()` was called. Common when the login URL requires HTTPS but your test server uses HTTP.
+
+**Fix**:
+- Add `await page.waitForURL()` after the login action to ensure navigation completed.
+- Check that `baseURL` in your config matches the actual server URL and protocol.
+- Add error handling to global setup with a meaningful error message:
+
+```typescript
+const response = await page.waitForResponse('**/api/auth/**');
+if (!response.ok()) {
+  throw new Error(`Login failed in global setup: ${response.status()} ${await response.text()}`);
+}
+```
+
+### Tests fail with 401 Unauthorized after running for a while
+
+**Cause**: The session token saved in `storageState` has expired. Short-lived JWTs (15-minute expiry) will not survive a long test suite.
+
+**Fix**:
+- Use the session refresh fixture pattern (see Session Refresh section).
+- Increase token expiry in test environment configuration.
+- Switch to API-based login in a worker-scoped fixture that re-authenticates per worker.
+
+### `storageState` file is empty or contains no cookies
+
+**Cause**: `storageState()` was called before the login response set cookies. The login may be async (POST returns, then a redirect sets the cookie).
+
+**Fix**:
+- Wait for the post-login page to load: `await page.waitForURL('/dashboard')`.
+- Wait for a specific cookie: use `await context.cookies()` in a polling check.
+- Verify cookies exist before saving:
+
+```typescript
+const cookies = await context.cookies();
+if (cookies.length === 0) {
+  throw new Error('No cookies found after login. Check that the login flow sets cookies.');
+}
+await context.storageState({ path: '.auth/user.json' });
+```
+
+### Different browsers get different cookies (cross-browser auth issues)
+
+**Cause**: Some auth flows set cookies with `SameSite=Strict` or use browser-specific cookie behavior. Chromium and Firefox handle third-party cookies differently.
+
+**Fix**:
+- Generate separate auth state files per browser project.
+- Check if your auth uses `SameSite=None; Secure` cookies that require HTTPS.
+- In `playwright.config`, set separate `storageState` paths per project:
+
+```typescript
+projects: [
+  {
+    name: 'chromium',
+    use: { ...devices['Desktop Chrome'], storageState: '.auth/chromium-user.json' },
+  },
+  {
+    name: 'firefox',
+    use: { ...devices['Desktop Firefox'], storageState: '.auth/firefox-user.json' },
+  },
+],
+```
+
+### Parallel tests interfere with each other's sessions
+
+**Cause**: Multiple workers share the same test account and one worker's actions (logout, password change, session invalidation) affect others.
+
+**Fix**:
+- Use per-worker test accounts: `worker-${test.info().parallelIndex}@test.com`.
+- Use the per-worker authentication fixture pattern (see Per-Worker Authentication section).
+- Make tests idempotent: each test should work regardless of what other tests did.
+
+### OAuth mock does not work — still redirects to real provider
+
+**Cause**: `page.route()` was registered after the navigation that triggers the OAuth redirect, or the route pattern does not match the actual redirect URL.
+
+**Fix**:
+- Register route handlers before any navigation: call `page.route()` before `page.goto()`.
+- Log the actual redirect URL to verify the pattern:
+
+```typescript
+page.on('request', (req) => {
+  if (req.url().includes('oauth') || req.url().includes('accounts.google')) {
+    console.log('OAuth request:', req.url());
+  }
+});
+```
+
+- Use a broad pattern first (`**accounts.google.com**`) then narrow it down.
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- custom fixtures for auth setup and teardown
+- [core/configuration.md](configuration.md) -- `storageState`, projects, and global setup configuration
+- [ci/global-setup-teardown.md](../ci/global-setup-teardown.md) -- global setup patterns and project dependencies
+- [core/network-mocking.md](network-mocking.md) -- route interception patterns used in OAuth mocking
+- [core/api-testing.md](api-testing.md) -- API request context used in API-based login
+- [core/flaky-tests.md](flaky-tests.md) -- diagnosing auth-related flakiness
+- [core/auth-flows.md](auth-flows.md) -- complete recipes for specific auth providers (Auth0, Okta, Firebase)

--- a/engineering-team/playwright skill/core/browser-apis.md
+++ b/engineering-team/playwright skill/core/browser-apis.md
@@ -1,0 +1,640 @@
+# Browser APIs
+
+> **When to use**: When testing features that depend on browser-native APIs -- geolocation, permissions, clipboard, notifications, camera/microphone, localStorage, sessionStorage, IndexedDB.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+// Geolocation — set via context options
+const context = await browser.newContext({
+  geolocation: { latitude: 40.7128, longitude: -74.0060 },
+  permissions: ['geolocation'],
+});
+
+// Permissions — grant at context level
+const context = await browser.newContext({
+  permissions: ['clipboard-read', 'clipboard-write', 'notifications'],
+});
+
+// localStorage / sessionStorage — access via page.evaluate
+await page.evaluate(() => localStorage.setItem('theme', 'dark'));
+const value = await page.evaluate(() => localStorage.getItem('theme'));
+
+// Clipboard — read/write in page context
+await page.evaluate(() => navigator.clipboard.writeText('copied text'));
+```
+
+## Patterns
+
+### Geolocation
+
+**Use when**: Your app uses `navigator.geolocation` for maps, store locators, delivery tracking, or location-based features.
+**Avoid when**: Your app never reads the user's location.
+
+Geolocation is set at the context level. You can also update it mid-test with `context.setGeolocation()`.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('shows nearest store based on geolocation', async ({ browser }) => {
+  const context = await browser.newContext({
+    geolocation: { latitude: 40.7128, longitude: -74.0060 }, // New York
+    permissions: ['geolocation'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/store-locator');
+  await page.getByRole('button', { name: 'Find nearby stores' }).click();
+
+  await expect(page.getByText('Manhattan Store')).toBeVisible();
+  await context.close();
+});
+
+test('update location mid-test for moving user', async ({ browser }) => {
+  const context = await browser.newContext({
+    geolocation: { latitude: 37.7749, longitude: -122.4194 }, // San Francisco
+    permissions: ['geolocation'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/delivery-tracker');
+  await expect(page.getByTestId('current-city')).toHaveText('San Francisco');
+
+  // Simulate user moving to a new location
+  await context.setGeolocation({ latitude: 34.0522, longitude: -118.2437 }); // Los Angeles
+
+  // Trigger location refresh
+  await page.getByRole('button', { name: 'Update location' }).click();
+  await expect(page.getByTestId('current-city')).toHaveText('Los Angeles');
+
+  await context.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('shows nearest store based on geolocation', async ({ browser }) => {
+  const context = await browser.newContext({
+    geolocation: { latitude: 40.7128, longitude: -74.0060 },
+    permissions: ['geolocation'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/store-locator');
+  await page.getByRole('button', { name: 'Find nearby stores' }).click();
+
+  await expect(page.getByText('Manhattan Store')).toBeVisible();
+  await context.close();
+});
+
+test('update location mid-test', async ({ browser }) => {
+  const context = await browser.newContext({
+    geolocation: { latitude: 37.7749, longitude: -122.4194 },
+    permissions: ['geolocation'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/delivery-tracker');
+  await expect(page.getByTestId('current-city')).toHaveText('San Francisco');
+
+  await context.setGeolocation({ latitude: 34.0522, longitude: -118.2437 });
+  await page.getByRole('button', { name: 'Update location' }).click();
+  await expect(page.getByTestId('current-city')).toHaveText('Los Angeles');
+
+  await context.close();
+});
+```
+
+You can also set geolocation globally in `playwright.config`:
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    geolocation: { latitude: 51.5074, longitude: -0.1278 }, // London
+    permissions: ['geolocation'],
+  },
+});
+```
+
+### Permissions
+
+**Use when**: Your app requests browser permissions -- notifications, camera, microphone, geolocation, clipboard.
+**Avoid when**: Your app does not use the Permissions API.
+
+Grant permissions at context creation. Playwright does not show permission dialogs; you pre-grant or deny them.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('notification permission granted shows notification UI', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['notifications'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/settings/notifications');
+
+  // App checks Notification.permission and shows the toggle
+  await expect(page.getByRole('switch', { name: 'Enable notifications' })).toBeEnabled();
+
+  await context.close();
+});
+
+test('notification permission denied shows upgrade prompt', async ({ browser }) => {
+  // No 'notifications' in permissions = denied
+  const context = await browser.newContext({
+    permissions: [],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/settings/notifications');
+
+  await expect(page.getByText('Notifications are blocked')).toBeVisible();
+  await context.close();
+});
+
+test('grant permissions mid-test', async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto('/camera-app');
+
+  // Initially no camera permission
+  await expect(page.getByText('Camera access needed')).toBeVisible();
+
+  // Grant permission dynamically
+  await context.grantPermissions(['camera'], { origin: 'https://localhost:3000' });
+
+  await page.getByRole('button', { name: 'Enable camera' }).click();
+  await expect(page.getByTestId('camera-preview')).toBeVisible();
+
+  // Revoke all permissions
+  await context.clearPermissions();
+  await context.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('notification permission granted shows notification UI', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['notifications'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/settings/notifications');
+  await expect(page.getByRole('switch', { name: 'Enable notifications' })).toBeEnabled();
+  await context.close();
+});
+
+test('grant permissions mid-test', async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto('/camera-app');
+
+  await context.grantPermissions(['camera'], { origin: 'https://localhost:3000' });
+  await page.getByRole('button', { name: 'Enable camera' }).click();
+  await expect(page.getByTestId('camera-preview')).toBeVisible();
+
+  await context.clearPermissions();
+  await context.close();
+});
+```
+
+### Clipboard API
+
+**Use when**: Testing copy/paste functionality, "Copy to clipboard" buttons, or paste-from-clipboard features.
+**Avoid when**: Your app does not interact with the clipboard.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('copy button puts text on clipboard', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/share');
+  await page.getByRole('button', { name: 'Copy link' }).click();
+
+  // Read clipboard content
+  const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboardText).toContain('https://example.com/share/');
+
+  await context.close();
+});
+
+test('paste from clipboard into editor', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/editor');
+
+  // Write to clipboard programmatically
+  await page.evaluate(() => navigator.clipboard.writeText('Pasted content from clipboard'));
+
+  // Focus the editor and trigger paste
+  const editor = page.getByRole('textbox', { name: 'Editor' });
+  await editor.focus();
+  await page.keyboard.press('ControlOrMeta+v');
+
+  await expect(editor).toContainText('Pasted content from clipboard');
+
+  await context.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('copy button puts text on clipboard', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/share');
+  await page.getByRole('button', { name: 'Copy link' }).click();
+
+  const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboardText).toContain('https://example.com/share/');
+  await context.close();
+});
+```
+
+### Camera and Microphone Mocking
+
+**Use when**: Testing video calls, QR code scanners, voice recording, or any feature using `getUserMedia`.
+**Avoid when**: Your app does not use camera or microphone.
+
+Chromium can use fake media devices. This is not available in Firefox or WebKit.
+
+**TypeScript**
+```typescript
+import { test, expect, chromium } from '@playwright/test';
+
+test('video call shows local preview with fake camera', async () => {
+  // Launch Chromium with fake media streams
+  const browser = await chromium.launch({
+    args: [
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+    ],
+  });
+
+  const context = await browser.newContext({
+    permissions: ['camera', 'microphone'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/video-call');
+  await page.getByRole('button', { name: 'Start camera' }).click();
+
+  // Verify the video element is playing
+  const isPlaying = await page.evaluate(() => {
+    const video = document.querySelector('video#local-preview') as HTMLVideoElement;
+    return video && !video.paused && video.readyState >= 2;
+  });
+  expect(isPlaying).toBe(true);
+
+  await context.close();
+  await browser.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect, chromium } = require('@playwright/test');
+
+test('video call shows local preview with fake camera', async () => {
+  const browser = await chromium.launch({
+    args: [
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+    ],
+  });
+
+  const context = await browser.newContext({
+    permissions: ['camera', 'microphone'],
+  });
+  const page = await context.newPage();
+
+  await page.goto('/video-call');
+  await page.getByRole('button', { name: 'Start camera' }).click();
+
+  const isPlaying = await page.evaluate(() => {
+    const video = document.querySelector('video#local-preview');
+    return video && !video.paused && video.readyState >= 2;
+  });
+  expect(isPlaying).toBe(true);
+
+  await context.close();
+  await browser.close();
+});
+```
+
+### localStorage and sessionStorage
+
+**Use when**: Your app persists state, tokens, preferences, or feature flags in web storage.
+**Avoid when**: You can set the state through the UI or API instead. Prefer those approaches for realism.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('app loads dark theme from localStorage preference', async ({ page }) => {
+  // Set localStorage before navigating
+  await page.goto('/');
+  await page.evaluate(() => localStorage.setItem('theme', 'dark'));
+
+  // Reload to pick up the stored preference
+  await page.reload();
+
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+});
+
+test('clear localStorage between scenarios', async ({ page }) => {
+  await page.goto('/');
+
+  // Seed some data
+  await page.evaluate(() => {
+    localStorage.setItem('cart', JSON.stringify([{ id: 1, qty: 2 }]));
+    localStorage.setItem('user_prefs', JSON.stringify({ currency: 'EUR' }));
+  });
+
+  // Read and verify
+  const cart = await page.evaluate(() => JSON.parse(localStorage.getItem('cart') || '[]'));
+  expect(cart).toHaveLength(1);
+
+  // Clear specific keys
+  await page.evaluate(() => localStorage.removeItem('cart'));
+
+  // Or clear everything
+  await page.evaluate(() => localStorage.clear());
+});
+
+test('sessionStorage survives navigations within the session', async ({ page }) => {
+  await page.goto('/step-1');
+  await page.evaluate(() => sessionStorage.setItem('wizard_step', '1'));
+
+  await page.goto('/step-2');
+  const step = await page.evaluate(() => sessionStorage.getItem('wizard_step'));
+  expect(step).toBe('1');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('app loads dark theme from localStorage preference', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.setItem('theme', 'dark'));
+  await page.reload();
+
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+});
+
+test('sessionStorage survives navigations within the session', async ({ page }) => {
+  await page.goto('/step-1');
+  await page.evaluate(() => sessionStorage.setItem('wizard_step', '1'));
+
+  await page.goto('/step-2');
+  const step = await page.evaluate(() => sessionStorage.getItem('wizard_step'));
+  expect(step).toBe('1');
+});
+```
+
+### IndexedDB Testing
+
+**Use when**: Your app uses IndexedDB for offline storage, caching, or large datasets (progressive web apps, offline-first apps).
+**Avoid when**: Your app only uses localStorage or server-side storage.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('offline-first app stores data in IndexedDB', async ({ page }) => {
+  await page.goto('/notes');
+
+  // Create a note through the UI
+  await page.getByRole('button', { name: 'New note' }).click();
+  await page.getByRole('textbox', { name: 'Title' }).fill('Test Note');
+  await page.getByRole('textbox', { name: 'Content' }).fill('This is stored in IndexedDB');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // Verify it is stored in IndexedDB
+  const storedNotes = await page.evaluate(() => {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open('NotesDB', 1);
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('notes', 'readonly');
+        const store = tx.objectStore('notes');
+        const getAll = store.getAll();
+        getAll.onsuccess = () => resolve(getAll.result);
+        getAll.onerror = () => reject(getAll.error);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  });
+
+  expect(storedNotes).toHaveLength(1);
+  expect(storedNotes[0]).toMatchObject({
+    title: 'Test Note',
+    content: 'This is stored in IndexedDB',
+  });
+});
+
+test('clear IndexedDB for a clean test state', async ({ page }) => {
+  await page.goto('/');
+
+  // Delete the entire database
+  await page.evaluate(() => {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.deleteDatabase('NotesDB');
+      request.onsuccess = () => resolve(undefined);
+      request.onerror = () => reject(request.error);
+    });
+  });
+
+  await page.reload();
+  await expect(page.getByText('No notes yet')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('offline-first app stores data in IndexedDB', async ({ page }) => {
+  await page.goto('/notes');
+
+  await page.getByRole('button', { name: 'New note' }).click();
+  await page.getByRole('textbox', { name: 'Title' }).fill('Test Note');
+  await page.getByRole('textbox', { name: 'Content' }).fill('This is stored in IndexedDB');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  const storedNotes = await page.evaluate(() => {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open('NotesDB', 1);
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('notes', 'readonly');
+        const store = tx.objectStore('notes');
+        const getAll = store.getAll();
+        getAll.onsuccess = () => resolve(getAll.result);
+        getAll.onerror = () => reject(getAll.error);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  });
+
+  expect(storedNotes).toHaveLength(1);
+  expect(storedNotes[0]).toMatchObject({
+    title: 'Test Note',
+    content: 'This is stored in IndexedDB',
+  });
+});
+```
+
+### Notifications
+
+**Use when**: Your app uses the browser Notification API to show desktop notifications.
+**Avoid when**: Notifications are purely server-side (push without Notification API).
+
+Playwright cannot capture the actual system notification. Instead, mock the Notification constructor and verify the app calls it correctly.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('app triggers a browser notification on new message', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['notifications'],
+  });
+  const page = await context.newPage();
+
+  // Intercept Notification constructor to capture calls
+  await page.evaluate(() => {
+    (window as any).__notifications = [];
+    const OriginalNotification = window.Notification;
+    (window as any).Notification = class MockNotification {
+      constructor(title: string, options?: NotificationOptions) {
+        (window as any).__notifications.push({ title, ...options });
+      }
+      static get permission() { return 'granted'; }
+      static requestPermission() { return Promise.resolve('granted' as NotificationPermission); }
+    };
+  });
+
+  await page.goto('/chat');
+
+  // Simulate receiving a message that triggers a notification
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('new-message', {
+      detail: { from: 'Alice', text: 'Hey there!' },
+    }));
+  });
+
+  // Check the notification was created with correct content
+  const notifications = await page.evaluate(() => (window as any).__notifications);
+  expect(notifications).toHaveLength(1);
+  expect(notifications[0].title).toBe('New message from Alice');
+  expect(notifications[0].body).toBe('Hey there!');
+
+  await context.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('app triggers a browser notification on new message', async ({ browser }) => {
+  const context = await browser.newContext({
+    permissions: ['notifications'],
+  });
+  const page = await context.newPage();
+
+  await page.evaluate(() => {
+    window.__notifications = [];
+    window.Notification = class MockNotification {
+      constructor(title, options) {
+        window.__notifications.push({ title, ...options });
+      }
+      static get permission() { return 'granted'; }
+      static requestPermission() { return Promise.resolve('granted'); }
+    };
+  });
+
+  await page.goto('/chat');
+
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('new-message', {
+      detail: { from: 'Alice', text: 'Hey there!' },
+    }));
+  });
+
+  const notifications = await page.evaluate(() => window.__notifications);
+  expect(notifications).toHaveLength(1);
+  expect(notifications[0].title).toBe('New message from Alice');
+  await context.close();
+});
+```
+
+## Decision Guide
+
+| Browser API | How to Test | Key Configuration |
+|---|---|---|
+| Geolocation | `geolocation` context option + `permissions: ['geolocation']` | `context.setGeolocation()` for mid-test changes |
+| Permissions (any) | `permissions` array in context options | `context.grantPermissions()` / `context.clearPermissions()` |
+| Clipboard | Grant `clipboard-read`/`clipboard-write` + `page.evaluate(navigator.clipboard...)` | Requires secure context (HTTPS or localhost) |
+| Notifications | Mock `Notification` constructor via `page.evaluate` | Grant `notifications` permission; capture constructor calls |
+| Camera / Microphone | Chromium `--use-fake-device-for-media-stream` launch arg | Only works in Chromium; grant `camera`/`microphone` permissions |
+| localStorage | `page.evaluate(() => localStorage.getItem/setItem(...))` | Set before navigation or reload to take effect |
+| sessionStorage | `page.evaluate(() => sessionStorage.getItem/setItem(...))` | Scoped to the browsing session; cleared on context close |
+| IndexedDB | `page.evaluate` with `indexedDB.open()` | Wrap in Promises for async operations |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Set `geolocation` without granting the permission | `getCurrentPosition` returns permission error | Always pair `geolocation` with `permissions: ['geolocation']` |
+| Test clipboard without secure context | `navigator.clipboard` throws in non-HTTPS contexts | Use `localhost` or configure HTTPS in your test server |
+| Access localStorage before navigating to the origin | `page.evaluate` runs in `about:blank` context initially | `page.goto('/')` first, then set localStorage, then reload |
+| Store test tokens in localStorage directly | Bypasses auth flow; may mask real login bugs | Use `storageState` or proper auth fixtures |
+| Rely on IndexedDB state from a previous test | Tests must be independent | Clear or delete the database in test setup |
+| Skip cleanup of injected mocks (Notification, etc.) | Mock leaks into subsequent tests if using the same context | Each test gets a fresh context by default; only a concern with shared contexts |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `geolocation` returns `undefined` in the app | Permission not granted | Add `permissions: ['geolocation']` to context options |
+| Clipboard `readText()` throws `DOMException` | Missing clipboard permissions or non-secure context | Grant `clipboard-read`; ensure HTTPS or localhost |
+| `localStorage.getItem()` returns `null` after `setItem` | Set was done on a different origin or before navigation | Verify you navigated to the correct origin before calling `setItem` |
+| Camera not working in Firefox/WebKit | Fake media devices are Chromium-only | Skip camera tests on non-Chromium browsers or mock `getUserMedia` via `page.evaluate` |
+| IndexedDB `evaluate` returns `undefined` | Forgot to return the Promise | Ensure the `page.evaluate` callback returns `new Promise(...)` |
+| Permissions change not reflected | App caches permission state on load | Reload the page after `grantPermissions()` or `clearPermissions()` |
+
+## Related
+
+- [core/configuration.md](configuration.md) -- global geolocation/permissions in config
+- [core/service-workers-and-pwa.md](service-workers-and-pwa.md) -- offline and cache testing using IndexedDB and service workers
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- wrap browser API setup in reusable fixtures
+- [core/debugging.md](debugging.md) -- inspecting storage and permissions in Playwright traces

--- a/engineering-team/playwright skill/core/browser-extensions.md
+++ b/engineering-team/playwright skill/core/browser-extensions.md
@@ -1,0 +1,319 @@
+# Browser Extensions
+
+> **When to use**: Testing Chrome extensions — popups, content scripts, background service workers, or extension-injected UI. Requires Chromium and a persistent browser context.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+// Load an unpacked extension with a persistent context (Chromium only)
+const context = await chromium.launchPersistentContext(userDataDir, {
+  headless: false, // Extensions require headed mode
+  args: [
+    `--disable-extensions-except=${pathToExtension}`,
+    `--load-extension=${pathToExtension}`,
+  ],
+});
+```
+
+**Hard constraints**: Extensions only work in Chromium. They require `launchPersistentContext` (not `browser.newContext`). Headed mode is mandatory — `headless: false` or use the `--headless=new` Chromium flag for "new headless" mode which supports extensions.
+
+## Patterns
+
+### Loading an Extension
+
+**Use when**: You need to test any Chrome extension functionality.
+**Avoid when**: You only need to test the web app that an extension interacts with — mock the extension's effects instead.
+
+**TypeScript**
+```typescript
+import { test as base, expect, chromium, type BrowserContext } from '@playwright/test';
+import path from 'path';
+
+// Create a fixture that provides a context with the extension loaded
+type ExtensionFixtures = {
+  context: BrowserContext;
+  extensionId: string;
+};
+
+export const test = base.extend<ExtensionFixtures>({
+  // Override the default context to load the extension
+  context: async ({}, use) => {
+    const extensionPath = path.resolve(__dirname, '../my-extension');
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  // Extract the extension ID from the service worker URL
+  extensionId: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    const extensionId = background.url().split('/')[2];
+    await use(extensionId);
+  },
+});
+
+export { expect };
+```
+
+**JavaScript**
+```javascript
+const { test: base, expect, chromium } = require('@playwright/test');
+const path = require('path');
+
+const test = base.extend({
+  context: async ({}, use) => {
+    const extensionPath = path.resolve(__dirname, '../my-extension');
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  extensionId: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    const extensionId = background.url().split('/')[2];
+    await use(extensionId);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### Testing Extension Popups
+
+**Use when**: Your extension has a browser action popup (the UI that appears when clicking the extension icon).
+**Avoid when**: The popup is trivial — test the content script or background logic instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from './extension-fixture';
+
+test('extension popup displays saved bookmarks', async ({ page, extensionId }) => {
+  // Navigate directly to the popup HTML
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  // Interact with popup UI using standard locators
+  await expect(page.getByRole('heading', { name: 'My Bookmarks' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add current page' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(1);
+});
+
+test('extension popup settings toggle works', async ({ page, extensionId }) => {
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  await page.getByRole('checkbox', { name: 'Enable notifications' }).check();
+  await expect(page.getByText('Notifications enabled')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./extension-fixture');
+
+test('extension popup displays saved bookmarks', async ({ page, extensionId }) => {
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  await expect(page.getByRole('heading', { name: 'My Bookmarks' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add current page' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(1);
+});
+```
+
+### Testing Content Scripts
+
+**Use when**: Your extension injects scripts or UI into web pages.
+**Avoid when**: The content script only modifies data without visible effects — test via the background worker or storage.
+
+**TypeScript**
+```typescript
+import { test, expect } from './extension-fixture';
+
+test('content script injects price comparison widget', async ({ context }) => {
+  const page = await context.newPage();
+  await page.goto('https://example-shop.com/product/123');
+
+  // Wait for the content script to inject its UI
+  // The extension adds a shadow DOM element — Playwright pierces it automatically
+  await expect(page.getByTestId('price-compare-widget')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText('Best price: $29.99')).toBeVisible();
+});
+
+test('content script highlights search terms', async ({ context }) => {
+  const page = await context.newPage();
+  await page.goto('https://example.com/article');
+
+  // Verify the content script added highlight spans
+  const highlights = page.locator('.ext-highlight');
+  await expect(highlights).toHaveCount(5);
+  await expect(highlights.first()).toHaveCSS('background-color', 'rgb(255, 255, 0)');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./extension-fixture');
+
+test('content script injects price comparison widget', async ({ context }) => {
+  const page = await context.newPage();
+  await page.goto('https://example-shop.com/product/123');
+
+  await expect(page.getByTestId('price-compare-widget')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText('Best price: $29.99')).toBeVisible();
+});
+```
+
+### Testing Background Service Workers
+
+**Use when**: Your extension uses Manifest V3 service workers for background processing, alarms, or message passing.
+**Avoid when**: The background logic is simple and already covered by popup or content script tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from './extension-fixture';
+
+test('background worker processes messages correctly', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  // Trigger an action that sends a message to the background worker
+  await page.getByRole('button', { name: 'Sync data' }).click();
+
+  // Verify the response from the background worker updates the popup
+  await expect(page.getByText('Last synced: just now')).toBeVisible();
+});
+
+test('service worker handles extension storage', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  // Set a value through the popup
+  await page.getByLabel('API Key').fill('test-key-123');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // Reload popup and verify persistence through the service worker
+  await page.reload();
+  await expect(page.getByLabel('API Key')).toHaveValue('test-key-123');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./extension-fixture');
+
+test('background worker processes messages correctly', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  await page.getByRole('button', { name: 'Sync data' }).click();
+  await expect(page.getByText('Last synced: just now')).toBeVisible();
+});
+```
+
+### Testing Extension Options Page
+
+**Use when**: Your extension has a dedicated options/settings page.
+**Avoid when**: Settings are fully covered by popup tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from './extension-fixture';
+
+test('options page saves preferences', async ({ page, extensionId }) => {
+  await page.goto(`chrome-extension://${extensionId}/options.html`);
+
+  await page.getByRole('combobox', { name: 'Theme' }).selectOption('dark');
+  await page.getByRole('checkbox', { name: 'Auto-update' }).check();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Settings saved')).toBeVisible();
+
+  // Verify persistence after reload
+  await page.reload();
+  await expect(page.getByRole('combobox', { name: 'Theme' })).toHaveValue('dark');
+  await expect(page.getByRole('checkbox', { name: 'Auto-update' })).toBeChecked();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./extension-fixture');
+
+test('options page saves preferences', async ({ page, extensionId }) => {
+  await page.goto(`chrome-extension://${extensionId}/options.html`);
+
+  await page.getByRole('combobox', { name: 'Theme' }).selectOption('dark');
+  await page.getByRole('checkbox', { name: 'Auto-update' }).check();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Settings saved')).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole('combobox', { name: 'Theme' })).toHaveValue('dark');
+  await expect(page.getByRole('checkbox', { name: 'Auto-update' })).toBeChecked();
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Test popup UI | Navigate to `chrome-extension://<id>/popup.html` | Direct access without needing to click the extension icon |
+| Test content script effects | Load a real or test page, assert injected elements | Content scripts run automatically on matching URLs |
+| Test background logic | Trigger via popup/content script, verify side effects | Cannot directly call service worker functions from Playwright |
+| Test extension storage | Use popup to set values, reload, verify persistence | `chrome.storage` is only accessible from extension pages |
+| Test options page | Navigate to `chrome-extension://<id>/options.html` | Same approach as popup testing |
+| Test cross-page behavior | Open multiple pages in the same context | Persistent context shares extension state across tabs |
+| Run in CI (headless) | Use `--headless=new` Chromium flag | New headless mode supports extensions unlike old headless |
+| Test with multiple extensions | Add multiple paths to `--load-extension` | Comma-separate paths in the flag value |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `browser.newContext()` for extensions | Extensions require persistent context | `chromium.launchPersistentContext()` |
+| `headless: true` without `--headless=new` | Old headless mode does not support extensions | Set `headless: false` or use `args: ['--headless=new']` |
+| Testing on Firefox or WebKit | Extensions only work in Chromium | Skip extension tests for non-Chromium projects |
+| Clicking the extension icon via coordinates | Fragile, toolbar layout varies | Navigate directly to `chrome-extension://<id>/popup.html` |
+| Hardcoding the extension ID | IDs change between builds and machines | Extract dynamically from the service worker URL |
+| Testing packed `.crx` files directly | Harder to debug, need to unpack first | Test the unpacked extension source directory |
+| Sharing persistent context user data dir | State leaks between test runs | Use an empty string `''` for a temp directory |
+| No timeout on content script assertions | Content scripts may load after page load | Use `{ timeout: 10000 }` on content script element assertions |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Extension does not load | Wrong path in `--load-extension` | Use `path.resolve()` to get the absolute path to the extension directory |
+| `context.serviceWorkers()` returns empty | Service worker not yet registered | Use `context.waitForEvent('serviceworker')` before extracting the ID |
+| Popup page is blank | Popup HTML path is wrong | Check `manifest.json` for the correct `default_popup` path |
+| Content script not injecting | Page URL does not match `matches` in manifest | Verify the URL pattern in `content_scripts[].matches` |
+| Extension works locally but not in CI | CI uses old headless mode | Add `--headless=new` to launch args for CI |
+| `chrome.storage` calls fail | Accessing storage from non-extension context | Only access storage through extension pages (popup, options, background) |
+| Multiple extensions conflict | Both extensions modify the same page elements | Test each extension in its own persistent context |
+| Tests are slow to start | Persistent context initialization overhead | Reuse context across tests in the same file with `test.describe` |
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- building custom fixtures for extension contexts
+- [core/service-workers-and-pwa.md](service-workers-and-pwa.md) -- service worker testing patterns (non-extension)
+- [core/iframes-and-shadow-dom.md](iframes-and-shadow-dom.md) -- content scripts often inject Shadow DOM elements
+- [core/configuration.md](configuration.md) -- project configuration for Chromium-only test suites
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI setup for headed/extension tests

--- a/engineering-team/playwright skill/core/canvas-and-webgl.md
+++ b/engineering-team/playwright skill/core/canvas-and-webgl.md
@@ -1,0 +1,494 @@
+# Canvas and WebGL Testing
+
+> **When to use**: When your application renders content on `<canvas>` elements -- charts (Chart.js, D3), maps (Mapbox, Leaflet), games, image editors, WebGL visualizations, drawing tools, signature pads.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```typescript
+// Screenshot comparison — the primary strategy for canvas
+await expect(page.locator('canvas#chart')).toHaveScreenshot('revenue-chart.png');
+
+// Click at specific coordinates on canvas
+await page.locator('canvas').click({ position: { x: 200, y: 150 } });
+
+// Read canvas state via page.evaluate
+const pixelColor = await page.evaluate(() => {
+  const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+  const ctx = canvas.getContext('2d')!;
+  const pixel = ctx.getImageData(100, 100, 1, 1).data;
+  return { r: pixel[0], g: pixel[1], b: pixel[2], a: pixel[3] };
+});
+```
+
+## Patterns
+
+### Screenshot Comparison (Visual Regression)
+
+**Use when**: Verifying the visual output of canvas-rendered content -- charts, graphs, maps, drawings. This is the most reliable approach because canvas pixels are not queryable via DOM.
+**Avoid when**: The canvas content is dynamic on every render (animations, timestamps). Use threshold or mask options.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('revenue chart renders correctly', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Wait for the chart to finish rendering
+  await expect(page.locator('canvas#revenue-chart')).toBeVisible();
+
+  // Optionally wait for a loading indicator to disappear
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+
+  // Screenshot comparison against a baseline
+  await expect(page.locator('canvas#revenue-chart')).toHaveScreenshot('revenue-chart.png', {
+    maxDiffPixelRatio: 0.01,  // Allow 1% pixel difference for anti-aliasing
+  });
+});
+
+test('chart updates after date range change', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Change date range
+  await page.getByRole('combobox', { name: 'Date range' }).selectOption('Last 30 days');
+
+  // Wait for chart to re-render
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+
+  // Compare against a different baseline
+  await expect(page.locator('canvas#revenue-chart')).toHaveScreenshot('revenue-chart-30d.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('mask dynamic areas in canvas screenshot', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page.locator('canvas#chart')).toHaveScreenshot('chart-stable.png', {
+    // Mask the timestamp area that changes every render
+    mask: [page.locator('.chart-timestamp')],
+    maxDiffPixelRatio: 0.02,
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('revenue chart renders correctly', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.locator('canvas#revenue-chart')).toBeVisible();
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+
+  await expect(page.locator('canvas#revenue-chart')).toHaveScreenshot('revenue-chart.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('chart updates after date range change', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('combobox', { name: 'Date range' }).selectOption('Last 30 days');
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+
+  await expect(page.locator('canvas#revenue-chart')).toHaveScreenshot('revenue-chart-30d.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+```
+
+### Interacting with Canvas via Coordinates
+
+**Use when**: Testing user interactions on canvas -- clicking chart data points, dragging on a drawing tool, selecting map regions.
+**Avoid when**: The element has an accessible DOM overlay (many chart libraries render tooltips as HTML). Interact with the overlay instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('click on chart data point shows tooltip', async ({ page }) => {
+  await page.goto('/analytics');
+
+  const canvas = page.locator('canvas#line-chart');
+  await expect(canvas).toBeVisible();
+
+  // Click at a specific coordinate on the canvas
+  await canvas.click({ position: { x: 200, y: 100 } });
+
+  // Tooltip appears as an HTML overlay (most chart libraries)
+  await expect(page.getByTestId('chart-tooltip')).toContainText('Revenue: $12,400');
+});
+
+test('draw a line on the canvas', async ({ page }) => {
+  await page.goto('/drawing-tool');
+
+  const canvas = page.locator('canvas#drawing-area');
+
+  // Simulate a drag to draw a line
+  await canvas.hover({ position: { x: 50, y: 50 } });
+  await page.mouse.down();
+  await page.mouse.move(200, 200, { steps: 10 }); // Smooth drag
+  await page.mouse.up();
+
+  // Verify via screenshot
+  await expect(canvas).toHaveScreenshot('drawn-line.png');
+});
+
+test('pinch-to-zoom on a map canvas', async ({ page }) => {
+  await page.goto('/map');
+
+  const canvas = page.locator('canvas#map');
+
+  // Scroll to zoom (common in map libraries)
+  await canvas.hover({ position: { x: 300, y: 300 } });
+  await page.mouse.wheel(0, -500); // Scroll up = zoom in
+
+  // Verify zoom level changed
+  await expect(page.getByTestId('zoom-level')).toHaveText('Zoom: 12');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('click on chart data point shows tooltip', async ({ page }) => {
+  await page.goto('/analytics');
+
+  const canvas = page.locator('canvas#line-chart');
+  await expect(canvas).toBeVisible();
+
+  await canvas.click({ position: { x: 200, y: 100 } });
+  await expect(page.getByTestId('chart-tooltip')).toContainText('Revenue: $12,400');
+});
+
+test('draw a line on the canvas', async ({ page }) => {
+  await page.goto('/drawing-tool');
+
+  const canvas = page.locator('canvas#drawing-area');
+  await canvas.hover({ position: { x: 50, y: 50 } });
+  await page.mouse.down();
+  await page.mouse.move(200, 200, { steps: 10 });
+  await page.mouse.up();
+
+  await expect(canvas).toHaveScreenshot('drawn-line.png');
+});
+```
+
+### Canvas API Testing via `page.evaluate()`
+
+**Use when**: You need to inspect canvas pixel data, read the rendering context state, or verify programmatic canvas operations.
+**Avoid when**: A screenshot comparison is sufficient. Pixel-level assertions are brittle.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('verify specific pixel color on canvas', async ({ page }) => {
+  await page.goto('/color-picker');
+
+  // Click the red swatch
+  await page.getByRole('button', { name: 'Red' }).click();
+
+  // Read the pixel color at the canvas center
+  const color = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas#preview') as HTMLCanvasElement;
+    const ctx = canvas.getContext('2d')!;
+    const centerX = Math.floor(canvas.width / 2);
+    const centerY = Math.floor(canvas.height / 2);
+    const pixel = ctx.getImageData(centerX, centerY, 1, 1).data;
+    return { r: pixel[0], g: pixel[1], b: pixel[2], a: pixel[3] };
+  });
+
+  expect(color.r).toBeGreaterThan(200); // Red channel high
+  expect(color.g).toBeLessThan(50);     // Green channel low
+  expect(color.b).toBeLessThan(50);     // Blue channel low
+});
+
+test('verify canvas dimensions match expected size', async ({ page }) => {
+  await page.goto('/editor');
+
+  const dimensions = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas#main') as HTMLCanvasElement;
+    return { width: canvas.width, height: canvas.height };
+  });
+
+  expect(dimensions).toEqual({ width: 1920, height: 1080 });
+});
+
+test('canvas has content (is not blank)', async ({ page }) => {
+  await page.goto('/chart');
+
+  // Wait for rendering
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+
+  const isBlank = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+    const ctx = canvas.getContext('2d')!;
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    // Check if all pixels are transparent (blank canvas)
+    return imageData.data.every((value, index) => {
+      return index % 4 === 3 ? value === 0 : true; // Check alpha channel
+    });
+  });
+
+  expect(isBlank).toBe(false);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('verify specific pixel color on canvas', async ({ page }) => {
+  await page.goto('/color-picker');
+  await page.getByRole('button', { name: 'Red' }).click();
+
+  const color = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas#preview');
+    const ctx = canvas.getContext('2d');
+    const centerX = Math.floor(canvas.width / 2);
+    const centerY = Math.floor(canvas.height / 2);
+    const pixel = ctx.getImageData(centerX, centerY, 1, 1).data;
+    return { r: pixel[0], g: pixel[1], b: pixel[2], a: pixel[3] };
+  });
+
+  expect(color.r).toBeGreaterThan(200);
+  expect(color.g).toBeLessThan(50);
+  expect(color.b).toBeLessThan(50);
+});
+
+test('canvas has content (is not blank)', async ({ page }) => {
+  await page.goto('/chart');
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+
+  const isBlank = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas');
+    const ctx = canvas.getContext('2d');
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    return imageData.data.every((value, index) => {
+      return index % 4 === 3 ? value === 0 : true;
+    });
+  });
+
+  expect(isBlank).toBe(false);
+});
+```
+
+### WebGL Rendering Verification
+
+**Use when**: Your app uses WebGL for 3D visualizations, data plots, or games.
+**Avoid when**: The canvas uses 2D context only.
+
+WebGL canvas cannot be read with `getImageData` from a 2D context. Use `toDataURL()` or screenshot comparison.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('WebGL scene renders a 3D model', async ({ page }) => {
+  await page.goto('/3d-viewer');
+
+  // Wait for WebGL to finish rendering
+  await page.waitForFunction(() => {
+    const canvas = document.querySelector('canvas#scene') as HTMLCanvasElement;
+    const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+    return gl !== null;
+  });
+
+  // Give the renderer time to complete the first frame
+  await expect(page.getByTestId('render-status')).toHaveText('Ready');
+
+  // Screenshot comparison is the most reliable approach for WebGL
+  await expect(page.locator('canvas#scene')).toHaveScreenshot('3d-model.png', {
+    maxDiffPixelRatio: 0.02, // WebGL has more rendering variance
+  });
+});
+
+test('WebGL canvas is not blank', async ({ page }) => {
+  await page.goto('/3d-viewer');
+  await expect(page.getByTestId('render-status')).toHaveText('Ready');
+
+  // Check that the WebGL canvas has drawn something
+  const hasContent = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas#scene') as HTMLCanvasElement;
+    // Convert canvas to data URL and check it's not a blank image
+    const dataUrl = canvas.toDataURL();
+    // A blank canvas produces a very short data URL
+    return dataUrl.length > 1000;
+  });
+
+  expect(hasContent).toBe(true);
+});
+
+test('rotate 3D model and verify new angle', async ({ page }) => {
+  await page.goto('/3d-viewer');
+  await expect(page.getByTestId('render-status')).toHaveText('Ready');
+
+  // Take baseline screenshot
+  const canvas = page.locator('canvas#scene');
+
+  // Drag to rotate
+  await canvas.hover({ position: { x: 300, y: 300 } });
+  await page.mouse.down();
+  await page.mouse.move(450, 300, { steps: 20 });
+  await page.mouse.up();
+
+  // Screenshot should differ from default angle
+  await expect(canvas).toHaveScreenshot('3d-model-rotated.png', {
+    maxDiffPixelRatio: 0.02,
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('WebGL scene renders a 3D model', async ({ page }) => {
+  await page.goto('/3d-viewer');
+
+  await page.waitForFunction(() => {
+    const canvas = document.querySelector('canvas#scene');
+    const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+    return gl !== null;
+  });
+
+  await expect(page.getByTestId('render-status')).toHaveText('Ready');
+  await expect(page.locator('canvas#scene')).toHaveScreenshot('3d-model.png', {
+    maxDiffPixelRatio: 0.02,
+  });
+});
+
+test('WebGL canvas is not blank', async ({ page }) => {
+  await page.goto('/3d-viewer');
+  await expect(page.getByTestId('render-status')).toHaveText('Ready');
+
+  const hasContent = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas#scene');
+    const dataUrl = canvas.toDataURL();
+    return dataUrl.length > 1000;
+  });
+
+  expect(hasContent).toBe(true);
+});
+```
+
+### Chart Library Testing Strategies
+
+**Use when**: Testing Chart.js, D3, Recharts, Highcharts, or similar chart libraries.
+**Avoid when**: Charts have full HTML/SVG DOM output (D3 with SVG). Use standard locators for SVG elements.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('bar chart shows correct number of bars (SVG-based chart)', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // SVG-based charts (D3, Recharts) render DOM elements — use locators
+  const bars = page.locator('svg.chart rect.bar');
+  await expect(bars).toHaveCount(12); // 12 months
+
+  // Check a specific bar's aria-label or tooltip
+  await bars.nth(0).hover();
+  await expect(page.getByTestId('chart-tooltip')).toContainText('January: $8,200');
+});
+
+test('canvas-based chart displays data (Chart.js)', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // Canvas charts — no DOM elements to query, use screenshot
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+  await expect(page.locator('canvas#monthly-chart')).toHaveScreenshot('monthly-chart.png');
+});
+
+test('chart legend toggles data series', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // Click legend item (usually HTML, not canvas)
+  await page.getByRole('button', { name: 'Revenue' }).click();
+
+  // Revenue series hidden — chart should look different
+  await expect(page.locator('canvas#chart')).toHaveScreenshot('chart-no-revenue.png');
+
+  // Click again to re-enable
+  await page.getByRole('button', { name: 'Revenue' }).click();
+  await expect(page.locator('canvas#chart')).toHaveScreenshot('chart-with-revenue.png');
+});
+
+test('export chart as image', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // Many chart libraries offer "download as PNG"
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export as PNG' }).click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toMatch(/chart.*\.png$/);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('bar chart shows correct number of bars (SVG-based)', async ({ page }) => {
+  await page.goto('/analytics');
+
+  const bars = page.locator('svg.chart rect.bar');
+  await expect(bars).toHaveCount(12);
+
+  await bars.nth(0).hover();
+  await expect(page.getByTestId('chart-tooltip')).toContainText('January: $8,200');
+});
+
+test('canvas-based chart displays data', async ({ page }) => {
+  await page.goto('/analytics');
+  await expect(page.getByTestId('chart-loading')).toBeHidden();
+  await expect(page.locator('canvas#monthly-chart')).toHaveScreenshot('monthly-chart.png');
+});
+```
+
+## Decision Guide
+
+| Scenario | Best Approach | Why |
+|---|---|---|
+| Verify chart looks correct | `toHaveScreenshot()` on canvas element | Canvas pixels are not DOM; screenshot is the source of truth |
+| Click a data point on chart | `canvas.click({ position: { x, y } })` | Canvas does not have clickable child elements |
+| Verify canvas is not blank | `page.evaluate` + `getImageData` or `toDataURL` | Quick programmatic check without baseline image |
+| Test SVG-based chart (D3) | Standard locators (`svg rect`, `svg path`) | SVG elements are in the DOM; use locator queries |
+| Read specific pixel color | `page.evaluate` + `getImageData` | Direct access to pixel data |
+| Test WebGL rendering | `toHaveScreenshot()` with higher `maxDiffPixelRatio` | WebGL has rendering variance; pixel assertions are unreliable |
+| Test canvas drag/draw | `mouse.down()` + `mouse.move()` + `mouse.up()` | Simulates real drawing interactions |
+| Chart tooltip after hover | `canvas.hover({ position })` then assert tooltip DOM | Tooltips are usually HTML overlays |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.getByRole('button')` inside a canvas | Canvas content has no DOM elements | Use `canvas.click({ position })` for coordinates |
+| Assert pixel colors with exact RGB values | Anti-aliasing and GPU differences cause 1-2 value variance | Use ranges (`toBeGreaterThan(200)`) or `toHaveScreenshot` |
+| Skip `maxDiffPixelRatio` in canvas screenshots | Different GPUs and OS versions render slightly differently | Set `maxDiffPixelRatio: 0.01` to `0.02` |
+| `waitForTimeout` to wait for chart render | Arbitrary; too slow or too fast | Wait for a loading indicator to disappear or use `waitForFunction` |
+| Read WebGL pixels via 2D context `getImageData` | WebGL and 2D contexts are mutually exclusive on the same canvas | Use `canvas.toDataURL()` or screenshot comparison |
+| Take full-page screenshots for canvas tests | Captures unrelated content; more brittle baselines | Scope screenshot to `page.locator('canvas#specific')` |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Screenshot baseline always differs | GPU rendering differences across CI and local machine | Use Docker with consistent GPU settings, or increase `maxDiffPixelRatio` |
+| Canvas click at coordinates hits wrong element | Coordinates are relative to element, but viewport changed | Use `position` relative to the canvas element, not the page |
+| `getImageData` returns all transparent pixels | Canvas has not finished rendering when evaluated | Wait for a render-complete signal or use `waitForFunction` |
+| `toDataURL` throws `SecurityError` | Canvas is tainted by cross-origin image | Serve images from the same origin or use CORS headers |
+| WebGL context is null | Browser does not support WebGL or it is disabled in CI | Use `--enable-webgl` flag or run tests on a GPU-capable CI runner |
+| Screenshot test passes locally, fails in CI | Different font rendering, DPI, or OS | Pin the Docker image, use `fonts` config, or increase threshold |
+
+## Related
+
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-retrying assertions and visual comparison options
+- [core/configuration.md](configuration.md) -- configure screenshot thresholds and update baselines
+- [core/iframes-and-shadow-dom.md](iframes-and-shadow-dom.md) -- canvas elements inside iframes
+- [core/debugging.md](debugging.md) -- debugging visual regression failures with trace viewer

--- a/engineering-team/playwright skill/core/ci/SKILL.md
+++ b/engineering-team/playwright skill/core/ci/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: playwright-ci
+description: Production-ready CI/CD configurations for Playwright — GitHub Actions, GitLab CI, CircleCI, Azure DevOps, Jenkins, Docker, parallel sharding, reporting, code coverage, and global setup/teardown.
+---
+
+# Playwright CI/CD
+
+> Ship reliable tests in every pipeline — CI-specific patterns for speed, stability, and actionable reports.
+
+**9 guides** covering CI/CD setup, parallel execution, containerized runs, reporting, and infrastructure patterns for all major CI providers.
+
+## Golden Rules
+
+1. **`retries: 2` in CI only** — surface flakiness in pipelines, not locally
+2. **`traces: 'on-first-retry'`** — capture rich debugging artifacts without slowing every run
+3. **Shard across runners** — `--shard=N/M` splits tests evenly; scale horizontally, not vertically
+4. **Cache browser binaries** — `~/.cache/ms-playwright` keyed on Playwright version
+5. **Upload artifacts on failure** — traces, screenshots, and HTML reports as CI artifacts
+6. **Use the official Docker image** — `mcr.microsoft.com/playwright:v*` has all OS deps pre-installed
+7. **Global setup for auth** — run login once in `globalSetup`, reuse `storageState` across workers
+8. **Fail fast, debug later** — keep CI runs short; use trace viewer and HTML reports to investigate
+
+## Guide Index
+
+### CI Providers
+
+| Provider | Guide |
+|---|---|
+| GitHub Actions | [ci-github-actions.md](ci-github-actions.md) |
+| GitLab CI | [ci-gitlab.md](ci-gitlab.md) |
+| CircleCI / Azure DevOps / Jenkins | [ci-other.md](ci-other.md) |
+
+### Execution & Scaling
+
+| Topic | Guide |
+|---|---|
+| Parallel execution & sharding | [parallel-and-sharding.md](parallel-and-sharding.md) |
+| Docker & containers | [docker-and-containers.md](docker-and-containers.md) |
+| Multi-project config | [projects-and-dependencies.md](projects-and-dependencies.md) |
+
+### Reporting & Setup
+
+| Topic | Guide |
+|---|---|
+| Reports & artifacts | [reporting-and-artifacts.md](reporting-and-artifacts.md) |
+| Code coverage | [test-coverage.md](test-coverage.md) |
+| Global setup/teardown | [global-setup-teardown.md](global-setup-teardown.md) |

--- a/engineering-team/playwright skill/core/ci/ci-github-actions.md
+++ b/engineering-team/playwright skill/core/ci/ci-github-actions.md
@@ -1,0 +1,581 @@
+# CI: GitHub Actions
+
+> **When to use**: Running Playwright tests automatically on pull requests, merges to main, or on a schedule. GitHub Actions is the most common CI for Playwright projects.
+
+## Quick Reference
+
+```bash
+# Key CLI flags for CI
+npx playwright install --with-deps    # install browsers + OS deps
+npx playwright test --shard=1/4       # run 1 of 4 shards
+npx playwright test --reporter=github # annotate PR with failures
+npx playwright merge-reports ./blob-report  # merge shard reports
+```
+
+## Patterns
+
+### Pattern 1: Production-Ready Workflow (Copy-Paste Starter)
+
+**Use when**: Any project using GitHub Actions. This is the complete, battle-tested workflow.
+
+```yaml
+# .github/workflows/playwright.yml
+name: Playwright Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs for the same PR/branch
+concurrency:
+  group: playwright-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  test:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7
+```
+
+### Pattern 2: Sharded Execution with Matrix Strategy
+
+**Use when**: Test suite takes more than 10 minutes. Split across parallel runners to cut wall-clock time.
+**Avoid when**: Suite runs under 5 minutes -- sharding overhead (checkout, install, merge) negates the benefit.
+
+```yaml
+# .github/workflows/playwright-sharded.yml
+name: Playwright Tests (Sharded)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: playwright-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Run Playwright tests (shard ${{ matrix.shard }})
+        run: npx playwright test --shard=${{ matrix.shard }}
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: blob-report-${{ strategy.job-index }}
+          path: blob-report/
+          retention-days: 1
+
+  merge-reports:
+    if: ${{ !cancelled() }}
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter=html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+**Config for sharding** -- add blob reporter so shard output can be merged:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [['blob'], ['github']]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+### Pattern 3: Reusable Workflow
+
+**Use when**: Multiple repositories or multiple workflow files need the same Playwright setup.
+**Avoid when**: Single repo with one workflow.
+
+```yaml
+# .github/workflows/playwright-reusable.yml
+name: Playwright Reusable
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        type: string
+        default: '20'
+      test-command:
+        type: string
+        default: 'npx playwright test'
+      shard-total:
+        type: number
+        default: 1
+    secrets:
+      BASE_URL:
+        required: false
+      TEST_PASSWORD:
+        required: false
+
+jobs:
+  test:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(format('[{0}]', join(fromJson(format('[{0}]', inputs.shard-total == 1 && '"1/1"' || '"1/4","2/4","3/4","4/4"')), ','))) }}
+
+    env:
+      CI: true
+      BASE_URL: ${{ secrets.BASE_URL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Run tests
+        run: ${{ inputs.test-command }} --shard=${{ matrix.shard }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ strategy.job-index }}
+          path: playwright-report/
+          retention-days: 14
+```
+
+**Calling the reusable workflow:**
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    uses: ./.github/workflows/playwright-reusable.yml
+    with:
+      node-version: '20'
+      shard-total: 4
+    secrets:
+      BASE_URL: ${{ secrets.STAGING_URL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+```
+
+### Pattern 4: Running in a Container
+
+**Use when**: You need a reproducible environment identical to local Docker runs, or the runner's OS dependencies cause issues.
+**Avoid when**: Standard `ubuntu-latest` with `--with-deps` works fine (the common case).
+
+```yaml
+# .github/workflows/playwright-container.yml
+name: Playwright (Container)
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      # No browser install needed -- they're in the container image
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          HOME: /root  # required when running as root in container
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+### Pattern 5: Environment Secrets and Deployment Targets
+
+**Use when**: Tests run against staging/production environments that require authentication credentials.
+**Avoid when**: Tests only run against a locally started dev server.
+
+```yaml
+# .github/workflows/playwright-staging.yml
+name: Playwright (Staging)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment: staging  # GitHub Environment with protection rules
+
+    env:
+      CI: true
+      BASE_URL: ${{ vars.STAGING_URL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      API_KEY: ${{ secrets.API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Run tests against staging
+        run: npx playwright test --grep @smoke
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: staging-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+### Pattern 6: Scheduled Runs (Nightly Regression)
+
+**Use when**: Full regression suite is too slow for every PR. Run it nightly against main.
+**Avoid when**: Suite runs in under 15 minutes and can run on every PR.
+
+```yaml
+# .github/workflows/playwright-nightly.yml
+name: Nightly Regression
+
+on:
+  schedule:
+    - cron: '0 3 * * 1-5'  # 3 AM UTC, Mon-Fri
+  workflow_dispatch:         # allow manual trigger
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    env:
+      CI: true
+      BASE_URL: ${{ vars.STAGING_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run full regression suite
+        run: npx playwright test --grep @regression
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: nightly-report-${{ github.run_number }}
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Notify on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": "Nightly Playwright regression failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Small suite (< 5 min) | Single job, no sharding | Overhead of sharding exceeds time saved |
+| Medium suite (5-20 min) | 2-4 shards with matrix | Cut wall-clock time by ~60-75% |
+| Large suite (20+ min) | 4-8 shards + blob report merge | Keep PR feedback under 10 minutes |
+| Cross-browser on PRs | Chromium only on PRs; all browsers on main | 3x fewer minutes burned on PRs |
+| Staging/prod smoke tests | Separate workflow with `environment:` | Isolate secrets, add approval gates |
+| Nightly full regression | `schedule` trigger + `workflow_dispatch` | Full coverage without blocking PRs |
+| Multiple repos, same setup | Reusable workflow with `workflow_call` | DRY; update one file, all repos benefit |
+| Reproducible env needed | Container job with Playwright image | Identical to local Docker environment |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| No `concurrency` group | Duplicate runs waste minutes on every push | Add `concurrency: { group: ..., cancel-in-progress: true }` |
+| `fail-fast: true` with sharding | One shard failure cancels others; you lose their results | Set `fail-fast: false` to collect all failures |
+| Installing browsers without caching | 60-90 seconds wasted every run | Cache `~/.cache/ms-playwright` keyed on lockfile hash |
+| `timeout-minutes` not set | Stuck jobs run for 6 hours (GitHub default) | Set explicit timeout: 20-30 minutes |
+| Uploading artifacts only on failure | No report when tests pass; can't verify results | Use `if: ${{ !cancelled() }}` to always upload |
+| Hardcoding secrets in workflow files | Security breach | Use GitHub Secrets and Environments |
+| Running all browsers on every PR | 3x CI cost for marginal benefit | Chromium on PR; cross-browser on main merge |
+| `actions/upload-artifact` with no retention | Default 90-day retention fills storage | Set `retention-days: 7-14` for reports |
+| No `--with-deps` on browser install | Missing OS libraries cause browser launch failures | Always use `npx playwright install --with-deps` |
+
+## Troubleshooting
+
+### Browser launch fails: "Missing dependencies"
+
+**Cause**: Browsers installed from cache but OS dependencies were not cached (they live in system directories, not `~/.cache`).
+
+**Fix**: Always run `npx playwright install-deps` on cache hit:
+
+```yaml
+- name: Install Playwright OS dependencies
+  if: steps.playwright-cache.outputs.cache-hit == 'true'
+  run: npx playwright install-deps
+```
+
+### Tests pass locally but fail in CI with timeouts
+
+**Cause**: CI runners have fewer CPU cores and less RAM than your dev machine. Default workers and timeouts are too aggressive.
+
+**Fix**: Reduce workers and increase timeouts for CI in your config:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  workers: process.env.CI ? '50%' : undefined,
+  use: {
+    actionTimeout: process.env.CI ? 15_000 : 10_000,
+    navigationTimeout: process.env.CI ? 30_000 : 15_000,
+  },
+});
+```
+
+### Sharded reports are incomplete -- some shards missing from merged report
+
+**Cause**: Using `actions/download-artifact@v4` without `merge-multiple: true`, or artifact names collide across shards.
+
+**Fix**: Give each shard a unique artifact name and use `merge-multiple`:
+
+```yaml
+# Upload in each shard job
+- uses: actions/upload-artifact@v4
+  with:
+    name: blob-report-${{ strategy.job-index }}
+    path: blob-report/
+
+# Download in merge job
+- uses: actions/download-artifact@v4
+  with:
+    path: all-blob-reports
+    pattern: blob-report-*
+    merge-multiple: true
+```
+
+### `webServer` fails in CI: "port 3000 already in use"
+
+**Cause**: Previous run left a zombie process, or another job step is using the port.
+
+**Fix**: Ensure `reuseExistingServer: false` in CI and add a pre-step to kill stale processes:
+
+```yaml
+- name: Kill stale processes
+  run: lsof -ti:3000 | xargs kill -9 2>/dev/null || true
+```
+
+### GitHub annotations not appearing on PR
+
+**Cause**: The `github` reporter is not configured.
+
+**Fix**: Add `github` reporter for CI runs:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+## Related
+
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- sharding strategies and blob report merging
+- [ci/reporting-and-artifacts.md](reporting-and-artifacts.md) -- reporter configuration and artifact management
+- [ci/docker-and-containers.md](docker-and-containers.md) -- container images for CI
+- [ci/ci-gitlab.md](ci-gitlab.md) -- GitLab CI equivalent
+- [ci/ci-other.md](ci-other.md) -- CircleCI, Azure DevOps, Jenkins
+- [core/configuration.md](../core/configuration.md) -- CI-aware config settings

--- a/engineering-team/playwright skill/core/ci/ci-gitlab.md
+++ b/engineering-team/playwright skill/core/ci/ci-gitlab.md
@@ -1,0 +1,421 @@
+# CI: GitLab CI/CD
+
+> **When to use**: Running Playwright tests in GitLab pipelines on merge requests, merges to main, or scheduled pipelines.
+
+## Quick Reference
+
+```bash
+# Key commands used in GitLab pipelines
+npx playwright install --with-deps    # install browsers + OS deps
+npx playwright test --shard=1/4       # run 1 of 4 parallel shards
+npx playwright merge-reports ./blob-report  # merge shard results
+npx playwright test --reporter=dot    # minimal output for CI logs
+```
+
+## Patterns
+
+### Pattern 1: Production-Ready Pipeline (Copy-Paste Starter)
+
+**Use when**: Any GitLab project with Playwright tests. This is the complete, recommended configuration.
+
+```yaml
+# .gitlab-ci.yml
+image: mcr.microsoft.com/playwright:v1.52.0-noble
+
+stages:
+  - install
+  - test
+  - report
+
+variables:
+  CI: "true"
+  npm_config_cache: "$CI_PROJECT_DIR/.npm"
+
+# Cache node_modules and npm cache across pipelines
+cache:
+  key:
+    files:
+      - package-lock.json
+  paths:
+    - .npm/
+    - node_modules/
+
+install:
+  stage: install
+  script:
+    - npm ci
+  artifacts:
+    paths:
+      - node_modules/
+    expire_in: 1 hour
+
+test:
+  stage: test
+  needs: [install]
+  script:
+    - npx playwright test
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+      - test-results/
+    expire_in: 14 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+### Pattern 2: Parallel Sharded Execution
+
+**Use when**: Test suite exceeds 10 minutes. Use GitLab's `parallel` keyword to split across jobs automatically.
+**Avoid when**: Suite runs under 5 minutes.
+
+```yaml
+# .gitlab-ci.yml
+image: mcr.microsoft.com/playwright:v1.52.0-noble
+
+stages:
+  - install
+  - test
+  - report
+
+variables:
+  CI: "true"
+  npm_config_cache: "$CI_PROJECT_DIR/.npm"
+
+cache:
+  key:
+    files:
+      - package-lock.json
+  paths:
+    - .npm/
+    - node_modules/
+
+install:
+  stage: install
+  script:
+    - npm ci
+  artifacts:
+    paths:
+      - node_modules/
+    expire_in: 1 hour
+
+test:
+  stage: test
+  needs: [install]
+  parallel: 4
+  script:
+    - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
+  artifacts:
+    when: always
+    paths:
+      - blob-report/
+    expire_in: 1 hour
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+merge-report:
+  stage: report
+  needs: [test]
+  when: always
+  script:
+    - npx playwright merge-reports --reporter=html ./blob-report
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+    expire_in: 14 days
+```
+
+**Config for sharded pipelines:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [['blob'], ['dot']]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+### Pattern 3: Merge Request Pipelines with Environment Variables
+
+**Use when**: Tests need secrets (API keys, passwords) and should only run on merge requests or the default branch.
+**Avoid when**: Tests are fully self-contained with no external dependencies.
+
+```yaml
+# .gitlab-ci.yml
+image: mcr.microsoft.com/playwright:v1.52.0-noble
+
+stages:
+  - test
+
+variables:
+  CI: "true"
+
+test:e2e:
+  stage: test
+  variables:
+    BASE_URL: $STAGING_URL
+    TEST_PASSWORD: $TEST_PASSWORD
+    API_KEY: $API_KEY
+  before_script:
+    - npm ci
+  script:
+    - npx playwright test
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+      - test-results/
+    expire_in: 14 days
+  rules:
+    # Run on merge requests
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    # Run on default branch pushes
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    # Allow manual trigger
+    - when: manual
+      allow_failure: true
+```
+
+**Setting variables in GitLab:**
+Navigate to **Settings > CI/CD > Variables** and add:
+- `STAGING_URL` -- not masked, not protected
+- `TEST_PASSWORD` -- masked, protected
+- `API_KEY` -- masked, protected
+
+### Pattern 4: Multi-Browser Testing with Child Pipelines
+
+**Use when**: Running Chromium on MRs and all browsers on the default branch.
+**Avoid when**: You only test one browser.
+
+```yaml
+# .gitlab-ci.yml
+image: mcr.microsoft.com/playwright:v1.52.0-noble
+
+stages:
+  - install
+  - test
+
+variables:
+  CI: "true"
+
+install:
+  stage: install
+  script:
+    - npm ci
+  artifacts:
+    paths:
+      - node_modules/
+    expire_in: 1 hour
+
+# Chromium only on merge requests (fast feedback)
+test:chromium:
+  stage: test
+  needs: [install]
+  script:
+    - npx playwright test --project=chromium
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+      - test-results/
+    expire_in: 14 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+# All browsers on default branch
+test:all-browsers:
+  stage: test
+  needs: [install]
+  parallel:
+    matrix:
+      - PROJECT: [chromium, firefox, webkit]
+  script:
+    - npx playwright test --project=$PROJECT
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+      - test-results/
+    expire_in: 14 days
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+### Pattern 5: Custom Docker Image with Application
+
+**Use when**: Tests need the application running alongside Playwright, or you need custom system dependencies.
+**Avoid when**: The official Playwright image plus `webServer` in config handles your use case.
+
+```yaml
+# .gitlab-ci.yml
+stages:
+  - test
+
+test:e2e:
+  stage: test
+  image: mcr.microsoft.com/playwright:v1.52.0-noble
+  services:
+    - name: postgres:16-alpine
+      alias: db
+    - name: redis:7-alpine
+      alias: cache
+  variables:
+    CI: "true"
+    DATABASE_URL: "postgresql://postgres:postgres@db:5432/test"
+    REDIS_URL: "redis://cache:6379"
+    POSTGRES_PASSWORD: "postgres"
+    POSTGRES_DB: "test"
+  before_script:
+    - npm ci
+    - npx prisma db push
+    - npx prisma db seed
+  script:
+    - npx playwright test
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+      - test-results/
+    expire_in: 14 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+### Pattern 6: Scheduled Nightly Regression
+
+**Use when**: Full regression is too slow for every MR. Run it on a schedule.
+
+```yaml
+# .gitlab-ci.yml (add to existing config)
+test:nightly:
+  stage: test
+  image: mcr.microsoft.com/playwright:v1.52.0-noble
+  before_script:
+    - npm ci
+  script:
+    - npx playwright test --grep @regression
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+```
+
+Set up the schedule in **CI/CD > Schedules**: `0 3 * * 1-5` (3 AM UTC, weekdays).
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Simple project, < 5 min suite | Single `test` job using Playwright Docker image | No sharding overhead; artifacts capture report |
+| Suite > 10 min | `parallel: N` with `--shard` | GitLab auto-assigns `CI_NODE_INDEX`/`CI_NODE_TOTAL` |
+| Merge request fast feedback | Chromium only on MRs; all browsers on main | 3x fewer pipeline minutes on MRs |
+| External services needed (DB, Redis) | `services:` keyword with Postgres/Redis images | GitLab manages service lifecycle |
+| Secrets for staging environment | GitLab CI/CD Variables (masked + protected) | Never hardcode secrets in `.gitlab-ci.yml` |
+| Full nightly regression | Pipeline schedule (`CI_PIPELINE_SOURCE == "schedule"`) | Avoids blocking MR pipelines |
+| Report browsing | `artifacts:` with `paths: [playwright-report/]` | Browse directly in GitLab job artifacts UI |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| Not using the Playwright Docker image | Installing browsers every run adds 1-2 minutes | Use `mcr.microsoft.com/playwright:v1.52.0-noble` as base image |
+| `artifacts: when: on_failure` only | No report when tests pass; can't verify results | Use `when: always` to capture reports regardless |
+| No `expire_in` on artifacts | Artifacts accumulate and consume storage | Set `expire_in: 14 days` for reports, `1 hour` for intermediate artifacts |
+| `parallel:` without `fail-fast: false` equivalent | GitLab does not cancel siblings by default (good), but `allow_failure: false` means the pipeline fails fast | Acceptable default behavior; no change needed |
+| Hardcoding `CI_NODE_TOTAL` in shard flag | Breaks when you change `parallel:` value | Use `--shard=$CI_NODE_INDEX/$CI_NODE_TOTAL` |
+| Skipping `needs:` between stages | Jobs wait for all previous stage jobs, not just their dependencies | Use `needs:` for precise dependency graphs |
+| Large `cache:` including `node_modules/` without key | Stale cache causes version conflicts | Key cache on `package-lock.json` hash |
+
+## Troubleshooting
+
+### Browser launch fails: "Failed to launch browser"
+
+**Cause**: Not using the Playwright Docker image, or using a version that doesn't match your `@playwright/test` version.
+
+**Fix**: Match the Docker image tag to your Playwright version:
+
+```yaml
+# Check your version
+# npm ls @playwright/test  ->  @playwright/test@1.52.0
+image: mcr.microsoft.com/playwright:v1.52.0-noble
+```
+
+### Tests hang in GitLab runner: "Navigation timeout exceeded"
+
+**Cause**: GitLab shared runners may have limited resources. Default timeouts too tight.
+
+**Fix**: Reduce workers and increase timeouts:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  workers: process.env.CI ? 2 : undefined,
+  use: {
+    navigationTimeout: process.env.CI ? 30_000 : 15_000,
+  },
+});
+```
+
+### Pipeline runs on every push, not just merge requests
+
+**Cause**: Missing `rules:` configuration. Default GitLab behavior runs on every push.
+
+**Fix**: Add explicit rules:
+
+```yaml
+rules:
+  - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+### Services (Postgres/Redis) not reachable from tests
+
+**Cause**: Using `localhost` instead of the service alias.
+
+**Fix**: Use the service alias as hostname:
+
+```yaml
+services:
+  - name: postgres:16-alpine
+    alias: db  # <-- use "db" as hostname
+
+variables:
+  DATABASE_URL: "postgresql://postgres:postgres@db:5432/test"  # not localhost
+```
+
+### Merged report is empty after sharded run
+
+**Cause**: Each shard job needs the `blob` reporter, not `html`. The merge step creates the HTML report.
+
+**Fix**: Configure blob reporter for CI:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [['blob'], ['dot']]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+## Related
+
+- [ci/ci-github-actions.md](ci-github-actions.md) -- GitHub Actions equivalent
+- [ci/ci-other.md](ci-other.md) -- CircleCI, Azure DevOps, Jenkins
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- sharding strategies
+- [ci/docker-and-containers.md](docker-and-containers.md) -- Docker image details
+- [ci/reporting-and-artifacts.md](reporting-and-artifacts.md) -- reporter configuration

--- a/engineering-team/playwright skill/core/ci/ci-other.md
+++ b/engineering-team/playwright skill/core/ci/ci-other.md
@@ -1,0 +1,582 @@
+# CI: CircleCI, Azure DevOps, and Jenkins
+
+> **When to use**: Running Playwright tests in CI platforms other than GitHub Actions or GitLab. Each section provides a production-ready config you can copy and adapt.
+
+## Quick Reference
+
+```bash
+# Common across all CI platforms
+npx playwright install --with-deps    # install browsers + OS deps
+npx playwright test --shard=1/4       # shard for parallelism
+npx playwright merge-reports ./blob-report  # merge shard results
+npx playwright test --reporter=dot,html     # multiple reporters
+```
+
+## Patterns
+
+### Pattern 1: CircleCI
+
+**Use when**: Your project runs on CircleCI.
+
+#### Basic Pipeline
+
+```yaml
+# .circleci/config.yml
+version: 2.1
+
+executors:
+  playwright:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.52.0-noble
+    working_directory: ~/project
+
+jobs:
+  install:
+    executor: playwright
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - npm-deps-{{ checksum "package-lock.json" }}
+      - run: npm ci
+      - save_cache:
+          key: npm-deps-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+
+  test:
+    executor: playwright
+    parallelism: 4
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Playwright tests
+          command: |
+            npx playwright test --shard=$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL
+      - store_artifacts:
+          path: playwright-report
+          destination: playwright-report
+      - store_artifacts:
+          path: test-results
+          destination: test-results
+      - store_test_results:
+          path: test-results/junit.xml
+
+workflows:
+  test:
+    jobs:
+      - install
+      - test:
+          requires:
+            - install
+```
+
+**Config for CircleCI JUnit integration:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [
+        ['dot'],
+        ['html', { open: 'never' }],
+        ['junit', { outputFile: 'test-results/junit.xml' }],
+      ]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+#### CircleCI with Orbs (Simplified)
+
+```yaml
+# .circleci/config.yml
+version: 2.1
+
+orbs:
+  node: circleci/node@6.1
+
+executors:
+  playwright:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.52.0-noble
+
+jobs:
+  e2e:
+    executor: playwright
+    parallelism: 4
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Run tests
+          command: npx playwright test --shard=$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL
+      - store_artifacts:
+          path: playwright-report
+      - store_test_results:
+          path: test-results/junit.xml
+
+workflows:
+  main:
+    jobs:
+      - e2e
+```
+
+---
+
+### Pattern 2: Azure DevOps
+
+**Use when**: Your project runs on Azure DevOps Pipelines.
+
+#### Basic Pipeline
+
+```yaml
+# azure-pipelines.yml
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  CI: 'true'
+  npm_config_cache: $(Pipeline.Workspace)/.npm
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '20.x'
+    displayName: 'Install Node.js'
+
+  - task: Cache@2
+    inputs:
+      key: 'npm | "$(Agent.OS)" | package-lock.json'
+      restoreKeys: |
+        npm | "$(Agent.OS)"
+      path: $(npm_config_cache)
+    displayName: 'Cache npm'
+
+  - script: npm ci
+    displayName: 'Install dependencies'
+
+  - script: npx playwright install --with-deps
+    displayName: 'Install Playwright browsers'
+
+  - script: npx playwright test
+    displayName: 'Run Playwright tests'
+
+  - task: PublishTestResults@2
+    condition: always()
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'test-results/junit.xml'
+      mergeTestResults: true
+      testRunTitle: 'Playwright Tests'
+    displayName: 'Publish test results'
+
+  - task: PublishPipelineArtifact@1
+    condition: always()
+    inputs:
+      targetPath: playwright-report
+      artifact: playwright-report
+      publishLocation: 'pipeline'
+    displayName: 'Upload report'
+```
+
+**Config for Azure DevOps JUnit integration:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [
+        ['dot'],
+        ['html', { open: 'never' }],
+        ['junit', { outputFile: 'test-results/junit.xml' }],
+      ]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+#### Azure DevOps with Sharding
+
+```yaml
+# azure-pipelines.yml
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  branches:
+    include:
+      - main
+
+variables:
+  CI: 'true'
+
+stages:
+  - stage: Test
+    jobs:
+      - job: Playwright
+        pool:
+          vmImage: 'ubuntu-latest'
+        strategy:
+          matrix:
+            shard1:
+              SHARD: '1/4'
+            shard2:
+              SHARD: '2/4'
+            shard3:
+              SHARD: '3/4'
+            shard4:
+              SHARD: '4/4'
+        steps:
+          - task: NodeTool@0
+            inputs:
+              versionSpec: '20.x'
+
+          - script: npm ci
+            displayName: 'Install dependencies'
+
+          - script: npx playwright install --with-deps
+            displayName: 'Install browsers'
+
+          - script: npx playwright test --shard=$(SHARD)
+            displayName: 'Run tests (shard $(SHARD))'
+
+          - task: PublishPipelineArtifact@1
+            condition: always()
+            inputs:
+              targetPath: blob-report
+              artifact: blob-report-$(System.JobPositionInPhase)
+            displayName: 'Upload blob report'
+
+  - stage: Report
+    dependsOn: Test
+    condition: always()
+    jobs:
+      - job: MergeReports
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: NodeTool@0
+            inputs:
+              versionSpec: '20.x'
+
+          - script: npm ci
+            displayName: 'Install dependencies'
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              patterns: 'blob-report-*/**'
+              path: all-blob-reports
+            displayName: 'Download all blob reports'
+
+          - script: npx playwright merge-reports --reporter=html ./all-blob-reports
+            displayName: 'Merge reports'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: playwright-report
+              artifact: playwright-report
+            displayName: 'Upload merged report'
+```
+
+---
+
+### Pattern 3: Jenkins
+
+**Use when**: Your project runs on Jenkins.
+
+#### Jenkinsfile (Declarative Pipeline)
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent {
+        docker {
+            image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+            args '-u root'  // Playwright needs root in container
+        }
+    }
+
+    environment {
+        CI = 'true'
+        HOME = '/root'
+        npm_config_cache = "${WORKSPACE}/.npm"
+    }
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+
+    stages {
+        stage('Install') {
+            steps {
+                sh 'npm ci'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh 'npx playwright test'
+            }
+            post {
+                always {
+                    // Publish JUnit results
+                    junit allowEmptyResults: true,
+                         testResults: 'test-results/junit.xml'
+
+                    // Archive HTML report
+                    archiveArtifacts artifacts: 'playwright-report/**',
+                                     allowEmptyArchive: true
+
+                    // Archive traces on failure
+                    archiveArtifacts artifacts: 'test-results/**',
+                                     allowEmptyArchive: true
+                }
+            }
+        }
+    }
+
+    post {
+        failure {
+            // Notify on failure (Slack, email, etc.)
+            echo 'Playwright tests failed!'
+        }
+        cleanup {
+            cleanWs()
+        }
+    }
+}
+```
+
+**Config for Jenkins JUnit integration:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [
+        ['dot'],
+        ['html', { open: 'never' }],
+        ['junit', { outputFile: 'test-results/junit.xml' }],
+      ]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+#### Jenkins with Parallel Stages
+
+```groovy
+// Jenkinsfile (sharded)
+pipeline {
+    agent none
+
+    environment {
+        CI = 'true'
+        HOME = '/root'
+    }
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
+    stages {
+        stage('Test') {
+            parallel {
+                stage('Shard 1') {
+                    agent {
+                        docker {
+                            image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+                            args '-u root'
+                        }
+                    }
+                    steps {
+                        sh 'npm ci'
+                        sh 'npx playwright test --shard=1/4'
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'blob-report/**',
+                                             allowEmptyArchive: true
+                        }
+                    }
+                }
+                stage('Shard 2') {
+                    agent {
+                        docker {
+                            image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+                            args '-u root'
+                        }
+                    }
+                    steps {
+                        sh 'npm ci'
+                        sh 'npx playwright test --shard=2/4'
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'blob-report/**',
+                                             allowEmptyArchive: true
+                        }
+                    }
+                }
+                stage('Shard 3') {
+                    agent {
+                        docker {
+                            image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+                            args '-u root'
+                        }
+                    }
+                    steps {
+                        sh 'npm ci'
+                        sh 'npx playwright test --shard=3/4'
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'blob-report/**',
+                                             allowEmptyArchive: true
+                        }
+                    }
+                }
+                stage('Shard 4') {
+                    agent {
+                        docker {
+                            image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+                            args '-u root'
+                        }
+                    }
+                    steps {
+                        sh 'npm ci'
+                        sh 'npx playwright test --shard=4/4'
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'blob-report/**',
+                                             allowEmptyArchive: true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Decision Guide
+
+| CI Platform | Docker Image Support | Native Parallelism | Artifact Browsing | JUnit Integration |
+|---|---|---|---|---|
+| CircleCI | First-class (`docker:` executor) | `parallelism: N` with `CIRCLE_NODE_INDEX` | Via artifacts tab | `store_test_results` |
+| Azure DevOps | Via `vmImage` or container jobs | `strategy.matrix` | Pipeline Artifacts UI | `PublishTestResults@2` |
+| Jenkins | Docker Pipeline plugin | `parallel` stages | Archived Artifacts | `junit` step |
+
+| Scenario | CircleCI | Azure DevOps | Jenkins |
+|---|---|---|---|
+| Shard variable | `$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL` | Define in matrix: `SHARD: '1/4'` | Hardcode per parallel stage |
+| Cache key | `checksum "package-lock.json"` | `Cache@2` with key template | `stash`/`unstash` or shared volume |
+| Secrets | Context + environment variables | Variable groups + pipeline variables | Credentials plugin |
+| Report upload | `store_artifacts` | `PublishPipelineArtifact@1` | `archiveArtifacts` |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| Installing browsers on bare metal without `--with-deps` | Missing OS libs cause launch failures | Use Playwright Docker image or `--with-deps` flag |
+| No JUnit reporter | CI platform can't display test results natively | Add `['junit', { outputFile: 'test-results/junit.xml' }]` |
+| Unlimited job timeout | Hung tests run indefinitely, consuming CI resources | Set explicit timeout (20-30 min) |
+| No artifact upload on success | Can't verify results when tests pass | Always upload reports (`condition: always()` / `when: always`) |
+| Running browsers as non-root in container without setup | Permission errors on browser binaries | Run as root or configure proper permissions |
+| Hardcoding shard count in config instead of using CI variables | Must update two places when changing parallelism | Use CI-native variables (`CI_NODE_TOTAL`, `CIRCLE_NODE_TOTAL`) |
+
+## Troubleshooting
+
+### CircleCI: "Error: browserType.launch: Executable doesn't exist"
+
+**Cause**: Not using the Playwright Docker image, or image version doesn't match `@playwright/test` version.
+
+**Fix**: Match image tag to your Playwright version:
+
+```yaml
+docker:
+  - image: mcr.microsoft.com/playwright:v1.52.0-noble  # match package.json version
+```
+
+### Azure DevOps: Test results not showing in Tests tab
+
+**Cause**: JUnit reporter not configured, or `PublishTestResults@2` task missing.
+
+**Fix**: Add both the reporter and the publish task:
+
+```ts
+// playwright.config.ts
+reporter: [['junit', { outputFile: 'test-results/junit.xml' }]],
+```
+
+```yaml
+- task: PublishTestResults@2
+  condition: always()
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: 'test-results/junit.xml'
+```
+
+### Jenkins: "Browser closed unexpectedly" in Docker agent
+
+**Cause**: Running as non-root user in container. Chromium's sandbox needs root or `--no-sandbox`.
+
+**Fix**: Run as root in the Docker agent:
+
+```groovy
+agent {
+    docker {
+        image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+        args '-u root'
+    }
+}
+environment {
+    HOME = '/root'
+}
+```
+
+### All platforms: Shard index off by one
+
+**Cause**: CircleCI's `CIRCLE_NODE_INDEX` is 0-based, but Playwright's `--shard` is 1-based.
+
+**Fix**: Add 1 to the index for CircleCI:
+
+```yaml
+# CircleCI
+command: npx playwright test --shard=$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL
+
+# GitLab (already 1-based)
+command: npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
+```
+
+## Related
+
+- [ci/ci-github-actions.md](ci-github-actions.md) -- GitHub Actions configuration
+- [ci/ci-gitlab.md](ci-gitlab.md) -- GitLab CI configuration
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- sharding strategies
+- [ci/docker-and-containers.md](docker-and-containers.md) -- Docker image details
+- [ci/reporting-and-artifacts.md](reporting-and-artifacts.md) -- reporter configuration for CI

--- a/engineering-team/playwright skill/core/ci/docker-and-containers.md
+++ b/engineering-team/playwright skill/core/ci/docker-and-containers.md
@@ -1,0 +1,436 @@
+# Docker and Containers
+
+> **When to use**: Running Playwright tests in containers for reproducible environments, CI pipelines, or local development with consistent browser versions. Essential when your team needs identical test environments across machines.
+
+## Quick Reference
+
+```bash
+# Official Playwright Docker images
+docker pull mcr.microsoft.com/playwright:v1.52.0-noble     # Ubuntu 24.04, all browsers
+docker pull mcr.microsoft.com/playwright:v1.52.0-jammy      # Ubuntu 22.04, all browsers
+
+# Run tests in container
+docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/playwright:v1.52.0-noble \
+  npx playwright test
+
+# Check your Playwright version (must match image tag)
+npx playwright --version
+```
+
+## Patterns
+
+### Pattern 1: Running Tests in the Official Image
+
+**Use when**: Quick, reproducible test runs without building a custom image.
+**Avoid when**: You need application services (database, API) running alongside -- use docker-compose instead.
+
+```bash
+# Run all tests
+docker run --rm \
+  -v $(pwd):/app \
+  -w /app \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  bash -c "npm ci && npx playwright test"
+
+# Run with environment variables
+docker run --rm \
+  -v $(pwd):/app \
+  -w /app \
+  -e CI=true \
+  -e BASE_URL=http://host.docker.internal:3000 \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  bash -c "npm ci && npx playwright test"
+
+# Run and extract report
+docker run --rm \
+  -v $(pwd):/app \
+  -w /app \
+  -v $(pwd)/playwright-report:/app/playwright-report \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  bash -c "npm ci && npx playwright test"
+```
+
+### Pattern 2: Custom Dockerfile
+
+**Use when**: You need additional system dependencies, pre-installed npm packages, or a smaller image with only certain browsers.
+**Avoid when**: The official image works as-is.
+
+```dockerfile
+# Dockerfile.playwright
+FROM mcr.microsoft.com/playwright:v1.52.0-noble
+
+WORKDIR /app
+
+# Copy package files first for better layer caching
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy the rest of the project
+COPY . .
+
+# Default command
+CMD ["npx", "playwright", "test"]
+```
+
+```bash
+# Build and run
+docker build -f Dockerfile.playwright -t my-e2e-tests .
+docker run --rm my-e2e-tests
+
+# Run with specific options
+docker run --rm my-e2e-tests npx playwright test --project=chromium
+
+# Extract report
+docker run --rm -v $(pwd)/reports:/app/playwright-report my-e2e-tests
+```
+
+**Slim image with only Chromium:**
+
+```dockerfile
+# Dockerfile.playwright-chromium
+FROM node:20-slim
+
+# Install only Chromium dependencies
+RUN npx playwright install --with-deps chromium
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+
+CMD ["npx", "playwright", "test", "--project=chromium"]
+```
+
+### Pattern 3: Docker Compose with Application Stack
+
+**Use when**: Tests need the full application stack: web server, database, cache, and Playwright running together.
+**Avoid when**: Tests run against a remote environment (staging/prod) -- no local services needed.
+
+```yaml
+# docker-compose.yml
+services:
+  # Application under test
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=test
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/test
+      - REDIS_URL=redis://cache:6379
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
+
+  # Database
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    tmpfs:
+      - /var/lib/postgresql/data  # RAM disk for speed
+
+  # Cache
+  cache:
+    image: redis:7-alpine
+
+  # Playwright test runner
+  e2e:
+    image: mcr.microsoft.com/playwright:v1.52.0-noble
+    working_dir: /app
+    volumes:
+      - .:/app
+      - /app/node_modules  # prevent host node_modules from overriding
+    environment:
+      - CI=true
+      - BASE_URL=http://app:3000
+    depends_on:
+      - app
+    command: bash -c "npm ci && npx playwright test"
+    profiles:
+      - test  # only start with: docker compose --profile test up
+```
+
+```bash
+# Run the full stack with tests
+docker compose --profile test up --abort-on-container-exit --exit-code-from e2e
+
+# Run just the app (for local dev)
+docker compose up app
+
+# Run tests against already-running stack
+docker compose --profile test run --rm e2e npx playwright test
+
+# Tear down everything
+docker compose --profile test down -v
+```
+
+### Pattern 4: Extracting Reports and Traces from Containers
+
+**Use when**: You need test artifacts (HTML reports, traces, screenshots) accessible on the host after container tests complete.
+**Avoid when**: CI handles artifact collection natively (GitHub Actions, GitLab artifacts).
+
+```bash
+# Method 1: Bind mount the output directories
+docker run --rm \
+  -v $(pwd):/app \
+  -v $(pwd)/playwright-report:/app/playwright-report \
+  -v $(pwd)/test-results:/app/test-results \
+  -w /app \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  bash -c "npm ci && npx playwright test"
+
+# Method 2: Copy artifacts from a stopped container
+docker run --name e2e-run \
+  -v $(pwd):/app \
+  -w /app \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  bash -c "npm ci && npx playwright test" || true
+
+docker cp e2e-run:/app/playwright-report ./playwright-report
+docker cp e2e-run:/app/test-results ./test-results
+docker rm e2e-run
+
+# View the report
+npx playwright show-report ./playwright-report
+```
+
+**Docker Compose for report extraction:**
+
+```yaml
+# docker-compose.yml (add to e2e service)
+services:
+  e2e:
+    image: mcr.microsoft.com/playwright:v1.52.0-noble
+    working_dir: /app
+    volumes:
+      - .:/app
+      - ./playwright-report:/app/playwright-report
+      - ./test-results:/app/test-results
+    # ... rest of config
+```
+
+### Pattern 5: CI Container Strategies
+
+**Use when**: Your CI environment benefits from containerized test execution.
+
+**GitHub Actions -- container job:**
+
+```yaml
+# .github/workflows/playwright.yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npx playwright test
+        env:
+          HOME: /root
+```
+
+**GitLab CI -- image directive:**
+
+```yaml
+# .gitlab-ci.yml
+test:
+  image: mcr.microsoft.com/playwright:v1.52.0-noble
+  script:
+    - npm ci
+    - npx playwright test
+```
+
+**Jenkins -- Docker agent:**
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent {
+        docker {
+            image 'mcr.microsoft.com/playwright:v1.52.0-noble'
+            args '-u root'
+        }
+    }
+    stages {
+        stage('Test') {
+            steps {
+                sh 'npm ci'
+                sh 'npx playwright test'
+            }
+        }
+    }
+}
+```
+
+### Pattern 6: Development Container (devcontainer)
+
+**Use when**: Your team uses VS Code Dev Containers or GitHub Codespaces and needs Playwright available in the development environment.
+**Avoid when**: Everyone installs Playwright locally and version differences don't cause issues.
+
+```json
+// .devcontainer/devcontainer.json
+{
+  "name": "Playwright Dev",
+  "image": "mcr.microsoft.com/playwright:v1.52.0-noble",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "npm ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-playwright.playwright"
+      ]
+    }
+  },
+  "forwardPorts": [3000, 9323],
+  "remoteUser": "root"
+}
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Simple CI pipeline | Official Playwright image as CI image | Browsers pre-installed; zero browser install time |
+| Tests need database + cache | Docker Compose with app, db, cache, e2e services | Full stack in isolated containers |
+| Team needs identical environments | Dev Container or custom Dockerfile | Eliminate "works on my machine" |
+| Only testing Chromium | Slim image: `node:20-slim` + `install --with-deps chromium` | Smaller image, faster pulls |
+| Cross-browser testing | Official Playwright image (has all browsers) | All three engines pre-installed |
+| Local development | Run directly on host, not in container | Faster iteration, easier debugging |
+| CI with artifact extraction | Bind mount report/results dirs or use CI artifact upload | Reports accessible after container exits |
+
+| Image | Size | Browsers | Base OS |
+|---|---|---|---|
+| `mcr.microsoft.com/playwright:v1.52.0-noble` | ~2 GB | Chromium, Firefox, WebKit | Ubuntu 24.04 |
+| `mcr.microsoft.com/playwright:v1.52.0-jammy` | ~2 GB | Chromium, Firefox, WebKit | Ubuntu 22.04 |
+| Custom slim (Chromium only) | ~800 MB | Chromium | Depends on base |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| Image tag doesn't match `@playwright/test` version | Browser binaries incompatible with Playwright library | Always match: `v1.52.0` image for `@playwright/test@1.52.0` |
+| Using `latest` tag | Unpredictable; image updates can break tests | Pin to exact version: `v1.52.0-noble` |
+| Installing browsers inside container at runtime | Wastes 60-90 seconds on every run | Use official image (browsers pre-installed) or build custom image with browsers baked in |
+| Running as non-root without configuring sandbox | Chromium sandbox fails with permission errors | Run as root (`-u root`) or disable sandbox (`--no-sandbox` in launch args) |
+| Bind-mounting `node_modules` from host | Platform-specific binaries (macOS vs Linux) cause crashes | Use anonymous volume: `-v /app/node_modules` |
+| No health checks on dependent services | Tests start before database is ready | Add `healthcheck` to db service; use `depends_on: condition: service_healthy` |
+| Building application inside the Playwright container | Large image, slow builds, wrong base for your app | Separate app and e2e containers in docker-compose |
+
+## Troubleshooting
+
+### "browserType.launch: Executable doesn't exist" in container
+
+**Cause**: Playwright version in `package.json` doesn't match the Docker image version.
+
+**Fix**: Ensure exact version match:
+
+```bash
+# Check your version
+npm ls @playwright/test
+# @playwright/test@1.52.0
+
+# Use matching image
+docker pull mcr.microsoft.com/playwright:v1.52.0-noble
+```
+
+### Tests fail with "net::ERR_CONNECTION_REFUSED" in docker-compose
+
+**Cause**: Tests are trying to reach `localhost:3000` but the app is in a different container.
+
+**Fix**: Use the service name as hostname and configure `baseURL`:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+  },
+  // Disable webServer in Docker -- app is managed by docker-compose
+  ...(process.env.CI ? {} : {
+    webServer: {
+      command: 'npm run dev',
+      url: 'http://localhost:3000',
+      reuseExistingServer: true,
+    },
+  }),
+});
+```
+
+```yaml
+# docker-compose.yml
+e2e:
+  environment:
+    - BASE_URL=http://app:3000  # "app" is the service name
+```
+
+### Permission denied on mounted volumes
+
+**Cause**: Container runs as root but host files are owned by your user, or vice versa.
+
+**Fix**: Match user IDs or run as root:
+
+```bash
+# Run as your host user
+docker run --rm -u $(id -u):$(id -g) \
+  -v $(pwd):/app -w /app \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  npx playwright test
+
+# Or run as root (simpler, fine for CI)
+docker run --rm \
+  -v $(pwd):/app -w /app \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  npx playwright test
+```
+
+### Container tests are much slower than local
+
+**Cause**: Docker Desktop on macOS/Windows has I/O overhead for bind-mounted volumes.
+
+**Fix**: Copy files into the container instead of mounting:
+
+```dockerfile
+# Dockerfile.playwright
+FROM mcr.microsoft.com/playwright:v1.52.0-noble
+WORKDIR /app
+COPY . .
+RUN npm ci
+CMD ["npx", "playwright", "test"]
+```
+
+Or use delegated mount on macOS:
+
+```bash
+docker run --rm \
+  -v $(pwd):/app:delegated \
+  -w /app \
+  mcr.microsoft.com/playwright:v1.52.0-noble \
+  bash -c "npm ci && npx playwright test"
+```
+
+## Related
+
+- [ci/ci-github-actions.md](ci-github-actions.md) -- container jobs in GitHub Actions
+- [ci/ci-gitlab.md](ci-gitlab.md) -- Docker images in GitLab CI
+- [ci/ci-other.md](ci-other.md) -- Docker agents in Jenkins, CircleCI
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- sharding within containers
+- [ci/reporting-and-artifacts.md](reporting-and-artifacts.md) -- extracting reports from containers

--- a/engineering-team/playwright skill/core/ci/global-setup-teardown.md
+++ b/engineering-team/playwright skill/core/ci/global-setup-teardown.md
@@ -1,0 +1,521 @@
+# Global Setup and Teardown
+
+> **When to use**: One-time operations that must run before or after the entire test suite -- database seeding, environment health checks, creating shared auth state, starting external services. Runs once per `npx playwright test` invocation, not once per test or per worker.
+
+## Quick Reference
+
+```
+globalSetup         →  runs ONCE before all tests in all projects
+  ↓
+setup projects      →  runs before dependent projects (has browser context)
+  ↓
+test projects       →  your actual tests
+  ↓
+teardown projects   →  runs after dependent projects (has browser context)
+  ↓
+globalTeardown      →  runs ONCE after all tests in all projects
+```
+
+**Key distinction:**
+- `globalSetup` / `globalTeardown`: No browser, no Playwright fixtures. Pure Node.js.
+- Setup projects with `dependencies`: Has full browser context, can use `page`, `request`, etc.
+
+## Patterns
+
+### Pattern 1: Basic Global Setup and Teardown
+
+**Use when**: One-time non-browser work like database seeding, environment validation, or external service preparation.
+**Avoid when**: You need a browser (use a setup project instead) or per-test isolation (use fixtures).
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  globalSetup: './tests/global-setup.ts',
+  globalTeardown: './tests/global-teardown.ts',
+  testDir: './tests',
+});
+```
+
+```ts
+// tests/global-setup.ts
+import type { FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  console.log('Global setup: seeding database...');
+
+  // Seed the test database
+  const { execSync } = await import('child_process');
+  execSync('npx prisma db push --force-reset', { stdio: 'inherit' });
+  execSync('npx prisma db seed', { stdio: 'inherit' });
+
+  // Store run metadata for tests to use
+  process.env.TEST_RUN_ID = `run-${Date.now()}`;
+}
+
+export default globalSetup;
+```
+
+```ts
+// tests/global-teardown.ts
+import type { FullConfig } from '@playwright/test';
+
+async function globalTeardown(config: FullConfig) {
+  console.log('Global teardown: cleaning up...');
+
+  const { execSync } = await import('child_process');
+  execSync('npx prisma db push --force-reset', { stdio: 'inherit' });
+}
+
+export default globalTeardown;
+```
+
+### Pattern 2: Environment Health Check in Global Setup
+
+**Use when**: Verifying the test environment is healthy before running any tests. Fails fast if services are down.
+**Avoid when**: Tests use `webServer` which already does a health check.
+
+```ts
+// tests/global-setup.ts
+import type { FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL || 'http://localhost:3000';
+  const maxRetries = 10;
+  const retryDelay = 2000;
+
+  console.log(`Checking if ${baseURL} is reachable...`);
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const response = await fetch(`${baseURL}/api/health`);
+      if (response.ok) {
+        console.log(`Environment is healthy (attempt ${i + 1})`);
+        return;
+      }
+    } catch {
+      // Connection refused or timeout -- retry
+    }
+    console.log(`Waiting for environment... (attempt ${i + 1}/${maxRetries})`);
+    await new Promise((resolve) => setTimeout(resolve, retryDelay));
+  }
+
+  throw new Error(`Environment at ${baseURL} is not reachable after ${maxRetries} attempts`);
+}
+
+export default globalSetup;
+```
+
+### Pattern 3: Authentication State in Global Setup (Without Browser)
+
+**Use when**: Creating auth tokens or session cookies via API, without needing a browser.
+**Avoid when**: Login requires browser interaction (use a setup project instead).
+
+```ts
+// tests/global-setup.ts
+import type { FullConfig } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL || 'http://localhost:3000';
+
+  // Authenticate via API (no browser needed)
+  const response = await fetch(`${baseURL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'admin@example.com',
+      password: process.env.TEST_PASSWORD,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Authentication failed: ${response.status} ${response.statusText}`);
+  }
+
+  const { token } = await response.json();
+
+  // Save the token as storageState for browser tests to pick up
+  const authDir = path.resolve(process.cwd(), 'playwright/.auth');
+  fs.mkdirSync(authDir, { recursive: true });
+
+  const storageState = {
+    cookies: [],
+    origins: [
+      {
+        origin: baseURL,
+        localStorage: [
+          { name: 'auth_token', value: token },
+        ],
+      },
+    ],
+  };
+
+  fs.writeFileSync(
+    path.join(authDir, 'user.json'),
+    JSON.stringify(storageState, null, 2)
+  );
+}
+
+export default globalSetup;
+```
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  globalSetup: './tests/global-setup.ts',
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+  ],
+});
+```
+
+### Pattern 4: Passing Data from Global Setup to Tests
+
+**Use when**: Global setup generates values (IDs, tokens, URLs) that tests need.
+**Avoid when**: Each test should create its own data (the usual case).
+
+**Method 1: Environment variables (simplest):**
+
+```ts
+// tests/global-setup.ts
+import type { FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  process.env.TEST_RUN_ID = `run-${Date.now()}`;
+  process.env.SEED_USER_ID = 'user-12345';
+}
+
+export default globalSetup;
+```
+
+```ts
+// tests/dashboard.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('dashboard shows seeded data', async ({ page }) => {
+  const userId = process.env.SEED_USER_ID;
+  await page.goto(`/users/${userId}/dashboard`);
+  await expect(page.getByRole('heading')).toBeVisible();
+});
+```
+
+**Method 2: Shared file (for complex data):**
+
+```ts
+// tests/global-setup.ts
+import type { FullConfig } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SETUP_DATA_PATH = path.resolve(process.cwd(), 'test-data/setup-data.json');
+
+async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL || 'http://localhost:3000';
+
+  // Create test data via API
+  const res = await fetch(`${baseURL}/api/test/seed`, { method: 'POST' });
+  const seedData = await res.json();
+
+  // Write to shared file
+  const dir = path.dirname(SETUP_DATA_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(SETUP_DATA_PATH, JSON.stringify(seedData, null, 2));
+}
+
+export default globalSetup;
+```
+
+```ts
+// tests/helpers/setup-data.ts
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SETUP_DATA_PATH = path.resolve(process.cwd(), 'test-data/setup-data.json');
+
+export function getSetupData(): { userId: string; orgId: string; apiKey: string } {
+  const raw = fs.readFileSync(SETUP_DATA_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+```
+
+```ts
+// tests/org-settings.spec.ts
+import { test, expect } from '@playwright/test';
+import { getSetupData } from './helpers/setup-data';
+
+test('org settings page loads', async ({ page }) => {
+  const { orgId } = getSetupData();
+  await page.goto(`/orgs/${orgId}/settings`);
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+});
+```
+
+### Pattern 5: Global Setup with `storageState` (Browser-Based Auth)
+
+**Use when**: Authentication requires browser interaction (form login, OAuth redirect, MFA).
+**Avoid when**: Auth can be done via API call (use Pattern 3 instead).
+
+**Important**: `globalSetup` has no browser. For browser-based auth, use a **setup project** instead.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    // Setup project: runs first, has a browser, saves auth state
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+    },
+
+    // Test projects: depend on setup, reuse saved auth state
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+
+```ts
+// tests/global.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Wait for navigation to confirm login succeeded
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  // Save signed-in state (cookies + localStorage)
+  await page.context().storageState({ path: authFile });
+});
+```
+
+### Pattern 6: Global Setup for External Services
+
+**Use when**: Starting or configuring external services (mock servers, test containers, feature flags) before any tests run.
+**Avoid when**: Per-test or per-worker isolation is needed (use fixtures).
+
+```ts
+// tests/global-setup.ts
+import type { FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  // Start a mock API server
+  const { createServer } = await import('../mocks/server');
+  const server = await createServer();
+  const port = await server.listen(0);
+  process.env.MOCK_API_URL = `http://localhost:${port}`;
+
+  // Configure feature flags for test environment
+  const baseURL = config.projects[0]?.use?.baseURL || 'http://localhost:3000';
+  await fetch(`${baseURL}/api/admin/feature-flags`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.ADMIN_API_KEY}`,
+    },
+    body: JSON.stringify({
+      newCheckout: true,
+      darkMode: false,
+      betaFeatures: true,
+    }),
+  });
+
+  // Return a cleanup function (Playwright calls globalTeardown separately)
+  // For cleanup, use globalTeardown
+}
+
+export default globalSetup;
+```
+
+```ts
+// tests/global-teardown.ts
+import type { FullConfig } from '@playwright/test';
+
+async function globalTeardown(config: FullConfig) {
+  // Reset feature flags
+  const baseURL = config.projects[0]?.use?.baseURL || 'http://localhost:3000';
+  await fetch(`${baseURL}/api/admin/feature-flags/reset`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${process.env.ADMIN_API_KEY}` },
+  });
+}
+
+export default globalTeardown;
+```
+
+## Decision Guide
+
+| Need | Use | Why |
+|---|---|---|
+| One-time DB seed | `globalSetup` | No browser needed; runs once before everything |
+| Browser-based login (shared state) | Setup project with `dependencies` | Needs `page` and `context` (not available in globalSetup) |
+| API-based auth token | `globalSetup` | Simple HTTP call, no browser needed |
+| Per-test unique data | Custom fixture via `test.extend()` | Each test gets isolated data |
+| Per-worker shared resource | Worker-scoped fixture (`{ scope: 'worker' }`) | Shared within worker, isolated between workers |
+| Health check before tests | `globalSetup` | Fail fast if environment is down |
+| Start mock server | `globalSetup` + `globalTeardown` | One-time server lifecycle |
+| Clean up after all tests | `globalTeardown` | Runs once at the end regardless of pass/fail |
+
+```
+Do I need globalSetup?
+│
+├── Does the work need a browser (page, context)?
+│   ├── YES → Use a setup project, not globalSetup
+│   └── NO  → globalSetup is appropriate
+│
+├── Does every test need unique/isolated data?
+│   ├── YES → Use a fixture with test.extend()
+│   └── NO  → globalSetup for shared, read-only data
+│
+├── Is it per-worker (expensive resource, connection pool)?
+│   ├── YES → Worker-scoped fixture
+│   └── NO  → globalSetup for truly global, one-time work
+│
+└── Is it cleanup?
+    ├── After all tests → globalTeardown
+    ├── After each test → Fixture teardown (after use())
+    └── After each worker → Worker-scoped fixture teardown
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| Browser login in `globalSetup` | No browser context available; complex workarounds | Use a setup project with `dependencies` |
+| Creating per-test data in `globalSetup` | All tests share the same data; not isolated | Use per-test fixtures for unique data |
+| `globalSetup` without `globalTeardown` | Database or services left in dirty state | Always pair setup with teardown |
+| Storing setup results in module-level variables | Workers are separate processes; variables don't share | Use environment variables or files |
+| Complex logic in `globalSetup` | Hard to debug; runs outside normal test lifecycle | Keep it minimal: seed, verify, set env vars |
+| `globalSetup` that takes > 60 seconds | Slows every test run, even for a single test | Move heavy work to a separate script or CI step |
+| Relying on `globalTeardown` for critical cleanup | If the process crashes, `globalTeardown` might not run | Design tests to be idempotent; use `beforeAll` in setup project |
+
+## Troubleshooting
+
+### Global setup runs but environment variables are not available in tests
+
+**Cause**: Each worker is a separate process. `process.env` mutations in `globalSetup` propagate to workers, but only if set before workers spawn.
+
+**Fix**: Set environment variables at the top level of `globalSetup`, before any async work that might delay:
+
+```ts
+// tests/global-setup.ts
+async function globalSetup() {
+  // This works -- set before returning
+  process.env.TEST_RUN_ID = `run-${Date.now()}`;
+}
+export default globalSetup;
+```
+
+If environment variables are still missing, write data to a file instead (Pattern 4, Method 2).
+
+### Global setup fails with "Cannot find module"
+
+**Cause**: The path in `globalSetup` is relative to the config file, but the module resolution is wrong.
+
+**Fix**: Use a path relative to the project root:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  globalSetup: './tests/global-setup.ts',   // relative to config location
+  globalTeardown: './tests/global-teardown.ts',
+});
+```
+
+### Global teardown doesn't run after test failure
+
+**Cause**: If the process is killed (SIGKILL, OOM) rather than exiting normally, teardown is skipped.
+
+**Fix**: Design your setup to be idempotent. Global setup should handle a dirty state from a previous incomplete run:
+
+```ts
+// tests/global-setup.ts
+async function globalSetup() {
+  // Always reset first, then seed -- handles dirty state
+  const { execSync } = await import('child_process');
+  execSync('npx prisma db push --force-reset', { stdio: 'inherit' });
+  execSync('npx prisma db seed', { stdio: 'inherit' });
+}
+export default globalSetup;
+```
+
+### Setup project runs every time, even when only running one test file
+
+**Cause**: The `dependencies` configuration requires the setup project to run before any dependent project.
+
+**Fix**: This is expected behavior. To skip setup during focused debugging:
+
+```bash
+# Skip setup by running without dependencies
+npx playwright test --project=chromium --no-deps tests/specific-test.spec.ts
+```
+
+### `storageState` file doesn't exist when tests start
+
+**Cause**: The setup project or `globalSetup` that creates the file failed silently, or the path is wrong.
+
+**Fix**: Add explicit error handling and verify the file exists:
+
+```ts
+// tests/global.setup.ts
+import { test as setup, expect } from '@playwright/test';
+import * as fs from 'fs';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await page.context().storageState({ path: authFile });
+
+  // Verify the file was created
+  if (!fs.existsSync(authFile)) {
+    throw new Error(`Auth state file was not created at ${authFile}`);
+  }
+});
+```
+
+## Related
+
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- per-test and per-worker fixtures (preferred over globalSetup for most cases)
+- [core/configuration.md](../core/configuration.md) -- `globalSetup`, `globalTeardown`, `webServer` config
+- [ci/projects-and-dependencies.md](projects-and-dependencies.md) -- setup projects with `dependencies`
+- [core/authentication.md](../core/authentication.md) -- authentication patterns using setup projects
+- [core/test-data-management.md](../core/test-data-management.md) -- seeding and managing test data

--- a/engineering-team/playwright skill/core/ci/parallel-and-sharding.md
+++ b/engineering-team/playwright skill/core/ci/parallel-and-sharding.md
@@ -1,0 +1,418 @@
+# Parallel Execution and Sharding
+
+> **When to use**: Speeding up test suites by running tests concurrently within a single machine (parallelism) or across multiple machines (sharding). Essential once your suite exceeds 5 minutes.
+
+## Quick Reference
+
+```bash
+# Workers (parallelism within one machine)
+npx playwright test --workers=4          # fixed worker count
+npx playwright test --workers=50%        # percentage of CPU cores
+
+# Sharding (splitting across machines)
+npx playwright test --shard=1/4          # run first quarter
+npx playwright test --shard=2/4          # run second quarter
+
+# Merging shard results
+npx playwright merge-reports ./blob-report          # merge to default HTML
+npx playwright merge-reports --reporter=html,json ./blob-report  # multiple formats
+
+# Fully parallel mode
+npx playwright test --fully-parallel     # override config for this run
+```
+
+## Patterns
+
+### Pattern 1: Configuring Workers
+
+**Use when**: Controlling how many tests run simultaneously on one machine.
+**Avoid when**: You only have 1-2 tests (parallelism has no effect).
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  // fullyParallel: true means tests WITHIN a file also run in parallel.
+  // Without it, only files run in parallel (tests within a file are serial).
+  fullyParallel: true,
+
+  // Workers: how many parallel processes
+  // - undefined: auto-detect (half CPU cores, capped at a reasonable number)
+  // - number: fixed count
+  // - string percentage: '50%' of CPU cores
+  workers: process.env.CI ? '50%' : undefined,
+});
+```
+
+**What `fullyParallel` actually controls:**
+
+| Setting | Files run in parallel | Tests within a file run in parallel |
+|---|---|---|
+| `fullyParallel: false` (default) | Yes | No -- serial within each file |
+| `fullyParallel: true` | Yes | Yes -- every test is independent |
+
+**Per-file override when one file needs serial execution:**
+
+```ts
+// tests/onboarding.spec.ts
+import { test, expect } from '@playwright/test';
+
+// This file's tests run serially even with fullyParallel: true in config
+test.describe.configure({ mode: 'serial' });
+
+test('step 1: enter company name', async ({ page }) => {
+  // ...
+});
+
+test('step 2: choose plan', async ({ page }) => {
+  // ...
+});
+```
+
+### Pattern 2: Sharding Across CI Machines
+
+**Use when**: Suite is too slow for a single machine even with maximum workers. Split work across N separate CI jobs.
+**Avoid when**: Suite runs under 5 minutes on one machine.
+
+Sharding splits the test file list into N equal groups. Each shard runs one group.
+
+```bash
+# Machine 1          Machine 2          Machine 3          Machine 4
+--shard=1/4          --shard=2/4          --shard=3/4          --shard=4/4
+```
+
+**Config for sharded runs -- use blob reporter:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  fullyParallel: true,
+  workers: process.env.CI ? '50%' : undefined,
+
+  // Blob reporter outputs a binary file that can be merged later.
+  // In non-CI, use HTML for local viewing.
+  reporter: process.env.CI
+    ? [['blob'], ['github']]
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+### Pattern 3: Merging Blob Reports from Shards
+
+**Use when**: You sharded your tests and need a single unified report.
+**Avoid when**: No sharding -- the regular HTML reporter works directly.
+
+Each shard produces a `.zip` file in `blob-report/`. After all shards complete, merge them:
+
+```bash
+# Download all blob-report/ directories into one folder, then:
+npx playwright merge-reports --reporter=html ./all-blob-reports
+
+# Multiple output formats
+npx playwright merge-reports --reporter=html,json,junit ./all-blob-reports
+
+# Custom output directory
+PLAYWRIGHT_HTML_REPORT=merged-report npx playwright merge-reports --reporter=html ./all-blob-reports
+```
+
+**GitHub Actions example (merge job):**
+
+```yaml
+merge-reports:
+  if: ${{ !cancelled() }}
+  needs: test
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+    - run: npm ci
+
+    - uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - run: npx playwright merge-reports --reporter=html ./all-blob-reports
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 14
+```
+
+### Pattern 4: Worker-Scoped Fixtures for Shared Resources
+
+**Use when**: Parallel workers each need an expensive resource (database connection, auth token) that should be created once per worker, not once per test.
+**Avoid when**: The resource is cheap to create -- use a regular test-scoped fixture.
+
+```ts
+// fixtures.ts
+import { test as base } from '@playwright/test';
+
+type WorkerFixtures = {
+  dbConnection: DatabaseClient;
+  workerAuthToken: string;
+};
+
+export const test = base.extend<{}, WorkerFixtures>({
+  // Created once per worker process, shared across all tests in that worker
+  dbConnection: [async ({}, use) => {
+    const db = await DatabaseClient.connect(process.env.DB_URL!);
+    await use(db);
+    await db.disconnect();
+  }, { scope: 'worker' }],
+
+  workerAuthToken: [async ({}, use, workerInfo) => {
+    // Each worker gets a unique user to avoid test interference
+    const response = await fetch(`${process.env.API_URL}/auth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: `worker-user-${workerInfo.workerIndex}`,
+        password: process.env.TEST_PASSWORD,
+      }),
+    });
+    const { token } = await response.json();
+    await use(token);
+  }, { scope: 'worker' }],
+});
+
+export { expect } from '@playwright/test';
+```
+
+### Pattern 5: Test Isolation for Safe Parallelism
+
+**Use when**: Preparing tests to run in parallel without interference.
+**Avoid when**: Never -- isolation is always required for reliable parallel execution.
+
+**The golden rule**: Each test must create its own state and clean up after itself. No test should depend on or modify state that another test uses.
+
+```ts
+// BAD: Tests share a hardcoded user -- parallel runs collide
+test('update profile', async ({ page }) => {
+  await page.goto('/users/shared-user/profile');
+  await page.getByLabel('Name').fill('New Name');
+  await page.getByRole('button', { name: 'Save' }).click();
+  // Another parallel test also editing "shared-user" -- race condition!
+});
+
+// GOOD: Each test creates its own user
+test('update profile', async ({ page, request }) => {
+  // Create a unique user for this test
+  const res = await request.post('/api/test/users', {
+    data: { name: `user-${Date.now()}`, email: `${Date.now()}@test.com` },
+  });
+  const user = await res.json();
+
+  await page.goto(`/users/${user.id}/profile`);
+  await page.getByLabel('Name').fill('Updated Name');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByLabel('Name')).toHaveValue('Updated Name');
+
+  // Cleanup
+  await request.delete(`/api/test/users/${user.id}`);
+});
+```
+
+**Using `workerInfo` and `testInfo` for unique identifiers:**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('create order', async ({ page }, testInfo) => {
+  const uniqueId = `order-${testInfo.workerIndex}-${Date.now()}`;
+  // Use uniqueId for any data this test creates
+  await page.goto(`/orders/new?ref=${uniqueId}`);
+  // ...
+});
+```
+
+### Pattern 6: Dynamic Shard Count Based on Test Count
+
+**Use when**: You want to automatically adjust shard count based on how many tests exist, rather than hardcoding.
+**Avoid when**: Your test count is stable and a fixed shard count works well.
+
+```yaml
+# .github/workflows/playwright.yml -- dynamic shard calculation
+jobs:
+  determine-shards:
+    runs-on: ubuntu-latest
+    outputs:
+      shard-count: ${{ steps.calc.outputs.count }}
+      shard-matrix: ${{ steps.calc.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - id: calc
+        run: |
+          TEST_COUNT=$(npx playwright test --list --reporter=json 2>/dev/null | node -e "
+            const data = require('fs').readFileSync('/dev/stdin', 'utf8');
+            const parsed = JSON.parse(data);
+            console.log(parsed.suites?.reduce((acc, s) => acc + (s.specs?.length || 0), 0) || 0);
+          ")
+          # 1 shard per 20 tests, minimum 1, maximum 8
+          SHARDS=$(( (TEST_COUNT + 19) / 20 ))
+          SHARDS=$(( SHARDS > 8 ? 8 : SHARDS ))
+          SHARDS=$(( SHARDS < 1 ? 1 : SHARDS ))
+          # Build matrix array: ["1/N", "2/N", ...]
+          MATRIX="["
+          for i in $(seq 1 $SHARDS); do
+            [ $i -gt 1 ] && MATRIX+=","
+            MATRIX+="\"$i/$SHARDS\""
+          done
+          MATRIX+="]"
+          echo "count=$SHARDS" >> $GITHUB_OUTPUT
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  test:
+    needs: determine-shards
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.determine-shards.outputs.shard-matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npx playwright test --shard=${{ matrix.shard }}
+```
+
+## Decision Guide
+
+| Scenario | Workers | Shards | Why |
+|---|---|---|---|
+| < 50 tests, < 5 min | Auto (default) | None | No optimization needed |
+| 50-200 tests, 5-15 min | `'50%'` in CI | 2-4 shards | Balance speed and CI cost |
+| 200+ tests, > 15 min | `'50%'` in CI | 4-8 shards | Keep feedback under 10 min |
+| Flaky tests due to resource contention | Reduce: `workers: 2` | Keep current | Fewer workers = less CPU/memory pressure |
+| Tests modify shared database | `workers: 1` or isolate per worker | Still useful | Sharding splits files; workers run them |
+| CI has limited CPU/RAM | `workers: 1` or `'25%'` | More shards | Compensate fewer workers with more machines |
+
+| Question | `workers` (in-process) | `--shard` (across machines) |
+|---|---|---|
+| What does it split? | Tests across CPU cores on one machine | Test files across separate CI jobs |
+| Controlled by? | `playwright.config.ts` or `--workers` CLI | `--shard=X/Y` CLI flag |
+| Shares memory? | Yes (same machine) | No (separate machines) |
+| Report merging needed? | No (single process) | Yes (`merge-reports`) |
+| Cost | Free (same machine) | More CI minutes (more machines) |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| `fullyParallel: false` with no reason | Tests within files run serially; slow suite | Set `fullyParallel: true` unless specific tests need serial |
+| `workers: 1` in CI "to be safe" | Negates parallelism entirely | Fix isolation issues; use `workers: '50%'` |
+| Tests sharing a hardcoded user account | Race conditions when parallel -- both tests modify same data | Each test creates unique data via API or fixture |
+| `--shard=1/4` without blob reporter | Each shard produces its own HTML report; no merged view | Configure `reporter: [['blob']]` for sharded CI runs |
+| Sharding with 3 tests | Overhead of shard setup exceeds time saved | Only shard when suite exceeds 5 minutes |
+| `test.describe.serial()` everywhere | Kills parallelism, creates hidden dependencies | Use only when tests genuinely depend on prior state |
+| Worker count higher than CPU cores | Context switching overhead; slower, not faster | Use `'50%'` or let Playwright auto-detect |
+| Not using `fail-fast: false` in CI matrix | One shard failure cancels others; incomplete results | Always set `fail-fast: false` for sharded strategies |
+
+## Troubleshooting
+
+### Tests pass alone but fail when run together
+
+**Cause**: Shared state between tests -- database rows, cookies, global variables, file system.
+
+**Fix**: Isolate each test. Use unique data per test:
+
+```ts
+test('create order', async ({ page, request }, testInfo) => {
+  // Unique product per test -- no collision with parallel tests
+  const product = await request.post('/api/test/products', {
+    data: { name: `Widget-${testInfo.workerIndex}-${Date.now()}` },
+  });
+  // ...
+});
+```
+
+### Shard produces no tests: "No tests found"
+
+**Cause**: Shard count exceeds the number of test files. A shard gets zero files.
+
+**Fix**: Reduce shard count to at most the number of test files:
+
+```bash
+# If you have 10 test files, max 10 shards
+npx playwright test --shard=1/10  # OK
+npx playwright test --shard=1/20  # Some shards will be empty
+```
+
+### Merged report missing some test results
+
+**Cause**: Blob report files from a shard were not downloaded or were overwritten due to name collision.
+
+**Fix**: Give each shard's artifact a unique name:
+
+```yaml
+# Each shard
+- uses: actions/upload-artifact@v4
+  with:
+    name: blob-report-${{ strategy.job-index }}  # unique per shard
+    path: blob-report/
+
+# Merge step
+- uses: actions/download-artifact@v4
+  with:
+    pattern: blob-report-*
+    merge-multiple: true
+    path: all-blob-reports
+```
+
+### Worker-scoped fixture not shared -- recreated per test
+
+**Cause**: Missing `{ scope: 'worker' }` option, or the fixture depends on a test-scoped fixture.
+
+**Fix**: Ensure the fixture uses worker scope and only depends on worker-scoped fixtures:
+
+```ts
+export const test = base.extend<{}, { sharedResource: Resource }>({
+  sharedResource: [async ({}, use) => {
+    const resource = await Resource.create();
+    await use(resource);
+    await resource.destroy();
+  }, { scope: 'worker' }],  // Don't forget this
+});
+```
+
+### Tests are slower with more workers
+
+**Cause**: Machine is CPU- or memory-bound. More workers cause thrashing.
+
+**Fix**: Reduce workers until you find the sweet spot:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  workers: process.env.CI ? 2 : undefined,  // Start low, increase if stable
+});
+```
+
+## Related
+
+- [ci/ci-github-actions.md](ci-github-actions.md) -- sharded GitHub Actions workflow
+- [ci/ci-gitlab.md](ci-gitlab.md) -- GitLab `parallel:` keyword with sharding
+- [ci/ci-other.md](ci-other.md) -- sharding on CircleCI, Azure DevOps, Jenkins
+- [ci/reporting-and-artifacts.md](reporting-and-artifacts.md) -- blob reporter and merge-reports
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- worker-scoped fixtures
+- [core/test-organization.md](../core/test-organization.md) -- parallel vs serial execution

--- a/engineering-team/playwright skill/core/ci/projects-and-dependencies.md
+++ b/engineering-team/playwright skill/core/ci/projects-and-dependencies.md
@@ -1,0 +1,640 @@
+# Projects and Dependencies
+
+> **When to use**: Running tests across multiple browsers, devices, or environments from a single config. Projects let you define different test configurations that can depend on each other, share setup work, and run selectively.
+
+## Quick Reference
+
+```bash
+# Run all projects
+npx playwright test
+
+# Run a specific project
+npx playwright test --project=chromium
+npx playwright test --project="Mobile Safari"
+
+# Run multiple projects
+npx playwright test --project=chromium --project=firefox
+
+# List all projects and their tests
+npx playwright test --list
+
+# Skip dependencies (e.g., skip setup during debugging)
+npx playwright test --project=chromium --no-deps
+```
+
+## Patterns
+
+### Pattern 1: Multi-Browser Testing
+
+**Use when**: Ensuring your application works across Chromium, Firefox, and WebKit.
+**Avoid when**: Early development -- start with Chromium only and add browsers later.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});
+```
+
+**Selective browser testing in CI (fast on PRs, thorough on main):**
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  test-pr:
+    if: github.event_name == 'pull_request'
+    steps:
+      # Chromium only on PRs for fast feedback
+      - run: npx playwright test --project=chromium
+
+  test-main:
+    if: github.ref == 'refs/heads/main'
+    steps:
+      # All browsers on main branch
+      - run: npx playwright test
+```
+
+### Pattern 2: Desktop and Mobile Projects
+
+**Use when**: Testing responsive layouts, touch interactions, or mobile-specific behavior.
+**Avoid when**: Your application is desktop-only.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+
+  projects: [
+    // Desktop browsers
+    {
+      name: 'Desktop Chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Desktop Firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'Desktop Safari',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    // Mobile devices
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 14'] },
+    },
+
+    // Tablet
+    {
+      name: 'iPad',
+      use: { ...devices['iPad Pro 11'] },
+    },
+  ],
+});
+```
+
+**Run only mobile or only desktop:**
+
+```bash
+npx playwright test --project="Mobile Chrome" --project="Mobile Safari"
+npx playwright test --project="Desktop Chrome" --project="Desktop Firefox"
+```
+
+### Pattern 3: Setup Project with Dependencies
+
+**Use when**: Tests need shared state (authentication, seeded data) that should be created once before all test projects run.
+**Avoid when**: Tests are fully independent with no shared setup phase.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+
+  projects: [
+    // Setup runs first -- no dependencies, so it runs immediately
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+    },
+
+    // Browser projects depend on setup
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+
+```ts
+// tests/global.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await page.context().storageState({ path: authFile });
+});
+```
+
+**How dependencies work:**
+1. Playwright identifies projects with no dependencies and runs them first.
+2. Once a dependency project completes successfully, dependent projects start.
+3. If a dependency project fails, all dependent projects are skipped.
+
+### Pattern 4: Multiple Auth Roles
+
+**Use when**: Tests need different user roles (admin, editor, viewer) with separate auth states.
+**Avoid when**: All tests use the same user -- use a single setup project.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+
+  projects: [
+    // Auth setup for each role
+    {
+      name: 'auth-admin',
+      testMatch: /auth\.setup\.ts/,
+      use: {
+        userRole: 'admin',
+        storageStatePath: 'playwright/.auth/admin.json',
+      },
+    },
+    {
+      name: 'auth-editor',
+      testMatch: /auth\.setup\.ts/,
+      use: {
+        userRole: 'editor',
+        storageStatePath: 'playwright/.auth/editor.json',
+      },
+    },
+
+    // Admin tests
+    {
+      name: 'admin-tests',
+      testDir: './tests/admin',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['auth-admin'],
+    },
+
+    // Editor tests
+    {
+      name: 'editor-tests',
+      testDir: './tests/editor',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/editor.json',
+      },
+      dependencies: ['auth-editor'],
+    },
+
+    // Unauthenticated tests (no dependencies, no storageState)
+    {
+      name: 'public-tests',
+      testDir: './tests/public',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+```ts
+// tests/auth.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const credentials: Record<string, { email: string; password: string }> = {
+  admin: { email: 'admin@example.com', password: process.env.ADMIN_PASSWORD! },
+  editor: { email: 'editor@example.com', password: process.env.EDITOR_PASSWORD! },
+};
+
+setup('authenticate', async ({ page }, testInfo) => {
+  const role = testInfo.project.use.userRole as string;
+  const authFile = testInfo.project.use.storageStatePath as string;
+  const { email, password } = credentials[role];
+
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await page.context().storageState({ path: authFile });
+});
+```
+
+### Pattern 5: Environment-Specific Projects
+
+**Use when**: Running the same tests against different environments (dev, staging, production) from one config.
+**Avoid when**: You only test one environment.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+const ENV = process.env.TEST_ENV || 'local';
+
+const envConfig: Record<string, { baseURL: string; retries: number }> = {
+  local:      { baseURL: 'http://localhost:3000',       retries: 0 },
+  staging:    { baseURL: 'https://staging.example.com', retries: 2 },
+  production: { baseURL: 'https://www.example.com',     retries: 2 },
+};
+
+const env = envConfig[ENV];
+
+export default defineConfig({
+  testDir: './tests',
+  retries: env.retries,
+  use: {
+    baseURL: env.baseURL,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // Only run smoke tests in production
+    ...(ENV === 'production'
+      ? [{
+          name: 'smoke',
+          testMatch: '**/*smoke*.spec.ts',
+          use: { ...devices['Desktop Chrome'] },
+          grep: /@smoke/,
+        }]
+      : []),
+  ],
+});
+```
+
+```bash
+# Run against different environments
+TEST_ENV=local npx playwright test
+TEST_ENV=staging npx playwright test
+TEST_ENV=production npx playwright test --project=smoke
+```
+
+### Pattern 6: Project with Custom `testDir` and `testMatch`
+
+**Use when**: Different projects need different test directories or file patterns.
+**Avoid when**: All projects run the same tests.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    // E2E tests -- run in all browsers
+    {
+      name: 'e2e-chromium',
+      testDir: './tests/e2e',
+      testMatch: '**/*.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'e2e-firefox',
+      testDir: './tests/e2e',
+      testMatch: '**/*.spec.ts',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    // API tests -- no browser needed, run once
+    {
+      name: 'api',
+      testDir: './tests/api',
+      testMatch: '**/*.spec.ts',
+      use: {
+        baseURL: 'https://api.example.com',
+      },
+    },
+
+    // Visual regression -- Chromium only
+    {
+      name: 'visual',
+      testDir: './tests/visual',
+      testMatch: '**/*.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Lock viewport for consistent screenshots
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+});
+```
+
+```bash
+# Run only API tests
+npx playwright test --project=api
+
+# Run only visual tests
+npx playwright test --project=visual
+
+# Run all E2E tests
+npx playwright test --project=e2e-chromium --project=e2e-firefox
+```
+
+### Pattern 7: Teardown Projects
+
+**Use when**: You need browser-based cleanup after tests complete (e.g., deleting test data via the UI).
+**Avoid when**: Cleanup can be done via API in `globalTeardown` or fixtures (the usual case).
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+      teardown: 'teardown',  // link to teardown project
+    },
+    {
+      name: 'teardown',
+      testMatch: /global\.teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+
+```ts
+// tests/global.teardown.ts
+import { test as teardown } from '@playwright/test';
+
+teardown('clean up test data', async ({ request }) => {
+  await request.post('/api/test/cleanup', {
+    headers: { Authorization: `Bearer ${process.env.ADMIN_API_KEY}` },
+  });
+});
+```
+
+**Execution order:**
+1. `setup` project runs
+2. `chromium` project runs (depends on setup)
+3. `teardown` project runs (linked via setup's `teardown` field)
+
+### Pattern 8: Grep and GrepInvert for Project Filtering
+
+**Use when**: Different projects should run different subsets of tests based on tags.
+**Avoid when**: All projects run all tests.
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+
+  projects: [
+    // Smoke tests -- only @smoke tagged tests, Chromium only
+    {
+      name: 'smoke',
+      use: { ...devices['Desktop Chrome'] },
+      grep: /@smoke/,
+    },
+
+    // Full regression -- everything except @slow, all browsers
+    {
+      name: 'regression-chromium',
+      use: { ...devices['Desktop Chrome'] },
+      grepInvert: /@slow/,
+    },
+    {
+      name: 'regression-firefox',
+      use: { ...devices['Desktop Firefox'] },
+      grepInvert: /@slow/,
+    },
+
+    // Slow tests -- only @slow, Chromium only, higher timeout
+    {
+      name: 'slow',
+      use: { ...devices['Desktop Chrome'] },
+      grep: /@slow/,
+      timeout: 120_000,
+    },
+  ],
+});
+```
+
+```bash
+# CI: run smoke on PRs
+npx playwright test --project=smoke
+
+# CI: run full regression on main
+npx playwright test --project=regression-chromium --project=regression-firefox
+
+# CI: run slow tests nightly
+npx playwright test --project=slow
+```
+
+## Decision Guide
+
+| Scenario | Number of Projects | Configuration |
+|---|---|---|
+| Getting started | 1 (chromium) | Single project, no dependencies |
+| Cross-browser testing | 3 (chromium, firefox, webkit) | One per browser engine |
+| Responsive design | 5-6 (desktop + mobile + tablet) | Use `devices` presets |
+| Authenticated tests | 1 setup + N browser projects | Setup with `dependencies` |
+| Multiple auth roles | N setup + N test projects | One setup project per role |
+| Different test types (E2E, API, visual) | One per type | Custom `testDir` per project |
+| Environment targeting | Same projects, different `baseURL` | Use `TEST_ENV` env var |
+| Smoke vs regression suites | Projects with `grep` / `grepInvert` | Tag-based filtering |
+
+| Feature | `dependencies` | `teardown` | `globalSetup` |
+|---|---|---|---|
+| Has browser context | Yes | Yes | No |
+| Runs when | Before dependent projects | After linked setup project's dependents | Before all projects |
+| Use for | Auth state, data seeding with browser | Browser-based cleanup | Non-browser setup (DB, health check) |
+| Skips dependents on failure | Yes | N/A | Yes (entire suite fails) |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| All browsers on every PR | 3x CI time for marginal benefit | Chromium on PRs; all browsers on main |
+| `dependencies` on projects that don't need shared state | Forced serial execution; slower | Only use dependencies when projects truly need shared state |
+| Duplicating config across projects | Hard to maintain; settings drift | Use shared `use` at the top level; override per project |
+| No `--project` filtering in CI | All projects always run; no control | Use `--project` to run subsets based on context |
+| Setup project modifies database without teardown | Dirty state for next run | Always pair setup with teardown or make setup idempotent |
+| Many projects with overlapping test directories | Same test runs multiple times unintentionally | Set explicit `testDir` and `testMatch` per project |
+| Not using `--no-deps` for debugging | Setup runs every time, even for one test | Use `--no-deps` to skip dependencies during focused debugging |
+
+## Troubleshooting
+
+### "No tests found" when running specific project
+
+**Cause**: The project's `testDir` or `testMatch` doesn't match any files.
+
+**Fix**: List tests for the project to see what matches:
+
+```bash
+npx playwright test --project=chromium --list
+```
+
+Check that `testDir` and `testMatch` are correct:
+
+```ts
+{
+  name: 'chromium',
+  testDir: './tests',         // must contain test files
+  testMatch: '**/*.spec.ts',  // must match your file naming
+}
+```
+
+### Setup project runs every time, even for a single test
+
+**Cause**: The test's project has `dependencies: ['setup']`, so setup always runs first.
+
+**Fix**: Use `--no-deps` to skip dependencies during development:
+
+```bash
+npx playwright test --project=chromium --no-deps tests/specific-test.spec.ts
+```
+
+### `storageState` file not found
+
+**Cause**: Setup project failed or didn't create the file. Or the path in `use.storageState` doesn't match the path in the setup project.
+
+**Fix**: Verify paths match exactly:
+
+```ts
+// In setup test:
+await page.context().storageState({ path: 'playwright/.auth/user.json' });
+
+// In project config:
+use: { storageState: 'playwright/.auth/user.json' }  // must match exactly
+```
+
+Add `.auth` to `.gitignore`:
+
+```bash
+echo "playwright/.auth/" >> .gitignore
+```
+
+### Dependent projects run even when setup fails
+
+**Cause**: This should not happen -- Playwright skips dependent projects when a dependency fails. If it seems like they run, check that `dependencies` is spelled correctly.
+
+**Fix**: Verify the dependency name matches exactly:
+
+```ts
+// Setup project name
+{ name: 'setup', ... }
+
+// Dependency reference (must match exactly, case-sensitive)
+{ dependencies: ['setup'] }  // correct
+{ dependencies: ['Setup'] }  // WRONG -- case mismatch
+```
+
+### Tests from multiple projects interfere with each other
+
+**Cause**: Projects share a database or external state. Since projects run in parallel by default, they can collide.
+
+**Fix**: Either:
+1. Use per-project isolated data (different test users, different database schemas)
+2. Run projects sequentially by adding artificial dependencies:
+
+```ts
+projects: [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  {
+    name: 'firefox',
+    use: { ...devices['Desktop Firefox'] },
+    dependencies: ['chromium'],  // forces serial execution
+  },
+],
+```
+
+### Custom `use` properties cause TypeScript errors
+
+**Cause**: Playwright's `use` type doesn't include your custom properties.
+
+**Fix**: Extend the type or use `as any`:
+
+```ts
+// Option 1: Declare custom properties
+declare module '@playwright/test' {
+  interface PlaywrightTestOptions {
+    userRole: string;
+    storageStatePath: string;
+  }
+}
+
+// Option 2: Quick fix (less type-safe)
+{
+  name: 'auth-admin',
+  use: {
+    userRole: 'admin',
+    storageStatePath: 'playwright/.auth/admin.json',
+  } as any,
+}
+```
+
+## Related
+
+- [core/configuration.md](../core/configuration.md) -- base config, `projects`, `use` settings
+- [ci/global-setup-teardown.md](global-setup-teardown.md) -- `globalSetup` vs setup projects
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- option fixtures configured per project
+- [core/authentication.md](../core/authentication.md) -- auth state via setup projects
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- sharding across projects
+- [ci/ci-github-actions.md](ci-github-actions.md) -- running specific projects in CI

--- a/engineering-team/playwright skill/core/ci/reporting-and-artifacts.md
+++ b/engineering-team/playwright skill/core/ci/reporting-and-artifacts.md
@@ -1,0 +1,501 @@
+# Reporting and Artifacts
+
+> **When to use**: Configuring test output for local debugging, CI dashboards, and team visibility. Every project needs a reporting strategy from day one.
+
+## Quick Reference
+
+```bash
+# View the last HTML report
+npx playwright show-report
+
+# Run with specific reporter
+npx playwright test --reporter=html
+npx playwright test --reporter=dot           # minimal CI output
+npx playwright test --reporter=line          # one line per test
+npx playwright test --reporter=json          # machine-readable
+npx playwright test --reporter=junit         # CI integration
+
+# Multiple reporters via CLI
+npx playwright test --reporter=dot,html
+
+# Merge shard reports
+npx playwright merge-reports --reporter=html ./blob-report
+```
+
+## Patterns
+
+### Pattern 1: Multi-Reporter Configuration
+
+**Use when**: Every project. You always want at least two reporters: one for humans, one for CI.
+**Avoid when**: Never -- always configure reporters.
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [
+        // CI: machine-readable + human-readable + CI annotations
+        ['dot'],                                    // minimal console output
+        ['html', { open: 'never' }],               // browsable report (uploaded as artifact)
+        ['junit', { outputFile: 'test-results/junit.xml' }],  // CI test tab integration
+        ['github'],                                 // PR annotations (GitHub Actions only)
+      ]
+    : [
+        // Local: detailed console + auto-opening report
+        ['list'],                                   // verbose console output
+        ['html', { open: 'on-failure' }],          // auto-open on failure
+      ],
+});
+```
+
+### Pattern 2: Built-in Reporters in Detail
+
+**Use when**: Choosing the right reporter for your context.
+
+| Reporter | Output | Best For |
+|---|---|---|
+| `list` | One line per test with pass/fail | Local development |
+| `line` | Updates a single line as tests complete | Local, less verbose |
+| `dot` | Single dot per test: `.` pass, `F` fail | CI logs (minimal) |
+| `html` | Interactive HTML page with traces | Post-run analysis |
+| `json` | Machine-readable JSON to stdout or file | Custom tooling, dashboards |
+| `junit` | JUnit XML | CI platforms (Azure DevOps, Jenkins, CircleCI) |
+| `github` | GitHub Actions annotations | GitHub PRs |
+| `blob` | Binary archive for shard merging | Sharded CI runs |
+
+**JSON reporter -- write to file:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['json', { outputFile: 'test-results/results.json' }],
+  ],
+});
+```
+
+**JUnit reporter -- customize output:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['junit', {
+      outputFile: 'test-results/junit.xml',
+      stripANSIControlSequences: true,
+      includeProjectInTestName: true,
+    }],
+  ],
+});
+```
+
+### Pattern 3: Custom Reporter
+
+**Use when**: Built-in reporters don't meet your needs -- you want Slack notifications, database logging, or custom dashboards.
+**Avoid when**: A built-in reporter or existing third-party reporter covers your case.
+
+```ts
+// reporters/slack-reporter.ts
+import type {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+  TestResult,
+} from '@playwright/test/reporter';
+
+class SlackReporter implements Reporter {
+  private passed = 0;
+  private failed = 0;
+  private skipped = 0;
+  private failures: string[] = [];
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    switch (result.status) {
+      case 'passed':
+        this.passed++;
+        break;
+      case 'failed':
+      case 'timedOut':
+        this.failed++;
+        this.failures.push(`${test.title}: ${result.error?.message?.split('\n')[0]}`);
+        break;
+      case 'skipped':
+        this.skipped++;
+        break;
+    }
+  }
+
+  async onEnd(result: FullResult) {
+    const total = this.passed + this.failed + this.skipped;
+    const emoji = this.failed > 0 ? ':red_circle:' : ':large_green_circle:';
+    const text = [
+      `${emoji} *Playwright Tests*: ${result.status}`,
+      `Passed: ${this.passed} | Failed: ${this.failed} | Skipped: ${this.skipped} | Total: ${total}`,
+      `Duration: ${(result.duration / 1000).toFixed(1)}s`,
+    ];
+
+    if (this.failures.length > 0) {
+      text.push('', '*Failures:*');
+      this.failures.slice(0, 5).forEach((f) => text.push(`  - ${f}`));
+      if (this.failures.length > 5) {
+        text.push(`  ...and ${this.failures.length - 5} more`);
+      }
+    }
+
+    const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+    if (webhookUrl) {
+      await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: text.join('\n') }),
+      });
+    }
+  }
+}
+
+export default SlackReporter;
+```
+
+**Register the custom reporter:**
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['dot'],
+    ['html', { open: 'never' }],
+    ['./reporters/slack-reporter.ts'],
+  ],
+});
+```
+
+### Pattern 4: Trace File Management
+
+**Use when**: Debugging test failures. Traces capture a complete timeline of actions, network requests, DOM snapshots, and console logs.
+**Avoid when**: Never disable traces entirely in CI -- the on-first-retry setting has minimal overhead.
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    // 'on-first-retry': records trace only when a test fails and retries.
+    // Minimal overhead on passing tests, full debugging on failures.
+    trace: 'on-first-retry',
+  },
+});
+```
+
+**Trace options:**
+
+| Value | Records trace | When | Overhead |
+|---|---|---|---|
+| `'off'` | Never | -- | None |
+| `'on'` | Every test | Always | High (large files) |
+| `'on-first-retry'` | On first retry after failure | Retries only | Minimal |
+| `'retain-on-failure'` | Every test, keeps only failures | Failures | Medium |
+| `'retain-on-first-failure'` | Every test, keeps only first failure | First failure | Medium |
+
+**Viewing traces:**
+
+```bash
+# Open trace viewer locally
+npx playwright show-trace test-results/my-test/trace.zip
+
+# Open trace from HTML report (click "Traces" tab in the report)
+npx playwright show-report
+
+# Online trace viewer (upload trace.zip)
+# https://trace.playwright.dev
+```
+
+### Pattern 5: Screenshot and Video Configuration
+
+**Use when**: Visual evidence of test failures is valuable for debugging or bug reports.
+**Avoid when**: Never disable screenshots in CI -- the on-failure setting is cheap.
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    // Screenshots
+    screenshot: 'only-on-failure',  // capture final state on failure
+
+    // Video
+    video: 'retain-on-failure',     // record all, keep only failures
+
+    // Video size (optional -- smaller = less disk)
+    video: {
+      mode: 'retain-on-failure',
+      size: { width: 1280, height: 720 },
+    },
+  },
+});
+```
+
+**Screenshot options:**
+
+| Value | Captures | Disk cost |
+|---|---|---|
+| `'off'` | Never | None |
+| `'on'` | Every test (at end) | High |
+| `'only-on-failure'` | Failed tests only | Low |
+
+**Video options:**
+
+| Value | Records | Keeps | Disk cost |
+|---|---|---|---|
+| `'off'` | Never | -- | None |
+| `'on'` | Every test | All | Very high |
+| `'on-first-retry'` | On retry | Retried tests | Low |
+| `'retain-on-failure'` | Every test | Failed only | Medium |
+
+### Pattern 6: Artifact Organization for CI
+
+**Use when**: Keeping test artifacts organized and accessible in CI.
+
+**Recommended directory structure:**
+
+```
+test-results/             # Playwright's default output directory
+├── my-test-chromium/
+│   ├── trace.zip         # Trace file
+│   ├── test-failed-1.png # Screenshot
+│   └── video.webm        # Video recording
+├── another-test-firefox/
+│   ├── trace.zip
+│   └── test-failed-1.png
+└── junit.xml             # JUnit report (if configured)
+
+playwright-report/        # HTML report directory
+├── index.html
+└── data/
+    └── ...
+
+blob-report/              # Blob report for shard merging
+└── report-1.zip
+```
+
+**GitHub Actions artifact upload:**
+
+```yaml
+# Upload HTML report (always -- useful even when tests pass)
+- uses: actions/upload-artifact@v4
+  if: ${{ !cancelled() }}
+  with:
+    name: playwright-report
+    path: playwright-report/
+    retention-days: 14
+
+# Upload traces and screenshots (only on failure -- saves storage)
+- uses: actions/upload-artifact@v4
+  if: failure()
+  with:
+    name: test-traces
+    path: |
+      test-results/**/trace.zip
+      test-results/**/*.png
+      test-results/**/*.webm
+    retention-days: 7
+```
+
+### Pattern 7: Allure Integration
+
+**Use when**: Your team uses Allure for test reporting across multiple test frameworks.
+**Avoid when**: The built-in HTML reporter meets your needs (it usually does).
+
+```bash
+# Install Allure reporter
+npm install -D allure-playwright
+```
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['line'],
+    ['allure-playwright', {
+      detail: true,
+      outputFolder: 'allure-results',
+      suiteTitle: true,
+    }],
+  ],
+});
+```
+
+```bash
+# Generate and view Allure report
+npx allure generate allure-results -o allure-report --clean
+npx allure open allure-report
+
+# Or use Allure CLI
+allure serve allure-results
+```
+
+**Add Allure metadata to tests:**
+
+```ts
+import { test, expect } from '@playwright/test';
+import { allure } from 'allure-playwright';
+
+test('checkout flow', async ({ page }) => {
+  await allure.epic('E-Commerce');
+  await allure.feature('Checkout');
+  await allure.story('Credit Card Payment');
+  await allure.severity('critical');
+
+  await page.goto('/checkout');
+  // ... test implementation
+});
+```
+
+## Decision Guide
+
+| Scenario | Reporter Configuration | Why |
+|---|---|---|
+| Local development | `[['list'], ['html', { open: 'on-failure' }]]` | Verbose console + auto-opening report on failure |
+| GitHub Actions | `[['dot'], ['html'], ['github']]` | Minimal logs + report artifact + PR annotations |
+| GitLab CI | `[['dot'], ['html'], ['junit']]` | Minimal logs + report artifact + test tab |
+| Azure DevOps / Jenkins | `[['dot'], ['html'], ['junit']]` | JUnit for native test results integration |
+| Sharded CI | `[['blob'], ['github']]` | Blob for merging; github for PR annotations |
+| Team uses Allure | `[['line'], ['allure-playwright']]` | Cross-framework reporting consistency |
+| Custom dashboard | `[['json', { outputFile: '...' }]]` + custom reporter | JSON for data, custom for notifications |
+
+| Artifact | When to Collect | Retention | Upload Condition |
+|---|---|---|---|
+| HTML report | Always | 14 days | `if: ${{ !cancelled() }}` |
+| Traces (`.zip`) | On failure | 7 days | `if: failure()` |
+| Screenshots (`.png`) | On failure | 7 days | `if: failure()` |
+| Videos (`.webm`) | On failure | 7 days | `if: failure()` |
+| JUnit XML | Always | 14 days | `if: ${{ !cancelled() }}` |
+| Blob report | Always (sharded) | 1 day | `if: ${{ !cancelled() }}` |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| No reporter configured | Default `list` only; no persistent report | Always configure `html` + one CI reporter |
+| `trace: 'on'` in CI | Massive artifacts (50-100 MB per test), slow uploads | Use `trace: 'on-first-retry'` |
+| `video: 'on'` in CI | Enormous storage cost; slows test execution | Use `video: 'retain-on-failure'` |
+| Only uploading artifacts on failure | No report when tests pass; can't verify results | Upload with `if: ${{ !cancelled() }}` (always) |
+| No retention limits on artifacts | CI storage fills up within weeks | Set `retention-days: 7-14` |
+| Using only `dot` reporter with no HTML | Can't drill into failures after the run | Always pair `dot` with `html` in CI |
+| JUnit output to stdout | Interferes with console output; hard to parse | Write to file: `['junit', { outputFile: 'results/junit.xml' }]` |
+| Custom reporter that blocks `onEnd` | Slow Slack/HTTP calls delay pipeline completion | Use `Promise.race` with a timeout in custom reporters |
+
+## Troubleshooting
+
+### HTML report is empty or missing tests
+
+**Cause**: Another reporter is conflicting, or `outputFolder` was overridden to a non-default path.
+
+**Fix**: Check your reporter config. The HTML report defaults to `playwright-report/`:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [['html', { outputFolder: 'playwright-report', open: 'never' }]],
+});
+```
+
+### Traces are too large for CI artifact upload
+
+**Cause**: `trace: 'on'` records every test, even passing ones.
+
+**Fix**: Switch to `'on-first-retry'` and ensure `retries > 0` in CI:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+### JUnit XML not recognized by CI platform
+
+**Cause**: Output path doesn't match what the CI task expects, or the file is empty.
+
+**Fix**: Ensure the path matches your CI configuration:
+
+```ts
+// playwright.config.ts -- the outputFile path
+reporter: [['junit', { outputFile: 'test-results/junit.xml' }]],
+```
+
+```yaml
+# GitHub Actions
+- uses: dorny/test-reporter@v1
+  with:
+    path: test-results/junit.xml
+    reporter: java-junit
+
+# Azure DevOps
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: 'test-results/junit.xml'
+
+# Jenkins
+junit 'test-results/junit.xml'
+```
+
+### `merge-reports` produces empty report
+
+**Cause**: Shards are using `html` reporter instead of `blob`. Only `blob` output can be merged.
+
+**Fix**: Use blob reporter for sharded runs:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [['blob'], ['dot']]  // blob for merge, dot for console
+    : [['html', { open: 'on-failure' }]],
+});
+```
+
+### Screenshots not appearing in HTML report
+
+**Cause**: `screenshot: 'off'` or screenshots are in `test-results/` but not linked to the report.
+
+**Fix**: Enable screenshots and ensure both directories are available:
+
+```ts
+use: {
+  screenshot: 'only-on-failure',
+},
+```
+
+The HTML report automatically embeds screenshots from `test-results/`. If you move or delete `test-results/`, screenshots will be missing from the report.
+
+## Related
+
+- [ci/ci-github-actions.md](ci-github-actions.md) -- artifact upload in GitHub Actions
+- [ci/ci-gitlab.md](ci-gitlab.md) -- artifact configuration in GitLab
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- blob reporter for sharded runs
+- [core/configuration.md](../core/configuration.md) -- trace, screenshot, video settings
+- [core/debugging.md](../core/debugging.md) -- using traces and screenshots for debugging

--- a/engineering-team/playwright skill/core/ci/test-coverage.md
+++ b/engineering-team/playwright skill/core/ci/test-coverage.md
@@ -1,0 +1,471 @@
+# Test Coverage
+
+> **When to use**: Measuring how much of your application code is exercised by Playwright E2E tests. Useful for identifying untested code paths and enforcing coverage thresholds in CI.
+
+## Quick Reference
+
+```bash
+# Install coverage dependencies
+npm install -D nyc istanbul-lib-coverage istanbul-reports v8-to-istanbul
+
+# Run with coverage collection
+npx playwright test                    # uses fixtures to collect coverage
+
+# Generate reports from collected data
+npx nyc report --reporter=html --reporter=text-summary
+npx nyc report --reporter=lcov        # for CI integration (Codecov, SonarQube)
+
+# Check coverage thresholds
+npx nyc check-coverage --lines 80 --branches 70 --functions 75
+```
+
+## Patterns
+
+### Pattern 1: V8 Coverage with Playwright (Recommended)
+
+**Use when**: Measuring code coverage of a web application during E2E tests. V8 coverage uses Chrome DevTools Protocol for accurate JavaScript coverage.
+**Avoid when**: Testing third-party sites you don't control.
+
+**Step 1: Create a coverage fixture:**
+
+```ts
+// fixtures/coverage.ts
+import { test as base, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+const coverageDir = path.resolve(process.cwd(), '.nyc_output');
+
+export const test = base.extend({
+  page: async ({ page, browserName }, use, testInfo) => {
+    // V8 coverage only works in Chromium
+    if (browserName === 'chromium') {
+      await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    }
+
+    await use(page);
+
+    if (browserName === 'chromium') {
+      const coverage = await page.coverage.stopJSCoverage();
+
+      // Filter to only your application code
+      const appCoverage = coverage.filter((entry) =>
+        entry.url.includes('localhost') && !entry.url.includes('node_modules')
+      );
+
+      if (appCoverage.length > 0) {
+        // Ensure output directory exists
+        fs.mkdirSync(coverageDir, { recursive: true });
+
+        // Write V8 coverage data
+        const coverageFile = path.join(
+          coverageDir,
+          `coverage-${crypto.randomUUID()}.json`
+        );
+        fs.writeFileSync(coverageFile, JSON.stringify({
+          result: appCoverage.map((entry) => ({
+            scriptId: '0',
+            url: entry.url,
+            functions: entry.functions || [],
+          })),
+        }));
+      }
+    }
+  },
+});
+
+export { expect };
+```
+
+**Step 2: Use the coverage fixture in tests:**
+
+```ts
+// tests/dashboard.spec.ts
+import { test, expect } from '../fixtures/coverage';
+
+test('dashboard loads with widgets', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  // Coverage is automatically collected and saved
+});
+```
+
+**Step 3: Generate coverage report after tests:**
+
+```json
+// package.json
+{
+  "scripts": {
+    "test:e2e": "npx playwright test",
+    "test:coverage": "npx playwright test --project=chromium && npx nyc report --reporter=html --reporter=text-summary",
+    "coverage:check": "npx nyc check-coverage --lines 80 --branches 70 --functions 75"
+  }
+}
+```
+
+### Pattern 2: Istanbul (Source-Map Based) Coverage
+
+**Use when**: Your application uses webpack, Vite, or another bundler and you want source-mapped coverage tied to original source files.
+**Avoid when**: V8 coverage works well enough -- it's simpler to set up.
+
+**Step 1: Instrument your application code:**
+
+For **Vite**:
+
+```bash
+npm install -D vite-plugin-istanbul
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import istanbul from 'vite-plugin-istanbul';
+
+export default defineConfig({
+  plugins: [
+    ...(process.env.COVERAGE === 'true'
+      ? [istanbul({
+          include: 'src/*',
+          exclude: ['node_modules', 'test/'],
+          extension: ['.js', '.ts', '.tsx', '.jsx'],
+          requireEnv: true,
+        })]
+      : []),
+  ],
+});
+```
+
+For **webpack** (Create React App):
+
+```bash
+npm install -D @istanbuljs/nyc-config-typescript babel-plugin-istanbul
+```
+
+```json
+// babel.config.json (or .babelrc)
+{
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  }
+}
+```
+
+**Step 2: Collect coverage from `window.__coverage__`:**
+
+```ts
+// fixtures/istanbul-coverage.ts
+import { test as base, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+const coverageDir = path.resolve(process.cwd(), '.nyc_output');
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await use(page);
+
+    // Istanbul instruments code and exposes coverage on window.__coverage__
+    const coverage = await page.evaluate(() => (window as any).__coverage__);
+    if (coverage) {
+      fs.mkdirSync(coverageDir, { recursive: true });
+      const coverageFile = path.join(
+        coverageDir,
+        `coverage-${crypto.randomUUID()}.json`
+      );
+      fs.writeFileSync(coverageFile, JSON.stringify(coverage));
+    }
+  },
+});
+
+export { expect };
+```
+
+**Step 3: Configure nyc:**
+
+```json
+// .nycrc.json
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "include": ["src/**/*.{ts,tsx,js,jsx}"],
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/*.spec.*",
+    "src/test/**",
+    "src/**/*.d.ts"
+  ],
+  "reporter": ["html", "text-summary", "lcov"],
+  "report-dir": "coverage"
+}
+```
+
+```bash
+# Start app with instrumentation
+COVERAGE=true npm run dev
+
+# Run tests (in another terminal or after dev server starts)
+npx playwright test --project=chromium
+
+# Generate report
+npx nyc report
+```
+
+### Pattern 3: Coverage Thresholds in CI
+
+**Use when**: Enforcing minimum coverage levels as a quality gate.
+**Avoid when**: You are just starting with coverage -- set thresholds after establishing a baseline.
+
+```json
+// .nycrc.json
+{
+  "check-coverage": true,
+  "lines": 80,
+  "branches": 70,
+  "functions": 75,
+  "statements": 80,
+  "reporter": ["html", "text-summary", "lcov"]
+}
+```
+
+**GitHub Actions with coverage check:**
+
+```yaml
+# .github/workflows/playwright.yml (add to test job steps)
+- name: Run Playwright tests with coverage
+  run: COVERAGE=true npx playwright test --project=chromium
+
+- name: Generate coverage report
+  run: npx nyc report --reporter=html --reporter=text-summary --reporter=lcov
+  if: ${{ !cancelled() }}
+
+- name: Check coverage thresholds
+  run: npx nyc check-coverage --lines 80 --branches 70 --functions 75
+
+- name: Upload coverage report
+  uses: actions/upload-artifact@v4
+  if: ${{ !cancelled() }}
+  with:
+    name: coverage-report
+    path: coverage/
+    retention-days: 14
+```
+
+### Pattern 4: Merging Coverage from Sharded Runs
+
+**Use when**: Tests are sharded across multiple CI machines and you need aggregate coverage.
+**Avoid when**: Tests run on a single machine.
+
+```yaml
+# .github/workflows/playwright.yml
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
+    steps:
+      # ... checkout, install, etc.
+
+      - name: Run sharded tests with coverage
+        run: COVERAGE=true npx playwright test --shard=${{ matrix.shard }} --project=chromium
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: coverage-${{ strategy.job-index }}
+          path: .nyc_output/
+          retention-days: 1
+
+  merge-coverage:
+    needs: test
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Download all coverage data
+        uses: actions/download-artifact@v4
+        with:
+          path: all-coverage
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Merge coverage
+        run: |
+          mkdir -p .nyc_output
+          cp all-coverage/*.json .nyc_output/
+          npx nyc report --reporter=html --reporter=text-summary --reporter=lcov
+          npx nyc check-coverage --lines 80 --branches 70 --functions 75
+
+      - name: Upload merged coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+```
+
+### Pattern 5: CSS Coverage
+
+**Use when**: Identifying unused CSS to reduce bundle size.
+**Avoid when**: CSS is not a performance concern for your application.
+
+```ts
+// fixtures/css-coverage.ts
+import { test as base, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const test = base.extend({
+  page: async ({ page, browserName }, use, testInfo) => {
+    if (browserName === 'chromium') {
+      await page.coverage.startCSSCoverage();
+    }
+
+    await use(page);
+
+    if (browserName === 'chromium') {
+      const coverage = await page.coverage.stopCSSCoverage();
+
+      // Calculate unused CSS percentage per file
+      const report = coverage.map((entry) => {
+        const totalBytes = entry.text.length;
+        const usedBytes = entry.ranges.reduce(
+          (acc, range) => acc + (range.end - range.start),
+          0
+        );
+        return {
+          url: entry.url,
+          totalBytes,
+          usedBytes,
+          unusedPercent: ((1 - usedBytes / totalBytes) * 100).toFixed(1),
+        };
+      });
+
+      // Save for analysis
+      const outputDir = path.resolve(process.cwd(), 'css-coverage');
+      fs.mkdirSync(outputDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(outputDir, `${testInfo.testId}.json`),
+        JSON.stringify(report, null, 2)
+      );
+    }
+  },
+});
+
+export { expect };
+```
+
+## Decision Guide
+
+| Coverage Type | Tool | Measures | Setup Effort | Accuracy |
+|---|---|---|---|---|
+| V8 (Chrome DevTools) | `page.coverage` API | JS execution in browser | Low | High (runtime) |
+| Istanbul (instrumentation) | `babel-plugin-istanbul` / `vite-plugin-istanbul` | JS with source maps | Medium | High (source-level) |
+| CSS | `page.coverage.startCSSCoverage()` | CSS rule usage | Low | High |
+
+| Metric | What It Measures | Good Threshold | Why |
+|---|---|---|---|
+| Lines | Lines of code executed | 80%+ | Most intuitive; catches dead code |
+| Branches | If/else paths taken | 70%+ | Catches untested conditionals |
+| Functions | Functions called | 75%+ | Catches unused functions |
+| Statements | Individual statements executed | 80%+ | Similar to lines but counts multi-statement lines |
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Just starting with coverage | V8 coverage, no thresholds | Establish baseline first |
+| Mature codebase | Istanbul + thresholds in CI | Source-mapped, enforced |
+| Sharded CI | Merge `.nyc_output` after all shards | Aggregate coverage view |
+| Only Chromium matters | V8 coverage fixture | Simplest setup, no build changes |
+| Need source-level accuracy | Istanbul with bundler plugin | Maps to original source |
+| Uploading to Codecov/SonarQube | Generate `lcov` format | Standard format for coverage services |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Do This Instead |
+|---|---|---|
+| Targeting 100% E2E coverage | E2E tests are expensive; diminishing returns past 80% | Set realistic thresholds; use unit tests for edge cases |
+| Coverage collection in all browsers | V8 coverage only works in Chromium; wasted effort | Run coverage only with `--project=chromium` |
+| No source filtering | Coverage includes `node_modules` and third-party code | Filter: `entry.url.includes('localhost') && !entry.url.includes('node_modules')` |
+| Coverage slowing down CI without value | Collecting coverage on every PR with no thresholds | Either enforce thresholds or skip coverage |
+| Istanbul instrumentation in production builds | Performance overhead; exposes internals | Only instrument when `COVERAGE=true` |
+| Measuring E2E coverage alone | E2E tests cover happy paths; unit tests cover branches | Combine E2E coverage with unit test coverage |
+
+## Troubleshooting
+
+### Coverage report shows 0% or empty
+
+**Cause (V8)**: Tests aren't using the coverage fixture, or `startJSCoverage()` wasn't called.
+
+**Fix**: Ensure tests import from the coverage fixture file, not directly from `@playwright/test`:
+
+```ts
+// Use this:
+import { test, expect } from '../fixtures/coverage';
+
+// Not this:
+import { test, expect } from '@playwright/test';
+```
+
+**Cause (Istanbul)**: Application wasn't instrumented, or `window.__coverage__` is undefined.
+
+**Fix**: Verify the app is running with instrumentation:
+
+```bash
+# Check if coverage is exposed
+COVERAGE=true npm run dev
+# In browser console: window.__coverage__  -> should be an object, not undefined
+```
+
+### Coverage files not merging correctly
+
+**Cause**: Coverage JSON files from different shards have incompatible formats or overlapping keys.
+
+**Fix**: Ensure all shards write to `.nyc_output/` with unique filenames:
+
+```ts
+const coverageFile = path.join(coverageDir, `coverage-${crypto.randomUUID()}.json`);
+```
+
+Then merge with `npx nyc report` (it reads all files in `.nyc_output/`).
+
+### V8 coverage doesn't map to source files
+
+**Cause**: V8 coverage reports against bundled/compiled URLs, not original source files.
+
+**Fix**: Use Istanbul instrumentation instead for source-level accuracy, or use `v8-to-istanbul` to convert:
+
+```bash
+npm install -D v8-to-istanbul
+```
+
+### Coverage drops when running in parallel
+
+**Cause**: Parallel workers override each other's coverage files if filenames collide.
+
+**Fix**: Include `workerInfo.workerIndex` or a UUID in the filename:
+
+```ts
+const coverageFile = path.join(
+  coverageDir,
+  `coverage-worker${workerInfo.workerIndex}-${crypto.randomUUID()}.json`
+);
+```
+
+## Related
+
+- [ci/parallel-and-sharding.md](parallel-and-sharding.md) -- merging coverage from sharded runs
+- [ci/ci-github-actions.md](ci-github-actions.md) -- coverage thresholds in CI
+- [ci/reporting-and-artifacts.md](reporting-and-artifacts.md) -- uploading coverage reports
+- [core/configuration.md](../core/configuration.md) -- project setup for coverage
+- [core/test-architecture.md](../core/test-architecture.md) -- E2E vs unit test coverage strategies

--- a/engineering-team/playwright skill/core/clock-and-time-mocking.md
+++ b/engineering-team/playwright skill/core/clock-and-time-mocking.md
@@ -1,0 +1,427 @@
+# Clock and Time Mocking
+
+> **When to use**: Testing time-dependent features -- countdown timers, scheduled events, expiration dates, age gates, session timeouts, or any UI that behaves differently based on the current time. Playwright's `page.clock` API lets you control time without waiting in real-time.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/configuration.md](configuration.md)
+
+## Quick Reference
+
+```typescript
+// Freeze time at a specific moment
+await page.clock.install({ time: new Date('2025-03-15T10:00:00Z') });
+await page.goto('/dashboard');
+
+// Advance time by 5 minutes
+await page.clock.fastForward('05:00');
+
+// Set time to a specific point (jumps, does not tick through)
+await page.clock.setFixedTime(new Date('2025-12-31T23:59:59Z'));
+
+// Let time resume ticking from current mocked point
+await page.clock.resume();
+```
+
+**Key concept**: `page.clock.install()` replaces `Date`, `setTimeout`, `setInterval`, and `requestAnimationFrame` in the page. Call it before `page.goto()` so the page loads with mocked time from the start.
+
+## Patterns
+
+### Frozen Time with `install()` and `setFixedTime()`
+
+**Use when**: Your test needs time to stand still at a specific moment -- verifying what the UI shows at a particular date/time.
+**Avoid when**: The feature under test depends on timers ticking (use `fastForward` instead).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('dashboard shows correct greeting based on time of day', async ({ page }) => {
+  // Install clock BEFORE navigating
+  await page.clock.install({ time: new Date('2025-06-15T08:30:00') });
+  await page.goto('/dashboard');
+  await expect(page.getByText('Good morning')).toBeVisible();
+
+  // Jump to afternoon
+  await page.clock.setFixedTime(new Date('2025-06-15T14:00:00'));
+  await page.reload();
+  await expect(page.getByText('Good afternoon')).toBeVisible();
+
+  // Jump to evening
+  await page.clock.setFixedTime(new Date('2025-06-15T20:00:00'));
+  await page.reload();
+  await expect(page.getByText('Good evening')).toBeVisible();
+});
+
+test('subscription shows correct expiration status', async ({ page }) => {
+  // Freeze time to a date when subscription is active
+  await page.clock.install({ time: new Date('2025-06-01T12:00:00Z') });
+  await page.goto('/account');
+
+  await expect(page.getByTestId('subscription-status')).toHaveText('Active');
+  await expect(page.getByTestId('days-remaining')).toContainText('29');
+
+  // Jump to the expiration date
+  await page.clock.setFixedTime(new Date('2025-06-30T12:00:00Z'));
+  await page.reload();
+
+  await expect(page.getByTestId('subscription-status')).toHaveText('Expiring today');
+});
+
+test('content displays correctly on a specific holiday', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-12-25T10:00:00') });
+  await page.goto('/');
+
+  await expect(page.getByText('Happy Holidays')).toBeVisible();
+  await expect(page.getByTestId('holiday-banner')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('dashboard shows correct greeting based on time of day', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-06-15T08:30:00') });
+  await page.goto('/dashboard');
+  await expect(page.getByText('Good morning')).toBeVisible();
+
+  await page.clock.setFixedTime(new Date('2025-06-15T14:00:00'));
+  await page.reload();
+  await expect(page.getByText('Good afternoon')).toBeVisible();
+});
+
+test('subscription shows correct expiration status', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-06-01T12:00:00Z') });
+  await page.goto('/account');
+
+  await expect(page.getByTestId('subscription-status')).toHaveText('Active');
+});
+```
+
+### Fast-Forwarding Time with `fastForward()`
+
+**Use when**: Testing timers, countdowns, debounced actions, or any feature that reacts to elapsed time. `fastForward` fires all pending timers up to the specified duration.
+**Avoid when**: You just need to check a static time-dependent display -- use `setFixedTime` instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('countdown timer reaches zero', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-15T10:00:00Z') });
+  await page.goto('/sale');
+
+  // Sale countdown starts at 2 hours
+  await expect(page.getByTestId('countdown')).toContainText('2:00:00');
+
+  // Fast-forward 1 hour
+  await page.clock.fastForward('01:00:00');
+  await expect(page.getByTestId('countdown')).toContainText('1:00:00');
+
+  // Fast-forward remaining time
+  await page.clock.fastForward('01:00:00');
+  await expect(page.getByTestId('countdown')).toContainText('0:00:00');
+  await expect(page.getByText('Sale ended')).toBeVisible();
+});
+
+test('auto-save triggers after 30 seconds of inactivity', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-15T10:00:00Z') });
+  await page.goto('/editor');
+
+  // Type something
+  await page.getByRole('textbox', { name: 'Content' }).fill('Draft content');
+
+  // Fast-forward past the auto-save interval
+  await page.clock.fastForward('00:30');
+
+  await expect(page.getByText('Saved')).toBeVisible();
+});
+
+test('session timeout warning appears after 25 minutes', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-15T10:00:00Z') });
+  await page.goto('/dashboard');
+
+  // Fast-forward to just before the warning (25 min)
+  await page.clock.fastForward('24:59');
+  await expect(page.getByRole('dialog', { name: 'Session timeout' })).not.toBeVisible();
+
+  // One more minute triggers the warning
+  await page.clock.fastForward('00:01');
+  await expect(page.getByRole('dialog', { name: 'Session timeout' })).toBeVisible();
+  await expect(page.getByText('Your session will expire in 5 minutes')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('countdown timer reaches zero', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-15T10:00:00Z') });
+  await page.goto('/sale');
+
+  await expect(page.getByTestId('countdown')).toContainText('2:00:00');
+
+  await page.clock.fastForward('01:00:00');
+  await expect(page.getByTestId('countdown')).toContainText('1:00:00');
+
+  await page.clock.fastForward('01:00:00');
+  await expect(page.getByText('Sale ended')).toBeVisible();
+});
+
+test('auto-save triggers after inactivity', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-15T10:00:00Z') });
+  await page.goto('/editor');
+
+  await page.getByRole('textbox', { name: 'Content' }).fill('Draft content');
+  await page.clock.fastForward('00:30');
+
+  await expect(page.getByText('Saved')).toBeVisible();
+});
+```
+
+### Resuming Time with `resume()`
+
+**Use when**: You need to start with a mocked time, then let time flow normally for interaction-dependent behavior.
+**Avoid when**: The entire test should use mocked time.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('notification appears in real-time after scheduled trigger', async ({ page }) => {
+  // Start at a known time
+  await page.clock.install({ time: new Date('2025-03-15T09:59:55Z') });
+  await page.goto('/dashboard');
+
+  // Notification is scheduled for 10:00:00 — advance to 5 seconds before
+  await expect(page.getByTestId('notification-bell')).not.toHaveAttribute('data-count');
+
+  // Let real time tick from this point
+  await page.clock.resume();
+
+  // The notification should appear within a few seconds
+  await expect(page.getByTestId('notification-bell')).toHaveAttribute('data-count', '1', {
+    timeout: 10000,
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('notification appears after scheduled trigger', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-15T09:59:55Z') });
+  await page.goto('/dashboard');
+
+  await page.clock.resume();
+
+  await expect(page.getByTestId('notification-bell')).toHaveAttribute('data-count', '1', {
+    timeout: 10000,
+  });
+});
+```
+
+### Testing Date-Dependent UI
+
+**Use when**: Features that change based on the current date -- age verification, expiration warnings, seasonal content, date pickers.
+**Avoid when**: The date is passed from the server and does not depend on client-side `Date`.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('age gate blocks users under 18', async ({ page }) => {
+  // User born on 2010-01-15 — under 18 as of 2025-06-01
+  await page.clock.install({ time: new Date('2025-06-01T12:00:00') });
+  await page.goto('/age-restricted');
+
+  await page.getByLabel('Date of birth').fill('2010-01-15');
+  await page.getByRole('button', { name: 'Verify age' }).click();
+
+  await expect(page.getByText('You must be 18 or older')).toBeVisible();
+});
+
+test('age gate allows users 18 and older', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-06-01T12:00:00') });
+  await page.goto('/age-restricted');
+
+  await page.getByLabel('Date of birth').fill('2005-01-15');
+  await page.getByRole('button', { name: 'Verify age' }).click();
+
+  await expect(page.getByText('Welcome')).toBeVisible();
+});
+
+test('trial expiration banner shows at correct times', async ({ page }) => {
+  // Day 1 of 14-day trial
+  await page.clock.install({ time: new Date('2025-03-01T12:00:00Z') });
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('trial-banner')).toContainText('13 days remaining');
+
+  // Day 12 — warning state
+  await page.clock.setFixedTime(new Date('2025-03-12T12:00:00Z'));
+  await page.reload();
+  await expect(page.getByTestId('trial-banner')).toContainText('2 days remaining');
+  await expect(page.getByTestId('trial-banner')).toHaveCSS('background-color', /rgb\(255/); // Red/warning
+
+  // Day 15 — expired
+  await page.clock.setFixedTime(new Date('2025-03-15T12:00:00Z'));
+  await page.reload();
+  await expect(page.getByText('Your trial has expired')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Upgrade now' })).toBeVisible();
+});
+
+test('date picker defaults to current mocked date', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-07-04T12:00:00') });
+  await page.goto('/booking');
+
+  await page.getByLabel('Check-in date').click();
+
+  // Calendar should open to July 2025
+  await expect(page.getByText('July 2025')).toBeVisible();
+
+  // Today (July 4) should be highlighted
+  const today = page.locator('[aria-current="date"]');
+  await expect(today).toHaveText('4');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('age gate blocks users under 18', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-06-01T12:00:00') });
+  await page.goto('/age-restricted');
+
+  await page.getByLabel('Date of birth').fill('2010-01-15');
+  await page.getByRole('button', { name: 'Verify age' }).click();
+
+  await expect(page.getByText('You must be 18 or older')).toBeVisible();
+});
+
+test('trial expiration shows correct days remaining', async ({ page }) => {
+  await page.clock.install({ time: new Date('2025-03-01T12:00:00Z') });
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('trial-banner')).toContainText('13 days remaining');
+
+  await page.clock.setFixedTime(new Date('2025-03-15T12:00:00Z'));
+  await page.reload();
+  await expect(page.getByText('Your trial has expired')).toBeVisible();
+});
+```
+
+### Timezone-Dependent Features
+
+**Use when**: Testing features that combine mocked time with specific timezones.
+**Avoid when**: The feature uses only UTC and does not render local times.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('business hours banner shows open/closed status', async ({ browser }) => {
+  // Business hours: 9 AM - 5 PM Eastern
+  const context = await browser.newContext({ timezoneId: 'America/New_York' });
+  const page = await context.newPage();
+
+  // 10 AM Eastern — should show "Open"
+  await page.clock.install({ time: new Date('2025-03-15T14:00:00Z') }); // 10 AM ET
+  await page.goto('/contact');
+  await expect(page.getByTestId('business-hours')).toContainText('Open');
+
+  // 6 PM Eastern — should show "Closed"
+  await page.clock.setFixedTime(new Date('2025-03-15T22:00:00Z')); // 6 PM ET
+  await page.reload();
+  await expect(page.getByTestId('business-hours')).toContainText('Closed');
+
+  await context.close();
+});
+
+test('scheduled event shows correct local time', async ({ browser }) => {
+  // Event at 2025-03-20T18:00:00Z
+
+  // User in Tokyo (UTC+9)
+  const tokyoCtx = await browser.newContext({ timezoneId: 'Asia/Tokyo' });
+  const tokyoPage = await tokyoCtx.newPage();
+  await tokyoPage.clock.install({ time: new Date('2025-03-20T10:00:00Z') });
+  await tokyoPage.goto('/events/upcoming');
+  // 18:00 UTC = 03:00 AM next day in Tokyo (UTC+9)
+  await expect(tokyoPage.getByTestId('event-time')).toContainText('3:00 AM');
+  await tokyoCtx.close();
+
+  // User in London (UTC+0 in March, before DST)
+  const londonCtx = await browser.newContext({ timezoneId: 'Europe/London' });
+  const londonPage = await londonCtx.newPage();
+  await londonPage.clock.install({ time: new Date('2025-03-20T10:00:00Z') });
+  await londonPage.goto('/events/upcoming');
+  await expect(londonPage.getByTestId('event-time')).toContainText('6:00 PM');
+  await londonCtx.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('business hours banner shows open/closed status', async ({ browser }) => {
+  const context = await browser.newContext({ timezoneId: 'America/New_York' });
+  const page = await context.newPage();
+
+  await page.clock.install({ time: new Date('2025-03-15T14:00:00Z') });
+  await page.goto('/contact');
+  await expect(page.getByTestId('business-hours')).toContainText('Open');
+
+  await page.clock.setFixedTime(new Date('2025-03-15T22:00:00Z'));
+  await page.reload();
+  await expect(page.getByTestId('business-hours')).toContainText('Closed');
+
+  await context.close();
+});
+```
+
+## Decision Guide
+
+| Scenario | API | Why |
+|---|---|---|
+| Check UI at a specific date/time | `clock.install()` + `clock.setFixedTime()` | Time is frozen; no timer ticking |
+| Test countdown or timer behavior | `clock.install()` + `clock.fastForward()` | Fires timers as time advances without real waiting |
+| Test after a long idle period | `clock.install()` + `clock.fastForward('30:00')` | Simulates 30 minutes without waiting 30 minutes |
+| Start mocked, then tick normally | `clock.install()` + `clock.resume()` | Useful when you need real `requestAnimationFrame` after setup |
+| Different timezone display | `browser.newContext({ timezoneId })` | Affects `Date` timezone rendering |
+| Timezone + mocked time | `newContext({ timezoneId })` + `clock.install()` | Both timezone and absolute time are controlled |
+| Test date picker defaults | `clock.install()` with target date | Calendar opens to the mocked "today" |
+| Test DST transitions | Set `timezoneId` + `install` at DST boundary | Tests the most common timezone bugs |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Calling `clock.install()` after `page.goto()` | Page already loaded with real `Date`; timers already fired | Call `clock.install()` BEFORE `page.goto()` |
+| Using `page.waitForTimeout(30000)` to test a 30-second timer | Wastes 30 real seconds per test run | `page.clock.fastForward('00:30')` completes instantly |
+| Testing time without mocking the clock | Results depend on when the test runs (morning vs evening, Monday vs Sunday) | Always mock time for time-dependent assertions |
+| Using `setFixedTime` when you need timers to fire | `setFixedTime` freezes time; `setInterval`/`setTimeout` will not trigger | Use `fastForward` to advance time and fire pending timers |
+| Mocking only `Date.now()` via `page.evaluate` | Does not affect `setTimeout`, `setInterval`, or `requestAnimationFrame` | Use `page.clock.install()` which mocks all time APIs |
+| Forgetting timezone when testing dates | Test passes locally but fails in CI (different timezone) | Always set `timezoneId` in context or use UTC dates |
+| Advancing time in very small increments | Slow test; many unnecessary timer firings | Advance to the exact time of interest in one call |
+| Not calling `resume()` before real-time-dependent assertions | Mocked timers will not fire naturally; assertions time out | Call `clock.resume()` when you need real time to flow |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `clock.install()` has no effect | Called after `page.goto()`; page already has real `Date` | Move `clock.install()` before navigation |
+| Timer callbacks never fire | Time is frozen with `setFixedTime`; timers need advancing | Use `fastForward()` to advance past the timer delay |
+| `fastForward` does not trigger timer | Timer was registered with a delay longer than the fast-forward amount | Fast-forward by at least the timer's delay |
+| Date is correct but timezone display is wrong | `clock.install` sets time in UTC; `timezoneId` not set on context | Create context with `{ timezoneId: 'Your/Timezone' }` |
+| Animations break with mocked clock | `requestAnimationFrame` is mocked and does not fire naturally | Call `clock.resume()` before animation-dependent assertions |
+| Test passes locally but fails in CI | Local timezone differs from CI timezone | Always set `timezoneId` explicitly in the context |
+| `setFixedTime` throws "clock not installed" | `install()` was not called first | Call `page.clock.install()` before any other clock methods |
+| Page makes fetch requests with wrong timestamps | Server sees mocked `Date.now()` in request payloads | This is expected; mock server responses if needed |
+
+## Related
+
+- [core/i18n-and-localization.md](i18n-and-localization.md) -- timezone and locale testing patterns
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-waiting vs time-based assertions
+- [core/error-and-edge-cases.md](error-and-edge-cases.md) -- testing timeout and expiration edge cases
+- [core/performance-testing.md](performance-testing.md) -- timing-related performance measurement
+- [core/websockets-and-realtime.md](websockets-and-realtime.md) -- real-time features that depend on timing

--- a/engineering-team/playwright skill/core/common-pitfalls.md
+++ b/engineering-team/playwright skill/core/common-pitfalls.md
@@ -1,0 +1,1318 @@
+# Common Pitfalls
+
+> **When to use**: When learning Playwright, reviewing tests for common mistakes, or onboarding new team members to your test suite.
+
+The 20 most common Playwright mistakes, ordered by how frequently they appear in real codebases. Each pitfall includes the symptom, root cause, and a complete fix.
+
+---
+
+## Pitfall 1: Using `page.waitForTimeout()` Instead of Assertions
+
+**Symptom**: Tests are slow and flaky. They pass on fast machines but fail on slow CI runners.
+
+**Why it happens**: Developers port habits from Selenium or Cypress where explicit waits were necessary. In Playwright, auto-retrying assertions handle timing automatically.
+
+**Fix**: Replace every `waitForTimeout` with a web-first assertion or an explicit wait for a specific condition.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD
+test('bad: arbitrary wait', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Load' }).click();
+  await page.waitForTimeout(3000);
+  await expect(page.getByTestId('chart')).toBeVisible();
+});
+
+// GOOD
+test('good: auto-retrying assertion', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Load' }).click();
+  await expect(page.getByTestId('chart')).toBeVisible();
+});
+
+// GOOD — when you need to wait for a specific network event
+test('good: wait for response', async ({ page }) => {
+  await page.goto('/dashboard');
+  const responsePromise = page.waitForResponse('**/api/chart-data');
+  await page.getByRole('button', { name: 'Load' }).click();
+  await responsePromise;
+  await expect(page.getByTestId('chart')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: arbitrary wait', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Load' }).click();
+  await page.waitForTimeout(3000);
+  await expect(page.getByTestId('chart')).toBeVisible();
+});
+
+// GOOD
+test('good: auto-retrying assertion', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Load' }).click();
+  await expect(page.getByTestId('chart')).toBeVisible();
+});
+```
+
+**The only acceptable use of `waitForTimeout`**: Debugging with `page.pause()` unavailable, or simulating real user "think time" in performance tests. Never in production test code.
+
+---
+
+## Pitfall 2: Not Awaiting Async Operations
+
+**Symptom**: Tests pass unpredictably. Assertions run before actions complete. Error messages reference detached frames or closed pages.
+
+**Why it happens**: Every Playwright API call is async. Missing a single `await` causes the next line to execute before the previous action finishes.
+
+**Fix**: Always `await` every Playwright call. Enable the `@typescript-eslint/no-floating-promises` ESLint rule.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — missing await on click, assertion runs before navigation
+test('bad: missing await', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password');
+  page.getByRole('button', { name: 'Sign in' }).click(); // MISSING AWAIT
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+
+// GOOD
+test('good: all actions awaited', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: missing await', async ({ page }) => {
+  await page.goto('/login');
+  page.getByRole('button', { name: 'Submit' }).click(); // MISSING AWAIT
+  await expect(page.getByText('Success')).toBeVisible();
+});
+
+// GOOD
+test('good: all actions awaited', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await expect(page.getByText('Success')).toBeVisible();
+});
+```
+
+**Prevention**: Add this ESLint config to catch floating promises at compile time:
+```json
+{
+  "rules": {
+    "@typescript-eslint/no-floating-promises": "error"
+  }
+}
+```
+
+---
+
+## Pitfall 3: Using CSS Selectors Instead of Role-Based Locators
+
+**Symptom**: Tests break whenever a CSS class name, DOM structure, or component library changes. Tests are hard to read because selectors look like `.btn-primary > span:nth-child(2)`.
+
+**Why it happens**: Developers use what they know from jQuery or DevTools. CSS selectors are implementation details that change frequently.
+
+**Fix**: Use Playwright's built-in locators that target accessible roles, labels, text, and test IDs.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — brittle CSS selectors
+test('bad: CSS selectors', async ({ page }) => {
+  await page.goto('/settings');
+  await page.locator('.form-group:nth-child(3) input.form-control').fill('new value');
+  await page.locator('button.btn.btn-primary.submit-btn').click();
+  await expect(page.locator('.alert.alert-success')).toBeVisible();
+});
+
+// GOOD — role-based locators
+test('good: accessible locators', async ({ page }) => {
+  await page.goto('/settings');
+  await page.getByLabel('Display name').fill('new value');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByRole('alert')).toHaveText('Settings saved');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: CSS selectors', async ({ page }) => {
+  await page.locator('.form-group:nth-child(3) input').fill('new value');
+  await page.locator('button.btn-primary').click();
+});
+
+// GOOD
+test('good: accessible locators', async ({ page }) => {
+  await page.getByLabel('Display name').fill('new value');
+  await page.getByRole('button', { name: 'Save' }).click();
+});
+```
+
+**Locator priority** (most resilient to least):
+1. `getByRole()` -- accessible role + name
+2. `getByLabel()` -- form fields by label text
+3. `getByPlaceholder()` -- inputs by placeholder
+4. `getByText()` -- visible text content
+5. `getByTestId()` -- stable `data-testid` attribute
+6. CSS/XPath selectors -- last resort only
+
+---
+
+## Pitfall 4: Asserting on `isVisible()` Return Value Instead of `expect().toBeVisible()`
+
+**Symptom**: Test passes when the element is not visible. Assertion is silently wrong. Flaky under timing pressure.
+
+**Why it happens**: `isVisible()` returns a boolean at one point in time -- no retry. If the element has not appeared yet, it returns `false` and `expect(false).toBe(true)` fails immediately without waiting.
+
+**Fix**: Always use `expect(locator).toBeVisible()`, which auto-retries until the element appears or the timeout expires.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — resolves once, no retry
+test('bad: isVisible check', async ({ page }) => {
+  await page.goto('/dashboard');
+  const visible = await page.getByTestId('widget').isVisible();
+  expect(visible).toBe(true); // Fails immediately if widget hasn't rendered yet
+});
+
+// GOOD — auto-retries for up to 5 seconds
+test('good: toBeVisible assertion', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('widget')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: isVisible check', async ({ page }) => {
+  const visible = await page.getByTestId('widget').isVisible();
+  expect(visible).toBe(true);
+});
+
+// GOOD
+test('good: toBeVisible assertion', async ({ page }) => {
+  await expect(page.getByTestId('widget')).toBeVisible();
+});
+```
+
+This applies to all "resolve once" methods: `isVisible()`, `isEnabled()`, `isChecked()`, `textContent()`, `getAttribute()`, `inputValue()`. Always use the `expect(locator)` web-first assertion counterpart.
+
+---
+
+## Pitfall 5: Sharing Mutable State Between Parallel Tests
+
+**Symptom**: Tests pass when run alone but fail in the full suite. Order-dependent failures. "Duplicate key" errors.
+
+**Why it happens**: Module-level variables, shared database rows, or `beforeAll`-created state is mutated by one test and seen by another running in parallel.
+
+**Fix**: Use test-scoped fixtures with unique data. Never store mutable state in module-level variables.
+
+**TypeScript**
+```typescript
+import { test as base, expect } from '@playwright/test';
+
+// BAD — module-level mutable state shared across parallel tests
+let userId: string;
+
+test.beforeAll(async ({ request }) => {
+  const res = await request.post('/api/users', {
+    data: { email: 'shared@test.com' },
+  });
+  userId = (await res.json()).id; // Every parallel worker overwrites this
+});
+
+test('bad: uses shared state', async ({ page }) => {
+  await page.goto(`/users/${userId}`); // userId may be from another worker
+});
+
+// GOOD — test-scoped fixture with unique data per test
+export const test = base.extend<{ testUser: { id: string; email: string } }>({
+  testUser: async ({ request }, use) => {
+    const email = `user-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
+    const res = await request.post('/api/users', { data: { email } });
+    const user = await res.json();
+
+    await use({ id: user.id, email });
+
+    await request.delete(`/api/users/${user.id}`);
+  },
+});
+
+test('good: isolated data per test', async ({ page, testUser }) => {
+  await page.goto(`/users/${testUser.id}`);
+  await expect(page.getByText(testUser.email)).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test: base, expect } = require('@playwright/test');
+
+// GOOD
+const test = base.extend({
+  testUser: async ({ request }, use) => {
+    const email = `user-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
+    const res = await request.post('/api/users', { data: { email } });
+    const user = await res.json();
+
+    await use({ id: user.id, email });
+
+    await request.delete(`/api/users/${user.id}`);
+  },
+});
+
+test('good: isolated data per test', async ({ page, testUser }) => {
+  await page.goto(`/users/${testUser.id}`);
+  await expect(page.getByText(testUser.email)).toBeVisible();
+});
+
+module.exports = { test };
+```
+
+---
+
+## Pitfall 6: Not Using `baseURL` (Hardcoding Full URLs)
+
+**Symptom**: Tests break when switching environments (local, staging, production). URL strings are duplicated everywhere.
+
+**Why it happens**: Developers start with `page.goto('http://localhost:3000/login')` and never refactor.
+
+**Fix**: Set `baseURL` in `playwright.config` and use relative paths in all tests.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+  },
+});
+```
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD
+test('bad: hardcoded URL', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+});
+
+// GOOD
+test('good: relative URL', async ({ page }) => {
+  await page.goto('/login');
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+  },
+});
+```
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: hardcoded URL', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+});
+
+// GOOD
+test('good: relative URL', async ({ page }) => {
+  await page.goto('/login');
+});
+```
+
+Run against different environments by setting the variable: `BASE_URL=https://staging.example.com npx playwright test`
+
+---
+
+## Pitfall 7: Using `page.$()` Instead of `page.locator()`
+
+**Symptom**: Element handle is `null`. Stale element errors. No auto-waiting.
+
+**Why it happens**: `page.$()` and `page.$$()` are ElementHandle APIs from Puppeteer. They resolve once and return a handle that can go stale. Locators are Playwright's replacement -- they are lazy and re-evaluate on every action.
+
+**Fix**: Always use `page.locator()`, `page.getByRole()`, or other locator methods.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — ElementHandle API, resolves once, can go stale
+test('bad: page.$ usage', async ({ page }) => {
+  await page.goto('/products');
+  const button = await page.$('.add-to-cart'); // null if not found, stale if DOM changes
+  if (button) {
+    await button.click();
+  }
+  const count = await page.$$('.cart-item');
+  expect(count.length).toBe(1); // No auto-retry
+});
+
+// GOOD — locator API, lazy evaluation, auto-waiting
+test('good: locator usage', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+  await expect(page.getByTestId('cart-item')).toHaveCount(1); // Auto-retries
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: page.$ usage', async ({ page }) => {
+  const button = await page.$('.add-to-cart');
+  if (button) await button.click();
+});
+
+// GOOD
+test('good: locator usage', async ({ page }) => {
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+});
+```
+
+---
+
+## Pitfall 8: Not Handling Navigation After Form Submission
+
+**Symptom**: Test fails with "Target page, context or browser has been closed" or assertions fail because the page navigated away before the assertion ran.
+
+**Why it happens**: Clicking a submit button triggers a full page navigation. The assertion runs against the old page that is being unloaded.
+
+**Fix**: Wait for the navigation to complete before asserting on the new page.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — assertion runs before navigation completes
+test('bad: no navigation handling', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  // Page is navigating — this may fail with "Execution context was destroyed"
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+
+// GOOD — wait for URL to change, then assert
+test('good: waitForURL after navigation', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+
+// GOOD — alternative: use expect().toHaveURL() which auto-retries
+test('good: toHaveURL assertion', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL(/.*dashboard/);
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// GOOD
+test('good: waitForURL after navigation', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Password').fill('password');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+```
+
+---
+
+## Pitfall 9: Testing Against `localhost` in CI Without `webServer` Config
+
+**Symptom**: Tests fail in CI with `ECONNREFUSED` on `localhost:3000`. Works locally because the dev server is already running.
+
+**Why it happens**: CI runners start with a clean environment. No dev server is running unless you explicitly start one.
+
+**Fix**: Use the `webServer` config option to start your app automatically.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    // Reuse existing server locally (faster), start fresh in CI
+    reuseExistingServer: !process.env.CI,
+    // Give the server time to start
+    timeout: 120_000,
+    // Capture server output for debugging startup failures
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});
+```
+
+For multiple servers (frontend + backend), pass an array:
+```typescript
+webServer: [
+  { command: 'npm run start:api', url: 'http://localhost:4000/health', reuseExistingServer: !process.env.CI },
+  { command: 'npm run start:web', url: 'http://localhost:3000', reuseExistingServer: !process.env.CI },
+],
+```
+
+---
+
+## Pitfall 10: Using `innerHTML` for Text Assertions Instead of `toHaveText()`
+
+**Symptom**: Tests break when HTML structure changes. Assertions are fragile and hard to read.
+
+**Why it happens**: Developers use `innerHTML()` or `textContent()` to get text and then assert on the resolved string. This resolves once with no retry.
+
+**Fix**: Use `expect(locator).toHaveText()` or `expect(locator).toContainText()` for auto-retrying text assertions.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — resolves once, includes HTML tags, no retry
+test('bad: innerHTML assertion', async ({ page }) => {
+  await page.goto('/product/123');
+  const html = await page.getByTestId('price').innerHTML();
+  expect(html).toContain('$49.99'); // Brittle: depends on HTML structure
+});
+
+// BAD — textContent resolves once, no retry
+test('bad: textContent assertion', async ({ page }) => {
+  await page.goto('/product/123');
+  const text = await page.getByTestId('price').textContent();
+  expect(text).toBe('$49.99'); // No retry if text hasn't loaded yet
+});
+
+// GOOD — auto-retrying, no HTML dependency
+test('good: toHaveText assertion', async ({ page }) => {
+  await page.goto('/product/123');
+  await expect(page.getByTestId('price')).toHaveText('$49.99');
+});
+
+// GOOD — partial match for flexible assertions
+test('good: toContainText assertion', async ({ page }) => {
+  await page.goto('/product/123');
+  await expect(page.getByTestId('price')).toContainText('$49');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: textContent assertion', async ({ page }) => {
+  const text = await page.getByTestId('price').textContent();
+  expect(text).toBe('$49.99');
+});
+
+// GOOD
+test('good: toHaveText assertion', async ({ page }) => {
+  await expect(page.getByTestId('price')).toHaveText('$49.99');
+});
+```
+
+---
+
+## Pitfall 11: Over-Mocking (Mocking Your Own API)
+
+**Symptom**: All tests pass but the app is broken in production. Mocked responses drift from the real API. False confidence.
+
+**Why it happens**: Developers mock every API call for speed and stability, including their own backend. The mocks become stale as the real API evolves.
+
+**Fix**: Only mock external third-party services. Test your own API for real. Use `webServer` to run your backend during tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — mocking your own API removes confidence
+test('bad: mocks own API', async ({ page }) => {
+  await page.route('**/api/users/me', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ name: 'Test User', role: 'admin' }),
+    })
+  );
+  await page.goto('/dashboard');
+  await expect(page.getByText('Test User')).toBeVisible(); // Passes even if API is broken
+});
+
+// GOOD — mock only external services, test your own API for real
+test('good: real API, mocked externals', async ({ page }) => {
+  // Block third-party analytics and ads
+  await page.route(/google-analytics|intercom|segment/, (route) => route.abort());
+
+  // Stub a flaky external payment provider
+  await page.route('**/api.stripe.com/**', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ status: 'succeeded' }),
+    })
+  );
+
+  // Test against the real app API
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// GOOD — mock only external services
+test('good: real API, mocked externals', async ({ page }) => {
+  await page.route(/google-analytics|intercom|segment/, (route) => route.abort());
+
+  await page.route('**/api.stripe.com/**', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ status: 'succeeded' }),
+    })
+  );
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**When mocking your own API is acceptable**: Testing specific error states (500, 503, network timeout) or edge cases that are hard to reproduce with a real backend.
+
+---
+
+## Pitfall 12: Not Using `test.describe` for Grouping
+
+**Symptom**: Test files are flat lists of unrelated tests. Shared configuration (`test.use()`, `test.beforeEach()`) cannot be scoped. HTML reports are hard to navigate.
+
+**Why it happens**: Developers write tests as a flat list, never grouping related tests together.
+
+**Fix**: Group related tests with `test.describe`. Use it for scoping shared setup, configuration overrides, and logical organization.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — flat list, no grouping, no shared context
+test('admin can view users', async ({ page }) => { /* ... */ });
+test('admin can delete user', async ({ page }) => { /* ... */ });
+test('viewer cannot delete user', async ({ page }) => { /* ... */ });
+test('viewer can view users', async ({ page }) => { /* ... */ });
+
+// GOOD — grouped by role, scoped configuration
+test.describe('admin users', () => {
+  test.use({ storageState: '.auth/admin.json' });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/users');
+  });
+
+  test('can view user list', async ({ page }) => {
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+
+  test('can delete a user', async ({ page }) => {
+    await page.getByRole('row').first().getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+});
+
+test.describe('viewer users', () => {
+  test.use({ storageState: '.auth/viewer.json' });
+
+  test('can view user list', async ({ page }) => {
+    await page.goto('/admin/users');
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+
+  test('cannot see delete button', async ({ page }) => {
+    await page.goto('/admin/users');
+    await expect(page.getByRole('button', { name: 'Delete' })).not.toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('admin users', () => {
+  test.use({ storageState: '.auth/admin.json' });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/users');
+  });
+
+  test('can view user list', async ({ page }) => {
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+
+  test('can delete a user', async ({ page }) => {
+    await page.getByRole('row').first().getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+});
+```
+
+---
+
+## Pitfall 13: Using `beforeAll` for Per-Test Setup
+
+**Symptom**: Tests that should be independent share state from `beforeAll`. One test modifies the state and subsequent tests fail.
+
+**Why it happens**: Developers think `beforeAll` is "more efficient" because it runs once. But `beforeAll` creates worker-scoped state that all tests in the file share.
+
+**Fix**: Use `beforeEach` for per-test setup, or use test-scoped fixtures for setup that needs teardown.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — beforeAll creates one user for all tests; tests mutate shared state
+test.beforeAll(async ({ request }) => {
+  // This user is shared across all tests in this file
+  await request.post('/api/users', { data: { email: 'shared@test.com', name: 'Original' } });
+});
+
+test('updates user name', async ({ page }) => {
+  await page.goto('/users/shared@test.com');
+  await page.getByLabel('Name').fill('Updated');
+  await page.getByRole('button', { name: 'Save' }).click();
+  // Now the shared user has name "Updated" — other tests see this
+});
+
+test('checks user name is Original', async ({ page }) => {
+  await page.goto('/users/shared@test.com');
+  // FAILS — previous test changed the name
+  await expect(page.getByLabel('Name')).toHaveValue('Original');
+});
+
+// GOOD — each test creates its own user
+test.describe('user profile', () => {
+  test('updates user name', async ({ page, request }) => {
+    const email = `user-${Date.now()}@test.com`;
+    await request.post('/api/users', { data: { email, name: 'Original' } });
+
+    await page.goto(`/users/${email}`);
+    await page.getByLabel('Name').fill('Updated');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByLabel('Name')).toHaveValue('Updated');
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// GOOD — per-test data creation
+test('updates user name', async ({ page, request }) => {
+  const email = `user-${Date.now()}@test.com`;
+  await request.post('/api/users', { data: { email, name: 'Original' } });
+
+  await page.goto(`/users/${email}`);
+  await page.getByLabel('Name').fill('Updated');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByLabel('Name')).toHaveValue('Updated');
+});
+```
+
+---
+
+## Pitfall 14: Storing Test Data in Variables Shared Between Tests
+
+**Symptom**: Test B depends on data created in Test A. Reordering or running tests in parallel breaks the suite.
+
+**Why it happens**: Developers declare `let` variables at the module level and assign them in one test, expecting another test to read them.
+
+**Fix**: Each test must create its own data. Use fixtures for shared setup logic.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — test B depends on test A creating the product
+let productId: string;
+
+test('test A: creates product', async ({ request }) => {
+  const res = await request.post('/api/products', { data: { name: 'Widget' } });
+  productId = (await res.json()).id;
+});
+
+test('test B: edits product', async ({ page }) => {
+  await page.goto(`/products/${productId}/edit`); // undefined if test A didn't run first
+});
+
+// GOOD — each test is self-contained
+test('creates and edits product', async ({ page, request }) => {
+  const res = await request.post('/api/products', { data: { name: `Widget-${Date.now()}` } });
+  const { id } = await res.json();
+
+  await page.goto(`/products/${id}/edit`);
+  await page.getByLabel('Name').fill('Updated Widget');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Updated Widget')).toBeVisible();
+
+  // Cleanup
+  await request.delete(`/api/products/${id}`);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// GOOD — self-contained test
+test('creates and edits product', async ({ page, request }) => {
+  const res = await request.post('/api/products', { data: { name: `Widget-${Date.now()}` } });
+  const { id } = await res.json();
+
+  await page.goto(`/products/${id}/edit`);
+  await page.getByLabel('Name').fill('Updated Widget');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Updated Widget')).toBeVisible();
+
+  await request.delete(`/api/products/${id}`);
+});
+```
+
+---
+
+## Pitfall 15: Deep Nesting of `test.describe` Blocks
+
+**Symptom**: Test structure is 3+ levels deep. Hard to read. `beforeEach` hooks from outer blocks are invisible at the test level. HTML reports are cluttered.
+
+**Why it happens**: Developers organize tests like they organize code -- deeply nested hierarchies. But tests should be flat and scannable.
+
+**Fix**: Limit nesting to 2 levels maximum. Use separate files instead of deep nesting.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — 4 levels deep, impossible to follow
+test.describe('admin', () => {
+  test.describe('settings', () => {
+    test.describe('security', () => {
+      test.describe('two-factor auth', () => {
+        test('enables TOTP', async ({ page }) => {
+          // Which beforeEach hooks ran before this? Good luck figuring out.
+        });
+      });
+    });
+  });
+});
+
+// GOOD — max 2 levels, clear and flat
+test.describe('admin security settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/settings/security');
+  });
+
+  test('enables two-factor auth via TOTP', async ({ page }) => {
+    await page.getByRole('button', { name: 'Enable 2FA' }).click();
+    await expect(page.getByText('Scan QR code')).toBeVisible();
+  });
+
+  test('disables two-factor auth', async ({ page }) => {
+    await page.getByRole('button', { name: 'Disable 2FA' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// GOOD — flat structure, max 2 levels
+test.describe('admin security settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/settings/security');
+  });
+
+  test('enables two-factor auth via TOTP', async ({ page }) => {
+    await page.getByRole('button', { name: 'Enable 2FA' }).click();
+    await expect(page.getByText('Scan QR code')).toBeVisible();
+  });
+});
+```
+
+If you need to organize many tests, split into separate files: `security-2fa.spec.ts`, `security-passwords.spec.ts`, `security-sessions.spec.ts`.
+
+---
+
+## Pitfall 16: Not Configuring Retries Differently for Local vs CI
+
+**Symptom**: Developers use retries locally (hiding bugs during development) or have no retries in CI (failing on intermittent issues that are not their fault).
+
+**Why it happens**: A single `retries` value is set without considering the environment.
+
+**Fix**: Zero retries locally (fail fast), 1-2 retries in CI (catch infrastructure blips).
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  // GOOD — different retry strategy per environment
+  retries: process.env.CI ? 2 : 0,
+
+  use: {
+    // Only capture traces on retry — saves CI time and storage
+    trace: 'on-first-retry',
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+**Important**: A test that consistently needs retries to pass is not "passing" -- it is flaky. Track retry counts and fix the root cause.
+
+---
+
+## Pitfall 17: Running All Browsers in Every CI Run
+
+**Symptom**: CI takes 3x longer than necessary. Most bugs are caught by a single browser engine.
+
+**Why it happens**: Developers enable Chromium + Firefox + WebKit in the config and never reconsider.
+
+**Fix**: Run Chromium on every PR. Run all browsers in a nightly or pre-release job.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+const allBrowsers = [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+  { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+];
+
+const chromeOnly = [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+];
+
+export default defineConfig({
+  // PR runs: Chromium only. Nightly: all browsers.
+  projects: process.env.ALL_BROWSERS ? allBrowsers : chromeOnly,
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+const allBrowsers = [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+  { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+];
+
+const chromeOnly = [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+];
+
+module.exports = defineConfig({
+  projects: process.env.ALL_BROWSERS ? allBrowsers : chromeOnly,
+});
+```
+
+```yaml
+# .github/workflows/tests.yml
+jobs:
+  pr-tests:
+    # Fast: Chromium only
+    runs-on: ubuntu-latest
+    steps:
+      - run: npx playwright test
+
+  nightly-full:
+    # Comprehensive: all browsers
+    schedule:
+      - cron: '0 3 * * *'
+    steps:
+      - run: ALL_BROWSERS=1 npx playwright test
+```
+
+---
+
+## Pitfall 18: Using `page.evaluate()` for Things Locators Can Do
+
+**Symptom**: Tests are verbose and fragile. Direct DOM manipulation bypasses Playwright's auto-waiting and actionability checks.
+
+**Why it happens**: Developers with vanilla JS or Puppeteer backgrounds use `evaluate()` for everything because it feels familiar.
+
+**Fix**: Use locator methods for all DOM interactions. Reserve `page.evaluate()` for things locators genuinely cannot do (reading computed styles, calling app-specific JS APIs, setting up test hooks).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — using evaluate for things locators handle better
+test('bad: evaluate for DOM interaction', async ({ page }) => {
+  await page.goto('/settings');
+
+  // Getting text
+  const text = await page.evaluate(() =>
+    document.querySelector('[data-testid="username"]')?.textContent
+  );
+  expect(text).toBe('John');
+
+  // Clicking
+  await page.evaluate(() => {
+    (document.querySelector('button.save-btn') as HTMLButtonElement)?.click();
+  });
+
+  // Checking visibility
+  const visible = await page.evaluate(() => {
+    const el = document.querySelector('.success-message');
+    return el ? window.getComputedStyle(el).display !== 'none' : false;
+  });
+  expect(visible).toBe(true);
+});
+
+// GOOD — locators with auto-waiting and retry
+test('good: locator methods', async ({ page }) => {
+  await page.goto('/settings');
+
+  await expect(page.getByTestId('username')).toHaveText('John');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Settings saved')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// BAD
+test('bad: evaluate for DOM interaction', async ({ page }) => {
+  const text = await page.evaluate(() =>
+    document.querySelector('[data-testid="username"]')?.textContent
+  );
+  expect(text).toBe('John');
+});
+
+// GOOD
+test('good: locator methods', async ({ page }) => {
+  await expect(page.getByTestId('username')).toHaveText('John');
+});
+```
+
+**When `evaluate()` is appropriate**: Reading `window.__APP_STATE__`, calling test-specific setup functions exposed by the app, manipulating `localStorage`/`sessionStorage`, or reading computed styles that have no locator equivalent.
+
+---
+
+## Pitfall 19: Not Using `test.step()` for Complex Flows
+
+**Symptom**: Long tests are hard to debug. When they fail, the trace shows 50+ actions with no logical grouping. The HTML report provides no structure.
+
+**Why it happens**: Developers write tests as a linear sequence of actions without labeling phases.
+
+**Fix**: Wrap logical phases in `test.step()`. Steps appear in traces, reports, and error messages.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — 30 lines of actions with no structure
+test('bad: flat checkout flow', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add Widget' }).click();
+  await page.getByRole('link', { name: 'Cart' }).click();
+  await page.getByRole('button', { name: 'Checkout' }).click();
+  await page.getByLabel('Email').fill('user@test.com');
+  await page.getByLabel('Address').fill('123 Test St');
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByLabel('Card number').fill('4242424242424242');
+  await page.getByRole('button', { name: 'Pay' }).click();
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+
+// GOOD — logical steps, clear in traces and reports
+test('good: structured checkout flow', async ({ page }) => {
+  await test.step('add item to cart', async () => {
+    await page.goto('/products');
+    await page.getByRole('button', { name: 'Add Widget' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+
+  await test.step('proceed to checkout', async () => {
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.getByRole('button', { name: 'Checkout' }).click();
+    await expect(page).toHaveURL(/.*checkout/);
+  });
+
+  await test.step('fill shipping details', async () => {
+    await page.getByLabel('Email').fill('user@test.com');
+    await page.getByLabel('Address').fill('123 Test St');
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+
+  await test.step('complete payment', async () => {
+    await page.getByLabel('Card number').fill('4242424242424242');
+    await page.getByRole('button', { name: 'Pay' }).click();
+    await expect(page.getByText('Order confirmed')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('good: structured checkout flow', async ({ page }) => {
+  await test.step('add item to cart', async () => {
+    await page.goto('/products');
+    await page.getByRole('button', { name: 'Add Widget' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+
+  await test.step('proceed to checkout', async () => {
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.getByRole('button', { name: 'Checkout' }).click();
+  });
+
+  await test.step('fill shipping details', async () => {
+    await page.getByLabel('Email').fill('user@test.com');
+    await page.getByLabel('Address').fill('123 Test St');
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+
+  await test.step('complete payment', async () => {
+    await page.getByLabel('Card number').fill('4242424242424242');
+    await page.getByRole('button', { name: 'Pay' }).click();
+    await expect(page.getByText('Order confirmed')).toBeVisible();
+  });
+});
+```
+
+When a step fails, the error message includes the step name: `Error in step "complete payment": ...`. This is significantly more helpful than line numbers alone.
+
+---
+
+## Pitfall 20: Catching Errors from Assertions (try/catch Around expect)
+
+**Symptom**: Tests pass when they should fail. Assertion errors are silently swallowed. Real bugs go undetected.
+
+**Why it happens**: Developers wrap assertions in try/catch to handle "optional" elements or to implement conditional logic. This defeats the purpose of assertions.
+
+**Fix**: Use `expect.soft()` for non-critical checks, `.not` assertions for absent elements, or restructure the test to avoid conditional logic.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// BAD — swallows real failures
+test('bad: try/catch around assertion', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  try {
+    await expect(page.getByRole('alert')).toBeVisible({ timeout: 2_000 });
+    // Dismiss the alert if it exists
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+  } catch {
+    // Alert didn't appear — that's fine
+  }
+
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+
+// GOOD — check count to determine if element exists, no try/catch needed
+test('good: conditional without try/catch', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // If an alert banner is present, dismiss it
+  const alertCount = await page.getByRole('alert').count();
+  if (alertCount > 0) {
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(page.getByRole('alert')).not.toBeVisible();
+  }
+
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+
+// GOOD — use soft assertions for non-critical checks
+test('good: soft assertions for nice-to-have checks', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // These are informational — test continues even if they fail
+  await expect.soft(page.getByTestId('revenue')).toContainText('$');
+  await expect.soft(page.getByTestId('users')).toContainText('active');
+
+  // This is the actual assertion — test fails if this fails
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+
+// GOOD — assert element is NOT present (no try/catch needed)
+test('good: assert absence directly', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // This auto-retries until the error disappears (or times out)
+  await expect(page.getByRole('alert')).not.toBeVisible();
+
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// GOOD — conditional without try/catch
+test('good: conditional without try/catch', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const alertCount = await page.getByRole('alert').count();
+  if (alertCount > 0) {
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(page.getByRole('alert')).not.toBeVisible();
+  }
+
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+
+// GOOD — soft assertions for non-critical checks
+test('good: soft assertions for nice-to-have checks', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect.soft(page.getByTestId('revenue')).toContainText('$');
+  await expect.soft(page.getByTestId('users')).toContainText('active');
+
+  await expect(page.getByRole('heading')).toHaveText('Dashboard');
+});
+```
+
+**Rule**: If you find yourself writing `try/catch` around an `expect()`, the test design is wrong. Rethink the assertion.
+
+---
+
+## Quick Lookup Table
+
+| # | Pitfall | One-Line Fix |
+|---|---|---|
+| 1 | `waitForTimeout()` | Replace with `expect(locator).toBeVisible()` |
+| 2 | Missing `await` | Add `await` + enable `no-floating-promises` ESLint rule |
+| 3 | CSS selectors | Use `getByRole()`, `getByLabel()`, `getByTestId()` |
+| 4 | `isVisible()` check | Use `expect(locator).toBeVisible()` |
+| 5 | Shared mutable state | Use test-scoped fixtures with unique data |
+| 6 | Hardcoded URLs | Set `baseURL` in config, use relative paths |
+| 7 | `page.$()` / `page.$$()` | Use `page.locator()` or `page.getByRole()` |
+| 8 | Navigation not handled | Add `page.waitForURL()` after form submissions |
+| 9 | No `webServer` in CI | Add `webServer` config with `reuseExistingServer: !process.env.CI` |
+| 10 | `innerHTML` / `textContent` | Use `expect(locator).toHaveText()` |
+| 11 | Over-mocking own API | Mock only external services |
+| 12 | No `test.describe` | Group related tests, scope `beforeEach` and `test.use()` |
+| 13 | `beforeAll` for per-test setup | Use `beforeEach` or test-scoped fixtures |
+| 14 | Module-level test data variables | Create data inside each test or via fixtures |
+| 15 | Deep `describe` nesting (3+) | Max 2 levels; split into separate files |
+| 16 | Same retries everywhere | `retries: process.env.CI ? 2 : 0` |
+| 17 | All browsers on every PR | Chromium on PRs, full matrix nightly |
+| 18 | `page.evaluate()` overuse | Use locator methods; reserve `evaluate` for JS APIs |
+| 19 | No `test.step()` | Wrap logical phases in named steps |
+| 20 | `try/catch` around `expect` | Use `expect.soft()`, `.not`, or `locator.count()` |
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategy hierarchy (Pitfalls 3, 7, 18)
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- web-first assertions (Pitfalls 1, 4, 10, 20)
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- fixtures vs hooks (Pitfalls 5, 13, 14)
+- [core/configuration.md](configuration.md) -- baseURL, webServer, retries (Pitfalls 6, 9, 16, 17)
+- [core/test-organization.md](test-organization.md) -- describe blocks, nesting, tags (Pitfalls 12, 15)
+- [core/flaky-tests.md](flaky-tests.md) -- diagnosing and fixing flaky tests (Pitfalls 1, 2, 5)
+- [core/debugging.md](debugging.md) -- traces, UI mode, page.pause()

--- a/engineering-team/playwright skill/core/component-testing.md
+++ b/engineering-team/playwright skill/core/component-testing.md
@@ -1,0 +1,1179 @@
+# Component Testing
+
+> **When to use**: When you need to test UI components in isolation — verifying rendering, interactions, and behavior without spinning up your full application. Ideal for design systems, shared component libraries, and complex interactive widgets.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+// Install for your framework:
+// npm init playwright@latest -- --ct          (interactive)
+// npm install -D @playwright/experimental-ct-react
+// npm install -D @playwright/experimental-ct-vue
+// npm install -D @playwright/experimental-ct-svelte
+
+// Mount a component, interact, assert:
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Button } from './Button';
+
+test('button renders and responds to click', async ({ mount }) => {
+  let clicked = false;
+  const component = await mount(
+    <Button label="Save" onClick={() => { clicked = true; }} />
+  );
+  await expect(component).toContainText('Save');
+  await component.click();
+  expect(clicked).toBe(true);
+});
+```
+
+## Patterns
+
+### 1. Setup and Configuration
+
+**Use when**: Starting component testing in an existing Playwright project.
+**Avoid when**: You only need full E2E tests against a running application — component testing adds build complexity that is not justified for pure integration tests.
+
+Component testing uses a separate config file (`playwright-ct.config.ts`) and a dedicated `playwright/index.html` entry point. Playwright bundles your component with Vite under the hood.
+
+**TypeScript**
+```typescript
+// playwright-ct.config.ts
+import { defineConfig, devices } from '@playwright/experimental-ct-react';
+
+export default defineConfig({
+  testDir: './src',
+  testMatch: '**/*.ct.tsx',
+  use: {
+    ctPort: 3100,
+    // Vite config for component bundling
+    ctViteConfig: {
+      resolve: {
+        alias: {
+          '@': '/src',
+        },
+      },
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});
+```
+
+```html
+<!-- playwright/index.html — entry point for component tests -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Component Tests</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>
+```
+
+```typescript
+// playwright/index.ts — global styles and providers for all component tests
+import '../src/styles/globals.css';
+```
+
+**JavaScript**
+```javascript
+// playwright-ct.config.js
+const { defineConfig, devices } = require('@playwright/experimental-ct-react');
+
+module.exports = defineConfig({
+  testDir: './src',
+  testMatch: '**/*.ct.jsx',
+  use: {
+    ctPort: 3100,
+    ctViteConfig: {
+      resolve: {
+        alias: {
+          '@': '/src',
+        },
+      },
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});
+```
+
+Run component tests with:
+```bash
+npx playwright test -c playwright-ct.config.ts
+```
+
+### 2. Mounting Components
+
+**Use when**: You need to render a component in a real browser with full DOM, CSS, and event handling.
+**Avoid when**: The component is trivial (a pure function that returns a string) — use a unit test instead.
+
+The `mount()` fixture renders your component into a real browser page. It returns a `Locator` pointed at the mounted component root.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Card } from './Card';
+
+test('mount a component with props', async ({ mount }) => {
+  const component = await mount(
+    <Card title="Welcome" description="Get started with Playwright" />
+  );
+
+  await expect(component.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await expect(component.getByText('Get started with Playwright')).toBeVisible();
+});
+
+test('mount with children', async ({ mount }) => {
+  const component = await mount(
+    <Card title="Actions">
+      <button>Click me</button>
+    </Card>
+  );
+
+  await expect(component.getByRole('button', { name: 'Click me' })).toBeVisible();
+});
+
+test('update props after mount', async ({ mount }) => {
+  const component = await mount(<Card title="Initial" description="First" />);
+  await expect(component.getByRole('heading', { name: 'Initial' })).toBeVisible();
+
+  // Re-render with new props
+  await component.update(<Card title="Updated" description="Second" />);
+  await expect(component.getByRole('heading', { name: 'Updated' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Card } = require('./Card');
+
+test('mount a component with props', async ({ mount }) => {
+  const component = await mount(
+    <Card title="Welcome" description="Get started with Playwright" />
+  );
+
+  await expect(component.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await expect(component.getByText('Get started with Playwright')).toBeVisible();
+});
+
+test('mount with children', async ({ mount }) => {
+  const component = await mount(
+    <Card title="Actions">
+      <button>Click me</button>
+    </Card>
+  );
+
+  await expect(component.getByRole('button', { name: 'Click me' })).toBeVisible();
+});
+
+test('update props after mount', async ({ mount }) => {
+  const component = await mount(<Card title="Initial" description="First" />);
+  await expect(component.getByRole('heading', { name: 'Initial' })).toBeVisible();
+
+  await component.update(<Card title="Updated" description="Second" />);
+  await expect(component.getByRole('heading', { name: 'Updated' })).toBeVisible();
+});
+```
+
+### 3. Testing Interactions
+
+**Use when**: The component has clickable elements, form inputs, keyboard handling, or hover states.
+**Avoid when**: You are testing browser-level behavior (navigation, cookies) — use E2E tests for that.
+
+Component test interactions use the same Playwright locator API as E2E tests. The `mount()` return value is a `Locator`, so all standard methods work.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Counter } from './Counter';
+import { SearchInput } from './SearchInput';
+import { Dropdown } from './Dropdown';
+
+test('click interactions', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={0} />);
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 2')).toBeVisible();
+
+  await component.getByRole('button', { name: 'Decrement' }).click();
+  await expect(component.getByText('Count: 1')).toBeVisible();
+});
+
+test('typing interactions', async ({ mount }) => {
+  const component = await mount(<SearchInput placeholder="Search..." />);
+
+  const input = component.getByRole('textbox', { name: 'Search' });
+  await input.fill('playwright');
+  await expect(component.getByText('Showing results for: playwright')).toBeVisible();
+
+  // Clear and type again
+  await input.clear();
+  await input.fill('testing');
+  await expect(component.getByText('Showing results for: testing')).toBeVisible();
+});
+
+test('keyboard interactions', async ({ mount }) => {
+  const component = await mount(<SearchInput placeholder="Search..." />);
+
+  const input = component.getByRole('textbox', { name: 'Search' });
+  await input.fill('playwright');
+  await input.press('Enter');
+  await expect(component.getByText('Searched: playwright')).toBeVisible();
+});
+
+test('select from dropdown', async ({ mount }) => {
+  const component = await mount(
+    <Dropdown
+      label="Color"
+      options={['Red', 'Green', 'Blue']}
+    />
+  );
+
+  await component.getByRole('combobox', { name: 'Color' }).click();
+  await component.getByRole('option', { name: 'Green' }).click();
+  await expect(component.getByText('Selected: Green')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Counter } = require('./Counter');
+const { SearchInput } = require('./SearchInput');
+const { Dropdown } = require('./Dropdown');
+
+test('click interactions', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={0} />);
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 2')).toBeVisible();
+
+  await component.getByRole('button', { name: 'Decrement' }).click();
+  await expect(component.getByText('Count: 1')).toBeVisible();
+});
+
+test('typing interactions', async ({ mount }) => {
+  const component = await mount(<SearchInput placeholder="Search..." />);
+
+  const input = component.getByRole('textbox', { name: 'Search' });
+  await input.fill('playwright');
+  await expect(component.getByText('Showing results for: playwright')).toBeVisible();
+
+  await input.clear();
+  await input.fill('testing');
+  await expect(component.getByText('Showing results for: testing')).toBeVisible();
+});
+
+test('keyboard interactions', async ({ mount }) => {
+  const component = await mount(<SearchInput placeholder="Search..." />);
+
+  const input = component.getByRole('textbox', { name: 'Search' });
+  await input.fill('playwright');
+  await input.press('Enter');
+  await expect(component.getByText('Searched: playwright')).toBeVisible();
+});
+
+test('select from dropdown', async ({ mount }) => {
+  const component = await mount(
+    <Dropdown label="Color" options={['Red', 'Green', 'Blue']} />
+  );
+
+  await component.getByRole('combobox', { name: 'Color' }).click();
+  await component.getByRole('option', { name: 'Green' }).click();
+  await expect(component.getByText('Selected: Green')).toBeVisible();
+});
+```
+
+### 4. Testing Props
+
+**Use when**: You need to verify a component renders correctly with different prop combinations — states, variants, edge cases.
+**Avoid when**: The prop differences are purely visual with no DOM change — use visual regression instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Alert } from './Alert';
+import { Badge } from './Badge';
+import { Avatar } from './Avatar';
+
+test('alert renders different severity levels', async ({ mount }) => {
+  const success = await mount(<Alert severity="success" message="Saved!" />);
+  await expect(success.getByRole('alert')).toContainText('Saved!');
+  await expect(success.getByRole('alert')).toHaveAttribute('data-severity', 'success');
+
+  const error = await mount(<Alert severity="error" message="Failed to save" />);
+  await expect(error.getByRole('alert')).toContainText('Failed to save');
+  await expect(error.getByRole('alert')).toHaveAttribute('data-severity', 'error');
+});
+
+test('badge renders count and caps at 99+', async ({ mount }) => {
+  const low = await mount(<Badge count={5} />);
+  await expect(low).toContainText('5');
+
+  const high = await mount(<Badge count={150} />);
+  await expect(high).toContainText('99+');
+
+  const zero = await mount(<Badge count={0} />);
+  await expect(zero).toBeHidden();
+});
+
+test('avatar shows initials when no image provided', async ({ mount }) => {
+  const withImage = await mount(
+    <Avatar src="/photo.jpg" name="Jane Doe" />
+  );
+  await expect(withImage.getByRole('img', { name: 'Jane Doe' })).toBeVisible();
+
+  const withoutImage = await mount(<Avatar name="Jane Doe" />);
+  await expect(withoutImage.getByText('JD')).toBeVisible();
+  await expect(withoutImage.getByRole('img')).toHaveCount(0);
+});
+
+test('disabled button is not interactive', async ({ mount }) => {
+  const component = await mount(
+    <button disabled>Submit</button>
+  );
+  await expect(component.getByRole('button', { name: 'Submit' })).toBeDisabled();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Alert } = require('./Alert');
+const { Badge } = require('./Badge');
+const { Avatar } = require('./Avatar');
+
+test('alert renders different severity levels', async ({ mount }) => {
+  const success = await mount(<Alert severity="success" message="Saved!" />);
+  await expect(success.getByRole('alert')).toContainText('Saved!');
+  await expect(success.getByRole('alert')).toHaveAttribute('data-severity', 'success');
+
+  const error = await mount(<Alert severity="error" message="Failed to save" />);
+  await expect(error.getByRole('alert')).toContainText('Failed to save');
+  await expect(error.getByRole('alert')).toHaveAttribute('data-severity', 'error');
+});
+
+test('badge renders count and caps at 99+', async ({ mount }) => {
+  const low = await mount(<Badge count={5} />);
+  await expect(low).toContainText('5');
+
+  const high = await mount(<Badge count={150} />);
+  await expect(high).toContainText('99+');
+
+  const zero = await mount(<Badge count={0} />);
+  await expect(zero).toBeHidden();
+});
+
+test('avatar shows initials when no image provided', async ({ mount }) => {
+  const withImage = await mount(<Avatar src="/photo.jpg" name="Jane Doe" />);
+  await expect(withImage.getByRole('img', { name: 'Jane Doe' })).toBeVisible();
+
+  const withoutImage = await mount(<Avatar name="Jane Doe" />);
+  await expect(withoutImage.getByText('JD')).toBeVisible();
+  await expect(withoutImage.getByRole('img')).toHaveCount(0);
+});
+
+test('disabled button is not interactive', async ({ mount }) => {
+  const component = await mount(<button disabled>Submit</button>);
+  await expect(component.getByRole('button', { name: 'Submit' })).toBeDisabled();
+});
+```
+
+### 5. Testing Events
+
+**Use when**: A component emits events or calls callback props — form submissions, toggle changes, custom events.
+**Avoid when**: You only care that something renders — use a prop/snapshot test instead.
+
+Capture events by passing callback props to `mount()`. Use closures or arrays to collect values for assertion.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Toggle } from './Toggle';
+import { ContactForm } from './ContactForm';
+import { TagInput } from './TagInput';
+
+test('toggle fires onChange with new value', async ({ mount }) => {
+  const events: boolean[] = [];
+  const component = await mount(
+    <Toggle
+      label="Dark mode"
+      onChange={(checked: boolean) => { events.push(checked); }}
+    />
+  );
+
+  await component.getByRole('switch', { name: 'Dark mode' }).click();
+  expect(events).toEqual([true]);
+
+  await component.getByRole('switch', { name: 'Dark mode' }).click();
+  expect(events).toEqual([true, false]);
+});
+
+test('form calls onSubmit with field values', async ({ mount }) => {
+  let submittedData: Record<string, string> | null = null;
+  const component = await mount(
+    <ContactForm
+      onSubmit={(data: Record<string, string>) => { submittedData = data; }}
+    />
+  );
+
+  await component.getByLabel('Name').fill('Jane Doe');
+  await component.getByLabel('Email').fill('jane@example.com');
+  await component.getByLabel('Message').fill('Hello!');
+  await component.getByRole('button', { name: 'Send' }).click();
+
+  expect(submittedData).toEqual({
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    message: 'Hello!',
+  });
+});
+
+test('tag input fires onTagAdd and onTagRemove', async ({ mount }) => {
+  const added: string[] = [];
+  const removed: string[] = [];
+  const component = await mount(
+    <TagInput
+      onTagAdd={(tag: string) => { added.push(tag); }}
+      onTagRemove={(tag: string) => { removed.push(tag); }}
+    />
+  );
+
+  const input = component.getByRole('textbox');
+  await input.fill('playwright');
+  await input.press('Enter');
+  expect(added).toEqual(['playwright']);
+
+  // Remove the tag
+  await component.getByRole('button', { name: 'Remove playwright' }).click();
+  expect(removed).toEqual(['playwright']);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Toggle } = require('./Toggle');
+const { ContactForm } = require('./ContactForm');
+const { TagInput } = require('./TagInput');
+
+test('toggle fires onChange with new value', async ({ mount }) => {
+  const events = [];
+  const component = await mount(
+    <Toggle
+      label="Dark mode"
+      onChange={(checked) => { events.push(checked); }}
+    />
+  );
+
+  await component.getByRole('switch', { name: 'Dark mode' }).click();
+  expect(events).toEqual([true]);
+
+  await component.getByRole('switch', { name: 'Dark mode' }).click();
+  expect(events).toEqual([true, false]);
+});
+
+test('form calls onSubmit with field values', async ({ mount }) => {
+  let submittedData = null;
+  const component = await mount(
+    <ContactForm
+      onSubmit={(data) => { submittedData = data; }}
+    />
+  );
+
+  await component.getByLabel('Name').fill('Jane Doe');
+  await component.getByLabel('Email').fill('jane@example.com');
+  await component.getByLabel('Message').fill('Hello!');
+  await component.getByRole('button', { name: 'Send' }).click();
+
+  expect(submittedData).toEqual({
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    message: 'Hello!',
+  });
+});
+
+test('tag input fires onTagAdd and onTagRemove', async ({ mount }) => {
+  const added = [];
+  const removed = [];
+  const component = await mount(
+    <TagInput
+      onTagAdd={(tag) => { added.push(tag); }}
+      onTagRemove={(tag) => { removed.push(tag); }}
+    />
+  );
+
+  const input = component.getByRole('textbox');
+  await input.fill('playwright');
+  await input.press('Enter');
+  expect(added).toEqual(['playwright']);
+
+  await component.getByRole('button', { name: 'Remove playwright' }).click();
+  expect(removed).toEqual(['playwright']);
+});
+```
+
+### 6. Testing Slots and Children
+
+**Use when**: Your component accepts children, named slots (Vue), or render props — layout components, wrappers, modals.
+**Avoid when**: The component has no slot/children API.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Modal } from './Modal';
+import { Accordion } from './Accordion';
+import { Layout } from './Layout';
+
+test('modal renders children in the dialog', async ({ mount }) => {
+  const component = await mount(
+    <Modal open={true} title="Confirm">
+      <p>Are you sure you want to delete this item?</p>
+      <button>Delete</button>
+      <button>Cancel</button>
+    </Modal>
+  );
+
+  await expect(component.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
+  await expect(component.getByText('Are you sure you want to delete this item?')).toBeVisible();
+  await expect(component.getByRole('button', { name: 'Delete' })).toBeVisible();
+  await expect(component.getByRole('button', { name: 'Cancel' })).toBeVisible();
+});
+
+test('accordion renders multiple sections', async ({ mount }) => {
+  const component = await mount(
+    <Accordion>
+      <Accordion.Item title="Section 1">Content for section 1</Accordion.Item>
+      <Accordion.Item title="Section 2">Content for section 2</Accordion.Item>
+    </Accordion>
+  );
+
+  // First section collapsed by default
+  await expect(component.getByText('Content for section 1')).toBeHidden();
+
+  // Expand first section
+  await component.getByRole('button', { name: 'Section 1' }).click();
+  await expect(component.getByText('Content for section 1')).toBeVisible();
+
+  // Second section remains collapsed
+  await expect(component.getByText('Content for section 2')).toBeHidden();
+});
+
+test('layout component renders header and body slots', async ({ mount }) => {
+  const component = await mount(
+    <Layout
+      header={<h1>Dashboard</h1>}
+      sidebar={<nav><a href="/settings">Settings</a></nav>}
+    >
+      <p>Main content goes here</p>
+    </Layout>
+  );
+
+  await expect(component.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(component.getByRole('link', { name: 'Settings' })).toBeVisible();
+  await expect(component.getByText('Main content goes here')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Modal } = require('./Modal');
+const { Accordion } = require('./Accordion');
+const { Layout } = require('./Layout');
+
+test('modal renders children in the dialog', async ({ mount }) => {
+  const component = await mount(
+    <Modal open={true} title="Confirm">
+      <p>Are you sure you want to delete this item?</p>
+      <button>Delete</button>
+      <button>Cancel</button>
+    </Modal>
+  );
+
+  await expect(component.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
+  await expect(component.getByText('Are you sure you want to delete this item?')).toBeVisible();
+  await expect(component.getByRole('button', { name: 'Delete' })).toBeVisible();
+  await expect(component.getByRole('button', { name: 'Cancel' })).toBeVisible();
+});
+
+test('accordion renders multiple sections', async ({ mount }) => {
+  const component = await mount(
+    <Accordion>
+      <Accordion.Item title="Section 1">Content for section 1</Accordion.Item>
+      <Accordion.Item title="Section 2">Content for section 2</Accordion.Item>
+    </Accordion>
+  );
+
+  await expect(component.getByText('Content for section 1')).toBeHidden();
+  await component.getByRole('button', { name: 'Section 1' }).click();
+  await expect(component.getByText('Content for section 1')).toBeVisible();
+  await expect(component.getByText('Content for section 2')).toBeHidden();
+});
+
+test('layout component renders header and body slots', async ({ mount }) => {
+  const component = await mount(
+    <Layout
+      header={<h1>Dashboard</h1>}
+      sidebar={<nav><a href="/settings">Settings</a></nav>}
+    >
+      <p>Main content goes here</p>
+    </Layout>
+  );
+
+  await expect(component.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(component.getByRole('link', { name: 'Settings' })).toBeVisible();
+  await expect(component.getByText('Main content goes here')).toBeVisible();
+});
+```
+
+**Vue Slots Example (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-vue';
+import Card from './Card.vue';
+
+test('vue named slots', async ({ mount }) => {
+  const component = await mount(Card, {
+    props: { title: 'My Card' },
+    slots: {
+      default: '<p>Card body content</p>',
+      footer: '<button>Save</button>',
+    },
+  });
+
+  await expect(component.getByText('Card body content')).toBeVisible();
+  await expect(component.getByRole('button', { name: 'Save' })).toBeVisible();
+});
+```
+
+### 7. Providing Context (Wrappers and Providers)
+
+**Use when**: Your components depend on React context, Vue provide/inject, or global state (theme, auth, i18n, store).
+**Avoid when**: The component has no context dependencies — do not wrap unnecessarily.
+
+Use the `playwright/index.ts` file to register global wrappers, or wrap per-test using a wrapper component.
+
+**TypeScript**
+```typescript
+// playwright/index.tsx — global wrapper for ALL component tests
+import '../src/styles/globals.css';
+import { ThemeProvider } from '../src/providers/ThemeProvider';
+import { IntlProvider } from '../src/providers/IntlProvider';
+
+// beforeMount runs before every component is mounted
+// Use it to wrap all components with global providers
+import { beforeMount } from '@playwright/experimental-ct-react/hooks';
+
+beforeMount(async ({ App }) => {
+  return (
+    <IntlProvider locale="en">
+      <ThemeProvider theme="light">
+        <App />
+      </ThemeProvider>
+    </IntlProvider>
+  );
+});
+```
+
+```typescript
+// Per-test provider wrapping — for tests that need specific context
+import { test, expect } from '@playwright/experimental-ct-react';
+import { UserProfile } from './UserProfile';
+import { AuthContext } from '../contexts/AuthContext';
+
+// Create a test wrapper component
+function AuthWrapper({ children, user }: { children: React.ReactNode; user: any }) {
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: true }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+test('profile shows authenticated user info', async ({ mount }) => {
+  const user = { name: 'Jane Doe', email: 'jane@example.com', role: 'admin' };
+
+  const component = await mount(
+    <AuthWrapper user={user}>
+      <UserProfile />
+    </AuthWrapper>
+  );
+
+  await expect(component.getByText('Jane Doe')).toBeVisible();
+  await expect(component.getByText('admin')).toBeVisible();
+});
+```
+
+```typescript
+// Redux/Zustand store wrapping
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { cartReducer } from '../store/cartSlice';
+import { CartSummary } from './CartSummary';
+
+test('cart summary shows item count from store', async ({ mount }) => {
+  const store = configureStore({
+    reducer: { cart: cartReducer },
+    preloadedState: {
+      cart: {
+        items: [
+          { id: '1', name: 'Widget', quantity: 2, price: 9.99 },
+          { id: '2', name: 'Gadget', quantity: 1, price: 24.99 },
+        ],
+      },
+    },
+  });
+
+  const component = await mount(
+    <Provider store={store}>
+      <CartSummary />
+    </Provider>
+  );
+
+  await expect(component.getByText('3 items')).toBeVisible();
+  await expect(component.getByText('$44.97')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// playwright/index.jsx — global wrapper
+import '../src/styles/globals.css';
+import { ThemeProvider } from '../src/providers/ThemeProvider';
+import { IntlProvider } from '../src/providers/IntlProvider';
+import { beforeMount } from '@playwright/experimental-ct-react/hooks';
+
+beforeMount(async ({ App }) => {
+  return (
+    <IntlProvider locale="en">
+      <ThemeProvider theme="light">
+        <App />
+      </ThemeProvider>
+    </IntlProvider>
+  );
+});
+```
+
+```javascript
+// Per-test store wrapping
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Provider } = require('react-redux');
+const { configureStore } = require('@reduxjs/toolkit');
+const { cartReducer } = require('../store/cartSlice');
+const { CartSummary } = require('./CartSummary');
+
+test('cart summary shows item count from store', async ({ mount }) => {
+  const store = configureStore({
+    reducer: { cart: cartReducer },
+    preloadedState: {
+      cart: {
+        items: [
+          { id: '1', name: 'Widget', quantity: 2, price: 9.99 },
+          { id: '2', name: 'Gadget', quantity: 1, price: 24.99 },
+        ],
+      },
+    },
+  });
+
+  const component = await mount(
+    <Provider store={store}>
+      <CartSummary />
+    </Provider>
+  );
+
+  await expect(component.getByText('3 items')).toBeVisible();
+  await expect(component.getByText('$44.97')).toBeVisible();
+});
+```
+
+### 8. Mocking Imports
+
+**Use when**: A component imports modules that should not run in tests — API clients, analytics, heavy third-party libraries.
+**Avoid when**: You can provide the dependency via props or context instead — explicit injection is always better than import mocking.
+
+Use the `beforeMount` hook in `playwright/index.ts` to intercept and replace modules.
+
+**TypeScript**
+```typescript
+// playwright/index.tsx — mock modules globally
+import { beforeMount } from '@playwright/experimental-ct-react/hooks';
+
+beforeMount(async ({ hooksConfig }) => {
+  // hooksConfig is passed from individual tests via mount options
+  if (hooksConfig?.mockApi) {
+    // Mock the API module before the component loads
+    const apiModule = await import('../src/api/client');
+    apiModule.fetchUser = async () => hooksConfig.mockUser;
+    apiModule.fetchProducts = async () => hooksConfig.mockProducts;
+  }
+});
+```
+
+```typescript
+// UserDashboard.ct.tsx
+import { test, expect } from '@playwright/experimental-ct-react';
+import { UserDashboard } from './UserDashboard';
+
+test('dashboard renders with mocked API data', async ({ mount }) => {
+  const component = await mount(<UserDashboard />, {
+    hooksConfig: {
+      mockApi: true,
+      mockUser: { name: 'Jane Doe', email: 'jane@example.com' },
+      mockProducts: [
+        { id: '1', name: 'Widget', price: 9.99 },
+        { id: '2', name: 'Gadget', price: 24.99 },
+      ],
+    },
+  });
+
+  await expect(component.getByText('Jane Doe')).toBeVisible();
+  await expect(component.getByRole('listitem')).toHaveCount(2);
+});
+```
+
+```typescript
+// Alternative: mock at the network level using page.route()
+import { test, expect } from '@playwright/experimental-ct-react';
+import { ProductList } from './ProductList';
+
+test('product list with network-level mocking', async ({ mount, page }) => {
+  // Intercept fetch/XHR calls made by the component
+  await page.route('**/api/products', (route) =>
+    route.fulfill({
+      json: [
+        { id: '1', name: 'Widget', price: 9.99 },
+        { id: '2', name: 'Gadget', price: 24.99 },
+      ],
+    })
+  );
+
+  const component = await mount(<ProductList />);
+  await expect(component.getByRole('listitem')).toHaveCount(2);
+  await expect(component.getByText('Widget')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// playwright/index.jsx — mock modules globally
+const { beforeMount } = require('@playwright/experimental-ct-react/hooks');
+
+beforeMount(async ({ hooksConfig }) => {
+  if (hooksConfig?.mockApi) {
+    const apiModule = await import('../src/api/client');
+    apiModule.fetchUser = async () => hooksConfig.mockUser;
+    apiModule.fetchProducts = async () => hooksConfig.mockProducts;
+  }
+});
+```
+
+```javascript
+// Alternative: network-level mocking
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { ProductList } = require('./ProductList');
+
+test('product list with network-level mocking', async ({ mount, page }) => {
+  await page.route('**/api/products', (route) =>
+    route.fulfill({
+      json: [
+        { id: '1', name: 'Widget', price: 9.99 },
+        { id: '2', name: 'Gadget', price: 24.99 },
+      ],
+    })
+  );
+
+  const component = await mount(<ProductList />);
+  await expect(component.getByRole('listitem')).toHaveCount(2);
+  await expect(component.getByText('Widget')).toBeVisible();
+});
+```
+
+### 9. Visual Component Testing
+
+**Use when**: You need pixel-level verification of component appearance — design system components, theme variants, responsive states.
+**Avoid when**: The component is purely functional with no meaningful visual output.
+
+Component tests support `toHaveScreenshot()` just like E2E tests. This is powerful for testing individual component states without needing a full application.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Button } from './Button';
+import { Card } from './Card';
+
+test('button visual variants', async ({ mount }) => {
+  const primary = await mount(<Button variant="primary">Save</Button>);
+  await expect(primary).toHaveScreenshot('button-primary.png');
+
+  const secondary = await mount(<Button variant="secondary">Cancel</Button>);
+  await expect(secondary).toHaveScreenshot('button-secondary.png');
+
+  const danger = await mount(<Button variant="danger">Delete</Button>);
+  await expect(danger).toHaveScreenshot('button-danger.png');
+});
+
+test('button states', async ({ mount }) => {
+  const component = await mount(<Button variant="primary">Save</Button>);
+
+  // Default state
+  await expect(component).toHaveScreenshot('button-default.png');
+
+  // Hover state
+  await component.hover();
+  await expect(component).toHaveScreenshot('button-hover.png');
+
+  // Focus state
+  await component.focus();
+  await expect(component).toHaveScreenshot('button-focus.png');
+});
+
+test('card renders consistently', async ({ mount }) => {
+  const component = await mount(
+    <Card title="Product" description="A great product for testing.">
+      <Button variant="primary">Buy now</Button>
+    </Card>
+  );
+
+  await expect(component).toHaveScreenshot('card-with-button.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('responsive component at different widths', async ({ mount, page }) => {
+  const component = await mount(<Card title="Responsive" description="Adapts to width" />);
+
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await expect(component).toHaveScreenshot('card-desktop.png');
+
+  await page.setViewportSize({ width: 375, height: 667 });
+  await expect(component).toHaveScreenshot('card-mobile.png');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Button } = require('./Button');
+const { Card } = require('./Card');
+
+test('button visual variants', async ({ mount }) => {
+  const primary = await mount(<Button variant="primary">Save</Button>);
+  await expect(primary).toHaveScreenshot('button-primary.png');
+
+  const secondary = await mount(<Button variant="secondary">Cancel</Button>);
+  await expect(secondary).toHaveScreenshot('button-secondary.png');
+
+  const danger = await mount(<Button variant="danger">Delete</Button>);
+  await expect(danger).toHaveScreenshot('button-danger.png');
+});
+
+test('button states', async ({ mount }) => {
+  const component = await mount(<Button variant="primary">Save</Button>);
+
+  await expect(component).toHaveScreenshot('button-default.png');
+
+  await component.hover();
+  await expect(component).toHaveScreenshot('button-hover.png');
+
+  await component.focus();
+  await expect(component).toHaveScreenshot('button-focus.png');
+});
+
+test('responsive component at different widths', async ({ mount, page }) => {
+  const component = await mount(<Card title="Responsive" description="Adapts to width" />);
+
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await expect(component).toHaveScreenshot('card-desktop.png');
+
+  await page.setViewportSize({ width: 375, height: 667 });
+  await expect(component).toHaveScreenshot('card-mobile.png');
+});
+```
+
+### 10. Component Test vs E2E Test
+
+**Use when**: Deciding whether to write a component test, an E2E test, or both for a piece of UI.
+**Avoid when**: You already have a clear testing strategy for your project.
+
+The core distinction: component tests verify **how a component behaves in isolation**, while E2E tests verify **how the whole system works together**. They complement each other.
+
+**TypeScript — Component test (isolated behavior)**
+```typescript
+// Button.ct.tsx — tests the Button component in isolation
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Button } from './Button';
+
+test('button shows loading spinner when loading prop is true', async ({ mount }) => {
+  const component = await mount(<Button loading={true}>Save</Button>);
+
+  await expect(component.getByRole('button', { name: 'Save' })).toBeDisabled();
+  await expect(component.getByRole('progressbar')).toBeVisible();
+  await expect(component.getByText('Save')).toBeVisible();
+});
+
+test('button calls onClick when clicked', async ({ mount }) => {
+  let clicked = false;
+  const component = await mount(
+    <Button onClick={() => { clicked = true; }}>Save</Button>
+  );
+
+  await component.click();
+  expect(clicked).toBe(true);
+});
+```
+
+```typescript
+// checkout.spec.ts — E2E test verifying the full flow
+import { test, expect } from '@playwright/test';
+
+test('complete checkout flow', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+  await page.getByRole('link', { name: 'Cart' }).click();
+  await page.getByRole('button', { name: 'Checkout' }).click();
+
+  // Fill shipping form
+  await page.getByLabel('Address').fill('123 Main St');
+  await page.getByLabel('City').fill('Springfield');
+  await page.getByRole('button', { name: 'Continue to payment' }).click();
+
+  // The Save button's loading state is tested in the component test.
+  // Here we test the real user flow end-to-end.
+  await page.getByRole('button', { name: 'Place order' }).click();
+  await expect(page.getByRole('heading', { name: 'Order confirmed' })).toBeVisible();
+});
+```
+
+**JavaScript — Component test (isolated behavior)**
+```javascript
+// Button.ct.jsx
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { Button } = require('./Button');
+
+test('button shows loading spinner when loading prop is true', async ({ mount }) => {
+  const component = await mount(<Button loading={true}>Save</Button>);
+
+  await expect(component.getByRole('button', { name: 'Save' })).toBeDisabled();
+  await expect(component.getByRole('progressbar')).toBeVisible();
+});
+
+test('button calls onClick when clicked', async ({ mount }) => {
+  let clicked = false;
+  const component = await mount(
+    <Button onClick={() => { clicked = true; }}>Save</Button>
+  );
+
+  await component.click();
+  expect(clicked).toBe(true);
+});
+```
+
+```javascript
+// checkout.spec.js — E2E test
+const { test, expect } = require('@playwright/test');
+
+test('complete checkout flow', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+  await page.getByRole('link', { name: 'Cart' }).click();
+  await page.getByRole('button', { name: 'Checkout' }).click();
+
+  await page.getByLabel('Address').fill('123 Main St');
+  await page.getByLabel('City').fill('Springfield');
+  await page.getByRole('button', { name: 'Continue to payment' }).click();
+
+  await page.getByRole('button', { name: 'Place order' }).click();
+  await expect(page.getByRole('heading', { name: 'Order confirmed' })).toBeVisible();
+});
+```
+
+## Decision Guide
+
+| UI Element | Component Test | E2E Test | Unit Test |
+|---|---|---|---|
+| **Button** (variants, states, loading) | Yes — test all visual variants, disabled state, loading state, click handlers | Only as part of a larger flow | No — needs real DOM for styling and accessibility |
+| **Form field** (validation, masking) | Yes — test validation messages, input masking, error states in isolation | Yes — test the full form submission flow with backend | Validate-only logic (regex, format functions) |
+| **Modal/Dialog** (open, close, content) | Yes — test open/close behavior, focus trap, content rendering | Yes — test the trigger flow that opens the modal | No — needs real DOM |
+| **Data table** (sorting, filtering, pagination) | Yes — test sort, filter, pagination with mock data | Yes — test with real API data and URL sync | Pure sort/filter logic on arrays |
+| **Navigation/Menu** | Partially — test dropdown behavior, active states | Yes — test actual route changes and page loads | No |
+| **Full page** (dashboard, settings) | No — too much context required; defeats isolation purpose | Yes — this is what E2E tests are for | No |
+| **Layout** (sidebar, header, grid) | Yes — test responsive behavior, slot rendering | Only if layout affects user flows (e.g., mobile nav) | No |
+| **Chart/Graph** | Yes — visual regression of rendered output | Only if charts are part of a critical flow | Data transformation logic only |
+| **Toast/Notification** | Yes — test appearance, auto-dismiss, action buttons | Yes — test that real actions trigger correct toasts | No |
+| **Design system primitives** | Yes — this is the primary use case for component testing | No — not needed for primitives | No |
+
+**Rule of thumb**: Component tests for **behavior and appearance in isolation**. E2E tests for **user journeys across multiple components and pages**. Unit tests for **pure logic with no DOM**.
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Check internal state (`component.state.count`) | Couples test to implementation; breaks on any refactor | Assert on visible output: `expect(component.getByText('Count: 5')).toBeVisible()` |
+| Mount an entire page in a component test | Requires too many providers, mock data, and context; slow; defeats isolation purpose | Use E2E tests for full pages; component test only the individual widgets |
+| Skip required providers/context | Component crashes with "Cannot read property of undefined" or "useContext must be inside Provider" | Wrap with required providers in `playwright/index.tsx` or per-test wrapper |
+| Test framework internals (React lifecycle, Vue watchers) | You are testing the framework, not your code; these are already tested by React/Vue | Test user-visible behavior: what renders, what happens on click |
+| Mount and immediately screenshot without waiting | Screenshot captures loading/transition state | `await expect(component.getByText('...')).toBeVisible()` before screenshot |
+| Duplicate E2E coverage in component tests | Same behavior tested twice adds maintenance cost with no new confidence | Component tests: isolated behavior. E2E tests: integrated flows. Overlap only at critical boundaries |
+| Test CSS class names or inline styles | Implementation detail; breaks on any styling refactor | Use `toHaveScreenshot()` for visual verification or `toBeVisible()`/`toBeHidden()` for behavior |
+| Create one giant test file per component | Hard to debug, slow feedback loop, poor test isolation | One test file per component, grouped by behavior with `test.describe()` |
+| Pass mock data that does not match real API shape | Tests pass but component breaks with real data | Define shared TypeScript types or use a factory function for consistent test data |
+| Use `page.goto()` in component tests | Component tests do not navigate — `mount()` renders directly | Use `mount(<Component />)` only; use `page.goto()` in E2E tests |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Cannot find module '@playwright/experimental-ct-react'` | Package not installed | `npm install -D @playwright/experimental-ct-react` (or `-vue`, `-svelte`) |
+| Component renders blank | Missing CSS imports or provider wrappers | Add global styles to `playwright/index.ts` and wrap with required providers |
+| `Error: No tests found` | Test file does not match `testMatch` pattern in `playwright-ct.config.ts` | Ensure files use the configured suffix (e.g., `*.ct.tsx`) and `testDir` is correct |
+| `Cannot use JSX` in test file | TypeScript/Vite not configured for JSX | Ensure test files use `.ct.tsx`/`.ct.jsx` extension and `tsconfig.json` has `"jsx": "react-jsx"` |
+| `useContext returns undefined` | Component depends on a context provider that was not wrapped | Add the provider in `playwright/index.tsx` via `beforeMount` hook or wrap per-test |
+| `hooksConfig` values are undefined | The `playwright/index.ts` hooks file is not set up or not reading `hooksConfig` | Ensure `beforeMount` destructures `{ hooksConfig }` and the file is at `playwright/index.ts` |
+| Screenshots differ between CI and local | Different OS renders fonts differently | Run screenshot tests in Docker or use `maxDiffPixelRatio` tolerance; generate baselines in CI |
+| Component test is slow (>5s per test) | Mounting a large component tree with many providers or importing heavy modules | Reduce provider scope; mock heavy imports; use `page.route()` instead of real API calls |
+| `mount()` returns but component is not visible | Component renders off-screen or with `display: none` by default | Check CSS and props; use `await expect(component).toBeVisible()` to debug |
+| `Error: page.route is not available` | Using `page` fixture without requesting it | Destructure `{ mount, page }` in the test function signature |
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) — fixtures work inside component tests the same way
+- [core/visual-regression.md](visual-regression.md) — screenshot comparison patterns applicable to component tests
+- [core/network-mocking.md](network-mocking.md) — `page.route()` works inside component tests for mocking API calls
+- [core/test-architecture.md](test-architecture.md) — when to use component vs E2E vs API tests
+- [core/react.md](react.md) — React-specific component testing setup
+- [core/vue.md](vue.md) — Vue-specific component testing with slots and provide/inject

--- a/engineering-team/playwright skill/core/configuration.md
+++ b/engineering-team/playwright skill/core/configuration.md
@@ -1,0 +1,729 @@
+# Configuration
+
+> **When to use**: Setting up a new Playwright project, adjusting timeouts, adding browser targets, configuring CI behavior, or connecting environment-specific settings.
+
+## Quick Reference
+
+```
+npx playwright init                    # scaffold config + first test
+npx playwright test --config=custom.config.ts  # use non-default config
+npx playwright test --project=chromium # run single project
+npx playwright test --reporter=html    # override reporter
+npx playwright show-report             # open last HTML report
+DEBUG=pw:api npx playwright test       # verbose Playwright logging
+```
+
+## Production-Ready Config (Copy-Paste Starter)
+
+### TypeScript
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables from .env file
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+export default defineConfig({
+  // ── Test discovery ──────────────────────────────────────────────
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+
+  // ── Execution ───────────────────────────────────────────────────
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,       // fail CI if test.only left in
+  retries: process.env.CI ? 2 : 0,    // retry flakes in CI only
+  workers: process.env.CI ? '50%' : undefined, // half CPU in CI, auto locally
+
+  // ── Reporting ───────────────────────────────────────────────────
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'on-failure' }]],
+
+  // ── Timeouts ────────────────────────────────────────────────────
+  timeout: 30_000,                     // per-test timeout
+  expect: {
+    timeout: 5_000,                    // per-assertion retry timeout
+  },
+
+  // ── Shared browser context options ──────────────────────────────
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    actionTimeout: 10_000,             // click, fill, etc.
+    navigationTimeout: 15_000,         // goto, waitForURL, etc.
+
+    // Artifact collection
+    trace: 'on-first-retry',          // full trace on first retry only
+    screenshot: 'only-on-failure',     // screenshot on failure
+    video: 'retain-on-failure',        // video only kept for failures
+
+    // Sensible defaults
+    locale: 'en-US',
+    timezoneId: 'America/New_York',
+    extraHTTPHeaders: {
+      'x-test-automation': 'playwright',
+    },
+  },
+
+  // ── Projects (browser targets) ─────────────────────────────────
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  // ── Dev server ──────────────────────────────────────────────────
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,                  // 2 min for cold builds
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});
+```
+
+### JavaScript
+
+```js
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+const dotenv = require('dotenv');
+const path = require('path');
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'on-failure' }]],
+
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+
+    locale: 'en-US',
+    timezoneId: 'America/New_York',
+    extraHTTPHeaders: {
+      'x-test-automation': 'playwright',
+    },
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});
+```
+
+## Patterns
+
+### Pattern 1: Environment-Specific Configuration
+
+**Use when**: Tests run against dev, staging, and production environments.
+**Avoid when**: Single-environment local-only projects.
+
+#### TypeScript
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment-specific .env file: .env.staging, .env.production, etc.
+const ENV = process.env.TEST_ENV || 'local';
+dotenv.config({ path: path.resolve(__dirname, `.env.${ENV}`) });
+
+const envConfig: Record<string, { baseURL: string; retries: number }> = {
+  local:      { baseURL: 'http://localhost:3000',       retries: 0 },
+  staging:    { baseURL: 'https://staging.example.com', retries: 2 },
+  production: { baseURL: 'https://www.example.com',     retries: 2 },
+};
+
+const env = envConfig[ENV];
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  retries: env.retries,
+  use: {
+    baseURL: env.baseURL,
+  },
+});
+```
+
+```bash
+# Run against staging
+TEST_ENV=staging npx playwright test
+
+# Run against production (subset of smoke tests)
+TEST_ENV=production npx playwright test --grep @smoke
+```
+
+#### JavaScript
+
+```js
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+const dotenv = require('dotenv');
+const path = require('path');
+
+const ENV = process.env.TEST_ENV || 'local';
+dotenv.config({ path: path.resolve(__dirname, `.env.${ENV}`) });
+
+const envConfig = {
+  local:      { baseURL: 'http://localhost:3000',       retries: 0 },
+  staging:    { baseURL: 'https://staging.example.com', retries: 2 },
+  production: { baseURL: 'https://www.example.com',     retries: 2 },
+};
+
+const env = envConfig[ENV];
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+  retries: env.retries,
+  use: {
+    baseURL: env.baseURL,
+  },
+});
+```
+
+### Pattern 2: Multi-Project with Setup Dependencies
+
+**Use when**: Tests need shared authentication state or database seeding before running.
+**Avoid when**: Tests are fully independent with no shared setup phase.
+
+#### TypeScript
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+
+  projects: [
+    // Setup project runs first, saves auth state
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+    },
+
+    // Browser projects depend on setup
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+
+```ts
+// tests/global.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await page.context().storageState({ path: authFile });
+});
+```
+
+#### JavaScript
+
+```js
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.js/,
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+
+```js
+// tests/global.setup.js
+const { test: setup, expect } = require('@playwright/test');
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await page.context().storageState({ path: authFile });
+});
+```
+
+### Pattern 3: `webServer` with Build Step
+
+**Use when**: Tests need a running application server. Let Playwright manage the server lifecycle.
+**Avoid when**: Testing against an already-deployed environment (staging/prod).
+
+#### TypeScript
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npm run start'  // production build in CI
+      : 'npm run dev',                    // dev server locally
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      NODE_ENV: 'test',
+      DATABASE_URL: process.env.DATABASE_URL || 'postgresql://localhost:5432/test',
+    },
+  },
+});
+```
+
+#### JavaScript
+
+```js
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npm run start'
+      : 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      NODE_ENV: 'test',
+      DATABASE_URL: process.env.DATABASE_URL || 'postgresql://localhost:5432/test',
+    },
+  },
+});
+```
+
+### Pattern 4: `globalSetup` / `globalTeardown`
+
+**Use when**: One-time non-browser work: seeding a database, starting a service, setting env vars. Runs once per `npx playwright test` invocation.
+**Avoid when**: You need browser context (use a setup project instead) or per-test isolation (use fixtures).
+
+#### TypeScript
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  globalSetup: './tests/global-setup.ts',
+  globalTeardown: './tests/global-teardown.ts',
+});
+```
+
+```ts
+// tests/global-setup.ts
+import { FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  // Seed test database
+  const { execSync } = await import('child_process');
+  execSync('npx prisma db seed', { stdio: 'inherit' });
+
+  // Store data for tests to use via environment variables
+  process.env.TEST_RUN_ID = `run-${Date.now()}`;
+}
+
+export default globalSetup;
+```
+
+```ts
+// tests/global-teardown.ts
+import { FullConfig } from '@playwright/test';
+
+async function globalTeardown(config: FullConfig) {
+  const { execSync } = await import('child_process');
+  execSync('npx prisma db push --force-reset', { stdio: 'inherit' });
+}
+
+export default globalTeardown;
+```
+
+#### JavaScript
+
+```js
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+  globalSetup: './tests/global-setup.js',
+  globalTeardown: './tests/global-teardown.js',
+});
+```
+
+```js
+// tests/global-setup.js
+const { execSync } = require('child_process');
+
+async function globalSetup(config) {
+  execSync('npx prisma db seed', { stdio: 'inherit' });
+  process.env.TEST_RUN_ID = `run-${Date.now()}`;
+}
+
+module.exports = globalSetup;
+```
+
+```js
+// tests/global-teardown.js
+const { execSync } = require('child_process');
+
+async function globalTeardown(config) {
+  execSync('npx prisma db push --force-reset', { stdio: 'inherit' });
+}
+
+module.exports = globalTeardown;
+```
+
+### Pattern 5: `.env` File Setup
+
+**Use when**: Managing secrets, URLs, or feature flags without hardcoding.
+**Avoid when**: Never commit `.env` files with real secrets. Provide `.env.example` instead.
+
+```bash
+# .env.example (commit this)
+BASE_URL=http://localhost:3000
+TEST_PASSWORD=
+API_KEY=
+
+# .env.local (gitignored)
+BASE_URL=http://localhost:3000
+TEST_PASSWORD=s3cret
+API_KEY=test-key-abc123
+
+# .env.staging (gitignored)
+BASE_URL=https://staging.example.com
+TEST_PASSWORD=staging-password
+API_KEY=staging-key-xyz789
+```
+
+```bash
+# .gitignore
+.env
+.env.local
+.env.staging
+.env.production
+playwright/.auth/
+```
+
+Install dotenv:
+
+```bash
+npm install -D dotenv
+```
+
+### Pattern 6: Trace, Screenshot, and Video Settings
+
+**Use when**: Deciding artifact collection strategy for local development vs CI.
+
+| Setting | Local | CI | Why |
+|---|---|---|---|
+| `trace` | `'off'` or `'on-first-retry'` | `'on-first-retry'` | Traces are large; only collect on failure |
+| `screenshot` | `'off'` | `'only-on-failure'` | Useful for CI debugging only |
+| `video` | `'off'` | `'retain-on-failure'` | Video is slow to record; keep only failures |
+
+#### TypeScript
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  use: {
+    // CI: capture everything on failure; Local: minimal overhead
+    trace: process.env.CI ? 'on-first-retry' : 'off',
+    screenshot: process.env.CI ? 'only-on-failure' : 'off',
+    video: process.env.CI ? 'retain-on-failure' : 'off',
+  },
+});
+```
+
+#### JavaScript
+
+```js
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+  use: {
+    trace: process.env.CI ? 'on-first-retry' : 'off',
+    screenshot: process.env.CI ? 'only-on-failure' : 'off',
+    video: process.env.CI ? 'retain-on-failure' : 'off',
+  },
+});
+```
+
+## Decision Guide
+
+### Which Timeout to Adjust
+
+| Symptom | Timeout to Change | Default | Recommended Range |
+|---|---|---|---|
+| Test takes too long overall | `timeout` | 30s | 30-60s (never above 120s) |
+| Assertion `expect()` keeps retrying too long or not long enough | `expect.timeout` | 5s | 5-10s |
+| `page.goto()` or `waitForURL()` times out | `navigationTimeout` | 30s | 10-30s |
+| `click()`, `fill()`, `check()` time out | `actionTimeout` | 0 (no limit) | 10-15s |
+| Dev server slow to start | `webServer.timeout` | 60s | 60-180s |
+
+### Server Management
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Local dev + CI, app in same repo | `webServer` with `reuseExistingServer: !process.env.CI` | Playwright manages server; reuses yours locally |
+| Separate frontend/backend repos | Manual start or Docker Compose | `webServer` can only run one command |
+| Testing deployed staging/production | No `webServer`; set `baseURL` via env var | Server already running remotely |
+| Multiple services needed (API + frontend) | Array of `webServer` entries | Each gets its own command and URL health check |
+
+### Single vs Multi-Project Config
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Starting out, early development | Single project (chromium only) | Faster feedback, simpler config |
+| Pre-release cross-browser validation | Multi-project: chromium + firefox + webkit | Catch rendering/API differences |
+| Mobile-responsive app | Add mobile projects alongside desktop | Viewport + touch differences matter |
+| Authenticated + unauthenticated tests | Setup project + dependent projects | Share auth state without re-login per test |
+| CI pipeline with tight time budget | Chromium in PR checks; all browsers on merge to main | Balance speed vs coverage |
+
+### globalSetup vs Setup Projects vs Fixtures
+
+| Need | Use | Why |
+|---|---|---|
+| One-time DB seed or external service prep | `globalSetup` | Runs once, no browser needed |
+| Shared browser auth (login once, reuse cookies) | Setup project with `dependencies` | Needs browser context; `globalSetup` has none |
+| Per-test isolated state (unique user, fresh data) | Custom fixture via `test.extend()` | Each test gets its own instance with teardown |
+| Cleanup after all tests | `globalTeardown` | Runs once at the end regardless of pass/fail |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `timeout: 300_000` globally | Masks flaky tests; CI runs take forever | Fix the root cause; keep timeout at 30s; raise `navigationTimeout` only if warranted |
+| Hardcoded URLs in tests: `page.goto('http://localhost:3000/login')` | Breaks in every non-local environment | Use `baseURL` in config, then `page.goto('/login')` |
+| Running chromium + firefox + webkit on every PR | 3x CI time for marginal benefit on most PRs | Chromium on PRs; all browsers on main branch merges |
+| `trace: 'on'` always in CI | Huge artifacts, slow uploads, disk full | `trace: 'on-first-retry'` -- only captures when a test fails and retries |
+| `video: 'on'` always in CI | Massive CI storage; recording slows tests | `video: 'retain-on-failure'` -- records all but only keeps failures |
+| Config values inline in test files: `test.use({ viewport: { width: 1280, height: 720 } })` in every file | Scattered, hard to maintain, inconsistent | Define once in project config; override per-file only when genuinely needed |
+| `retries: 3` locally | Hides flakiness during development | `retries: 0` locally, `retries: 2` in CI |
+| No `forbidOnly` in CI | Accidentally committed `test.only` runs a single test, everything else silently skipped | `forbidOnly: !!process.env.CI` |
+| `globalSetup` for browser auth | No browser context available; complex workarounds needed | Use a setup project with `dependencies` |
+| Committing `.env` files with real credentials | Security risk | Commit `.env.example` only; gitignore real `.env` files |
+
+## Troubleshooting
+
+### "baseURL" not working -- tests navigate to full URL
+
+**Cause**: Using `page.goto('http://localhost:3000/path')` instead of `page.goto('/path')`. When `goto` receives an absolute URL, it ignores `baseURL`.
+
+**Fix**: Always pass relative paths to `page.goto()`:
+
+```ts
+// Wrong -- ignores baseURL
+await page.goto('http://localhost:3000/dashboard');
+
+// Correct -- uses baseURL from config
+await page.goto('/dashboard');
+```
+
+### webServer starts but tests still fail with connection refused
+
+**Cause**: The `url` in `webServer` does not match what the server actually serves, or the health check endpoint returns non-200.
+
+**Fix**: Ensure `webServer.url` matches the actual server address. Add a health check route if needed:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000/api/health',  // use a real endpoint
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+### Tests pass locally but timeout in CI
+
+**Cause**: CI machines are slower. Default timeouts too tight for CI hardware.
+
+**Fix**: Increase `navigationTimeout` for CI, reduce `workers` to avoid resource contention:
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  workers: process.env.CI ? '50%' : undefined,
+  use: {
+    navigationTimeout: process.env.CI ? 30_000 : 15_000,
+    actionTimeout: process.env.CI ? 15_000 : 10_000,
+  },
+});
+```
+
+### "Error: page.goto: Target page, context or browser has been closed"
+
+**Cause**: Test exceeded its `timeout` and Playwright tore down the browser while an action was still running.
+
+**Fix**: Do not increase the global timeout. Instead, find the slow step using `--trace on` and fix it. Common causes: waiting for a slow API, unresolved network request, or missing `await`.
+
+```bash
+# Record a trace for debugging
+npx playwright test --trace on
+npx playwright show-report
+```
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- custom fixtures that replace `globalSetup` for per-test state
+- [core/test-organization.md](test-organization.md) -- file structure, naming conventions, test grouping
+- [core/authentication.md](authentication.md) -- setup projects for shared auth state
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI-specific config and caching
+- [ci/projects-and-dependencies.md](../ci/projects-and-dependencies.md) -- advanced multi-project patterns

--- a/engineering-team/playwright skill/core/crud-testing.md
+++ b/engineering-team/playwright skill/core/crud-testing.md
@@ -1,0 +1,945 @@
+# CRUD Testing Recipes
+
+> **When to use**: You need to test create, read, update, or delete operations on any resource -- forms, tables, lists, cards, inline edits, or bulk actions.
+
+---
+
+## Recipe 1: Creating a Resource (Fill Form, Submit, Verify)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('creates a new product via form', async ({ page }) => {
+  await page.goto('/products');
+
+  // Click the create button
+  await page.getByRole('button', { name: 'Add product' }).click();
+
+  // Fill out the creation form
+  await page.getByLabel('Product name').fill('Wireless Keyboard');
+  await page.getByLabel('SKU').fill('KB-WIRELESS-001');
+  await page.getByLabel('Price').fill('79.99');
+  await page.getByLabel('Description').fill('Ergonomic wireless keyboard with backlit keys');
+  await page.getByLabel('Category').selectOption('Electronics');
+  await page.getByLabel('In stock').check();
+
+  // Submit
+  await page.getByRole('button', { name: 'Save product' }).click();
+
+  // Verify success notification
+  await expect(page.getByRole('alert')).toContainText('Product created successfully');
+
+  // Verify the new item appears in the list
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toContainText('$79.99');
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toContainText('KB-WIRELESS-001');
+});
+
+test('shows validation errors for invalid form data', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add product' }).click();
+
+  // Submit empty form
+  await page.getByRole('button', { name: 'Save product' }).click();
+
+  // Verify field-level validation messages
+  await expect(page.getByText('Product name is required')).toBeVisible();
+  await expect(page.getByText('Price is required')).toBeVisible();
+
+  // Fill in invalid data
+  await page.getByLabel('Product name').fill('A'); // too short
+  await page.getByLabel('Price').fill('-5');
+
+  await page.getByRole('button', { name: 'Save product' }).click();
+
+  await expect(page.getByText('Name must be at least 3 characters')).toBeVisible();
+  await expect(page.getByText('Price must be a positive number')).toBeVisible();
+});
+
+test('prevents duplicate resource creation', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add product' }).click();
+
+  // Try to create a product with a SKU that already exists
+  await page.getByLabel('Product name').fill('Duplicate Product');
+  await page.getByLabel('SKU').fill('EXISTING-SKU-001');
+  await page.getByLabel('Price').fill('29.99');
+  await page.getByRole('button', { name: 'Save product' }).click();
+
+  await expect(page.getByRole('alert')).toContainText(/already exists|duplicate/i);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('creates a new product via form', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByRole('button', { name: 'Add product' }).click();
+
+  await page.getByLabel('Product name').fill('Wireless Keyboard');
+  await page.getByLabel('SKU').fill('KB-WIRELESS-001');
+  await page.getByLabel('Price').fill('79.99');
+  await page.getByLabel('Description').fill('Ergonomic wireless keyboard with backlit keys');
+  await page.getByLabel('Category').selectOption('Electronics');
+  await page.getByLabel('In stock').check();
+
+  await page.getByRole('button', { name: 'Save product' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Product created successfully');
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toContainText('$79.99');
+});
+```
+
+---
+
+## Recipe 2: Reading / Listing Resources (Table, Cards, Pagination)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('reading resources in a table', () => {
+  test('displays resources in a table with correct columns', async ({ page }) => {
+    await page.goto('/products');
+
+    // Verify table headers
+    const headers = page.getByRole('columnheader');
+    await expect(headers).toContainText(['Name', 'SKU', 'Price', 'Category', 'Status']);
+
+    // Verify at least one row of data exists
+    const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+    await expect(rows.first()).toBeVisible();
+
+    // Verify specific data in a row
+    const firstRow = rows.first();
+    await expect(firstRow.getByRole('cell').nth(0)).not.toBeEmpty();
+    await expect(firstRow.getByRole('cell').nth(2)).toContainText('$');
+  });
+
+  test('sorts table by column', async ({ page }) => {
+    await page.goto('/products');
+
+    // Click the Price header to sort
+    await page.getByRole('columnheader', { name: 'Price' }).click();
+
+    // Get all prices from the table
+    const priceCells = page.getByRole('row')
+      .filter({ hasNot: page.getByRole('columnheader') })
+      .getByRole('cell')
+      .nth(2);
+
+    const prices = await priceCells.allTextContents();
+    const numericPrices = prices.map((p) => parseFloat(p.replace(/[$,]/g, '')));
+
+    // Verify sorted ascending
+    for (let i = 1; i < numericPrices.length; i++) {
+      expect(numericPrices[i]).toBeGreaterThanOrEqual(numericPrices[i - 1]);
+    }
+
+    // Click again for descending
+    await page.getByRole('columnheader', { name: 'Price' }).click();
+
+    const pricesDesc = await priceCells.allTextContents();
+    const numericDesc = pricesDesc.map((p) => parseFloat(p.replace(/[$,]/g, '')));
+
+    for (let i = 1; i < numericDesc.length; i++) {
+      expect(numericDesc[i]).toBeLessThanOrEqual(numericDesc[i - 1]);
+    }
+  });
+
+  test('paginates through results', async ({ page }) => {
+    await page.goto('/products');
+
+    // Verify pagination controls are visible
+    const pagination = page.getByRole('navigation', { name: /pagination/i });
+    await expect(pagination).toBeVisible();
+
+    // Get first page content
+    const firstPageFirstRow = await page
+      .getByRole('row')
+      .filter({ hasNot: page.getByRole('columnheader') })
+      .first()
+      .textContent();
+
+    // Go to page 2
+    await pagination.getByRole('button', { name: '2' }).click();
+
+    // Wait for data to load
+    await expect(page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') }).first())
+      .not.toHaveText(firstPageFirstRow!);
+
+    // Verify page 2 is active
+    await expect(pagination.getByRole('button', { name: '2' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+
+    // Verify URL updated with page parameter
+    await expect(page).toHaveURL(/[?&]page=2/);
+  });
+
+  test('shows correct item count', async ({ page }) => {
+    await page.goto('/products');
+
+    // Verify the total count display
+    await expect(page.getByText(/showing \d+.+of \d+/i)).toBeVisible();
+  });
+});
+
+test.describe('reading resources as cards', () => {
+  test('displays resources in a card grid', async ({ page }) => {
+    await page.goto('/products?view=grid');
+
+    // Verify cards are displayed
+    const cards = page.getByRole('article');
+    await expect(cards.first()).toBeVisible();
+
+    // Verify card content
+    const firstCard = cards.first();
+    await expect(firstCard.getByRole('heading')).toBeVisible();
+    await expect(firstCard.getByText('$')).toBeVisible();
+    await expect(firstCard.getByRole('img')).toBeVisible();
+  });
+
+  test('switches between list and grid view', async ({ page }) => {
+    await page.goto('/products');
+
+    // Start in table/list view
+    await expect(page.getByRole('table')).toBeVisible();
+
+    // Switch to grid
+    await page.getByRole('button', { name: /grid view/i }).click();
+    await expect(page.getByRole('article').first()).toBeVisible();
+    await expect(page.getByRole('table')).not.toBeVisible();
+
+    // Switch back to list
+    await page.getByRole('button', { name: /list view/i }).click();
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('displays resources in a table with correct columns', async ({ page }) => {
+  await page.goto('/products');
+
+  const headers = page.getByRole('columnheader');
+  await expect(headers).toContainText(['Name', 'SKU', 'Price', 'Category', 'Status']);
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+
+test('paginates through results', async ({ page }) => {
+  await page.goto('/products');
+
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+  await expect(pagination).toBeVisible();
+
+  const firstPageFirstRow = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .first()
+    .textContent();
+
+  await pagination.getByRole('button', { name: '2' }).click();
+
+  await expect(page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') }).first())
+    .not.toHaveText(firstPageFirstRow);
+
+  await expect(page).toHaveURL(/[?&]page=2/);
+});
+```
+
+---
+
+## Recipe 3: Updating a Resource (Edit Form, Save, Verify Changes)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('updates an existing product', async ({ page }) => {
+  await page.goto('/products');
+
+  // Find the target row and click edit
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await row.getByRole('button', { name: 'Edit' }).click();
+
+  // Verify the edit form is pre-filled with existing data
+  await expect(page.getByLabel('Product name')).toHaveValue('Wireless Keyboard');
+  await expect(page.getByLabel('Price')).toHaveValue('79.99');
+
+  // Update the fields
+  await page.getByLabel('Product name').clear();
+  await page.getByLabel('Product name').fill('Wireless Keyboard Pro');
+  await page.getByLabel('Price').clear();
+  await page.getByLabel('Price').fill('99.99');
+
+  // Save changes
+  await page.getByRole('button', { name: 'Save changes' }).click();
+
+  // Verify success notification
+  await expect(page.getByRole('alert')).toContainText('Product updated successfully');
+
+  // Verify the list reflects the changes
+  await expect(page.getByRole('row', { name: /Wireless Keyboard Pro/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Wireless Keyboard Pro/ })).toContainText('$99.99');
+
+  // Verify old name is gone
+  await expect(page.getByRole('row', { name: /^Wireless Keyboard$/ })).not.toBeVisible();
+});
+
+test('edit form preserves data when navigating away and back', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await row.getByRole('button', { name: 'Edit' }).click();
+
+  // Make changes but do not save
+  await page.getByLabel('Product name').clear();
+  await page.getByLabel('Product name').fill('Modified Name');
+
+  // Try navigating away
+  await page.getByRole('link', { name: 'Dashboard' }).click();
+
+  // Expect unsaved changes warning
+  page.on('dialog', async (dialog) => {
+    expect(dialog.message()).toContain('unsaved changes');
+    await dialog.dismiss(); // Stay on page
+  });
+
+  // Verify data is still there after dismissing navigation
+  await expect(page.getByLabel('Product name')).toHaveValue('Modified Name');
+});
+
+test('cancelling edit discards changes', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await row.getByRole('button', { name: 'Edit' }).click();
+
+  // Make changes
+  await page.getByLabel('Product name').clear();
+  await page.getByLabel('Product name').fill('Should Not Save');
+
+  // Cancel
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  // Verify original data is preserved
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Should Not Save/ })).not.toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('updates an existing product', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await row.getByRole('button', { name: 'Edit' }).click();
+
+  await expect(page.getByLabel('Product name')).toHaveValue('Wireless Keyboard');
+  await expect(page.getByLabel('Price')).toHaveValue('79.99');
+
+  await page.getByLabel('Product name').clear();
+  await page.getByLabel('Product name').fill('Wireless Keyboard Pro');
+  await page.getByLabel('Price').clear();
+  await page.getByLabel('Price').fill('99.99');
+
+  await page.getByRole('button', { name: 'Save changes' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Product updated successfully');
+  await expect(page.getByRole('row', { name: /Wireless Keyboard Pro/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Wireless Keyboard Pro/ })).toContainText('$99.99');
+});
+
+test('cancelling edit discards changes', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await row.getByRole('button', { name: 'Edit' }).click();
+
+  await page.getByLabel('Product name').clear();
+  await page.getByLabel('Product name').fill('Should Not Save');
+
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Should Not Save/ })).not.toBeVisible();
+});
+```
+
+---
+
+## Recipe 4: Deleting a Resource (Delete, Confirm Dialog, Verify Removal)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('deletes a product with confirmation dialog', async ({ page }) => {
+  await page.goto('/products');
+
+  // Count items before deletion
+  const rowsBefore = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const countBefore = await rowsBefore.count();
+
+  // Click delete on a specific product
+  const targetRow = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await expect(targetRow).toBeVisible();
+  await targetRow.getByRole('button', { name: 'Delete' }).click();
+
+  // Confirmation dialog should appear
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Are you sure you want to delete');
+  await expect(dialog).toContainText('Wireless Keyboard');
+  await expect(dialog.getByText(/cannot be undone/i)).toBeVisible();
+
+  // Confirm the deletion
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  // Verify the dialog closes
+  await expect(dialog).not.toBeVisible();
+
+  // Verify success notification
+  await expect(page.getByRole('alert')).toContainText('Product deleted');
+
+  // Verify the item is removed from the list
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).not.toBeVisible();
+
+  // Verify count decreased
+  const rowsAfter = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rowsAfter).toHaveCount(countBefore - 1);
+});
+
+test('cancel delete preserves the resource', async ({ page }) => {
+  await page.goto('/products');
+
+  const targetRow = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await targetRow.getByRole('button', { name: 'Delete' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  // Cancel the deletion
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+  // Dialog closes, item is still present
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+});
+
+test('handles delete error gracefully', async ({ page }) => {
+  // Mock the delete endpoint to fail
+  await page.route('**/api/products/*', async (route) => {
+    if (route.request().method() === 'DELETE') {
+      await route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Cannot delete product with active orders',
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto('/products');
+
+  const targetRow = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await targetRow.getByRole('button', { name: 'Delete' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  // Verify error is shown to user
+  await expect(page.getByRole('alert')).toContainText('Cannot delete product with active orders');
+
+  // Item should still be in the list
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('deletes a product with confirmation dialog', async ({ page }) => {
+  await page.goto('/products');
+
+  const rowsBefore = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const countBefore = await rowsBefore.count();
+
+  const targetRow = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await targetRow.getByRole('button', { name: 'Delete' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Wireless Keyboard');
+
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole('alert')).toContainText('Product deleted');
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).not.toBeVisible();
+
+  const rowsAfter = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rowsAfter).toHaveCount(countBefore - 1);
+});
+
+test('cancel delete preserves the resource', async ({ page }) => {
+  await page.goto('/products');
+
+  const targetRow = page.getByRole('row', { name: /Wireless Keyboard/ });
+  await targetRow.getByRole('button', { name: 'Delete' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/ })).toBeVisible();
+});
+```
+
+---
+
+## Recipe 5: Inline Editing
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('edits a field inline by double-clicking', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  const nameCell = row.getByRole('cell').first();
+
+  // Double-click to enter edit mode
+  await nameCell.dblclick();
+
+  // The cell should now contain an input
+  const inlineInput = nameCell.getByRole('textbox');
+  await expect(inlineInput).toBeVisible();
+  await expect(inlineInput).toHaveValue('Wireless Keyboard');
+
+  // Edit the value
+  await inlineInput.clear();
+  await inlineInput.fill('Wireless Keyboard v2');
+
+  // Press Enter to save
+  await inlineInput.press('Enter');
+
+  // Verify the cell shows the updated value (no longer an input)
+  await expect(nameCell.getByRole('textbox')).not.toBeVisible();
+  await expect(nameCell).toHaveText('Wireless Keyboard v2');
+
+  // Verify a success indicator appears
+  await expect(page.getByRole('alert')).toContainText(/saved|updated/i);
+});
+
+test('cancels inline edit with Escape key', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  const nameCell = row.getByRole('cell').first();
+
+  await nameCell.dblclick();
+
+  const inlineInput = nameCell.getByRole('textbox');
+  await inlineInput.clear();
+  await inlineInput.fill('Temporary Value');
+
+  // Press Escape to cancel
+  await inlineInput.press('Escape');
+
+  // Verify original value is restored
+  await expect(nameCell).toHaveText('Wireless Keyboard');
+  await expect(nameCell.getByRole('textbox')).not.toBeVisible();
+});
+
+test('inline edit with click-away saves changes', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  const nameCell = row.getByRole('cell').first();
+
+  await nameCell.dblclick();
+
+  const inlineInput = nameCell.getByRole('textbox');
+  await inlineInput.clear();
+  await inlineInput.fill('Keyboard Updated');
+
+  // Click somewhere else on the page to trigger save
+  await page.getByRole('heading').first().click();
+
+  await expect(nameCell).toHaveText('Keyboard Updated');
+});
+
+test('inline edit shows validation error', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  const priceCell = row.getByRole('cell').nth(2);
+
+  await priceCell.dblclick();
+
+  const inlineInput = priceCell.getByRole('textbox');
+  await inlineInput.clear();
+  await inlineInput.fill('-10');
+  await inlineInput.press('Enter');
+
+  // Validation error should appear inline
+  await expect(priceCell.getByText(/positive number|invalid/i)).toBeVisible();
+
+  // Input should remain visible for correction
+  await expect(inlineInput).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('edits a field inline by double-clicking', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  const nameCell = row.getByRole('cell').first();
+
+  await nameCell.dblclick();
+
+  const inlineInput = nameCell.getByRole('textbox');
+  await expect(inlineInput).toBeVisible();
+  await expect(inlineInput).toHaveValue('Wireless Keyboard');
+
+  await inlineInput.clear();
+  await inlineInput.fill('Wireless Keyboard v2');
+  await inlineInput.press('Enter');
+
+  await expect(nameCell.getByRole('textbox')).not.toBeVisible();
+  await expect(nameCell).toHaveText('Wireless Keyboard v2');
+});
+
+test('cancels inline edit with Escape key', async ({ page }) => {
+  await page.goto('/products');
+
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+  const nameCell = row.getByRole('cell').first();
+
+  await nameCell.dblclick();
+  const inlineInput = nameCell.getByRole('textbox');
+  await inlineInput.clear();
+  await inlineInput.fill('Temporary Value');
+  await inlineInput.press('Escape');
+
+  await expect(nameCell).toHaveText('Wireless Keyboard');
+});
+```
+
+---
+
+## Recipe 6: Bulk Operations
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('selects multiple items and performs bulk delete', async ({ page }) => {
+  await page.goto('/products');
+
+  // Select multiple items via checkboxes
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+
+  await rows.nth(0).getByRole('checkbox').check();
+  await rows.nth(1).getByRole('checkbox').check();
+  await rows.nth(2).getByRole('checkbox').check();
+
+  // Verify selection count is shown
+  await expect(page.getByText('3 items selected')).toBeVisible();
+
+  // Verify bulk action toolbar appears
+  const bulkToolbar = page.getByRole('toolbar', { name: /bulk actions/i });
+  await expect(bulkToolbar).toBeVisible();
+
+  // Click bulk delete
+  await bulkToolbar.getByRole('button', { name: 'Delete selected' }).click();
+
+  // Confirm in dialog
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toContainText('Delete 3 products');
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  // Verify items removed
+  await expect(page.getByRole('alert')).toContainText('3 products deleted');
+
+  // Verify selection count is cleared
+  await expect(page.getByText('items selected')).not.toBeVisible();
+  await expect(bulkToolbar).not.toBeVisible();
+});
+
+test('select all and deselect all', async ({ page }) => {
+  await page.goto('/products');
+
+  // Click "Select all" checkbox in the header
+  const selectAllCheckbox = page
+    .getByRole('row')
+    .filter({ has: page.getByRole('columnheader') })
+    .getByRole('checkbox');
+
+  await selectAllCheckbox.check();
+
+  // All row checkboxes should be checked
+  const rowCheckboxes = page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .getByRole('checkbox');
+
+  const count = await rowCheckboxes.count();
+  for (let i = 0; i < count; i++) {
+    await expect(rowCheckboxes.nth(i)).toBeChecked();
+  }
+
+  await expect(page.getByText(`${count} items selected`)).toBeVisible();
+
+  // Deselect all
+  await selectAllCheckbox.uncheck();
+
+  for (let i = 0; i < count; i++) {
+    await expect(rowCheckboxes.nth(i)).not.toBeChecked();
+  }
+
+  await expect(page.getByText('items selected')).not.toBeVisible();
+});
+
+test('bulk status change', async ({ page }) => {
+  await page.goto('/products');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await rows.nth(0).getByRole('checkbox').check();
+  await rows.nth(1).getByRole('checkbox').check();
+
+  const bulkToolbar = page.getByRole('toolbar', { name: /bulk actions/i });
+  await bulkToolbar.getByRole('button', { name: 'Change status' }).click();
+
+  // Select new status from dropdown
+  await page.getByRole('menuitem', { name: 'Archived' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('2 products archived');
+
+  // Verify status changed in the rows
+  await expect(rows.nth(0)).toContainText('Archived');
+  await expect(rows.nth(1)).toContainText('Archived');
+});
+
+test('bulk export selected items', async ({ page }) => {
+  await page.goto('/products');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await rows.nth(0).getByRole('checkbox').check();
+  await rows.nth(1).getByRole('checkbox').check();
+
+  const bulkToolbar = page.getByRole('toolbar', { name: /bulk actions/i });
+
+  // Start waiting for download before clicking
+  const downloadPromise = page.waitForEvent('download');
+  await bulkToolbar.getByRole('button', { name: 'Export' }).click();
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/products.*\.csv$/);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('selects multiple items and performs bulk delete', async ({ page }) => {
+  await page.goto('/products');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await rows.nth(0).getByRole('checkbox').check();
+  await rows.nth(1).getByRole('checkbox').check();
+  await rows.nth(2).getByRole('checkbox').check();
+
+  await expect(page.getByText('3 items selected')).toBeVisible();
+
+  const bulkToolbar = page.getByRole('toolbar', { name: /bulk actions/i });
+  await bulkToolbar.getByRole('button', { name: 'Delete selected' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toContainText('Delete 3 products');
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('3 products deleted');
+});
+
+test('select all and deselect all', async ({ page }) => {
+  await page.goto('/products');
+
+  const selectAllCheckbox = page
+    .getByRole('row')
+    .filter({ has: page.getByRole('columnheader') })
+    .getByRole('checkbox');
+
+  await selectAllCheckbox.check();
+
+  const rowCheckboxes = page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .getByRole('checkbox');
+
+  const count = await rowCheckboxes.count();
+  for (let i = 0; i < count; i++) {
+    await expect(rowCheckboxes.nth(i)).toBeChecked();
+  }
+});
+```
+
+---
+
+## Variations
+
+### Create with Multi-Step Wizard
+
+```typescript
+test('creates a resource through a multi-step wizard', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add product' }).click();
+
+  // Step 1: Basic info
+  await expect(page.getByText('Step 1 of 3')).toBeVisible();
+  await page.getByLabel('Product name').fill('Wireless Keyboard');
+  await page.getByLabel('Category').selectOption('Electronics');
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  // Step 2: Pricing
+  await expect(page.getByText('Step 2 of 3')).toBeVisible();
+  await page.getByLabel('Price').fill('79.99');
+  await page.getByLabel('Tax rate').selectOption('Standard (20%)');
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  // Step 3: Review and confirm
+  await expect(page.getByText('Step 3 of 3')).toBeVisible();
+  await expect(page.getByText('Wireless Keyboard')).toBeVisible();
+  await expect(page.getByText('$79.99')).toBeVisible();
+  await page.getByRole('button', { name: 'Create product' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Product created');
+});
+```
+
+### CRUD with API Verification
+
+```typescript
+test('create and verify via API', async ({ page, request }) => {
+  await page.goto('/products');
+  await page.getByRole('button', { name: 'Add product' }).click();
+
+  await page.getByLabel('Product name').fill('API Verified Product');
+  await page.getByLabel('Price').fill('49.99');
+  await page.getByRole('button', { name: 'Save product' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Product created');
+
+  // Also verify via API that the data was persisted correctly
+  const response = await request.get('/api/products?search=API+Verified+Product');
+  const data = await response.json();
+
+  expect(data.products).toHaveLength(1);
+  expect(data.products[0].name).toBe('API Verified Product');
+  expect(data.products[0].price).toBe(49.99);
+});
+```
+
+### Optimistic UI Updates
+
+```typescript
+test('shows optimistic update then confirms', async ({ page }) => {
+  // Slow down the API response to observe optimistic behavior
+  await page.route('**/api/products/*', async (route) => {
+    if (route.request().method() === 'PATCH') {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.continue();
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto('/products');
+  const row = page.getByRole('row', { name: /Wireless Keyboard/ });
+
+  await row.getByRole('button', { name: 'Toggle status' }).click();
+
+  // Verify UI updates immediately (optimistic)
+  await expect(row.getByText('Active')).toBeVisible();
+
+  // Verify loading indicator while API catches up
+  await expect(row.getByRole('progressbar')).toBeVisible();
+
+  // After API responds, loading indicator disappears
+  await expect(row.getByRole('progressbar')).not.toBeVisible({ timeout: 5000 });
+  await expect(row.getByText('Active')).toBeVisible();
+});
+```
+
+---
+
+## Tips
+
+1. **Always verify state after mutations**. After a create, update, or delete, assert that the UI reflects the change. Do not assume the success notification alone means the operation worked. Check that the list, table, or card actually changed.
+
+2. **Use unique identifiers in test data**. Include timestamps or random strings in test data to prevent collisions: `Keyboard-${Date.now()}`. This avoids flaky tests from leftover data.
+
+3. **Test the full lifecycle**. Write a single test that creates, reads, updates, and then deletes a resource. This catches integration issues between operations that isolated tests miss.
+
+4. **Clean up test data via API**. Use `test.afterEach` or `test.afterAll` with the `request` fixture to delete resources created during tests, so tests remain independent and repeatable.
+
+5. **Prefer `getByRole('row', { name: ... })` for table operations**. This targets accessible row content and is resilient to column reordering. Avoid relying on `nth()` indices for specific data rows since ordering can change.
+
+---
+
+## Related
+
+- `recipes/search-and-filter.md` -- Filter and search within resource lists
+- `recipes/file-upload-download.md` -- Upload files as part of resource creation
+- `patterns/page-objects.md` -- Encapsulate CRUD forms in page objects
+- `foundations/selectors.md` -- Best practices for selecting table cells and form fields

--- a/engineering-team/playwright skill/core/debugging.md
+++ b/engineering-team/playwright skill/core/debugging.md
@@ -1,0 +1,720 @@
+# Debugging Playwright Tests
+
+> **When to use**: A test is failing and you need to understand why — wrong selectors, timing issues, network failures, or unexpected application state.
+
+## Quick Reference
+
+| Tool | Command | Best For |
+|---|---|---|
+| UI Mode | `npx playwright test --ui` | Interactive exploration, visual timeline, re-running tests |
+| Playwright Inspector | `PWDEBUG=1 npx playwright test` | Step-through debugging, selector playground |
+| Trace Viewer | `npx playwright show-trace trace.zip` | Post-mortem CI failure analysis |
+| Headed mode | `npx playwright test --headed` | Watching the browser during test execution |
+| Slow motion | `npx playwright test --headed --slow-mo=500` | Visually following fast interactions |
+| `page.pause()` | Insert in test code | Pausing at an exact point to inspect state |
+| Verbose API logs | `DEBUG=pw:api npx playwright test` | Seeing every Playwright API call with timing |
+| VS Code extension | Playwright Test for VS Code | Breakpoints, step-through, pick locator |
+
+## Systematic Debugging Workflow
+
+Follow this order. Do not skip to step 5 — most issues resolve by step 2.
+
+```
+1. Read the full error message
+   └─ Check troubleshooting/error-index.md for known patterns
+2. Run with --ui to see what happened visually
+   └─ Timeline shows every action, screenshot at failure point
+3. Enable tracing if not already on
+   └─ use: { trace: 'on' } temporarily in config
+4. Check the network tab in trace for API failures
+   └─ Missing responses, 4xx/5xx, CORS errors
+5. Insert page.pause() at the failure point
+   └─ Inspect live DOM, try selectors in console
+6. Check browser console for JavaScript errors
+   └─ page.on('console') or console tab in trace
+```
+
+## Patterns
+
+### Pattern 1: UI Mode for Interactive Debugging
+
+**Use when**: Developing new tests, investigating failures locally, exploring application behavior.
+**Avoid when**: CI environments (use traces instead).
+
+UI Mode provides a visual timeline, DOM snapshots at each step, network waterfall, and the ability to re-run individual tests.
+
+**TypeScript**
+```typescript
+// Launch UI Mode from terminal:
+// npx playwright test --ui
+
+// Run a specific test file in UI Mode:
+// npx playwright test tests/checkout.spec.ts --ui
+
+// playwright.config.ts — configure for UI Mode convenience
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    // Traces are always available in UI Mode regardless of this setting,
+    // but this ensures traces are captured for CI failures too
+    trace: 'on-first-retry',
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// Launch UI Mode from terminal:
+// npx playwright test --ui
+
+// Run a specific test file in UI Mode:
+// npx playwright test tests/checkout.spec.js --ui
+
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+### Pattern 2: Playwright Inspector with PWDEBUG
+
+**Use when**: You need to step through actions one at a time, test selectors interactively, or see the exact state before and after each action.
+**Avoid when**: The failure is visible from the error message or trace alone.
+
+**TypeScript**
+```typescript
+// Launch Inspector from terminal:
+// PWDEBUG=1 npx playwright test tests/login.spec.ts
+
+// On Windows PowerShell:
+// $env:PWDEBUG=1; npx playwright test tests/login.spec.ts
+
+// On Windows CMD:
+// set PWDEBUG=1 && npx playwright test tests/login.spec.ts
+
+// Inspector opens automatically. Use these controls:
+// - "Step over" button: execute one action at a time
+// - "Pick locator" button: hover elements to see the best locator
+// - "Resume" button: run to the next page.pause() or end
+
+import { test, expect } from '@playwright/test';
+
+test('debug login flow', async ({ page }) => {
+  await page.goto('/login');
+
+  // Inspector pauses before each action when PWDEBUG=1
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// Launch Inspector from terminal:
+// PWDEBUG=1 npx playwright test tests/login.spec.js
+
+const { test, expect } = require('@playwright/test');
+
+test('debug login flow', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+### Pattern 3: Trace Viewer for CI Failure Analysis
+
+**Use when**: A test fails in CI and you need to understand what happened without re-running locally.
+**Avoid when**: You can reproduce the failure locally (use UI Mode or Inspector instead).
+
+**TypeScript**
+```typescript
+// playwright.config.ts — trace configuration
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    // 'on-first-retry' — captures trace on first retry only (recommended for CI)
+    // 'on' — captures every run (use temporarily for stubborn failures)
+    // 'retain-on-failure' — captures every run, keeps only failures
+    trace: 'on-first-retry',
+  },
+});
+
+// After CI failure, download the trace artifact and open it:
+// npx playwright show-trace test-results/tests-login-Login-test-chromium/trace.zip
+
+// Or open from URL:
+// npx playwright show-trace https://ci.example.com/artifacts/trace.zip
+
+// Or use trace.playwright.dev to view traces in the browser — drag and drop the zip file
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+
+// After CI failure, download the trace artifact and open it:
+// npx playwright show-trace test-results/tests-login-Login-test-chromium/trace.zip
+```
+
+**Reading a trace — what to check in order:**
+
+1. **Actions tab** — see every Playwright action with before/after screenshots
+2. **Console tab** — browser console output (errors, warnings, logs)
+3. **Network tab** — every HTTP request with status, timing, request/response bodies
+4. **Source tab** — test source code highlighting the failing line
+5. **Call tab** — exact arguments and return values of each Playwright call
+
+### Pattern 4: Headed Mode with Slow Motion
+
+**Use when**: You want to watch the browser during execution without the full Inspector overhead.
+**Avoid when**: The test runs too fast to follow even with slow-mo (use Inspector instead).
+
+**TypeScript**
+```typescript
+// From terminal — quick visual debugging:
+// npx playwright test tests/checkout.spec.ts --headed --slow-mo=500
+
+// playwright.config.ts — configure headed mode for local development
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    // Do NOT commit these — use CLI flags or environment checks instead
+    headless: !process.env.HEADED,
+    launchOptions: {
+      slowMo: process.env.SLOW_MO ? parseInt(process.env.SLOW_MO) : 0,
+    },
+  },
+});
+
+// Then run:
+// HEADED=1 SLOW_MO=500 npx playwright test tests/checkout.spec.ts
+```
+
+**JavaScript**
+```javascript
+// From terminal:
+// npx playwright test tests/checkout.spec.js --headed --slow-mo=500
+
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    headless: !process.env.HEADED,
+    launchOptions: {
+      slowMo: process.env.SLOW_MO ? parseInt(process.env.SLOW_MO) : 0,
+    },
+  },
+});
+```
+
+### Pattern 5: VS Code Integration
+
+**Use when**: You prefer IDE-based debugging with breakpoints, variable inspection, and integrated test running.
+**Avoid when**: You are debugging CI-only failures that do not reproduce locally.
+
+Install the **Playwright Test for VS Code** extension (`ms-playwright.playwright`).
+
+**Key capabilities:**
+- **Run/debug individual tests** — click the green play button in the gutter next to any `test()`
+- **Set breakpoints** — click the gutter to set breakpoints; tests pause at them automatically
+- **Pick locator** — use the "Pick locator" command to hover over elements and get the best selector
+- **Show browser** — check "Show Browser" in the testing sidebar to see the browser during execution
+- **Watch mode** — enable to re-run tests on file save
+
+**TypeScript**
+```typescript
+// When debugging in VS Code, use test.only() to focus on one test
+// instead of running the entire suite through the debugger
+import { test, expect } from '@playwright/test';
+
+test.only('debug this specific test', async ({ page }) => {
+  await page.goto('/products');
+
+  // Set a VS Code breakpoint on this line, then inspect `page` in the debug panel
+  const productCard = page.getByRole('listitem').filter({ hasText: 'Widget' });
+  await expect(productCard).toBeVisible();
+
+  await productCard.getByRole('button', { name: 'Add to cart' }).click();
+  await expect(page.getByTestId('cart-count')).toHaveText('1');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.only('debug this specific test', async ({ page }) => {
+  await page.goto('/products');
+
+  const productCard = page.getByRole('listitem').filter({ hasText: 'Widget' });
+  await expect(productCard).toBeVisible();
+
+  await productCard.getByRole('button', { name: 'Add to cart' }).click();
+  await expect(page.getByTestId('cart-count')).toHaveText('1');
+});
+```
+
+### Pattern 6: Capturing Browser Console Logs
+
+**Use when**: Suspecting JavaScript errors, failed client-side API calls, or application-level logging that explains the failure.
+**Avoid when**: The issue is clearly a selector or timing problem visible in the trace.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('capture console output', async ({ page }) => {
+  // Collect all console messages
+  const consoleLogs: string[] = [];
+  page.on('console', (msg) => {
+    consoleLogs.push(`[${msg.type()}] ${msg.text()}`);
+  });
+
+  // Capture uncaught exceptions
+  page.on('pageerror', (error) => {
+    console.error('Page error:', error.message);
+  });
+
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Load data' }).click();
+  await expect(page.getByRole('table')).toBeVisible();
+
+  // Print collected logs on failure for debugging context
+  console.log('Browser console output:', consoleLogs);
+});
+
+// Reusable fixture for console logging across all tests
+import { test as base } from '@playwright/test';
+
+type ConsoleFixtures = {
+  consoleMessages: string[];
+};
+
+export const test = base.extend<ConsoleFixtures>({
+  consoleMessages: async ({ page }, use) => {
+    const messages: string[] = [];
+    page.on('console', (msg) => messages.push(`[${msg.type()}] ${msg.text()}`));
+    page.on('pageerror', (err) => messages.push(`[pageerror] ${err.message}`));
+    await use(messages);
+  },
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('capture console output', async ({ page }) => {
+  const consoleLogs = [];
+  page.on('console', (msg) => {
+    consoleLogs.push(`[${msg.type()}] ${msg.text()}`);
+  });
+
+  page.on('pageerror', (error) => {
+    console.error('Page error:', error.message);
+  });
+
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Load data' }).click();
+  await expect(page.getByRole('table')).toBeVisible();
+
+  console.log('Browser console output:', consoleLogs);
+});
+
+// Reusable fixture for console logging
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  consoleMessages: async ({ page }, use) => {
+    const messages = [];
+    page.on('console', (msg) => messages.push(`[${msg.type()}] ${msg.text()}`));
+    page.on('pageerror', (err) => messages.push(`[pageerror] ${err.message}`));
+    await use(messages);
+  },
+});
+
+module.exports = { test };
+```
+
+### Pattern 7: Screenshots on Failure
+
+**Use when**: You need a visual snapshot at the exact moment of failure.
+**Avoid when**: Traces are enabled (they already include screenshots at every step).
+
+**TypeScript**
+```typescript
+// playwright.config.ts — automatic screenshots on failure
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    // 'off' — no screenshots (default)
+    // 'on' — screenshot after every test
+    // 'only-on-failure' — screenshot only when test fails (recommended)
+    screenshot: 'only-on-failure',
+  },
+});
+```
+
+```typescript
+// Manual screenshot at a specific point
+import { test, expect } from '@playwright/test';
+
+test('debug visual state', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Promo code').fill('SAVE20');
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  // Capture screenshot before assertion for debugging
+  await page.screenshot({ path: 'test-results/before-discount.png', fullPage: true });
+
+  await expect(page.getByTestId('discount-amount')).toHaveText('-$20.00');
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    screenshot: 'only-on-failure',
+  },
+});
+```
+
+```javascript
+// Manual screenshot
+const { test, expect } = require('@playwright/test');
+
+test('debug visual state', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Promo code').fill('SAVE20');
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await page.screenshot({ path: 'test-results/before-discount.png', fullPage: true });
+
+  await expect(page.getByTestId('discount-amount')).toHaveText('-$20.00');
+});
+```
+
+### Pattern 8: Network Debugging
+
+**Use when**: Suspecting API failures, wrong request payloads, missing auth headers, or slow responses causing timeouts.
+**Avoid when**: The trace network tab already shows the problem.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('debug network requests', async ({ page }) => {
+  // Log all requests
+  page.on('request', (request) => {
+    console.log(`>> ${request.method()} ${request.url()}`);
+  });
+
+  // Log all responses with status
+  page.on('response', (response) => {
+    console.log(`<< ${response.status()} ${response.url()}`);
+  });
+
+  // Log failed requests (network errors, not HTTP errors)
+  page.on('requestfailed', (request) => {
+    console.log(`FAILED: ${request.url()} ${request.failure()?.errorText}`);
+  });
+
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByRole('table')).toBeVisible();
+});
+
+// Wait for a specific API response and inspect it
+test('inspect API response', async ({ page }) => {
+  await page.goto('/products');
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('/api/products') && resp.status() === 200
+  );
+
+  await page.getByRole('button', { name: 'Load products' }).click();
+
+  const response = await responsePromise;
+  const body = await response.json();
+  console.log('API response:', JSON.stringify(body, null, 2));
+
+  await expect(page.getByRole('listitem')).toHaveCount(body.products.length);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('debug network requests', async ({ page }) => {
+  page.on('request', (request) => {
+    console.log(`>> ${request.method()} ${request.url()}`);
+  });
+
+  page.on('response', (response) => {
+    console.log(`<< ${response.status()} ${response.url()}`);
+  });
+
+  page.on('requestfailed', (request) => {
+    console.log(`FAILED: ${request.url()} ${request.failure()?.errorText}`);
+  });
+
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByRole('table')).toBeVisible();
+});
+
+test('inspect API response', async ({ page }) => {
+  await page.goto('/products');
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('/api/products') && resp.status() === 200
+  );
+
+  await page.getByRole('button', { name: 'Load products' }).click();
+
+  const response = await responsePromise;
+  const body = await response.json();
+  console.log('API response:', JSON.stringify(body, null, 2));
+
+  await expect(page.getByRole('listitem')).toHaveCount(body.products.length);
+});
+```
+
+### Pattern 9: Verbose API Logs
+
+**Use when**: You need to see every single Playwright API call with timing to identify where the test is spending time or getting stuck.
+**Avoid when**: You already know which action is failing (use Inspector or `page.pause()` instead).
+
+```bash
+# See all Playwright API calls with timestamps
+DEBUG=pw:api npx playwright test tests/slow-test.spec.ts
+
+# See browser protocol messages (very verbose — use sparingly)
+DEBUG=pw:protocol npx playwright test tests/slow-test.spec.ts
+
+# Combine multiple debug channels
+DEBUG=pw:api,pw:browser npx playwright test tests/slow-test.spec.ts
+
+# Windows PowerShell
+$env:DEBUG="pw:api"; npx playwright test tests/slow-test.spec.ts
+
+# Windows CMD
+set DEBUG=pw:api && npx playwright test tests/slow-test.spec.ts
+```
+
+### Pattern 10: `page.pause()` — Inline Breakpoints
+
+**Use when**: You need to pause execution at a precise point to inspect the live DOM, try locators, or check application state.
+**Avoid when**: You can use `PWDEBUG=1` which pauses at every step automatically.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('debug with pause', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Email').fill('user@example.com');
+
+  // Execution pauses here — Inspector opens with:
+  // - Live DOM inspection
+  // - Selector playground (try locators in the console)
+  // - Step through remaining actions
+  await page.pause();
+
+  // These actions wait until you click "Resume" in the Inspector
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('debug with pause', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Email').fill('user@example.com');
+
+  // Execution pauses here — Inspector opens
+  await page.pause();
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**Important**: Remove `page.pause()` before committing. It will hang indefinitely in CI. Use this lint rule or CI check:
+
+```bash
+# Add to your pre-commit hook or CI pipeline
+grep -r "page.pause()" tests/ && echo "ERROR: Remove page.pause() before committing" && exit 1
+```
+
+## Decision Guide
+
+Use this table to pick the right tool based on the failure type.
+
+| Failure Type | First Tool | Why |
+|---|---|---|
+| **Element not found** (selector wrong) | UI Mode (`--ui`) | See the DOM at the moment of failure, try selectors in Pick Locator |
+| **Element not found** (timing issue) | Trace Viewer — Actions tab | Compare before/after screenshots to see if element appeared after timeout |
+| **Wrong text / value** | Trace Viewer — Actions tab | Inspect the actual DOM content at each action step |
+| **Test hangs / times out** | `DEBUG=pw:api` | See which API call is waiting and never resolving |
+| **Network / API failure** | Trace Viewer — Network tab | See request/response status codes, payloads, timing |
+| **Auth / session issues** | Network debugging (`page.on('response')`) | Check for 401/403 responses, missing cookies/tokens |
+| **Visual rendering wrong** | `--headed --slow-mo=500` | Watch the actual rendering in the browser |
+| **JavaScript error in app** | Console logging (`page.on('console')`) | Catch uncaught exceptions and error logs |
+| **CI-only failure** | Trace Viewer (from CI artifact) | Reproduce the exact CI state without running locally |
+| **Flaky / intermittent** | Trace on every run (`trace: 'on'`) + retries | Compare passing and failing traces side by side |
+| **State pollution** | Run single test with `test.only()` | Isolate from other tests; if it passes alone, state leaks from another test |
+
+## Anti-Patterns
+
+### Adding `waitForTimeout` to fix timing issues
+
+```typescript
+// WRONG — arbitrary delays mask the real problem and make tests slow and flaky
+await page.getByRole('button', { name: 'Submit' }).click();
+await page.waitForTimeout(3000); // "It works with this delay"
+await expect(page.getByText('Success')).toBeVisible();
+
+// RIGHT — wait for the actual condition
+await page.getByRole('button', { name: 'Submit' }).click();
+await expect(page.getByText('Success')).toBeVisible(); // Auto-retries for up to 5s
+```
+
+If the default timeout is insufficient, investigate *why* the operation is slow, then either:
+- Fix the application performance
+- Increase the specific assertion timeout: `await expect(locator).toBeVisible({ timeout: 15000 })`
+- Wait for a prerequisite: `await page.waitForResponse('**/api/submit')`
+
+### Commenting out tests to isolate a failure
+
+```typescript
+// WRONG — commenting out tests to find which one causes the failure
+// test('test A', ...);
+// test('test B', ...);
+test('test C — this one fails', async ({ page }) => { /* ... */ });
+
+// RIGHT — use .only to run a single test
+test.only('test C — this one fails', async ({ page }) => { /* ... */ });
+
+// RIGHT — use grep to run tests matching a pattern
+// npx playwright test --grep "test C"
+```
+
+### Not reading the full error message
+
+Playwright error messages include:
+- The **expected** vs **actual** value
+- The **locator** that was used
+- A **call log** showing what Playwright tried before timing out
+- The **line number** in your test
+
+Read all of it. The call log alone often shows exactly what went wrong (e.g., "waiting for selector to be visible" when the element exists but is hidden).
+
+### Debugging in CI without traces
+
+```typescript
+// WRONG — no traces in CI, no way to debug failures
+export default defineConfig({
+  use: {
+    trace: 'off',
+  },
+});
+
+// RIGHT — always capture traces on failure in CI
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+### Using `console.log` instead of proper debugging tools
+
+```typescript
+// WRONG — sprinkling console.log everywhere
+test('debug with logs', async ({ page }) => {
+  await page.goto('/dashboard');
+  console.log('page loaded');
+  const el = page.getByRole('button', { name: 'Save' });
+  console.log('button found:', await el.isVisible());
+  console.log('button text:', await el.textContent());
+  // ...20 more console.log calls
+
+  // RIGHT — use page.pause() at the point of interest
+  await page.goto('/dashboard');
+  await page.pause(); // Inspect everything interactively
+});
+```
+
+### Leaving `page.pause()` or `test.only()` in committed code
+
+```typescript
+// WRONG — these should never reach CI
+test.only('focused test', async ({ page }) => {  // Skips all other tests
+  await page.goto('/');
+  await page.pause();  // Hangs forever in CI
+});
+
+// Add a CI guard if needed during development
+if (!process.env.CI) {
+  await page.pause();
+}
+```
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Inspector does not open with `PWDEBUG=1` | Running in headless mode or workers > 1 | Run with `--headed` and `--workers=1` |
+| Trace is empty or missing | `trace: 'off'` in config, or test did not retry | Set `trace: 'on'` temporarily, or `trace: 'retain-on-failure'` |
+| UI Mode shows stale test results | File watcher did not pick up changes | Stop UI Mode, clear `test-results/`, restart |
+| `page.pause()` does nothing | `PWDEBUG` is not set and running headless | Run with `--headed` or set `PWDEBUG=1` |
+| Screenshots are blank or wrong size | Viewport not set or test runs on wrong project | Set `viewport` in config; check which browser project ran |
+| Verbose logs are overwhelming | Using `DEBUG=pw:protocol` | Use `DEBUG=pw:api` for a manageable level of detail |
+| Trace file is too large | `trace: 'on'` for all tests, including passing | Switch to `trace: 'on-first-retry'` or `trace: 'retain-on-failure'` |
+| VS Code does not detect tests | Wrong `testDir` or `testMatch` config | Ensure config paths match and extension settings point to your `playwright.config` |
+| Network events not firing | Request was made before listener was attached | Attach `page.on('request')` and `page.on('response')` before `page.goto()` |
+
+## Related
+
+- [core/error-index.md](error-index.md) — look up specific error messages
+- [core/flaky-tests.md](flaky-tests.md) — intermittent failure patterns and fixes
+- [core/common-pitfalls.md](common-pitfalls.md) — common beginner mistakes
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) — web-first assertions and auto-waiting
+- [core/configuration.md](configuration.md) — trace, screenshot, and retry configuration
+- [ci/reporting-and-artifacts.md](../ci/reporting-and-artifacts.md) — CI artifact collection for traces and screenshots

--- a/engineering-team/playwright skill/core/drag-and-drop.md
+++ b/engineering-team/playwright skill/core/drag-and-drop.md
@@ -1,0 +1,919 @@
+# Drag and Drop Recipes
+
+> **When to use**: You need to test drag-and-drop interactions -- sortable lists, kanban boards, file drop zones, or any element that can be repositioned by dragging.
+
+---
+
+## Recipe 1: Native HTML5 Drag and Drop
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('drags an item from one container to another', async ({ page }) => {
+  await page.goto('/drag-demo');
+
+  const sourceItem = page.getByText('Draggable Item');
+  const dropZone = page.locator('#drop-zone');
+
+  // Verify initial state
+  await expect(sourceItem).toBeVisible();
+  await expect(dropZone).not.toContainText('Draggable Item');
+
+  // Perform drag and drop
+  await sourceItem.dragTo(dropZone);
+
+  // Verify the item moved to the drop zone
+  await expect(dropZone).toContainText('Draggable Item');
+});
+
+test('drags between two drop zones using locators', async ({ page }) => {
+  await page.goto('/drag-demo');
+
+  const item = page.locator('[data-testid="item-1"]');
+  const zoneA = page.locator('[data-testid="zone-a"]');
+  const zoneB = page.locator('[data-testid="zone-b"]');
+
+  // Item starts in zone A
+  await expect(zoneA).toContainText('Item 1');
+
+  // Drag to zone B
+  await item.dragTo(zoneB);
+
+  // Item is now in zone B, not zone A
+  await expect(zoneB).toContainText('Item 1');
+  await expect(zoneA).not.toContainText('Item 1');
+
+  // Drag back to zone A
+  await zoneB.getByText('Item 1').dragTo(zoneA);
+
+  await expect(zoneA).toContainText('Item 1');
+  await expect(zoneB).not.toContainText('Item 1');
+});
+
+test('verifies drag visual feedback', async ({ page }) => {
+  await page.goto('/drag-demo');
+
+  const sourceItem = page.getByText('Draggable Item');
+  const dropZone = page.locator('#drop-zone');
+
+  // Start drag manually to check intermediate states
+  await sourceItem.hover();
+  await page.mouse.down();
+
+  // Move toward the drop zone
+  const dropBox = await dropZone.boundingBox();
+  await page.mouse.move(dropBox!.x + dropBox!.width / 2, dropBox!.y + dropBox!.height / 2);
+
+  // Verify the drop zone shows a visual indicator while hovering
+  await expect(dropZone).toHaveClass(/drag-over|highlight/);
+
+  // Complete the drop
+  await page.mouse.up();
+
+  // Verify drop zone returns to normal styling
+  await expect(dropZone).not.toHaveClass(/drag-over|highlight/);
+  await expect(dropZone).toContainText('Draggable Item');
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('drags an item from one container to another', async ({ page }) => {
+  await page.goto('/drag-demo');
+
+  const sourceItem = page.getByText('Draggable Item');
+  const dropZone = page.locator('#drop-zone');
+
+  await expect(sourceItem).toBeVisible();
+  await expect(dropZone).not.toContainText('Draggable Item');
+
+  await sourceItem.dragTo(dropZone);
+
+  await expect(dropZone).toContainText('Draggable Item');
+});
+
+test('drags between two drop zones', async ({ page }) => {
+  await page.goto('/drag-demo');
+
+  const item = page.locator('[data-testid="item-1"]');
+  const zoneA = page.locator('[data-testid="zone-a"]');
+  const zoneB = page.locator('[data-testid="zone-b"]');
+
+  await expect(zoneA).toContainText('Item 1');
+
+  await item.dragTo(zoneB);
+
+  await expect(zoneB).toContainText('Item 1');
+  await expect(zoneA).not.toContainText('Item 1');
+});
+```
+
+---
+
+## Recipe 2: Sortable Lists (Reordering Items)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('reorders items in a sortable list', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+
+  // Verify initial order
+  const initialItems = await list.getByRole('listitem').allTextContents();
+  expect(initialItems[0]).toContain('Task A');
+  expect(initialItems[1]).toContain('Task B');
+  expect(initialItems[2]).toContain('Task C');
+
+  // Drag Task C to the top (above Task A)
+  const taskC = list.getByRole('listitem').filter({ hasText: 'Task C' });
+  const taskA = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  await taskC.dragTo(taskA);
+
+  // Verify new order
+  const reorderedItems = await list.getByRole('listitem').allTextContents();
+  expect(reorderedItems[0]).toContain('Task C');
+  expect(reorderedItems[1]).toContain('Task A');
+  expect(reorderedItems[2]).toContain('Task B');
+});
+
+test('reorders using drag handle', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+
+  // Use the drag handle (grip icon) instead of the whole item
+  const dragHandle = list
+    .getByRole('listitem')
+    .filter({ hasText: 'Task C' })
+    .getByRole('button', { name: /drag|reorder|grip/i });
+
+  const targetItem = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  await dragHandle.dragTo(targetItem);
+
+  const reorderedItems = await list.getByRole('listitem').allTextContents();
+  expect(reorderedItems[0]).toContain('Task C');
+});
+
+test('reorder persists after page reload', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+
+  const taskC = list.getByRole('listitem').filter({ hasText: 'Task C' });
+  const taskA = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  await taskC.dragTo(taskA);
+
+  // Wait for the save API call to complete
+  await page.waitForResponse((response) =>
+    response.url().includes('/api/tasks/reorder') && response.status() === 200
+  );
+
+  // Reload and verify persistence
+  await page.reload();
+
+  const items = await list.getByRole('listitem').allTextContents();
+  expect(items[0]).toContain('Task C');
+  expect(items[1]).toContain('Task A');
+  expect(items[2]).toContain('Task B');
+});
+
+test('reorders with precise mouse movements for libraries that need it', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+  const sourceItem = list.getByRole('listitem').filter({ hasText: 'Task C' });
+  const targetItem = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  const sourceBox = await sourceItem.boundingBox();
+  const targetBox = await targetItem.boundingBox();
+
+  // Some drag libraries (react-beautiful-dnd, dnd-kit) require specific mouse event sequences
+  await sourceItem.hover();
+  await page.mouse.down();
+
+  // Move in small steps -- some libraries require incremental movement to register
+  const steps = 10;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(
+      sourceBox!.x + sourceBox!.width / 2,
+      sourceBox!.y + (targetBox!.y - sourceBox!.y) * (i / steps),
+      { steps: 1 }
+    );
+  }
+
+  await page.mouse.up();
+
+  const items = await list.getByRole('listitem').allTextContents();
+  expect(items[0]).toContain('Task C');
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('reorders items in a sortable list', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+
+  const initialItems = await list.getByRole('listitem').allTextContents();
+  expect(initialItems[0]).toContain('Task A');
+  expect(initialItems[1]).toContain('Task B');
+  expect(initialItems[2]).toContain('Task C');
+
+  const taskC = list.getByRole('listitem').filter({ hasText: 'Task C' });
+  const taskA = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  await taskC.dragTo(taskA);
+
+  const reorderedItems = await list.getByRole('listitem').allTextContents();
+  expect(reorderedItems[0]).toContain('Task C');
+  expect(reorderedItems[1]).toContain('Task A');
+  expect(reorderedItems[2]).toContain('Task B');
+});
+
+test('reorders with precise mouse movements', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+  const sourceItem = list.getByRole('listitem').filter({ hasText: 'Task C' });
+  const targetItem = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  const sourceBox = await sourceItem.boundingBox();
+  const targetBox = await targetItem.boundingBox();
+
+  await sourceItem.hover();
+  await page.mouse.down();
+
+  const steps = 10;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + (targetBox.y - sourceBox.y) * (i / steps),
+      { steps: 1 }
+    );
+  }
+
+  await page.mouse.up();
+
+  const items = await list.getByRole('listitem').allTextContents();
+  expect(items[0]).toContain('Task C');
+});
+```
+
+---
+
+## Recipe 3: Kanban Board (Moving Between Columns)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('moves a card from Todo to In Progress', async ({ page }) => {
+  await page.goto('/board');
+
+  const todoColumn = page.locator('[data-column="todo"]');
+  const inProgressColumn = page.locator('[data-column="in-progress"]');
+
+  // Verify initial state
+  const card = todoColumn.getByText('Fix login bug');
+  await expect(card).toBeVisible();
+
+  const todoCountBefore = await todoColumn.getByRole('article').count();
+  const inProgressCountBefore = await inProgressColumn.getByRole('article').count();
+
+  // Drag the card to In Progress
+  await card.dragTo(inProgressColumn);
+
+  // Verify the card moved
+  await expect(inProgressColumn.getByText('Fix login bug')).toBeVisible();
+  await expect(todoColumn.getByText('Fix login bug')).not.toBeVisible();
+
+  // Verify counts updated
+  await expect(todoColumn.getByRole('article')).toHaveCount(todoCountBefore - 1);
+  await expect(inProgressColumn.getByRole('article')).toHaveCount(inProgressCountBefore + 1);
+
+  // Verify column header count badge updated
+  await expect(todoColumn.getByText(`(${todoCountBefore - 1})`)).toBeVisible();
+  await expect(inProgressColumn.getByText(`(${inProgressCountBefore + 1})`)).toBeVisible();
+});
+
+test('moves a card through all stages', async ({ page }) => {
+  await page.goto('/board');
+
+  const columns = {
+    todo: page.locator('[data-column="todo"]'),
+    inProgress: page.locator('[data-column="in-progress"]'),
+    review: page.locator('[data-column="review"]'),
+    done: page.locator('[data-column="done"]'),
+  };
+
+  // Todo -> In Progress
+  await columns.todo.getByText('Fix login bug').dragTo(columns.inProgress);
+  await expect(columns.inProgress.getByText('Fix login bug')).toBeVisible();
+
+  // In Progress -> Review
+  await columns.inProgress.getByText('Fix login bug').dragTo(columns.review);
+  await expect(columns.review.getByText('Fix login bug')).toBeVisible();
+
+  // Review -> Done
+  await columns.review.getByText('Fix login bug').dragTo(columns.done);
+  await expect(columns.done.getByText('Fix login bug')).toBeVisible();
+
+  // Verify the card is only in the Done column
+  await expect(columns.todo.getByText('Fix login bug')).not.toBeVisible();
+  await expect(columns.inProgress.getByText('Fix login bug')).not.toBeVisible();
+  await expect(columns.review.getByText('Fix login bug')).not.toBeVisible();
+});
+
+test('reorders cards within the same column', async ({ page }) => {
+  await page.goto('/board');
+
+  const todoColumn = page.locator('[data-column="todo"]');
+
+  const cardA = todoColumn.getByRole('article').filter({ hasText: 'Task A' });
+  const cardC = todoColumn.getByRole('article').filter({ hasText: 'Task C' });
+
+  // Drag Task C above Task A within the same column
+  await cardC.dragTo(cardA);
+
+  // Verify new order within the column
+  const cards = await todoColumn.getByRole('article').allTextContents();
+  expect(cards.indexOf('Task C')).toBeLessThan(cards.indexOf('Task A'));
+});
+
+test('kanban board state persists via API', async ({ page }) => {
+  await page.goto('/board');
+
+  const todoColumn = page.locator('[data-column="todo"]');
+  const inProgressColumn = page.locator('[data-column="in-progress"]');
+
+  // Wait for the PATCH/PUT to complete after the drag
+  const responsePromise = page.waitForResponse(
+    (r) => r.url().includes('/api/cards') && r.request().method() === 'PATCH'
+  );
+
+  await todoColumn.getByText('Fix login bug').dragTo(inProgressColumn);
+
+  const response = await responsePromise;
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  expect(body.column).toBe('in-progress');
+
+  // Reload to confirm persistence
+  await page.reload();
+  await expect(inProgressColumn.getByText('Fix login bug')).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('moves a card from Todo to In Progress', async ({ page }) => {
+  await page.goto('/board');
+
+  const todoColumn = page.locator('[data-column="todo"]');
+  const inProgressColumn = page.locator('[data-column="in-progress"]');
+
+  const card = todoColumn.getByText('Fix login bug');
+  await expect(card).toBeVisible();
+
+  await card.dragTo(inProgressColumn);
+
+  await expect(inProgressColumn.getByText('Fix login bug')).toBeVisible();
+  await expect(todoColumn.getByText('Fix login bug')).not.toBeVisible();
+});
+
+test('moves a card through all stages', async ({ page }) => {
+  await page.goto('/board');
+
+  const columns = {
+    todo: page.locator('[data-column="todo"]'),
+    inProgress: page.locator('[data-column="in-progress"]'),
+    review: page.locator('[data-column="review"]'),
+    done: page.locator('[data-column="done"]'),
+  };
+
+  await columns.todo.getByText('Fix login bug').dragTo(columns.inProgress);
+  await expect(columns.inProgress.getByText('Fix login bug')).toBeVisible();
+
+  await columns.inProgress.getByText('Fix login bug').dragTo(columns.review);
+  await expect(columns.review.getByText('Fix login bug')).toBeVisible();
+
+  await columns.review.getByText('Fix login bug').dragTo(columns.done);
+  await expect(columns.done.getByText('Fix login bug')).toBeVisible();
+});
+```
+
+---
+
+## Recipe 4: File Drop Zone
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('uploads a file by dropping it on the drop zone', async ({ page }) => {
+  await page.goto('/upload');
+
+  const dropZone = page.locator('[data-testid="file-drop-zone"]');
+
+  // Verify initial state
+  await expect(dropZone).toContainText('Drag files here');
+
+  // Create a DataTransfer-like event using the file chooser approach
+  // Since Playwright cannot simulate native DnD file events from the OS,
+  // we use the underlying input[type=file] that drop zones rely on
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/sample-document.pdf'));
+
+  // Verify file appears in the upload list
+  await expect(page.getByText('sample-document.pdf')).toBeVisible();
+  await expect(page.getByText(/\d+ KB/)).toBeVisible();
+});
+
+test('simulates drag-over visual feedback via JavaScript dispatch', async ({ page }) => {
+  await page.goto('/upload');
+
+  const dropZone = page.locator('[data-testid="file-drop-zone"]');
+
+  // Dispatch dragenter/dragover events to test visual feedback
+  await dropZone.dispatchEvent('dragenter', {
+    dataTransfer: { types: ['Files'] },
+  });
+
+  // Verify the drop zone shows the active/hover state
+  await expect(dropZone).toHaveClass(/drag-active|drop-highlight/);
+  await expect(dropZone).toContainText(/drop.*here|release.*upload/i);
+
+  // Dispatch dragleave to reset
+  await dropZone.dispatchEvent('dragleave');
+
+  await expect(dropZone).not.toHaveClass(/drag-active|drop-highlight/);
+});
+
+test('rejects invalid file types in drop zone', async ({ page }) => {
+  await page.goto('/upload');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Try to upload a file type that is not allowed
+  await fileInput.setInputFiles({
+    name: 'malware.exe',
+    mimeType: 'application/x-msdownload',
+    buffer: Buffer.from('fake-content'),
+  });
+
+  await expect(page.getByRole('alert')).toContainText(/not allowed|invalid file type/i);
+  await expect(page.getByText('malware.exe')).not.toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('uploads a file by dropping it on the drop zone', async ({ page }) => {
+  await page.goto('/upload');
+
+  const dropZone = page.locator('[data-testid="file-drop-zone"]');
+  await expect(dropZone).toContainText('Drag files here');
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/sample-document.pdf'));
+
+  await expect(page.getByText('sample-document.pdf')).toBeVisible();
+});
+
+test('rejects invalid file types in drop zone', async ({ page }) => {
+  await page.goto('/upload');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles({
+    name: 'malware.exe',
+    mimeType: 'application/x-msdownload',
+    buffer: Buffer.from('fake-content'),
+  });
+
+  await expect(page.getByRole('alert')).toContainText(/not allowed|invalid file type/i);
+});
+```
+
+---
+
+## Recipe 5: Drag with Custom Preview / Ghost Image
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('shows custom drag preview during drag operation', async ({ page }) => {
+  await page.goto('/board');
+
+  const card = page.locator('[data-testid="card-1"]');
+  const targetColumn = page.locator('[data-column="in-progress"]');
+
+  const cardBox = await card.boundingBox();
+  const targetBox = await targetColumn.boundingBox();
+
+  // Start dragging
+  await card.hover();
+  await page.mouse.down();
+
+  // Move partially toward the target
+  const midX = (cardBox!.x + targetBox!.x) / 2;
+  const midY = (cardBox!.y + targetBox!.y) / 2;
+  await page.mouse.move(midX, midY, { steps: 5 });
+
+  // Take a screenshot to visually verify the drag preview
+  // The custom preview element should be visible during drag
+  await expect(page.locator('.drag-preview')).toBeVisible();
+
+  // Verify the original card shows a placeholder/ghost
+  await expect(card).toHaveClass(/dragging|placeholder/);
+
+  // Complete the drag
+  await page.mouse.move(
+    targetBox!.x + targetBox!.width / 2,
+    targetBox!.y + targetBox!.height / 2,
+    { steps: 5 }
+  );
+  await page.mouse.up();
+
+  // Preview should disappear after drop
+  await expect(page.locator('.drag-preview')).not.toBeVisible();
+});
+
+test('drag preview shows item count for multi-select drag', async ({ page }) => {
+  await page.goto('/board');
+
+  // Select multiple cards
+  await page.locator('[data-testid="card-1"]').click();
+  await page.locator('[data-testid="card-2"]').click({ modifiers: ['Shift'] });
+  await page.locator('[data-testid="card-3"]').click({ modifiers: ['Shift'] });
+
+  // Start dragging one of the selected cards
+  const card = page.locator('[data-testid="card-1"]');
+  const targetColumn = page.locator('[data-column="done"]');
+
+  await card.hover();
+  await page.mouse.down();
+
+  const targetBox = await targetColumn.boundingBox();
+  await page.mouse.move(targetBox!.x + 50, targetBox!.y + 50, { steps: 5 });
+
+  // Verify the preview shows the count of selected items
+  await expect(page.locator('.drag-preview')).toContainText('3 items');
+
+  await page.mouse.up();
+
+  // All three cards should be in the target column
+  await expect(targetColumn.locator('[data-testid="card-1"]')).toBeVisible();
+  await expect(targetColumn.locator('[data-testid="card-2"]')).toBeVisible();
+  await expect(targetColumn.locator('[data-testid="card-3"]')).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('shows custom drag preview during drag operation', async ({ page }) => {
+  await page.goto('/board');
+
+  const card = page.locator('[data-testid="card-1"]');
+  const targetColumn = page.locator('[data-column="in-progress"]');
+
+  const cardBox = await card.boundingBox();
+  const targetBox = await targetColumn.boundingBox();
+
+  await card.hover();
+  await page.mouse.down();
+
+  const midX = (cardBox.x + targetBox.x) / 2;
+  const midY = (cardBox.y + targetBox.y) / 2;
+  await page.mouse.move(midX, midY, { steps: 5 });
+
+  await expect(page.locator('.drag-preview')).toBeVisible();
+  await expect(card).toHaveClass(/dragging|placeholder/);
+
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 5 }
+  );
+  await page.mouse.up();
+
+  await expect(page.locator('.drag-preview')).not.toBeVisible();
+});
+```
+
+---
+
+## Recipe 6: Testing Drag Position and Coordinates
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('drags an element to a specific coordinate on a canvas', async ({ page }) => {
+  await page.goto('/canvas-editor');
+
+  const canvas = page.locator('#design-canvas');
+  const element = page.locator('[data-testid="shape-1"]');
+
+  // Get the initial position
+  const initialBox = await element.boundingBox();
+  expect(initialBox).toBeTruthy();
+
+  // Define target position (absolute coordinates within the canvas)
+  const canvasBox = await canvas.boundingBox();
+  const targetX = canvasBox!.x + 300;
+  const targetY = canvasBox!.y + 200;
+
+  // Drag to specific coordinates
+  await element.hover();
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 10 });
+  await page.mouse.up();
+
+  // Verify element moved to approximately the right position
+  const newBox = await element.boundingBox();
+  expect(newBox!.x).toBeCloseTo(targetX - newBox!.width / 2, -1);
+  expect(newBox!.y).toBeCloseTo(targetY - newBox!.height / 2, -1);
+});
+
+test('snaps element to grid when dropped', async ({ page }) => {
+  await page.goto('/canvas-editor');
+
+  const element = page.locator('[data-testid="shape-1"]');
+  const canvas = page.locator('#design-canvas');
+
+  const canvasBox = await canvas.boundingBox();
+
+  // Drag to a position that is not on the grid
+  await element.hover();
+  await page.mouse.down();
+  await page.mouse.move(canvasBox!.x + 147, canvasBox!.y + 83, { steps: 10 });
+  await page.mouse.up();
+
+  // With a 20px grid, position should snap to nearest grid point
+  const snappedBox = await element.boundingBox();
+  expect(snappedBox!.x % 20).toBeCloseTo(0, 0);
+  expect(snappedBox!.y % 20).toBeCloseTo(0, 0);
+});
+
+test('constrains drag within boundaries', async ({ page }) => {
+  await page.goto('/canvas-editor');
+
+  const element = page.locator('[data-testid="constrained-element"]');
+  const container = page.locator('#constraint-box');
+
+  const containerBox = await container.boundingBox();
+
+  // Try to drag far outside the container
+  await element.hover();
+  await page.mouse.down();
+  await page.mouse.move(containerBox!.x + containerBox!.width + 500, containerBox!.y - 200, {
+    steps: 10,
+  });
+  await page.mouse.up();
+
+  // Element should be clamped within the container
+  const elementBox = await element.boundingBox();
+
+  expect(elementBox!.x).toBeGreaterThanOrEqual(containerBox!.x);
+  expect(elementBox!.y).toBeGreaterThanOrEqual(containerBox!.y);
+  expect(elementBox!.x + elementBox!.width).toBeLessThanOrEqual(
+    containerBox!.x + containerBox!.width
+  );
+  expect(elementBox!.y + elementBox!.height).toBeLessThanOrEqual(
+    containerBox!.y + containerBox!.height
+  );
+});
+
+test('resizes an element by dragging its handle', async ({ page }) => {
+  await page.goto('/canvas-editor');
+
+  const element = page.locator('[data-testid="shape-1"]');
+  await element.click(); // Select to show resize handles
+
+  const resizeHandle = element.locator('.resize-handle-se'); // south-east corner
+  const handleBox = await resizeHandle.boundingBox();
+
+  const initialBox = await element.boundingBox();
+
+  // Drag the resize handle to make the element larger
+  await resizeHandle.hover();
+  await page.mouse.down();
+  await page.mouse.move(handleBox!.x + 100, handleBox!.y + 80, { steps: 5 });
+  await page.mouse.up();
+
+  const newBox = await element.boundingBox();
+  expect(newBox!.width).toBeCloseTo(initialBox!.width + 100, -1);
+  expect(newBox!.height).toBeCloseTo(initialBox!.height + 80, -1);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('drags an element to a specific coordinate on a canvas', async ({ page }) => {
+  await page.goto('/canvas-editor');
+
+  const canvas = page.locator('#design-canvas');
+  const element = page.locator('[data-testid="shape-1"]');
+
+  const canvasBox = await canvas.boundingBox();
+  const targetX = canvasBox.x + 300;
+  const targetY = canvasBox.y + 200;
+
+  await element.hover();
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 10 });
+  await page.mouse.up();
+
+  const newBox = await element.boundingBox();
+  expect(newBox.x).toBeCloseTo(targetX - newBox.width / 2, -1);
+  expect(newBox.y).toBeCloseTo(targetY - newBox.height / 2, -1);
+});
+
+test('constrains drag within boundaries', async ({ page }) => {
+  await page.goto('/canvas-editor');
+
+  const element = page.locator('[data-testid="constrained-element"]');
+  const container = page.locator('#constraint-box');
+
+  const containerBox = await container.boundingBox();
+
+  await element.hover();
+  await page.mouse.down();
+  await page.mouse.move(containerBox.x + containerBox.width + 500, containerBox.y - 200, {
+    steps: 10,
+  });
+  await page.mouse.up();
+
+  const elementBox = await element.boundingBox();
+  expect(elementBox.x).toBeGreaterThanOrEqual(containerBox.x);
+  expect(elementBox.y).toBeGreaterThanOrEqual(containerBox.y);
+});
+```
+
+---
+
+## Variations
+
+### Drag and Drop with Keyboard Accessibility
+
+```typescript
+test('reorders items using keyboard', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+  const taskC = list.getByRole('listitem').filter({ hasText: 'Task C' });
+
+  // Focus the item
+  await taskC.focus();
+
+  // Use keyboard shortcut to pick up the item
+  await page.keyboard.press('Space');
+
+  // Move up twice
+  await page.keyboard.press('ArrowUp');
+  await page.keyboard.press('ArrowUp');
+
+  // Drop the item
+  await page.keyboard.press('Space');
+
+  const items = await list.getByRole('listitem').allTextContents();
+  expect(items[0]).toContain('Task C');
+});
+```
+
+### Drag and Drop Between iframes
+
+```typescript
+test('drags between main page and iframe', async ({ page }) => {
+  await page.goto('/editor');
+
+  const sourceItem = page.getByText('Widget A');
+  const iframe = page.frameLocator('#preview-frame');
+  const dropTarget = iframe.locator('#content-area');
+
+  // Cross-frame drag requires coordinates since dragTo does not work across frames
+  const sourceBox = await sourceItem.boundingBox();
+  const iframeElement = page.locator('#preview-frame');
+  const iframeBox = await iframeElement.boundingBox();
+
+  // Calculate target position within the iframe
+  const targetX = iframeBox!.x + 100;
+  const targetY = iframeBox!.y + 100;
+
+  await sourceItem.hover();
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 20 });
+  await page.mouse.up();
+
+  await expect(iframe.getByText('Widget A')).toBeVisible();
+});
+```
+
+### Touch-Based Drag on Mobile
+
+```typescript
+test('drags items on mobile via touch events', async ({ page }) => {
+  await page.goto('/tasks');
+
+  const list = page.getByRole('list', { name: 'Task list' });
+  const sourceItem = list.getByRole('listitem').filter({ hasText: 'Task C' });
+  const targetItem = list.getByRole('listitem').filter({ hasText: 'Task A' });
+
+  const sourceBox = await sourceItem.boundingBox();
+  const targetBox = await targetItem.boundingBox();
+
+  // Simulate long-press then drag using touch
+  await page.touchscreen.tap(sourceBox!.x + sourceBox!.width / 2, sourceBox!.y + sourceBox!.height / 2);
+
+  // Dispatch touchstart, touchmove, touchend for libraries that use touch events
+  await sourceItem.dispatchEvent('touchstart', {
+    touches: [{ clientX: sourceBox!.x + 10, clientY: sourceBox!.y + 10 }],
+  });
+
+  // Move in steps
+  for (let i = 1; i <= 5; i++) {
+    const y = sourceBox!.y + (targetBox!.y - sourceBox!.y) * (i / 5);
+    await sourceItem.dispatchEvent('touchmove', {
+      touches: [{ clientX: sourceBox!.x + 10, clientY: y }],
+    });
+  }
+
+  await sourceItem.dispatchEvent('touchend');
+
+  const items = await list.getByRole('listitem').allTextContents();
+  expect(items[0]).toContain('Task C');
+});
+```
+
+---
+
+## Tips
+
+1. **Use `dragTo()` first, then fall back to manual mouse events**. Playwright's built-in `dragTo()` handles most native HTML5 drag and drop. Only use `page.mouse.down()` / `move()` / `up()` sequences for custom drag libraries (react-beautiful-dnd, dnd-kit, SortableJS) that need specific event sequences.
+
+2. **Add intermediate mouse move steps for drag libraries**. Libraries like `react-beautiful-dnd` require multiple `mousemove` events with small increments to detect a drag. Use `{ steps: 10 }` or a manual loop. A single jump from source to target often fails silently.
+
+3. **Always assert the final state, not just the drop event**. After a drag-and-drop, verify that the DOM actually reflects the change -- item order, column contents, position coordinates. Visual feedback during drag is nice to test but the final persisted state matters most.
+
+4. **Use `boundingBox()` for coordinate-based assertions**. When testing canvas editors, grid layouts, or position-sensitive drops, capture the bounding box after the operation and compare against expected coordinates. Use `toBeCloseTo()` for tolerance.
+
+5. **Test undo after drag operations**. If your app supports Ctrl+Z to undo a reorder or move, test that the drag operation is reversible. This catches state management bugs that only appear on undo.
+
+---
+
+## Related
+
+- [Playwright Drag and Drop Docs](https://playwright.dev/docs/input#drag-and-drop)
+- `recipes/file-upload-download.md` -- File drop zones specifically
+- `foundations/actions.md` -- Mouse and keyboard interaction basics
+- `patterns/page-objects.md` -- Encapsulate complex drag flows

--- a/engineering-team/playwright skill/core/electron-testing.md
+++ b/engineering-team/playwright skill/core/electron-testing.md
@@ -1,0 +1,622 @@
+# Electron Testing
+
+> **When to use**: When your application is an Electron desktop app and you need end-to-end tests covering the renderer process, main process, IPC communication, native dialogs, system tray, and multi-window workflows.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+import { _electron as electron } from 'playwright';
+
+// Launch the Electron app
+const app = await electron.launch({ args: ['./main.js'] });
+
+// Get the first window (renderer process)
+const window = await app.firstWindow();
+
+// Access the main process for evaluation
+const appPath = await app.evaluate(async ({ app }) => {
+  return app.getPath('userData');
+});
+
+// Close the app
+await app.close();
+```
+
+## Patterns
+
+### Basic Electron App Setup
+
+**Use when**: Starting to test an Electron app with Playwright for the first time.
+**Avoid when**: Your app is a web app, not an Electron app.
+
+**TypeScript**
+```typescript
+import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test';
+
+let app: ElectronApplication;
+let window: Page;
+
+test.beforeAll(async () => {
+  // Launch the Electron app from your project directory
+  app = await electron.launch({
+    args: ['./dist/main.js'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+    },
+  });
+
+  // Wait for the first BrowserWindow to open
+  window = await app.firstWindow();
+
+  // Optional: wait for the app to be fully loaded
+  await window.waitForLoadState('domcontentloaded');
+});
+
+test.afterAll(async () => {
+  await app.close();
+});
+
+test('app window has correct title', async () => {
+  const title = await window.title();
+  expect(title).toBe('My Electron App');
+});
+
+test('main page renders', async () => {
+  await expect(window.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect, _electron: electron } = require('@playwright/test');
+
+let app;
+let window;
+
+test.beforeAll(async () => {
+  app = await electron.launch({
+    args: ['./dist/main.js'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+    },
+  });
+  window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+});
+
+test.afterAll(async () => {
+  await app.close();
+});
+
+test('app window has correct title', async () => {
+  const title = await window.title();
+  expect(title).toBe('My Electron App');
+});
+
+test('main page renders', async () => {
+  await expect(window.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+});
+```
+
+### Electron App Fixture (Recommended)
+
+**Use when**: You want isolated, reusable Electron app instances across test files.
+**Avoid when**: All tests can share a single app instance (rare in practice).
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test';
+
+type ElectronFixtures = {
+  electronApp: ElectronApplication;
+  window: Page;
+};
+
+export const test = base.extend<ElectronFixtures>({
+  electronApp: async ({}, use) => {
+    const app = await electron.launch({
+      args: ['./dist/main.js'],
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+    await use(app);
+    await app.close();
+  },
+
+  window: async ({ electronApp }, use) => {
+    const window = await electronApp.firstWindow();
+    await window.waitForLoadState('domcontentloaded');
+    await use(window);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// app.spec.ts
+import { test, expect } from './fixtures';
+
+test('navigate to settings', async ({ window }) => {
+  await window.getByRole('link', { name: 'Settings' }).click();
+  await expect(window.getByRole('heading', { name: 'Settings' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect, _electron: electron } = require('@playwright/test');
+
+const test = base.extend({
+  electronApp: async ({}, use) => {
+    const app = await electron.launch({
+      args: ['./dist/main.js'],
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+    await use(app);
+    await app.close();
+  },
+
+  window: async ({ electronApp }, use) => {
+    const window = await electronApp.firstWindow();
+    await window.waitForLoadState('domcontentloaded');
+    await use(window);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### Accessing the Main Process
+
+**Use when**: You need to read Electron app state, check paths, get app version, or verify main process behavior.
+**Avoid when**: Everything you need is in the renderer (UI). Prefer testing through the UI.
+
+`app.evaluate()` runs code in the main process with access to all Electron APIs.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('verify app version and paths', async ({ electronApp }) => {
+  // Evaluate in the main process — receives the Electron module
+  const appInfo = await electronApp.evaluate(async ({ app }) => {
+    return {
+      version: app.getVersion(),
+      name: app.getName(),
+      userData: app.getPath('userData'),
+      locale: app.getLocale(),
+      isPackaged: app.isPackaged,
+    };
+  });
+
+  expect(appInfo.version).toMatch(/^\d+\.\d+\.\d+$/);
+  expect(appInfo.name).toBe('my-electron-app');
+  expect(appInfo.userData).toBeTruthy();
+  expect(appInfo.isPackaged).toBe(false); // false during development
+});
+
+test('main process environment variables are set', async ({ electronApp }) => {
+  const nodeEnv = await electronApp.evaluate(async () => {
+    return process.env.NODE_ENV;
+  });
+
+  expect(nodeEnv).toBe('test');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('verify app version and paths', async ({ electronApp }) => {
+  const appInfo = await electronApp.evaluate(async ({ app }) => {
+    return {
+      version: app.getVersion(),
+      name: app.getName(),
+      userData: app.getPath('userData'),
+      isPackaged: app.isPackaged,
+    };
+  });
+
+  expect(appInfo.version).toMatch(/^\d+\.\d+\.\d+$/);
+  expect(appInfo.name).toBe('my-electron-app');
+});
+```
+
+### Testing IPC Communication
+
+**Use when**: Your app uses `ipcMain` / `ipcRenderer` for communication between the main and renderer processes.
+**Avoid when**: IPC is an implementation detail and the behavior is fully testable through the UI.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('renderer sends IPC message and gets response', async ({ electronApp, window }) => {
+  // Trigger an IPC call from the renderer
+  const result = await window.evaluate(async () => {
+    // Assumes your preload script exposes ipcRenderer via contextBridge
+    return await (window as any).electronAPI.getSystemInfo();
+  });
+
+  expect(result).toHaveProperty('platform');
+  expect(result).toHaveProperty('arch');
+  expect(result.platform).toBeTruthy();
+});
+
+test('main process handles IPC file-read request', async ({ electronApp, window }) => {
+  // Set up a listener in the main process first
+  await electronApp.evaluate(async ({ ipcMain }) => {
+    ipcMain.handle('test-ping', async () => {
+      return { pong: true, timestamp: Date.now() };
+    });
+  });
+
+  // Send from renderer
+  const response = await window.evaluate(async () => {
+    return await (window as any).electronAPI.invoke('test-ping');
+  });
+
+  expect(response.pong).toBe(true);
+  expect(response.timestamp).toBeGreaterThan(0);
+});
+
+test('IPC event triggers UI update', async ({ window }) => {
+  // Simulate the main process sending an event to the renderer
+  await window.evaluate(() => {
+    // Trigger a custom event that the app listens for
+    window.dispatchEvent(new CustomEvent('app:notification', {
+      detail: { message: 'Update available', version: '2.0.0' },
+    }));
+  });
+
+  await expect(window.getByText('Update available')).toBeVisible();
+  await expect(window.getByText('Version 2.0.0')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('renderer sends IPC message and gets response', async ({ electronApp, window }) => {
+  const result = await window.evaluate(async () => {
+    return await window.electronAPI.getSystemInfo();
+  });
+
+  expect(result).toHaveProperty('platform');
+  expect(result).toHaveProperty('arch');
+});
+
+test('IPC event triggers UI update', async ({ window }) => {
+  await window.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('app:notification', {
+      detail: { message: 'Update available', version: '2.0.0' },
+    }));
+  });
+
+  await expect(window.getByText('Update available')).toBeVisible();
+});
+```
+
+### File System Dialogs
+
+**Use when**: Your app uses Electron's `dialog.showOpenDialog`, `dialog.showSaveDialog`, or similar native file dialogs.
+**Avoid when**: File selection is handled by a web input (`<input type="file">`). Use standard Playwright file chooser for that.
+
+Native dialogs cannot be interacted with directly. Mock them in the main process.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('open file dialog and load a document', async ({ electronApp, window }) => {
+  // Mock the dialog to return a specific file path
+  await electronApp.evaluate(async ({ dialog }) => {
+    dialog.showOpenDialog = async () => ({
+      canceled: false,
+      filePaths: ['/tmp/test-document.txt'],
+    });
+  });
+
+  // Click the "Open File" button in the renderer
+  await window.getByRole('button', { name: 'Open File' }).click();
+
+  // Verify the app loaded the file
+  await expect(window.getByTestId('file-name')).toHaveText('test-document.txt');
+});
+
+test('save file dialog returns selected path', async ({ electronApp, window }) => {
+  await electronApp.evaluate(async ({ dialog }) => {
+    dialog.showSaveDialog = async () => ({
+      canceled: false,
+      filePath: '/tmp/exported-report.pdf',
+    });
+  });
+
+  await window.getByRole('button', { name: 'Export PDF' }).click();
+  await expect(window.getByText('Saved to /tmp/exported-report.pdf')).toBeVisible();
+});
+
+test('handle canceled file dialog', async ({ electronApp, window }) => {
+  await electronApp.evaluate(async ({ dialog }) => {
+    dialog.showOpenDialog = async () => ({
+      canceled: true,
+      filePaths: [],
+    });
+  });
+
+  await window.getByRole('button', { name: 'Open File' }).click();
+
+  // App should not crash or change state
+  await expect(window.getByTestId('file-name')).toHaveText('No file selected');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('open file dialog and load a document', async ({ electronApp, window }) => {
+  await electronApp.evaluate(async ({ dialog }) => {
+    dialog.showOpenDialog = async () => ({
+      canceled: false,
+      filePaths: ['/tmp/test-document.txt'],
+    });
+  });
+
+  await window.getByRole('button', { name: 'Open File' }).click();
+  await expect(window.getByTestId('file-name')).toHaveText('test-document.txt');
+});
+
+test('handle canceled file dialog', async ({ electronApp, window }) => {
+  await electronApp.evaluate(async ({ dialog }) => {
+    dialog.showOpenDialog = async () => ({
+      canceled: true,
+      filePaths: [],
+    });
+  });
+
+  await window.getByRole('button', { name: 'Open File' }).click();
+  await expect(window.getByTestId('file-name')).toHaveText('No file selected');
+});
+```
+
+### System Tray Testing
+
+**Use when**: Your app has a system tray icon with context menus or status indicators.
+**Avoid when**: Your app has no tray functionality.
+
+Playwright cannot directly click system tray icons. Test the tray logic by evaluating in the main process.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('tray icon is created on app launch', async ({ electronApp }) => {
+  const hasTray = await electronApp.evaluate(async ({ BrowserWindow }) => {
+    // Access the tray via a reference your app stores
+    const { tray } = require('./tray-manager');
+    return tray !== null && !tray.isDestroyed();
+  });
+
+  expect(hasTray).toBe(true);
+});
+
+test('tray tooltip shows unread count', async ({ electronApp }) => {
+  const tooltip = await electronApp.evaluate(async () => {
+    const { tray } = require('./tray-manager');
+    return tray.getToolTip();
+  });
+
+  expect(tooltip).toMatch(/\d+ unread messages?/);
+});
+
+test('clicking tray "Show" menu item opens the window', async ({ electronApp }) => {
+  // Simulate clicking a tray menu item by invoking its callback
+  await electronApp.evaluate(async ({ BrowserWindow }) => {
+    const { trayMenu } = require('./tray-manager');
+    // Find the "Show" menu item and invoke its click handler
+    const showItem = trayMenu.items.find((item: any) => item.label === 'Show');
+    if (showItem && showItem.click) {
+      showItem.click();
+    }
+  });
+
+  // The main window should now be visible
+  const window = await electronApp.firstWindow();
+  const isVisible = await window.evaluate(() => {
+    return document.visibilityState === 'visible';
+  });
+  expect(isVisible).toBe(true);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('tray icon is created on app launch', async ({ electronApp }) => {
+  const hasTray = await electronApp.evaluate(async () => {
+    const { tray } = require('./tray-manager');
+    return tray !== null && !tray.isDestroyed();
+  });
+
+  expect(hasTray).toBe(true);
+});
+```
+
+### Multiple Windows
+
+**Use when**: Your Electron app opens multiple windows (preferences, about, detached panels).
+**Avoid when**: Your app uses a single window.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('open and interact with preferences window', async ({ electronApp, window }) => {
+  // Click the menu item or button that opens the preferences window
+  await window.getByRole('menuitem', { name: 'Preferences' }).click();
+
+  // Wait for the new window to appear
+  const prefsWindow = await electronApp.waitForEvent('window');
+  await prefsWindow.waitForLoadState('domcontentloaded');
+
+  // Interact with the preferences window
+  await prefsWindow.getByLabel('Theme').selectOption('dark');
+  await prefsWindow.getByRole('button', { name: 'Save' }).click();
+
+  // Verify the main window reflects the change
+  await expect(window.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+  // Close the preferences window
+  await prefsWindow.close();
+});
+
+test('get all open windows', async ({ electronApp, window }) => {
+  // Open a second window
+  await window.getByRole('button', { name: 'New Window' }).click();
+
+  // Get all windows
+  const allWindows = electronApp.windows();
+  expect(allWindows.length).toBe(2);
+
+  // Find the new window (not the main one)
+  const newWindow = allWindows.find((w) => w !== window)!;
+  await expect(newWindow.getByRole('heading')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('open and interact with preferences window', async ({ electronApp, window }) => {
+  await window.getByRole('menuitem', { name: 'Preferences' }).click();
+
+  const prefsWindow = await electronApp.waitForEvent('window');
+  await prefsWindow.waitForLoadState('domcontentloaded');
+
+  await prefsWindow.getByLabel('Theme').selectOption('dark');
+  await prefsWindow.getByRole('button', { name: 'Save' }).click();
+
+  await expect(window.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await prefsWindow.close();
+});
+```
+
+### Testing Packaged/Built Apps
+
+**Use when**: You want to test the production build of your Electron app (after `electron-builder`, `electron-forge`, etc.).
+**Avoid when**: Development mode testing is sufficient for your CI pipeline.
+
+**TypeScript**
+```typescript
+import { test, expect, _electron as electron } from '@playwright/test';
+import path from 'path';
+
+test('packaged app launches and works', async () => {
+  // Path to the packaged app executable
+  const appPath = process.platform === 'darwin'
+    ? path.join(__dirname, '../dist/mac/MyApp.app/Contents/MacOS/MyApp')
+    : process.platform === 'win32'
+      ? path.join(__dirname, '../dist/win-unpacked/MyApp.exe')
+      : path.join(__dirname, '../dist/linux-unpacked/my-app');
+
+  const app = await electron.launch({
+    executablePath: appPath,
+  });
+
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  // Verify the packaged app works correctly
+  const title = await window.title();
+  expect(title).toBe('My Electron App');
+
+  await expect(window.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+
+  // Verify it reports as packaged
+  const isPackaged = await app.evaluate(async ({ app }) => app.isPackaged);
+  expect(isPackaged).toBe(true);
+
+  await app.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect, _electron: electron } = require('@playwright/test');
+const path = require('path');
+
+test('packaged app launches and works', async () => {
+  const appPath = process.platform === 'darwin'
+    ? path.join(__dirname, '../dist/mac/MyApp.app/Contents/MacOS/MyApp')
+    : process.platform === 'win32'
+      ? path.join(__dirname, '../dist/win-unpacked/MyApp.exe')
+      : path.join(__dirname, '../dist/linux-unpacked/my-app');
+
+  const app = await electron.launch({
+    executablePath: appPath,
+  });
+
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  const title = await window.title();
+  expect(title).toBe('My Electron App');
+
+  await expect(window.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await app.close();
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Launch Electron app for testing | `_electron.launch({ args: ['./main.js'] })` | Playwright's built-in Electron support |
+| Get the main window | `app.firstWindow()` | Returns the first `BrowserWindow` as a Playwright `Page` |
+| Read main process state | `app.evaluate(({ app }) => ...)` | Runs code in the main process with Electron APIs |
+| Test IPC round-trips | `window.evaluate` (renderer) + `app.evaluate` (main) | Cover both sides of the IPC bridge |
+| Mock native file dialogs | Override `dialog.showOpenDialog` via `app.evaluate` | Native dialogs cannot be automated directly |
+| Test system tray | `app.evaluate` to invoke tray callbacks | Tray icons are OS-native; not clickable via Playwright |
+| Multiple windows | `app.waitForEvent('window')` | Captures new `BrowserWindow` instances as they open |
+| Test packaged builds | `electron.launch({ executablePath })` | Points to the built binary instead of source |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `const { app } = require('electron')` in test files | Electron APIs are not available in Playwright's Node process | Use `electronApp.evaluate(({ app }) => ...)` |
+| Directly import renderer code into tests | Bypasses the actual app lifecycle and IPC | Test through the UI via the `window` (Page) object |
+| Skip `waitForLoadState` after `firstWindow()` | Window may not be fully rendered | Always `await window.waitForLoadState('domcontentloaded')` |
+| Test tray by clicking system-level UI | Playwright cannot interact with native OS chrome | Mock tray menu callbacks via `app.evaluate` |
+| Share a single `ElectronApplication` across all tests without cleanup | State leaks between tests | Use fixtures with `app.close()` in teardown |
+| Forget to close the app in `afterAll` | Leaves Electron processes running, eating CI resources | Always `await app.close()` in teardown |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `electron.launch()` throws "cannot find module" | `args` path does not point to your main entry file | Verify the path: `args: ['./dist/main.js']` relative to the working directory |
+| `firstWindow()` times out | App does not open a `BrowserWindow` in time | Check that the app creates a window on startup; increase timeout |
+| `app.evaluate` cannot access Electron modules | Destructuring the wrong parameter | Destructure correctly: `evaluate(async ({ app, dialog, BrowserWindow }) => ...)` |
+| Dialog mock does not take effect | Mock applied after the dialog was already called | Set up mocks before triggering the UI action that opens the dialog |
+| Second window not captured | `waitForEvent('window')` registered after the window opened | Register the event listener before triggering the action that opens the window |
+| Tests hang after `app.close()` | Child processes spawned by the app are still running | Ensure your Electron app cleans up child processes on quit |
+| Packaged app test fails with path error | Executable path varies by OS and build tool | Use `process.platform` to compute the correct path |
+| `window.evaluate` throws context destroyed | Window was closed or navigated during evaluation | Ensure the window is stable before evaluating |
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- wrapping Electron app launch in fixtures
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- all standard assertions work on Electron windows
+- [core/iframes-and-shadow-dom.md](iframes-and-shadow-dom.md) -- Electron apps often embed web components or iframes
+- [core/browser-apis.md](browser-apis.md) -- localStorage, IndexedDB, and other APIs work the same in Electron

--- a/engineering-team/playwright skill/core/error-and-edge-cases.md
+++ b/engineering-team/playwright skill/core/error-and-edge-cases.md
@@ -1,0 +1,1137 @@
+# Error States and Edge Cases
+
+> **When to use**: Testing how your application handles errors, failures, boundary conditions, and unusual user behavior. These tests catch bugs that happy-path tests miss.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/network-mocking.md](network-mocking.md) for route interception
+
+## Quick Reference
+
+```typescript
+// Mock a 500 server error
+await page.route('**/api/data', (route) => route.fulfill({ status: 500 }));
+
+// Simulate offline mode
+await page.context().setOffline(true);
+
+// Test empty state
+await page.route('**/api/items', (route) =>
+  route.fulfill({ status: 200, json: [] })
+);
+
+// Browser back/forward
+await page.goBack();
+await page.goForward();
+
+// Abort a network request (simulate network failure)
+await page.route('**/api/save', (route) => route.abort('connectionfailed'));
+```
+
+## Patterns
+
+### HTTP Error Status Codes
+
+**Use when**: Testing that your application displays appropriate error pages or messages for 4xx and 5xx responses.
+**Avoid when**: The error is handled silently (no user-facing feedback). Test via API or logs instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('displays 404 page for missing resources', async ({ page }) => {
+  // Navigate directly to a non-existent URL
+  await page.goto('/this-page-does-not-exist');
+
+  await expect(page.getByRole('heading', { name: /not found/i })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Go home' })).toBeVisible();
+});
+
+test('handles 500 server error gracefully', async ({ page }) => {
+  // Intercept the API call and return a 500
+  await page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Internal server error' }),
+    })
+  );
+
+  await page.goto('/dashboard');
+
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+});
+
+test('handles 403 forbidden with redirect to login', async ({ page }) => {
+  await page.route('**/api/admin/**', (route) =>
+    route.fulfill({ status: 403 })
+  );
+
+  await page.goto('/admin/settings');
+
+  // Should redirect to login or show access denied
+  await expect(page.getByText(/access denied|not authorized/i)).toBeVisible();
+});
+
+test('handles 429 rate limiting', async ({ page }) => {
+  await page.route('**/api/search*', (route) =>
+    route.fulfill({
+      status: 429,
+      headers: { 'Retry-After': '30' },
+      body: JSON.stringify({ error: 'Too many requests' }),
+    })
+  );
+
+  await page.goto('/search');
+  await page.getByLabel('Search').fill('test');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  await expect(page.getByText(/too many requests|try again later/i)).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('displays 404 page for missing resources', async ({ page }) => {
+  await page.goto('/this-page-does-not-exist');
+
+  await expect(page.getByRole('heading', { name: /not found/i })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Go home' })).toBeVisible();
+});
+
+test('handles 500 server error gracefully', async ({ page }) => {
+  await page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Internal server error' }),
+    })
+  );
+
+  await page.goto('/dashboard');
+
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+});
+
+test('handles 403 forbidden with redirect to login', async ({ page }) => {
+  await page.route('**/api/admin/**', (route) =>
+    route.fulfill({ status: 403 })
+  );
+
+  await page.goto('/admin/settings');
+  await expect(page.getByText(/access denied|not authorized/i)).toBeVisible();
+});
+
+test('handles 429 rate limiting', async ({ page }) => {
+  await page.route('**/api/search*', (route) =>
+    route.fulfill({
+      status: 429,
+      headers: { 'Retry-After': '30' },
+      body: JSON.stringify({ error: 'Too many requests' }),
+    })
+  );
+
+  await page.goto('/search');
+  await page.getByLabel('Search').fill('test');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  await expect(page.getByText(/too many requests|try again later/i)).toBeVisible();
+});
+```
+
+### Network Failure and Offline Mode
+
+**Use when**: Testing how the app behaves when the network is down, requests fail, or the connection is intermittent.
+**Avoid when**: The app has no offline or error handling behavior to test.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('offline mode shows offline banner', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  // Go offline
+  await page.context().setOffline(true);
+
+  // Trigger a network-dependent action
+  await page.getByRole('button', { name: 'Refresh' }).click();
+
+  await expect(page.getByText(/offline|no connection/i)).toBeVisible();
+
+  // Go back online
+  await page.context().setOffline(false);
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByText(/offline|no connection/i)).not.toBeVisible();
+});
+
+test('network request failure shows error state', async ({ page }) => {
+  // Abort specific requests to simulate network failure
+  await page.route('**/api/user/profile', (route) =>
+    route.abort('connectionfailed')
+  );
+
+  await page.goto('/profile');
+
+  await expect(page.getByText('Failed to load profile')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+});
+
+test('request timeout shows timeout message', async ({ page }) => {
+  // Delay the response beyond the app's timeout threshold
+  await page.route('**/api/reports', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    await route.fulfill({ status: 200, json: { data: [] } });
+  });
+
+  await page.goto('/reports');
+
+  // App should show timeout message before Playwright's own timeout
+  await expect(page.getByText(/timed out|taking too long/i)).toBeVisible({
+    timeout: 20_000,
+  });
+});
+
+test('intermittent connectivity — request fails then succeeds', async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route('**/api/data', (route) => {
+    requestCount++;
+    if (requestCount <= 2) {
+      return route.abort('connectionfailed');
+    }
+    return route.fulfill({ status: 200, json: { items: ['a', 'b', 'c'] } });
+  });
+
+  await page.goto('/data');
+
+  // First load fails
+  await expect(page.getByText(/failed|error/i)).toBeVisible();
+
+  // User retries — still fails
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText(/failed|error/i)).toBeVisible();
+
+  // Third attempt succeeds
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(3);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('offline mode shows offline banner', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.context().setOffline(true);
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByText(/offline|no connection/i)).toBeVisible();
+
+  await page.context().setOffline(false);
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByText(/offline|no connection/i)).not.toBeVisible();
+});
+
+test('network request failure shows error state', async ({ page }) => {
+  await page.route('**/api/user/profile', (route) =>
+    route.abort('connectionfailed')
+  );
+
+  await page.goto('/profile');
+
+  await expect(page.getByText('Failed to load profile')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+});
+
+test('intermittent connectivity — request fails then succeeds', async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route('**/api/data', (route) => {
+    requestCount++;
+    if (requestCount <= 2) {
+      return route.abort('connectionfailed');
+    }
+    return route.fulfill({ status: 200, json: { items: ['a', 'b', 'c'] } });
+  });
+
+  await page.goto('/data');
+
+  await expect(page.getByText(/failed|error/i)).toBeVisible();
+
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText(/failed|error/i)).toBeVisible();
+
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(3);
+});
+```
+
+### Empty States and Boundary Testing
+
+**Use when**: Testing what the UI shows when there is no data, when inputs are at their minimum or maximum values, or when inputs contain special characters.
+**Avoid when**: Never. Every feature should have empty state and boundary tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('empty state is shown when no items exist', async ({ page }) => {
+  // Mock an empty response
+  await page.route('**/api/tasks', (route) =>
+    route.fulfill({ status: 200, json: [] })
+  );
+
+  await page.goto('/tasks');
+
+  await expect(page.getByText('No tasks yet')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Create your first task' })).toBeVisible();
+
+  // List elements should not be present
+  await expect(page.getByRole('listitem')).toHaveCount(0);
+});
+
+test('handles maximum length input', async ({ page }) => {
+  await page.goto('/profile');
+
+  // Fill with max-length string
+  const maxLengthName = 'A'.repeat(255);
+  await page.getByLabel('Display name').fill(maxLengthName);
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // Verify the name was saved (or truncated, depending on app behavior)
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+
+test('handles special characters in input', async ({ page }) => {
+  await page.goto('/search');
+
+  const specialInputs = [
+    '<script>alert("xss")</script>',
+    '"; DROP TABLE users; --',
+    'unicode: \u00e9\u00e0\u00fc\u00f1 \u4f60\u597d \ud83d\ude80',
+    'null bytes: \x00\x01\x02',
+    'path traversal: ../../etc/passwd',
+  ];
+
+  for (const input of specialInputs) {
+    await page.getByLabel('Search').fill(input);
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    // App should not crash — either show results or "no results"
+    await expect(
+      page.getByText(/results|no results|no matches/i)
+    ).toBeVisible();
+  }
+});
+
+test('handles zero, one, and many items (0-1-N pattern)', async ({ page }) => {
+  // Zero items
+  await page.route('**/api/notifications', (route) =>
+    route.fulfill({ status: 200, json: [] })
+  );
+  await page.goto('/notifications');
+  await expect(page.getByText('No notifications')).toBeVisible();
+
+  // One item
+  await page.route('**/api/notifications', (route) =>
+    route.fulfill({
+      status: 200,
+      json: [{ id: 1, message: 'Welcome!' }],
+    })
+  );
+  await page.reload();
+  await expect(page.getByRole('listitem')).toHaveCount(1);
+  await expect(page.getByText('No notifications')).not.toBeVisible();
+
+  // Many items — verify pagination or "load more"
+  await page.route('**/api/notifications', (route) =>
+    route.fulfill({
+      status: 200,
+      json: Array.from({ length: 50 }, (_, i) => ({
+        id: i + 1,
+        message: `Notification ${i + 1}`,
+      })),
+    })
+  );
+  await page.reload();
+  await expect(page.getByRole('listitem').first()).toBeVisible();
+  await expect(page.getByRole('button', { name: /load more|show all/i })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('empty state is shown when no items exist', async ({ page }) => {
+  await page.route('**/api/tasks', (route) =>
+    route.fulfill({ status: 200, json: [] })
+  );
+
+  await page.goto('/tasks');
+
+  await expect(page.getByText('No tasks yet')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Create your first task' })).toBeVisible();
+  await expect(page.getByRole('listitem')).toHaveCount(0);
+});
+
+test('handles maximum length input', async ({ page }) => {
+  await page.goto('/profile');
+
+  const maxLengthName = 'A'.repeat(255);
+  await page.getByLabel('Display name').fill(maxLengthName);
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+
+test('handles special characters in input', async ({ page }) => {
+  await page.goto('/search');
+
+  const specialInputs = [
+    '<script>alert("xss")</script>',
+    '"; DROP TABLE users; --',
+    'unicode: \u00e9\u00e0\u00fc\u00f1 \u4f60\u597d \ud83d\ude80',
+    'path traversal: ../../etc/passwd',
+  ];
+
+  for (const input of specialInputs) {
+    await page.getByLabel('Search').fill(input);
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    await expect(
+      page.getByText(/results|no results|no matches/i)
+    ).toBeVisible();
+  }
+});
+
+test('handles zero, one, and many items (0-1-N pattern)', async ({ page }) => {
+  await page.route('**/api/notifications', (route) =>
+    route.fulfill({ status: 200, json: [] })
+  );
+  await page.goto('/notifications');
+  await expect(page.getByText('No notifications')).toBeVisible();
+
+  await page.route('**/api/notifications', (route) =>
+    route.fulfill({
+      status: 200,
+      json: [{ id: 1, message: 'Welcome!' }],
+    })
+  );
+  await page.reload();
+  await expect(page.getByRole('listitem')).toHaveCount(1);
+
+  await page.route('**/api/notifications', (route) =>
+    route.fulfill({
+      status: 200,
+      json: Array.from({ length: 50 }, (_, i) => ({
+        id: i + 1,
+        message: `Notification ${i + 1}`,
+      })),
+    })
+  );
+  await page.reload();
+  await expect(page.getByRole('listitem').first()).toBeVisible();
+  await expect(page.getByRole('button', { name: /load more|show all/i })).toBeVisible();
+});
+```
+
+### Loading States and Skeletons
+
+**Use when**: Verifying that loading indicators, skeleton screens, or spinners appear during data fetching and disappear when data arrives.
+**Avoid when**: The application renders synchronously with no loading indicators (SSR without client-side fetching).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('loading skeleton appears and resolves', async ({ page }) => {
+  // Delay the API response to observe the loading state
+  let resolveResponse: () => void;
+  const responseReady = new Promise<void>((resolve) => {
+    resolveResponse = resolve;
+  });
+
+  await page.route('**/api/dashboard', async (route) => {
+    await responseReady;
+    await route.fulfill({
+      status: 200,
+      json: { revenue: 12400, users: 350 },
+    });
+  });
+
+  await page.goto('/dashboard');
+
+  // Skeleton should be visible while loading
+  await expect(page.getByTestId('skeleton-revenue')).toBeVisible();
+  await expect(page.getByTestId('skeleton-users')).toBeVisible();
+
+  // Real content should not be visible yet
+  await expect(page.getByText('$12,400')).not.toBeVisible();
+
+  // Release the response
+  resolveResponse!();
+
+  // Skeleton disappears, real content appears
+  await expect(page.getByTestId('skeleton-revenue')).not.toBeVisible();
+  await expect(page.getByText('$12,400')).toBeVisible();
+  await expect(page.getByText('350')).toBeVisible();
+});
+
+test('spinner shown during form submission', async ({ page }) => {
+  let resolveSubmit: () => void;
+  const submitReady = new Promise<void>((resolve) => {
+    resolveSubmit = resolve;
+  });
+
+  await page.route('**/api/contact', async (route) => {
+    await submitReady;
+    await route.fulfill({ status: 200, json: { success: true } });
+  });
+
+  await page.goto('/contact');
+  await page.getByLabel('Name').fill('Jane');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Test');
+
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  // Loading spinner/state during submission
+  await expect(page.getByRole('button', { name: /sending/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /sending/i })).toBeDisabled();
+
+  // Complete the submission
+  resolveSubmit!();
+
+  await expect(page.getByText('Message sent')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('loading skeleton appears and resolves', async ({ page }) => {
+  let resolveResponse;
+  const responseReady = new Promise((resolve) => {
+    resolveResponse = resolve;
+  });
+
+  await page.route('**/api/dashboard', async (route) => {
+    await responseReady;
+    await route.fulfill({
+      status: 200,
+      json: { revenue: 12400, users: 350 },
+    });
+  });
+
+  await page.goto('/dashboard');
+
+  await expect(page.getByTestId('skeleton-revenue')).toBeVisible();
+  await expect(page.getByTestId('skeleton-users')).toBeVisible();
+  await expect(page.getByText('$12,400')).not.toBeVisible();
+
+  resolveResponse();
+
+  await expect(page.getByTestId('skeleton-revenue')).not.toBeVisible();
+  await expect(page.getByText('$12,400')).toBeVisible();
+  await expect(page.getByText('350')).toBeVisible();
+});
+
+test('spinner shown during form submission', async ({ page }) => {
+  let resolveSubmit;
+  const submitReady = new Promise((resolve) => {
+    resolveSubmit = resolve;
+  });
+
+  await page.route('**/api/contact', async (route) => {
+    await submitReady;
+    await route.fulfill({ status: 200, json: { success: true } });
+  });
+
+  await page.goto('/contact');
+  await page.getByLabel('Name').fill('Jane');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Test');
+
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByRole('button', { name: /sending/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /sending/i })).toBeDisabled();
+
+  resolveSubmit();
+
+  await expect(page.getByText('Message sent')).toBeVisible();
+});
+```
+
+### Retry Behavior Testing
+
+**Use when**: Testing that the application retries failed requests automatically or via a user-triggered "retry" button.
+**Avoid when**: The application has no retry mechanism.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('retry button recovers from a failed API call', async ({ page }) => {
+  let callCount = 0;
+
+  await page.route('**/api/feed', (route) => {
+    callCount++;
+    if (callCount === 1) {
+      return route.fulfill({ status: 500 });
+    }
+    return route.fulfill({
+      status: 200,
+      json: { posts: [{ id: 1, title: 'Hello World' }] },
+    });
+  });
+
+  await page.goto('/feed');
+
+  // First load fails
+  await expect(page.getByText(/something went wrong/i)).toBeVisible();
+
+  // Click retry — second call succeeds
+  await page.getByRole('button', { name: 'Try again' }).click();
+
+  await expect(page.getByText('Hello World')).toBeVisible();
+  expect(callCount).toBe(2);
+});
+
+test('automatic retry with exponential backoff', async ({ page }) => {
+  const callTimestamps: number[] = [];
+
+  await page.route('**/api/status', (route) => {
+    callTimestamps.push(Date.now());
+    if (callTimestamps.length <= 3) {
+      return route.fulfill({ status: 503 });
+    }
+    return route.fulfill({ status: 200, json: { status: 'ok' } });
+  });
+
+  await page.goto('/status');
+
+  // Wait for the auto-retry to eventually succeed
+  await expect(page.getByText('System operational')).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Verify multiple retry attempts were made
+  expect(callTimestamps.length).toBeGreaterThanOrEqual(4);
+
+  // Verify backoff: gaps between retries should increase
+  if (callTimestamps.length >= 3) {
+    const gap1 = callTimestamps[1] - callTimestamps[0];
+    const gap2 = callTimestamps[2] - callTimestamps[1];
+    expect(gap2).toBeGreaterThanOrEqual(gap1);
+  }
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('retry button recovers from a failed API call', async ({ page }) => {
+  let callCount = 0;
+
+  await page.route('**/api/feed', (route) => {
+    callCount++;
+    if (callCount === 1) {
+      return route.fulfill({ status: 500 });
+    }
+    return route.fulfill({
+      status: 200,
+      json: { posts: [{ id: 1, title: 'Hello World' }] },
+    });
+  });
+
+  await page.goto('/feed');
+
+  await expect(page.getByText(/something went wrong/i)).toBeVisible();
+
+  await page.getByRole('button', { name: 'Try again' }).click();
+
+  await expect(page.getByText('Hello World')).toBeVisible();
+  expect(callCount).toBe(2);
+});
+
+test('automatic retry with exponential backoff', async ({ page }) => {
+  const callTimestamps = [];
+
+  await page.route('**/api/status', (route) => {
+    callTimestamps.push(Date.now());
+    if (callTimestamps.length <= 3) {
+      return route.fulfill({ status: 503 });
+    }
+    return route.fulfill({ status: 200, json: { status: 'ok' } });
+  });
+
+  await page.goto('/status');
+
+  await expect(page.getByText('System operational')).toBeVisible({
+    timeout: 30_000,
+  });
+
+  expect(callTimestamps.length).toBeGreaterThanOrEqual(4);
+});
+```
+
+### Browser Back/Forward Navigation
+
+**Use when**: Testing that the application handles browser history navigation correctly — preserving state, URL updates, and content after going back or forward.
+**Avoid when**: The app is a single-page application that does not use the browser history API. Focus on client-side routing tests instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('browser back preserves navigation context', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('link', { name: 'Running Shoes' }).click();
+  await page.waitForURL('**/products/running-shoes');
+
+  // Go back
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/products$/);
+  await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
+});
+
+test('browser forward returns to previous page', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('link', { name: 'Running Shoes' }).click();
+  await page.waitForURL('**/products/running-shoes');
+
+  await page.goBack();
+  await page.goForward();
+
+  await expect(page).toHaveURL(/\/products\/running-shoes/);
+  await expect(page.getByRole('heading', { name: 'Running Shoes' })).toBeVisible();
+});
+
+test('form state after browser back', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Fill form on step 1
+  await page.getByLabel('Address').fill('123 Main St');
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Arrived at step 2
+  await expect(page.getByRole('heading', { name: 'Payment' })).toBeVisible();
+
+  // Go back to step 1
+  await page.goBack();
+
+  // Data should be preserved (depends on app implementation)
+  await expect(page.getByLabel('Address')).toHaveValue('123 Main St');
+});
+
+test('back button after form submission does not re-submit', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Name').fill('Jane');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Test');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Message sent')).toBeVisible();
+
+  // Going back should show the form, not re-submit
+  await page.goBack();
+  await expect(page.getByLabel('Name')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('browser back preserves navigation context', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('link', { name: 'Running Shoes' }).click();
+  await page.waitForURL('**/products/running-shoes');
+
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/products$/);
+  await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
+});
+
+test('browser forward returns to previous page', async ({ page }) => {
+  await page.goto('/products');
+  await page.getByRole('link', { name: 'Running Shoes' }).click();
+  await page.waitForURL('**/products/running-shoes');
+
+  await page.goBack();
+  await page.goForward();
+
+  await expect(page).toHaveURL(/\/products\/running-shoes/);
+  await expect(page.getByRole('heading', { name: 'Running Shoes' })).toBeVisible();
+});
+
+test('form state after browser back', async ({ page }) => {
+  await page.goto('/checkout');
+
+  await page.getByLabel('Address').fill('123 Main St');
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Payment' })).toBeVisible();
+
+  await page.goBack();
+  await expect(page.getByLabel('Address')).toHaveValue('123 Main St');
+});
+
+test('back button after form submission does not re-submit', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Name').fill('Jane');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Test');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Message sent')).toBeVisible();
+
+  await page.goBack();
+  await expect(page.getByLabel('Name')).toBeVisible();
+});
+```
+
+### Concurrent User Actions
+
+**Use when**: Testing that rapid user interactions do not cause race conditions — double-clicking submit, typing while data is loading, navigating during an async operation.
+**Avoid when**: The UI has no async operations that could conflict with user actions.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('double-click submit does not create duplicate entries', async ({ page }) => {
+  const requests: string[] = [];
+
+  await page.route('**/api/orders', (route) => {
+    requests.push(route.request().method());
+    return route.fulfill({
+      status: 201,
+      json: { id: 1, status: 'created' },
+    });
+  });
+
+  await page.goto('/checkout');
+  await page.getByLabel('Item').fill('Widget');
+
+  const submitButton = page.getByRole('button', { name: 'Place order' });
+
+  // Rapid double-click
+  await submitButton.dblclick();
+
+  // Wait for the result
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+
+  // The app should prevent duplicate submissions
+  // (button disabled after first click, or server deduplication)
+  expect(requests.filter((m) => m === 'POST').length).toBeLessThanOrEqual(1);
+});
+
+test('typing during navigation does not crash', async ({ page }) => {
+  await page.goto('/search');
+
+  // Start typing and immediately navigate
+  await page.getByLabel('Search').pressSequentially('test query', { delay: 30 });
+  await page.getByRole('link', { name: 'Home' }).click();
+
+  // Should arrive at home page without errors
+  await page.waitForURL('**/');
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+});
+
+test('rapid filter changes use latest value', async ({ page }) => {
+  const requestUrls: string[] = [];
+
+  await page.route('**/api/products*', (route) => {
+    requestUrls.push(route.request().url());
+    return route.fulfill({
+      status: 200,
+      json: { products: [{ name: 'Latest result' }] },
+    });
+  });
+
+  await page.goto('/products');
+
+  // Rapidly change the filter
+  await page.getByLabel('Category').selectOption('electronics');
+  await page.getByLabel('Category').selectOption('clothing');
+  await page.getByLabel('Category').selectOption('books');
+
+  // Wait for the final result
+  await expect(page.getByText('Latest result')).toBeVisible();
+
+  // The UI should show results for "books", not an earlier selection
+  // Some apps debounce; some cancel in-flight requests
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('double-click submit does not create duplicate entries', async ({ page }) => {
+  const requests = [];
+
+  await page.route('**/api/orders', (route) => {
+    requests.push(route.request().method());
+    return route.fulfill({
+      status: 201,
+      json: { id: 1, status: 'created' },
+    });
+  });
+
+  await page.goto('/checkout');
+  await page.getByLabel('Item').fill('Widget');
+
+  const submitButton = page.getByRole('button', { name: 'Place order' });
+  await submitButton.dblclick();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+
+  expect(requests.filter((m) => m === 'POST').length).toBeLessThanOrEqual(1);
+});
+
+test('typing during navigation does not crash', async ({ page }) => {
+  await page.goto('/search');
+
+  await page.getByLabel('Search').pressSequentially('test query', { delay: 30 });
+  await page.getByRole('link', { name: 'Home' }).click();
+
+  await page.waitForURL('**/');
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+});
+
+test('rapid filter changes use latest value', async ({ page }) => {
+  const requestUrls = [];
+
+  await page.route('**/api/products*', (route) => {
+    requestUrls.push(route.request().url());
+    return route.fulfill({
+      status: 200,
+      json: { products: [{ name: 'Latest result' }] },
+    });
+  });
+
+  await page.goto('/products');
+
+  await page.getByLabel('Category').selectOption('electronics');
+  await page.getByLabel('Category').selectOption('clothing');
+  await page.getByLabel('Category').selectOption('books');
+
+  await expect(page.getByText('Latest result')).toBeVisible();
+});
+```
+
+### Graceful Degradation
+
+**Use when**: Testing that the app continues to function when non-critical services fail (analytics, chat widget, recommendations).
+**Avoid when**: The failing service is critical to the core workflow.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('page works when analytics service fails', async ({ page }) => {
+  // Block analytics and tracking scripts
+  await page.route('**/analytics/**', (route) => route.abort());
+  await page.route('**/tracking/**', (route) => route.abort());
+
+  await page.goto('/products');
+
+  // Core functionality still works
+  await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
+  await page.getByRole('link', { name: 'Running Shoes' }).click();
+  await expect(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+});
+
+test('page works when recommendation engine fails', async ({ page }) => {
+  await page.route('**/api/recommendations', (route) =>
+    route.fulfill({ status: 500 })
+  );
+
+  await page.goto('/products/running-shoes');
+
+  // Main product content loads
+  await expect(page.getByRole('heading', { name: 'Running Shoes' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+
+  // Recommendations section shows fallback
+  await expect(
+    page.getByText(/recommendations unavailable|you may also like/i)
+  ).toBeVisible();
+});
+
+test('page works when third-party chat widget fails to load', async ({ page }) => {
+  // Block the chat widget script
+  await page.route('**/chat-widget.js', (route) => route.abort());
+
+  await page.goto('/support');
+
+  // Core support page loads
+  await expect(page.getByRole('heading', { name: 'Help Center' })).toBeVisible();
+
+  // No console errors from the blocked widget should crash the page
+  const errors: string[] = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  // Navigate around to ensure no cascade failures
+  await page.getByRole('link', { name: 'FAQ' }).click();
+  await expect(page.getByRole('heading', { name: 'FAQ' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('page works when analytics service fails', async ({ page }) => {
+  await page.route('**/analytics/**', (route) => route.abort());
+  await page.route('**/tracking/**', (route) => route.abort());
+
+  await page.goto('/products');
+
+  await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
+  await page.getByRole('link', { name: 'Running Shoes' }).click();
+  await expect(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+});
+
+test('page works when recommendation engine fails', async ({ page }) => {
+  await page.route('**/api/recommendations', (route) =>
+    route.fulfill({ status: 500 })
+  );
+
+  await page.goto('/products/running-shoes');
+
+  await expect(page.getByRole('heading', { name: 'Running Shoes' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+});
+
+test('page works when third-party chat widget fails to load', async ({ page }) => {
+  await page.route('**/chat-widget.js', (route) => route.abort());
+
+  await page.goto('/support');
+
+  await expect(page.getByRole('heading', { name: 'Help Center' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'FAQ' }).click();
+  await expect(page.getByRole('heading', { name: 'FAQ' })).toBeVisible();
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Key API |
+|---|---|---|
+| 404 page | Navigate to non-existent URL, assert error page | `page.goto('/nonexistent')` |
+| 500 server error | Mock route with `status: 500` | `page.route(url, route => route.fulfill({ status: 500 }))` |
+| Network failure | Abort the route | `route.abort('connectionfailed')` |
+| Offline mode | Toggle offline on the browser context | `page.context().setOffline(true)` |
+| Slow response | Delay route fulfillment with a Promise | `await new Promise(r => setTimeout(r, delay))` in route handler |
+| Empty state | Mock API to return empty array | `route.fulfill({ json: [] })` |
+| Boundary values | Fill inputs with min/max/special values | `locator.fill('A'.repeat(255))` |
+| Loading skeleton | Delay route, assert skeleton visible, release, assert content | Promise-based route handler |
+| Retry behavior | Track route call count, fail first N, succeed after | Counter in route handler |
+| Browser history | Use `page.goBack()` and `page.goForward()` | Assert URL and content after navigation |
+| Double submit | `dblclick()` on submit, verify single POST | Track requests in route handler |
+| Third-party failure | Abort non-critical routes, verify core works | `route.abort()` on optional services |
+| Console error monitoring | Listen for `pageerror` event | `page.on('pageerror', handler)` |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Only testing the happy path | Real users hit errors. Errors in production are more expensive than test time. | Add error/edge case tests for every feature |
+| `page.route('**/*', route => route.abort())` | Blocks ALL requests including the page itself | Target specific URLs: `page.route('**/api/specific', ...)` |
+| Using `page.waitForTimeout()` to simulate slow loading | Arbitrary, flaky, slows tests | Use promise-based route handlers to control timing precisely |
+| Hardcoding error messages in assertions | Messages change. Tests break on copy edits. | Use regex or partial matches: `getByText(/error/i)` |
+| Testing every error code in one mega-test | Hard to debug, slow, first failure hides the rest | One test per error scenario, or use `test.describe` groups |
+| Skipping empty state tests | Empty states are the first thing new users see; often broken | Always test 0-item state alongside 1-item and N-item |
+| Testing offline by disconnecting real network | Flaky, affects parallel tests, CI may not support it | Use `context.setOffline(true)` — deterministic and scoped |
+| Not cleaning up route mocks between tests | Routes persist on the page. Test B inherits test A's mocks. | Each test sets its own routes; Playwright resets between tests by default |
+| Asserting on exact error strings from the server | Couples tests to backend implementation details | Assert the UI message, not the raw API response body |
+| Using `try/catch` to "handle" expected errors | Swallows real bugs; test passes when it shouldn't | Let errors propagate; use route mocking to control the response |
+
+## Troubleshooting
+
+### Route handler is not intercepting requests
+
+**Cause**: The URL pattern does not match, or the route was registered after the navigation that triggers the request.
+
+```typescript
+// Always register routes BEFORE navigating
+await page.route('**/api/data', (route) => route.fulfill({ status: 500 }));
+await page.goto('/dashboard'); // route is active before the page loads
+
+// Debug: log all requests to find the actual URL pattern
+page.on('request', (req) => console.log(req.url()));
+```
+
+### `context.setOffline(true)` does not affect Service Worker
+
+**Cause**: Service Workers have their own network handling. `setOffline` simulates offline at the browser level, but a Service Worker may serve cached responses.
+
+```typescript
+// Unregister service workers first
+await page.evaluate(async () => {
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  for (const registration of registrations) {
+    await registration.unregister();
+  }
+});
+await page.context().setOffline(true);
+```
+
+### Delayed route handler causes test timeout
+
+**Cause**: The promise in the route handler never resolves, or the delay exceeds the test timeout.
+
+```typescript
+// Always ensure the delay is less than the assertion timeout
+await page.route('**/api/slow', async (route) => {
+  await new Promise((resolve) => setTimeout(resolve, 5_000)); // 5s delay
+  await route.fulfill({ status: 200, json: {} });
+});
+
+// Increase assertion timeout to account for the artificial delay
+await expect(page.getByText('Data loaded')).toBeVisible({ timeout: 10_000 });
+```
+
+### `goBack()` does not navigate
+
+**Cause**: There is no history entry to go back to. `goBack()` requires at least one previous navigation.
+
+```typescript
+// Ensure there is history before calling goBack
+await page.goto('/page-a');
+await page.goto('/page-b');
+await page.goBack(); // goes to /page-a
+
+// If using SPA client-side routing, goBack may not work if the router
+// does not push to browser history. Use the app's own back button instead.
+await page.getByRole('button', { name: 'Back' }).click();
+```
+
+## Related
+
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- assertion strategies for error states
+- [core/network-mocking.md](network-mocking.md) -- detailed network interception and mocking patterns
+- [core/forms-and-validation.md](forms-and-validation.md) -- form validation error testing
+- [core/flaky-tests.md](flaky-tests.md) -- fixing timing issues in error/edge case tests
+- [core/service-workers-and-pwa.md](service-workers-and-pwa.md) -- offline-first and PWA testing patterns
+- [core/multi-context-and-popups.md](multi-context-and-popups.md) -- testing concurrent browser contexts

--- a/engineering-team/playwright skill/core/error-index.md
+++ b/engineering-team/playwright skill/core/error-index.md
@@ -1,0 +1,1903 @@
+# Playwright Error Index
+
+Quick-reference for specific Playwright error messages. Find your error, understand the cause, apply the fix.
+
+> **How to use**: Search this file for the exact error text you see in your terminal or test report. Each entry gives you the cause and a working fix.
+
+---
+
+## Locator & Element Errors
+
+---
+
+### "locator.click: Target closed"
+
+**Cause**: The page or frame navigated away (or was closed) before Playwright finished executing the action on the element.
+
+**Common triggers**:
+- Clicking a link that triggers navigation while another action is still pending
+- A form submit causes a page reload before a subsequent `click()` or `fill()` resolves
+- Calling `page.close()` or `context.close()` in a `finally` block that races with an in-flight action
+- An unhandled exception in the application triggers an error page redirect
+
+**Fix**: Wait for navigation to complete before performing the next action, or use `Promise.all` to coordinate the click and navigation together.
+
+```typescript
+// TypeScript — wait for navigation caused by clicking a link
+await Promise.all([
+  page.waitForURL('**/dashboard'),
+  page.getByRole('link', { name: 'Dashboard' }).click(),
+]);
+```
+
+```javascript
+// JavaScript — same pattern
+await Promise.all([
+  page.waitForURL('**/dashboard'),
+  page.getByRole('link', { name: 'Dashboard' }).click(),
+]);
+```
+
+If the page is closing intentionally (e.g., a popup), capture a reference before the action:
+
+```typescript
+// TypeScript — handle popup that closes itself
+const popupPromise = page.waitForEvent('popup');
+await page.getByRole('button', { name: 'Open popup' }).click();
+const popup = await popupPromise;
+await popup.waitForLoadState();
+// interact with popup before it closes
+await popup.getByRole('button', { name: 'Confirm' }).click();
+```
+
+```javascript
+// JavaScript — handle popup that closes itself
+const popupPromise = page.waitForEvent('popup');
+await page.getByRole('button', { name: 'Open popup' }).click();
+const popup = await popupPromise;
+await popup.waitForLoadState();
+await popup.getByRole('button', { name: 'Confirm' }).click();
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/multi-context-and-popups.md](multi-context-and-popups.md)
+
+---
+
+### "waiting for locator('...') to be visible"
+
+**Cause**: Playwright's auto-waiting timed out because the element never appeared in the DOM or remained hidden (e.g., `display: none`, `visibility: hidden`, zero size, or behind `aria-hidden`).
+
+**Common triggers**:
+- The element renders conditionally and the condition was not met (missing data, unauthenticated state)
+- Content loads asynchronously and the locator was evaluated before the API response arrived
+- The selector is wrong — typo in role, name, or test ID
+- The element exists but is off-screen or inside a collapsed container
+- CSS animation or transition keeps the element at `opacity: 0` without making it visible to Playwright
+
+**Fix**: First confirm the locator matches what you expect using the Playwright Inspector. Then ensure the precondition for the element to appear is met.
+
+```typescript
+// TypeScript — debug: check what the locator resolves to
+console.log(await page.getByRole('button', { name: 'Submit' }).count());
+// If 0, the element is not in the DOM — check your selector or page state
+
+// Correct approach: wait for the data to load first
+await page.waitForResponse(resp =>
+  resp.url().includes('/api/data') && resp.status() === 200
+);
+await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+```
+
+```javascript
+// JavaScript — same approach
+console.log(await page.getByRole('button', { name: 'Submit' }).count());
+
+await page.waitForResponse(resp =>
+  resp.url().includes('/api/data') && resp.status() === 200
+);
+await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+```
+
+**Related**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+---
+
+### "locator.click: Error: strict mode violation"
+
+**Cause**: The locator matched more than one element and Playwright's strict mode (enabled by default) refuses to act on ambiguous matches.
+
+**Common triggers**:
+- Using `getByRole('button')` when multiple buttons exist on the page
+- Using `getByText('Save')` when both "Save" and "Save as draft" are present
+- Partial text matching when `exact: true` is needed
+- The same component is rendered multiple times (e.g., in a list)
+
+**Fix**: Make the locator more specific so it resolves to exactly one element.
+
+```typescript
+// TypeScript
+
+// BAD — matches multiple buttons
+await page.getByRole('button', { name: 'Save' }).click();
+
+// GOOD — use exact matching
+await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+// GOOD — scope to a specific container
+await page.getByRole('dialog')
+  .getByRole('button', { name: 'Save' }).click();
+
+// GOOD — use .first(), .last(), .nth() when order is meaningful
+await page.getByRole('listitem').first().click();
+
+// GOOD — chain with filter for list items
+await page.getByRole('listitem')
+  .filter({ hasText: 'Project Alpha' })
+  .getByRole('button', { name: 'Delete' }).click();
+```
+
+```javascript
+// JavaScript
+
+// BAD — matches multiple buttons
+await page.getByRole('button', { name: 'Save' }).click();
+
+// GOOD — use exact matching
+await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+// GOOD — scope to a specific container
+await page.getByRole('dialog')
+  .getByRole('button', { name: 'Save' }).click();
+
+// GOOD — use .first(), .last(), .nth() when order is meaningful
+await page.getByRole('listitem').first().click();
+
+// GOOD — chain with filter for list items
+await page.getByRole('listitem')
+  .filter({ hasText: 'Project Alpha' })
+  .getByRole('button', { name: 'Delete' }).click();
+```
+
+**Related**: [core/locators.md](locators.md), [core/locator-strategy.md](locator-strategy.md)
+
+---
+
+### "Error: expect(locator).toBeVisible() — locator resolved to X elements"
+
+**Cause**: Same root cause as strict mode violation above — the assertion's locator matched multiple elements, so Playwright cannot determine which one to assert on.
+
+**Common triggers**:
+- Same as strict mode violation triggers above
+- Writing `expect(page.locator('.item')).toBeVisible()` when there are many `.item` elements
+
+**Fix**: Narrow the locator to a single element (see strict mode violation fix above). Alternatively, if you intentionally want to check all matches:
+
+```typescript
+// TypeScript — assert count instead of visibility
+await expect(page.getByRole('listitem')).toHaveCount(5);
+
+// Or assert on a specific one
+await expect(page.getByRole('listitem').first()).toBeVisible();
+
+// Or assert all are visible with a loop
+for (const item of await page.getByRole('listitem').all()) {
+  await expect(item).toBeVisible();
+}
+```
+
+```javascript
+// JavaScript — assert count instead of visibility
+await expect(page.getByRole('listitem')).toHaveCount(5);
+
+// Or assert on a specific one
+await expect(page.getByRole('listitem').first()).toBeVisible();
+
+// Or assert all are visible with a loop
+for (const item of await page.getByRole('listitem').all()) {
+  await expect(item).toBeVisible();
+}
+```
+
+**Related**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+---
+
+### "locator.fill: Error: Element is not an <input>, <textarea> or [contenteditable] element"
+
+**Cause**: `fill()` only works on `<input>`, `<textarea>`, or elements with `contenteditable`. The locator resolved to a different element type (e.g., a `<div>`, `<label>`, or the `<form>` itself).
+
+**Common triggers**:
+- Locating by label text but the label and input are not properly associated via `for`/`id`
+- Using `getByText()` instead of `getByLabel()` or `getByRole('textbox')`
+- Custom components that wrap the actual `<input>` in a styled `<div>`
+- Rich text editors that use `contenteditable` on an inner element, not the outer wrapper
+
+**Fix**: Target the actual input element.
+
+```typescript
+// TypeScript
+
+// BAD — targets the label, not the input
+await page.getByText('Email').fill('user@example.com');
+
+// GOOD — getByLabel finds the associated input
+await page.getByLabel('Email').fill('user@example.com');
+
+// GOOD — target by role
+await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+// For contenteditable rich text editors
+await page.locator('[contenteditable="true"]').fill('Hello world');
+
+// If fill() still doesn't work (e.g., custom widget), use keyboard input
+await page.getByRole('textbox', { name: 'Email' }).click();
+await page.keyboard.type('user@example.com');
+```
+
+```javascript
+// JavaScript
+
+// BAD — targets the label, not the input
+await page.getByText('Email').fill('user@example.com');
+
+// GOOD — getByLabel finds the associated input
+await page.getByLabel('Email').fill('user@example.com');
+
+// GOOD — target by role
+await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+// For contenteditable rich text editors
+await page.locator('[contenteditable="true"]').fill('Hello world');
+
+// If fill() still doesn't work (e.g., custom widget), use keyboard input
+await page.getByRole('textbox', { name: 'Email' }).click();
+await page.keyboard.type('user@example.com');
+```
+
+**Related**: [core/locators.md](locators.md), [core/forms-and-validation.md](forms-and-validation.md)
+
+---
+
+### "Error: elementHandle.click: Node is not an Element"
+
+**Cause**: You are using the legacy ElementHandle API and the handle has gone stale — the underlying DOM node was removed or replaced by a re-render.
+
+**Common triggers**:
+- Storing an `elementHandle` in a variable and using it after a navigation or React/Vue re-render
+- Using `page.$()` or `page.$$()` instead of Locator API
+- Framework hydration replaces the server-rendered node with a client-rendered one
+
+**Fix**: Switch from ElementHandle to Locator. Locators re-query the DOM on every action and never go stale.
+
+```typescript
+// TypeScript
+
+// BAD — stale handle
+const button = await page.$('button.submit');
+// ... page re-renders ...
+await button!.click(); // Node is not an Element
+
+// GOOD — locator always re-queries
+const button = page.getByRole('button', { name: 'Submit' });
+// ... page re-renders ...
+await button.click(); // works fine
+```
+
+```javascript
+// JavaScript
+
+// BAD — stale handle
+const button = await page.$('button.submit');
+// ... page re-renders ...
+await button.click(); // Node is not an Element
+
+// GOOD — locator always re-queries
+const button = page.getByRole('button', { name: 'Submit' });
+// ... page re-renders ...
+await button.click(); // works fine
+```
+
+**Related**: [core/locators.md](locators.md)
+
+---
+
+### "Error: locator.click: Timeout 30000ms exceeded"
+
+**Cause**: The element was found in the DOM but was not actionable within the timeout. "Actionable" means visible, stable (not animating), enabled, and not obscured by another element.
+
+**Common triggers**:
+- An overlay, modal, or toast is covering the element
+- The element is disabled (`disabled` attribute or `aria-disabled="true"`)
+- CSS animation has not completed (element is still moving)
+- A loading spinner overlays the button
+- The element is outside the viewport and Playwright's auto-scroll failed
+
+**Fix**: Identify what is blocking the action using traces, then address it.
+
+```typescript
+// TypeScript
+
+// Step 1: Enable tracing to diagnose
+// In playwright.config.ts:
+// use: { trace: 'on-first-retry' }
+// Then run: npx playwright show-trace trace.zip
+
+// Common fix: wait for the overlay to disappear
+await expect(page.locator('.loading-overlay')).toBeHidden();
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Common fix: force click when you know the overlay is benign
+// (use sparingly — this skips actionability checks)
+await page.getByRole('button', { name: 'Submit' }).click({ force: true });
+
+// Common fix: wait for the element to be enabled
+await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
+await page.getByRole('button', { name: 'Submit' }).click();
+```
+
+```javascript
+// JavaScript
+
+// Common fix: wait for the overlay to disappear
+await expect(page.locator('.loading-overlay')).toBeHidden();
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Common fix: force click (use sparingly)
+await page.getByRole('button', { name: 'Submit' }).click({ force: true });
+
+// Common fix: wait for the element to be enabled
+await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
+await page.getByRole('button', { name: 'Submit' }).click();
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/debugging.md](debugging.md)
+
+---
+
+## Navigation & Page Errors
+
+---
+
+### "page.goto: net::ERR_CONNECTION_REFUSED"
+
+**Cause**: Playwright could not connect to the target URL. The server is not running or is not listening on the expected host/port.
+
+**Common triggers**:
+- Forgot to start the dev server before running tests
+- Dev server is on a different port than `baseURL` in config
+- Server is listening on `127.0.0.1` but test uses `localhost` (or vice versa) and the OS resolves them differently
+- In CI, the application build/start step failed silently
+- Docker container networking: the app runs inside a container but the test tries to reach `localhost`
+
+**Fix**: Use the `webServer` config option to let Playwright start and manage the dev server automatically.
+
+```typescript
+// TypeScript — playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000, // 2 minutes for server start
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+```
+
+```javascript
+// JavaScript — playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+```
+
+**Related**: [core/configuration.md](configuration.md), [ci/ci-github-actions.md](../ci/ci-github-actions.md)
+
+---
+
+### "page.goto: Timeout 30000ms exceeded"
+
+**Cause**: The page did not reach the `load` state (by default) within the navigation timeout. The server responded but the page took too long to fully load.
+
+**Common triggers**:
+- Large assets (images, fonts, scripts) slow the page load
+- Third-party scripts (analytics, ads) blocking the load event
+- The page makes many API calls before becoming interactive
+- The server responded with a redirect chain that takes too long
+
+**Fix**: Use a more appropriate `waitUntil` option or increase the navigation timeout.
+
+```typescript
+// TypeScript
+
+// Use 'domcontentloaded' instead of 'load' if you don't need all assets
+await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+// Or increase the navigation timeout for known slow pages
+await page.goto('/dashboard', { timeout: 60_000 });
+
+// Or set it globally in config
+// playwright.config.ts
+export default defineConfig({
+  use: {
+    navigationTimeout: 60_000,
+  },
+});
+```
+
+```javascript
+// JavaScript
+
+await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+await page.goto('/dashboard', { timeout: 60_000 });
+
+// playwright.config.js
+module.exports = defineConfig({
+  use: {
+    navigationTimeout: 60_000,
+  },
+});
+```
+
+**Related**: [core/configuration.md](configuration.md)
+
+---
+
+### "Error: page.goto: Navigation failed because page was closed!"
+
+**Cause**: The page or browser context was closed while `goto()` was still in progress. This typically happens in teardown/cleanup race conditions.
+
+**Common triggers**:
+- `afterEach` or a fixture closes the page/context before navigation completes
+- Another test or hook called `browser.close()` prematurely
+- A test failed and the cleanup ran while an async navigation was still pending
+- Using `test.fixme()` or `test.skip()` after an async operation has started
+
+**Fix**: Ensure cleanup only runs after all page operations complete. Use fixtures for lifecycle management instead of manual `afterEach`.
+
+```typescript
+// TypeScript
+
+// BAD — race condition between test body and cleanup
+test.afterEach(async ({ page }) => {
+  await page.close(); // may race with in-flight navigation
+});
+
+// GOOD — let Playwright manage page lifecycle via fixtures
+// Playwright automatically creates and destroys the page per test
+// No manual cleanup needed
+
+// If you need custom cleanup, make sure to await all navigation first
+test('navigates to dashboard', async ({ page }) => {
+  const responsePromise = page.waitForResponse('**/api/user');
+  await page.goto('/dashboard');
+  await responsePromise; // ensure all async ops are done
+  // test assertions here
+});
+```
+
+```javascript
+// JavaScript — same pattern
+
+test('navigates to dashboard', async ({ page }) => {
+  const responsePromise = page.waitForResponse('**/api/user');
+  await page.goto('/dashboard');
+  await responsePromise;
+  // test assertions here
+});
+```
+
+**Related**: [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+---
+
+### "page.waitForNavigation: Timeout 30000ms exceeded"
+
+**Cause**: `waitForNavigation()` waited for a full page navigation that never happened. In SPAs, client-side routing does not trigger a navigation event.
+
+**Common triggers**:
+- Using `waitForNavigation()` with a SPA that uses React Router, Vue Router, or Next.js client-side navigation
+- The navigation already happened before `waitForNavigation()` was called (race condition)
+- Using the deprecated pattern when `waitForURL()` is the correct replacement
+
+**Fix**: Replace `waitForNavigation()` with `waitForURL()` which works with both SPAs and traditional page loads.
+
+```typescript
+// TypeScript
+
+// BAD — deprecated, race-prone, doesn't work with SPA routing
+await page.waitForNavigation();
+
+// GOOD — works with SPAs and full navigations
+await page.getByRole('link', { name: 'Dashboard' }).click();
+await page.waitForURL('**/dashboard');
+
+// GOOD — combine with glob patterns
+await page.waitForURL(/\/dashboard\/\d+/);
+
+// GOOD — for SPA route changes, assert on visible content
+await page.getByRole('link', { name: 'Settings' }).click();
+await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+```
+
+```javascript
+// JavaScript
+
+// BAD — deprecated, race-prone
+await page.waitForNavigation();
+
+// GOOD — works with SPAs and full navigations
+await page.getByRole('link', { name: 'Dashboard' }).click();
+await page.waitForURL('**/dashboard');
+
+// GOOD — combine with glob patterns
+await page.waitForURL(/\/dashboard\/\d+/);
+
+// GOOD — for SPA route changes, assert on visible content
+await page.getByRole('link', { name: 'Settings' }).click();
+await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+---
+
+### "Error: frame.goto: Frame was detached"
+
+**Cause**: The iframe was removed from the DOM (detached) while Playwright was navigating or interacting with it.
+
+**Common triggers**:
+- The parent page re-rendered and recreated the iframe element
+- JavaScript on the parent page removed and re-added the iframe
+- A SPA route change unmounted the component containing the iframe
+- An ad iframe reloaded itself
+
+**Fix**: Re-acquire the frame reference after the parent page updates.
+
+```typescript
+// TypeScript
+
+// BAD — frame reference becomes stale
+const frame = page.frameLocator('#my-iframe');
+// ... parent page re-renders ...
+await frame.getByRole('button').click(); // Frame was detached
+
+// GOOD — use frameLocator (re-evaluates each time)
+// frameLocator itself is lazy, but the frame it points to must exist
+await expect(page.frameLocator('#my-iframe').getByRole('button')).toBeVisible();
+await page.frameLocator('#my-iframe').getByRole('button').click();
+
+// GOOD — wait for the iframe to be present after a re-render
+await expect(page.locator('#my-iframe')).toBeAttached();
+await page.frameLocator('#my-iframe').getByRole('button').click();
+```
+
+```javascript
+// JavaScript
+
+// GOOD — frameLocator re-evaluates lazily
+await expect(page.frameLocator('#my-iframe').getByRole('button')).toBeVisible();
+await page.frameLocator('#my-iframe').getByRole('button').click();
+
+// GOOD — wait for the iframe to be present after a re-render
+await expect(page.locator('#my-iframe')).toBeAttached();
+await page.frameLocator('#my-iframe').getByRole('button').click();
+```
+
+**Related**: [core/iframes-and-shadow-dom.md](iframes-and-shadow-dom.md)
+
+---
+
+## Test Framework Errors
+
+---
+
+### "Error: Test timeout of 30000ms exceeded"
+
+**Cause**: The entire test (including all hooks and assertions) did not complete within the configured test timeout.
+
+**Common triggers**:
+- Waiting for an element that never appears (wrong locator, missing data)
+- Unresolved `page.waitForEvent()` — the expected event never fires
+- Slow test environment (CI with limited resources)
+- Too many sequential actions in a single test
+- A `beforeEach` hook performs expensive setup (login, data seeding)
+
+**Fix**: Identify the slow step using `test.step()` and traces, then either fix the root cause or adjust the timeout.
+
+```typescript
+// TypeScript
+
+// Increase timeout for a specific slow test
+test('generates large report', async ({ page }) => {
+  test.setTimeout(120_000); // 2 minutes for this test only
+  // ...
+});
+
+// Increase timeout globally in config
+// playwright.config.ts
+export default defineConfig({
+  timeout: 60_000, // 60 seconds per test
+});
+
+// Better: diagnose with test.step() to find what's slow
+test('checkout flow', async ({ page }) => {
+  await test.step('add item to cart', async () => {
+    await page.goto('/products');
+    await page.getByRole('button', { name: 'Add to Cart' }).click();
+  });
+
+  await test.step('complete checkout', async () => {
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.getByRole('button', { name: 'Checkout' }).click();
+  });
+});
+```
+
+```javascript
+// JavaScript
+
+test('generates large report', async ({ page }) => {
+  test.setTimeout(120_000);
+  // ...
+});
+
+// playwright.config.js
+module.exports = defineConfig({
+  timeout: 60_000,
+});
+
+test('checkout flow', async ({ page }) => {
+  await test.step('add item to cart', async () => {
+    await page.goto('/products');
+    await page.getByRole('button', { name: 'Add to Cart' }).click();
+  });
+
+  await test.step('complete checkout', async () => {
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.getByRole('button', { name: 'Checkout' }).click();
+  });
+});
+```
+
+**Related**: [core/configuration.md](configuration.md), [core/debugging.md](debugging.md)
+
+---
+
+### "Error: expect(received).toMatchSnapshot()"
+
+**Cause**: The current screenshot or text does not match the stored baseline snapshot.
+
+**Common triggers**:
+- Legitimate UI changes that require updating the snapshot
+- Different rendering between local and CI (fonts, anti-aliasing, OS-level rendering)
+- Dynamic content (timestamps, random IDs, ads) that changes between runs
+- Different viewport sizes or device emulation settings between environments
+
+**Fix**: Update the snapshot if the change is intentional, or mask/hide dynamic areas.
+
+```typescript
+// TypeScript
+
+// Update snapshots after intentional changes
+// Run: npx playwright test --update-snapshots
+
+// Mask dynamic content before taking a screenshot
+await expect(page).toHaveScreenshot('dashboard.png', {
+  mask: [
+    page.locator('.timestamp'),
+    page.locator('.random-ad'),
+  ],
+  maxDiffPixelRatio: 0.01, // allow 1% pixel difference
+});
+
+// Use text snapshot with a sanitizer for dynamic values
+const content = await page.getByRole('main').textContent();
+const sanitized = content!.replace(/\d{4}-\d{2}-\d{2}/g, 'DATE');
+expect(sanitized).toMatchSnapshot('dashboard-content.txt');
+```
+
+```javascript
+// JavaScript
+
+// Update snapshots: npx playwright test --update-snapshots
+
+await expect(page).toHaveScreenshot('dashboard.png', {
+  mask: [
+    page.locator('.timestamp'),
+    page.locator('.random-ad'),
+  ],
+  maxDiffPixelRatio: 0.01,
+});
+
+const content = await page.getByRole('main').textContent();
+const sanitized = content.replace(/\d{4}-\d{2}-\d{2}/g, 'DATE');
+expect(sanitized).toMatchSnapshot('dashboard-content.txt');
+```
+
+**Related**: [core/visual-regression.md](visual-regression.md)
+
+---
+
+### "Error: browserType.launch: Executable doesn't exist"
+
+**Cause**: The Playwright browser binaries are not installed on this machine or they were installed for a different Playwright version.
+
+**Common triggers**:
+- Fresh clone of a project without running the install step
+- Upgrading `@playwright/test` without reinstalling browsers
+- CI environment missing the install step
+- Using `npm ci` which cleans `node_modules` but does not trigger the browser install postinstall script
+- Multiple Playwright versions installed (global vs local)
+
+**Fix**: Install the browsers.
+
+```bash
+# Install all browsers
+npx playwright install
+
+# Install only the browser you need (faster in CI)
+npx playwright install chromium
+
+# Install browsers with OS dependencies (needed in CI/Docker)
+npx playwright install --with-deps
+
+# If you're on a CI Dockerfile, add this to your Dockerfile
+# RUN npx playwright install --with-deps chromium
+```
+
+For CI pipelines, always include the install step:
+
+```yaml
+# GitHub Actions example
+- name: Install Playwright Browsers
+  run: npx playwright install --with-deps
+```
+
+**Related**: [ci/ci-github-actions.md](../ci/ci-github-actions.md), [ci/docker-and-containers.md](../ci/docker-and-containers.md)
+
+---
+
+### "Error: Cannot use import statement outside a module"
+
+**Cause**: Node.js is running the test file as CommonJS but the file uses ES module `import` syntax without the right configuration.
+
+**Common triggers**:
+- Missing or misconfigured `tsconfig.json`
+- Using `.ts` files without `@playwright/test` properly resolving TypeScript
+- `package.json` does not have `"type": "module"` but test files use `import`
+- Running test files directly with `node` instead of through `npx playwright test`
+- Conflicting Babel or ts-node configuration
+
+**Fix**: Ensure TypeScript is configured correctly and always run tests through the Playwright CLI.
+
+```bash
+# Always run tests through the Playwright CLI — never with node directly
+npx playwright test
+
+# NOT this:
+# node tests/example.spec.ts  <-- will fail
+```
+
+```typescript
+// TypeScript — tsconfig.json (minimal working config)
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+If using JavaScript without TypeScript:
+
+```javascript
+// JavaScript — ensure package.json has "type": "module"
+// Or rename files to .mjs
+
+// In playwright.config.js — use require if package.json lacks "type": "module"
+const { defineConfig } = require('@playwright/test');
+module.exports = defineConfig({ /* ... */ });
+```
+
+**Related**: [core/configuration.md](configuration.md)
+
+---
+
+### "Error: fixture \"xxx\" has already been registered"
+
+**Cause**: A custom fixture was defined with the same name in multiple `test.extend()` calls that got merged, or the same fixture name was registered twice in the same extension.
+
+**Common triggers**:
+- Two different fixture files both define a fixture with the same name
+- Importing the extended `test` object from multiple files that each add overlapping fixtures
+- Copy-pasting fixture definitions without renaming
+
+**Fix**: Ensure each fixture name is unique across your merged fixture chain. Use a single fixture file that combines all extensions.
+
+```typescript
+// TypeScript
+
+// BAD — two separate extensions with the same fixture name
+// fixtures/auth.ts
+export const test = base.extend<{ user: User }>({
+  user: async ({}, use) => { /* ... */ },
+});
+
+// fixtures/data.ts — CONFLICT: "user" already exists
+export const test = base.extend<{ user: User }>({
+  user: async ({}, use) => { /* ... */ },
+});
+
+// GOOD — single combined fixture file
+// fixtures/index.ts
+import { test as base } from '@playwright/test';
+
+type MyFixtures = {
+  authenticatedUser: User;
+  testData: TestData;
+};
+
+export const test = base.extend<MyFixtures>({
+  authenticatedUser: async ({}, use) => {
+    const user = await createUser();
+    await use(user);
+    await deleteUser(user);
+  },
+  testData: async ({}, use) => {
+    const data = await seedData();
+    await use(data);
+    await cleanupData(data);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```javascript
+// JavaScript
+
+// GOOD — single combined fixture file
+// fixtures/index.js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  authenticatedUser: async ({}, use) => {
+    const user = await createUser();
+    await use(user);
+    await deleteUser(user);
+  },
+  testData: async ({}, use) => {
+    const data = await seedData();
+    await use(data);
+    await cleanupData(data);
+  },
+});
+
+module.exports = { test };
+```
+
+**Related**: [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+---
+
+## Network & API Errors
+
+---
+
+### "page.route: Pattern should start with..."
+
+**Cause**: The URL pattern passed to `page.route()` does not match the expected format. Playwright expects a glob pattern (starting with `**/` or `http`), a regex, or a predicate function.
+
+**Common triggers**:
+- Passing a bare path like `/api/users` instead of `**/api/users`
+- Missing the `**` glob prefix for relative patterns
+- Passing an object or invalid type instead of a string/regex
+
+**Fix**: Use the correct pattern format.
+
+```typescript
+// TypeScript
+
+// BAD — bare path without glob prefix
+await page.route('/api/users', route => route.fulfill({ body: '[]' }));
+
+// GOOD — glob pattern
+await page.route('**/api/users', route =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([{ id: 1, name: 'Alice' }]),
+  })
+);
+
+// GOOD — regex pattern
+await page.route(/\/api\/users\/\d+/, route =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ id: 1, name: 'Alice' }),
+  })
+);
+
+// GOOD — predicate function for complex matching
+await page.route(
+  url => url.pathname.startsWith('/api/') && url.searchParams.has('filter'),
+  route => route.fulfill({ body: '[]' })
+);
+```
+
+```javascript
+// JavaScript
+
+// GOOD — glob pattern
+await page.route('**/api/users', route =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([{ id: 1, name: 'Alice' }]),
+  })
+);
+
+// GOOD — regex pattern
+await page.route(/\/api\/users\/\d+/, route =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ id: 1, name: 'Alice' }),
+  })
+);
+
+// GOOD — predicate function
+await page.route(
+  url => url.pathname.startsWith('/api/') && url.searchParams.has('filter'),
+  route => route.fulfill({ body: '[]' })
+);
+```
+
+**Related**: [core/network-mocking.md](network-mocking.md)
+
+---
+
+### "Error: apiRequestContext.get: connect ECONNREFUSED"
+
+**Cause**: The API request made via `request.get()` (or `.post()`, `.put()`, etc.) could not connect to the target server. Same underlying issue as `page.goto: net::ERR_CONNECTION_REFUSED` but for API testing.
+
+**Common triggers**:
+- API server not running when using `request` fixture
+- Wrong `baseURL` in the config or in the API request context
+- Running API tests against a service that hasn't started yet
+- In CI, the API service container is not ready
+
+**Fix**: Ensure the API server is running. Use `webServer` config to auto-start it, or add a health check.
+
+```typescript
+// TypeScript — playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: [
+    {
+      command: 'npm run start:api',
+      url: 'http://localhost:4000/health',
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'npm run start:web',
+      url: 'http://localhost:3000',
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+
+// In tests, use the request fixture with explicit baseURL for API calls
+test('fetch users', async ({ request }) => {
+  const response = await request.get('http://localhost:4000/api/users');
+  expect(response.ok()).toBeTruthy();
+});
+```
+
+```javascript
+// JavaScript — playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  webServer: [
+    {
+      command: 'npm run start:api',
+      url: 'http://localhost:4000/health',
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'npm run start:web',
+      url: 'http://localhost:3000',
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+```
+
+**Related**: [core/api-testing.md](api-testing.md), [core/configuration.md](configuration.md)
+
+---
+
+### "Request was not handled: GET https://..."
+
+**Cause**: A route handler was registered with `page.route()` using `{ times: N }` or `page.unrouteAll()` was called, and a subsequent request matching that pattern was not intercepted — Playwright warns you that a request fell through.
+
+**Common triggers**:
+- Using `page.route()` with `{ times: 1 }` but the app makes the same request more than once
+- Calling `route.fallback()` or `route.continue()` without a handler to catch it
+- Calling `page.unrouteAll({ behavior: 'wait' })` mid-test and the app makes another request
+
+**Fix**: Ensure your route handler covers all expected requests, or let unhandled requests pass through.
+
+```typescript
+// TypeScript
+
+// BAD — only handles the first request, second one is unhandled
+await page.route('**/api/data', route =>
+  route.fulfill({ body: '{}' }),
+  { times: 1 }
+);
+
+// GOOD — handle all requests to this URL
+await page.route('**/api/data', route =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ items: [] }),
+  })
+);
+
+// GOOD — if you only want to intercept once, use waitForResponse for subsequent
+await page.route('**/api/data', route =>
+  route.fulfill({ body: '{"items": []}' }),
+  { times: 1 }
+);
+// For the second call, let it go to the real server (no route needed)
+```
+
+```javascript
+// JavaScript
+
+// GOOD — handle all requests to this URL
+await page.route('**/api/data', route =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ items: [] }),
+  })
+);
+```
+
+**Related**: [core/network-mocking.md](network-mocking.md)
+
+---
+
+## Authentication & State Errors
+
+---
+
+### "Error: browserContext.storageState: No such file"
+
+**Cause**: The `storageState` path referenced in the config or test does not point to an existing file. The auth state file has not been generated yet.
+
+**Common triggers**:
+- Running tests before running the auth setup project
+- The `globalSetup` or auth setup project did not complete successfully
+- The file path in the config does not match the path used in the setup
+- `.gitignore` excluded the storage state file and it was not regenerated after a fresh clone
+- CI cache expired and the state file was not recreated
+
+**Fix**: Ensure the auth setup runs first and the file path is consistent.
+
+```typescript
+// TypeScript — playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+export default defineConfig({
+  projects: [
+    // Setup project runs first and creates the auth state file
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: {
+        storageState: authFile,
+      },
+      dependencies: ['setup'], // ensures setup runs first
+    },
+  ],
+});
+
+// auth.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+  // Save the authenticated state
+  await page.context().storageState({ path: authFile });
+});
+```
+
+```javascript
+// JavaScript — playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+const authFile = 'playwright/.auth/user.json';
+
+module.exports = defineConfig({
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.js/,
+    },
+    {
+      name: 'chromium',
+      use: {
+        storageState: authFile,
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});
+
+// auth.setup.js
+const { test: setup, expect } = require('@playwright/test');
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+  await page.context().storageState({ path: authFile });
+});
+```
+
+Ensure the auth directory exists and is in `.gitignore`:
+
+```bash
+mkdir -p playwright/.auth
+echo "playwright/.auth/" >> .gitignore
+```
+
+**Related**: [core/authentication.md](authentication.md), [core/auth-flows.md](auth-flows.md)
+
+---
+
+### "Error: Target page, context or browser has been closed"
+
+**Cause**: Code attempted to use a `page`, `context`, or `browser` object that has already been closed or disposed.
+
+**Common triggers**:
+- Using a `page` reference after `page.close()` was called
+- Storing a `page` or `context` in a module-level variable and reusing it across tests
+- A fixture tore down the browser context while an async callback was still running
+- A `beforeAll` created a context that was closed before all tests finished using it
+- Using `browser.newContext()` manually and forgetting to manage its lifecycle
+
+**Fix**: Never store page/context references in shared mutable state. Use Playwright fixtures for lifecycle management.
+
+```typescript
+// TypeScript
+
+// BAD — shared module-level variable
+let sharedPage: Page;
+test.beforeAll(async ({ browser }) => {
+  sharedPage = await browser.newPage();
+});
+test.afterAll(async () => {
+  await sharedPage.close();
+});
+test('first', async () => {
+  await sharedPage.goto('/'); // might fail if afterAll from another describe ran first
+});
+
+// GOOD — use the built-in page fixture (one per test, auto-managed)
+test('first', async ({ page }) => {
+  await page.goto('/'); // always a fresh, open page
+});
+
+// GOOD — for shared state across tests, use a worker-scoped fixture
+import { test as base } from '@playwright/test';
+
+export const test = base.extend<{}, { adminContext: BrowserContext }>({
+  adminContext: [async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  }, { scope: 'worker' }],
+});
+```
+
+```javascript
+// JavaScript
+
+// GOOD — use the built-in page fixture
+test('first', async ({ page }) => {
+  await page.goto('/');
+});
+
+// GOOD — for shared state, use a worker-scoped fixture
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  adminContext: [async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  }, { scope: 'worker' }],
+});
+```
+
+**Related**: [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+---
+
+## CI-Specific Errors
+
+---
+
+### "Error: browserType.launch: Browser closed unexpectedly"
+
+**Cause**: The browser process crashed immediately after launch, usually because required OS-level dependencies are missing in the CI environment.
+
+**Common triggers**:
+- Running on a minimal Docker image (e.g., `node:alpine`) without browser dependencies
+- Missing shared libraries (`libgbm`, `libnss3`, `libatk-bridge`, etc.) on Linux CI
+- Insufficient shared memory (`/dev/shm` too small) — browsers use shared memory for rendering
+- Running as root in Docker without `--no-sandbox` (Chromium refuses to run as root with sandbox)
+- Out-of-memory kill on CI (browser process is OOM-killed by the OS)
+
+**Fix**: Install OS-level dependencies and configure the environment.
+
+```bash
+# Install browsers with their OS dependencies (recommended)
+npx playwright install --with-deps chromium
+
+# If using Docker, use the official Playwright image
+# Dockerfile
+FROM mcr.microsoft.com/playwright:v1.50.0-noble
+WORKDIR /app
+COPY . .
+RUN npm ci
+RUN npx playwright install chromium
+CMD ["npx", "playwright", "test"]
+```
+
+For shared memory issues:
+
+```yaml
+# GitHub Actions — increase /dev/shm
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      options: --shm-size=2gb
+
+# Docker run — increase shared memory
+# docker run --shm-size=2gb my-test-image
+```
+
+For running as root in Docker:
+
+```typescript
+// TypeScript — playwright.config.ts (only for Docker/CI)
+export default defineConfig({
+  use: {
+    launchOptions: {
+      args: process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+    },
+  },
+});
+```
+
+```javascript
+// JavaScript — playwright.config.js
+module.exports = defineConfig({
+  use: {
+    launchOptions: {
+      args: process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+    },
+  },
+});
+```
+
+**Related**: [ci/ci-github-actions.md](../ci/ci-github-actions.md), [ci/docker-and-containers.md](../ci/docker-and-containers.md)
+
+---
+
+### "Error: Playwright Test needs to be invoked via 'npx playwright test'"
+
+**Cause**: The test file was executed directly with `node` or `ts-node` instead of through the Playwright test runner.
+
+**Common triggers**:
+- Running `node tests/example.spec.ts` or `ts-node tests/example.spec.ts`
+- A misconfigured IDE run configuration that invokes `node` directly
+- Using Jest or Mocha to run Playwright test files that import from `@playwright/test`
+- A CI script that calls the wrong command
+
+**Fix**: Always use the Playwright CLI to run tests.
+
+```bash
+# Correct invocations
+npx playwright test                           # run all tests
+npx playwright test tests/login.spec.ts       # run specific file
+npx playwright test --grep "login"            # run tests matching pattern
+npx playwright test --project=chromium        # run specific project
+npx playwright test --debug                   # run with inspector
+
+# If using a package.json script
+# package.json
+# "scripts": { "test:e2e": "playwright test" }
+npm run test:e2e
+```
+
+For IDE configuration (VS Code):
+
+```json
+// .vscode/settings.json — install the Playwright VS Code extension instead of custom configs
+{
+  "playwright.reuseBrowser": true
+}
+```
+
+**Related**: [core/configuration.md](configuration.md)
+
+---
+
+## Additional Common Errors
+
+---
+
+### "Error: page.evaluate: Execution context was destroyed"
+
+**Cause**: The page navigated or reloaded while `page.evaluate()` was executing JavaScript in the browser context.
+
+**Common triggers**:
+- Calling `evaluate()` while the page is in the middle of a navigation
+- A timer or event on the page triggers a redirect during evaluation
+- Running `evaluate()` in a `beforeEach` that races with `page.goto()`
+
+**Fix**: Ensure the page is stable before evaluating.
+
+```typescript
+// TypeScript
+
+// BAD — evaluate races with navigation
+await page.goto('/dashboard');
+const title = await page.evaluate(() => document.title); // context might be destroyed
+
+// GOOD — wait for load state first
+await page.goto('/dashboard');
+await page.waitForLoadState('domcontentloaded');
+const title = await page.evaluate(() => document.title);
+
+// GOOD — prefer locator-based assertions (no evaluate needed)
+await page.goto('/dashboard');
+await expect(page).toHaveTitle('Dashboard');
+```
+
+```javascript
+// JavaScript
+
+// GOOD — wait for load state first
+await page.goto('/dashboard');
+await page.waitForLoadState('domcontentloaded');
+const title = await page.evaluate(() => document.title);
+
+// GOOD — prefer locator-based assertions
+await page.goto('/dashboard');
+await expect(page).toHaveTitle('Dashboard');
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+---
+
+### "Error: page.screenshot: Cannot take a screenshot larger than..."
+
+**Cause**: The requested screenshot dimensions exceed Playwright's limit (typically 16384x16384 pixels). This happens with full-page screenshots of very long pages.
+
+**Common triggers**:
+- `page.screenshot({ fullPage: true })` on an infinitely-scrolling page
+- Pages with extremely tall content (long data tables, chat logs)
+- CSS bugs that create enormous element heights
+
+**Fix**: Clip the screenshot to a specific region or limit the viewport.
+
+```typescript
+// TypeScript
+
+// BAD — might exceed size limits on tall pages
+await page.screenshot({ fullPage: true, path: 'full.png' });
+
+// GOOD — clip to a specific region
+await page.screenshot({
+  path: 'clipped.png',
+  clip: { x: 0, y: 0, width: 1280, height: 2000 },
+});
+
+// GOOD — screenshot a specific element instead
+await page.getByRole('main').screenshot({ path: 'main-content.png' });
+
+// GOOD — set a reasonable viewport before full-page screenshot
+await page.setViewportSize({ width: 1280, height: 720 });
+await page.screenshot({ fullPage: true, path: 'full.png' });
+```
+
+```javascript
+// JavaScript
+
+// GOOD — clip to a specific region
+await page.screenshot({
+  path: 'clipped.png',
+  clip: { x: 0, y: 0, width: 1280, height: 2000 },
+});
+
+// GOOD — screenshot a specific element
+await page.getByRole('main').screenshot({ path: 'main-content.png' });
+```
+
+**Related**: [core/visual-regression.md](visual-regression.md)
+
+---
+
+### "Error: waiting for locator('...').toBeAttached()"
+
+**Cause**: The element never entered the DOM within the assertion timeout. Unlike `toBeVisible()`, `toBeAttached()` only checks DOM presence — but the element was never rendered at all.
+
+**Common triggers**:
+- The component is conditionally rendered and the condition is not met
+- A network request that populates the data has not completed
+- Wrong selector that does not match any element
+- The element is rendered by a lazy-loaded chunk that has not downloaded yet
+
+**Fix**: Verify the precondition for the element to render.
+
+```typescript
+// TypeScript
+
+// Ensure the data loads before asserting
+await page.goto('/users');
+await page.waitForResponse(resp => resp.url().includes('/api/users'));
+await expect(page.getByRole('table')).toBeAttached();
+
+// For lazy-loaded content, wait longer or trigger the load
+await page.getByRole('tab', { name: 'Advanced' }).click();
+await expect(page.getByTestId('advanced-panel')).toBeAttached({ timeout: 10_000 });
+```
+
+```javascript
+// JavaScript
+
+await page.goto('/users');
+await page.waitForResponse(resp => resp.url().includes('/api/users'));
+await expect(page.getByRole('table')).toBeAttached();
+
+await page.getByRole('tab', { name: 'Advanced' }).click();
+await expect(page.getByTestId('advanced-panel')).toBeAttached({ timeout: 10_000 });
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/locators.md](locators.md)
+
+---
+
+### "Error: protocol error: Target.createTarget: Failed to create target"
+
+**Cause**: The browser could not create a new tab or context, usually due to resource exhaustion.
+
+**Common triggers**:
+- Opening too many pages or contexts without closing them
+- Memory leak in tests — each test opens a context but never closes it
+- Running many parallel workers on a resource-constrained CI machine
+- Browser process is unstable after a previous crash
+
+**Fix**: Reduce parallelism, close unused contexts, or use fewer workers.
+
+```typescript
+// TypeScript — playwright.config.ts
+
+export default defineConfig({
+  // Reduce parallelism if resources are limited
+  workers: process.env.CI ? 2 : undefined,
+
+  // Limit to one browser context per worker
+  fullyParallel: false, // run test files serially within a worker
+});
+```
+
+```javascript
+// JavaScript — playwright.config.js
+
+module.exports = defineConfig({
+  workers: process.env.CI ? 2 : undefined,
+  fullyParallel: false,
+});
+```
+
+If you manually create contexts, always close them:
+
+```typescript
+// TypeScript
+test('multi-user test', async ({ browser }) => {
+  const userContext = await browser.newContext();
+  const adminContext = await browser.newContext();
+  try {
+    const userPage = await userContext.newPage();
+    const adminPage = await adminContext.newPage();
+    // ... test logic
+  } finally {
+    await userContext.close();
+    await adminContext.close();
+  }
+});
+```
+
+```javascript
+// JavaScript
+test('multi-user test', async ({ browser }) => {
+  const userContext = await browser.newContext();
+  const adminContext = await browser.newContext();
+  try {
+    const userPage = await userContext.newPage();
+    const adminPage = await adminContext.newPage();
+    // ... test logic
+  } finally {
+    await userContext.close();
+    await adminContext.close();
+  }
+});
+```
+
+**Related**: [ci/parallel-and-sharding.md](../ci/parallel-and-sharding.md), [core/multi-user-and-collaboration.md](multi-user-and-collaboration.md)
+
+---
+
+### "Error: expect(locator).toHaveText() — expected string but received array"
+
+**Cause**: The locator matched multiple elements and `toHaveText()` returned an array of strings instead of a single string.
+
+**Common triggers**:
+- Using a broad locator like `page.locator('.item')` that matches a list
+- Expecting a single heading but the selector matches multiple
+- Not scoping the locator to a specific container
+
+**Fix**: Either narrow the locator to one element or use the array form of `toHaveText()`.
+
+```typescript
+// TypeScript
+
+// BAD — locator matches multiple elements
+await expect(page.locator('.item')).toHaveText('First Item');
+
+// GOOD — narrow to one element
+await expect(page.locator('.item').first()).toHaveText('First Item');
+
+// GOOD — assert against an array when multiple elements are expected
+await expect(page.locator('.item')).toHaveText([
+  'First Item',
+  'Second Item',
+  'Third Item',
+]);
+
+// GOOD — use a more specific locator
+await expect(page.getByRole('heading', { level: 1 })).toHaveText('Welcome');
+```
+
+```javascript
+// JavaScript
+
+// GOOD — narrow to one element
+await expect(page.locator('.item').first()).toHaveText('First Item');
+
+// GOOD — assert against an array
+await expect(page.locator('.item')).toHaveText([
+  'First Item',
+  'Second Item',
+  'Third Item',
+]);
+
+// GOOD — use a more specific locator
+await expect(page.getByRole('heading', { level: 1 })).toHaveText('Welcome');
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/locators.md](locators.md)
+
+---
+
+### "Error: page.waitForSelector: Timeout 30000ms exceeded (deprecated)"
+
+**Cause**: `page.waitForSelector()` timed out. This method is deprecated in favor of locator-based assertions.
+
+**Common triggers**:
+- Using legacy `page.waitForSelector()` from older tutorials or migration from Puppeteer
+- The selector does not match any element in the DOM
+- The element exists but does not meet the state requirement (e.g., `{ state: 'visible' }` but element is hidden)
+
+**Fix**: Replace `waitForSelector()` with locator-based assertions.
+
+```typescript
+// TypeScript
+
+// BAD — deprecated, no auto-retry, not composable
+await page.waitForSelector('.loading', { state: 'hidden' });
+await page.waitForSelector('.content', { state: 'visible' });
+
+// GOOD — locator-based assertions with auto-retry
+await expect(page.locator('.loading')).toBeHidden();
+await expect(page.locator('.content')).toBeVisible();
+
+// GOOD — use role-based locators for even more resilience
+await expect(page.getByRole('progressbar')).toBeHidden();
+await expect(page.getByRole('main')).toBeVisible();
+```
+
+```javascript
+// JavaScript
+
+// BAD — deprecated
+await page.waitForSelector('.loading', { state: 'hidden' });
+await page.waitForSelector('.content', { state: 'visible' });
+
+// GOOD — locator-based assertions
+await expect(page.locator('.loading')).toBeHidden();
+await expect(page.locator('.content')).toBeVisible();
+
+// GOOD — role-based locators
+await expect(page.getByRole('progressbar')).toBeHidden();
+await expect(page.getByRole('main')).toBeVisible();
+```
+
+**Related**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md), [migration/from-selenium.md](../migration/from-selenium.md)
+
+---
+
+### "Error: Test was expected to have a title matching /.../"
+
+**Cause**: The `expect(page).toHaveTitle()` assertion failed because the page title did not match the expected value or pattern within the timeout.
+
+**Common triggers**:
+- The page has not finished loading and the title is still the initial empty or default value
+- The SPA updates the document title asynchronously after rendering
+- The expected title has a typo or does not match case-sensitively
+- The page redirected to an error page with a different title
+
+**Fix**: Ensure the page is fully loaded and use the correct expected value.
+
+```typescript
+// TypeScript
+
+// toHaveTitle auto-retries, but ensure the page has loaded
+await page.goto('/dashboard');
+await expect(page).toHaveTitle('Dashboard | MyApp');
+
+// Use regex for flexible matching
+await expect(page).toHaveTitle(/Dashboard/);
+
+// Debug: check what the actual title is
+console.log(await page.title());
+```
+
+```javascript
+// JavaScript
+
+await page.goto('/dashboard');
+await expect(page).toHaveTitle('Dashboard | MyApp');
+
+// Use regex for flexible matching
+await expect(page).toHaveTitle(/Dashboard/);
+
+// Debug: check what the actual title is
+console.log(await page.title());
+```
+
+**Related**: [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+---
+
+### "Error: page.type: Element is not focusable"
+
+**Cause**: `page.type()` or `locator.type()` could not focus the target element before typing. The element may be hidden, disabled, or not an input.
+
+**Common triggers**:
+- The element is covered by an overlay or modal
+- The element has `tabindex="-1"` and is not natively focusable
+- Using `type()` instead of `fill()` — `fill()` is preferred in almost all cases
+- The element is inside a Shadow DOM and the locator does not pierce it
+
+**Fix**: Use `fill()` instead of `type()`. Only use `type()` when you specifically need to simulate individual keystrokes.
+
+```typescript
+// TypeScript
+
+// BAD — type() is slower and more fragile
+await page.locator('#search').type('hello');
+
+// GOOD — fill() clears and sets the value directly
+await page.getByRole('searchbox').fill('hello');
+
+// When you truly need keystroke-by-keystroke input (e.g., autocomplete trigger)
+await page.getByRole('searchbox').pressSequentially('hello', { delay: 100 });
+```
+
+```javascript
+// JavaScript
+
+// GOOD — fill() is preferred
+await page.getByRole('searchbox').fill('hello');
+
+// Keystroke-by-keystroke when needed (e.g., autocomplete)
+await page.getByRole('searchbox').pressSequentially('hello', { delay: 100 });
+```
+
+**Related**: [core/locators.md](locators.md), [core/forms-and-validation.md](forms-and-validation.md)
+
+---
+
+### "Error: page.setInputFiles: Non-multiple file input can only accept single file"
+
+**Cause**: Attempted to upload multiple files to an `<input type="file">` that does not have the `multiple` attribute.
+
+**Common triggers**:
+- Passing an array of files to a single-file upload input
+- The app uses a custom upload component that only handles one file at a time
+
+**Fix**: Upload one file at a time, or ensure the input supports multiple files.
+
+```typescript
+// TypeScript
+
+// BAD — input does not have multiple attribute
+await page.getByLabel('Upload file').setInputFiles([
+  'file1.pdf',
+  'file2.pdf', // error: non-multiple input
+]);
+
+// GOOD — single file
+await page.getByLabel('Upload file').setInputFiles('file1.pdf');
+
+// GOOD — for multiple file input (must have multiple attribute in HTML)
+await page.getByLabel('Upload files').setInputFiles([
+  'file1.pdf',
+  'file2.pdf',
+]);
+
+// To clear the file input
+await page.getByLabel('Upload file').setInputFiles([]);
+```
+
+```javascript
+// JavaScript
+
+// GOOD — single file
+await page.getByLabel('Upload file').setInputFiles('file1.pdf');
+
+// GOOD — multiple files (input must have multiple attribute)
+await page.getByLabel('Upload files').setInputFiles([
+  'file1.pdf',
+  'file2.pdf',
+]);
+
+// To clear the file input
+await page.getByLabel('Upload file').setInputFiles([]);
+```
+
+**Related**: [core/file-operations.md](file-operations.md), [core/file-upload-download.md](file-upload-download.md)
+
+---
+
+### "Error: browser.newContext: Could not parse content-type application/json"
+
+**Cause**: The `storageState` option was given a path to a file with invalid JSON content, or the file is not a valid Playwright storage state format.
+
+**Common triggers**:
+- The auth setup wrote an empty file or incomplete JSON
+- The storage state file was corrupted or truncated
+- Manually editing the storage state file and introducing a syntax error
+- The auth setup failed silently (login did not complete) and saved an invalid state
+
+**Fix**: Delete the storage state file and regenerate it.
+
+```bash
+# Delete the corrupted file
+rm -f playwright/.auth/user.json
+
+# Re-run the setup
+npx playwright test --project=setup
+```
+
+To prevent this, add error checking in the auth setup:
+
+```typescript
+// TypeScript — auth.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Verify login actually succeeded before saving state
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.context().storageState({ path: authFile });
+});
+```
+
+```javascript
+// JavaScript — auth.setup.js
+const { test: setup, expect } = require('@playwright/test');
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Verify login actually succeeded before saving state
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.context().storageState({ path: authFile });
+});
+```
+
+**Related**: [core/authentication.md](authentication.md), [core/auth-flows.md](auth-flows.md)
+
+---
+
+## Quick Diagnostic Checklist
+
+When you hit an error not listed above, run through this checklist:
+
+1. **Read the full error** — Playwright errors include the locator, action, and a snippet of the page state. The answer is often in the details.
+2. **Enable traces** — Add `trace: 'on'` temporarily or `trace: 'on-first-retry'` in config. Run `npx playwright show-trace trace.zip` to see screenshots, DOM, network, and console at the point of failure.
+3. **Use the Playwright Inspector** — Run `npx playwright test --debug` to step through the test interactively.
+4. **Check the locator** — Run `npx playwright codegen <url>` to verify locators against the live page.
+5. **Check the Playwright version** — Run `npx playwright --version`. Ensure `@playwright/test` and browser binaries are the same version.
+6. **Search the Playwright issue tracker** — Many errors have known solutions in [github.com/microsoft/playwright/issues](https://github.com/microsoft/playwright/issues).

--- a/engineering-team/playwright skill/core/file-operations.md
+++ b/engineering-team/playwright skill/core/file-operations.md
@@ -1,0 +1,749 @@
+# File Operations
+
+> **When to use**: Testing file uploads, downloads, drag-and-drop file interactions, file type validation, and download verification.
+> **Prerequisites**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Reference
+
+```typescript
+// Upload — single file
+await page.getByLabel('Upload').setInputFiles('fixtures/resume.pdf');
+
+// Upload — multiple files
+await page.getByLabel('Upload').setInputFiles(['fixtures/a.png', 'fixtures/b.png']);
+
+// Upload — clear selection
+await page.getByLabel('Upload').setInputFiles([]);
+
+// Download — wait and save
+const download = await page.waitForEvent('download');
+await page.getByRole('button', { name: 'Export CSV' }).click();
+const path = await download.path();           // temp path
+await download.saveAs('test-results/export.csv'); // permanent path
+
+// File chooser dialog — non-input uploads
+const fileChooser = await page.waitForEvent('filechooser');
+await page.getByRole('button', { name: 'Choose file' }).click();
+await fileChooser.setFiles('fixtures/photo.jpg');
+```
+
+## Patterns
+
+### Single File Upload
+
+**Use when**: A form has a standard `<input type="file">` element.
+**Avoid when**: The upload uses a drag-and-drop zone with no underlying file input.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('upload a single document', async ({ page }) => {
+  await page.goto('/settings/profile');
+
+  const filePath = path.join(__dirname, '../fixtures/avatar.png');
+  await page.getByLabel('Profile picture').setInputFiles(filePath);
+
+  // Verify the file name appears in the UI
+  await expect(page.getByText('avatar.png')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('upload a single document', async ({ page }) => {
+  await page.goto('/settings/profile');
+
+  const filePath = path.join(__dirname, '../fixtures/avatar.png');
+  await page.getByLabel('Profile picture').setInputFiles(filePath);
+
+  await expect(page.getByText('avatar.png')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+```
+
+### Multiple File Upload
+
+**Use when**: The file input accepts `multiple` and you need to attach several files at once.
+**Avoid when**: The UI only allows one file. Use single file upload.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('upload multiple attachments', async ({ page }) => {
+  await page.goto('/tickets/new');
+
+  const fixtures = ['doc1.pdf', 'doc2.pdf', 'screenshot.png'].map(
+    (f) => path.join(__dirname, '../fixtures', f)
+  );
+
+  await page.getByLabel('Attachments').setInputFiles(fixtures);
+
+  // Verify all files are listed
+  await expect(page.getByTestId('file-list').getByRole('listitem')).toHaveCount(3);
+
+  // Remove one file by clearing and re-setting
+  await page.getByLabel('Attachments').setInputFiles(fixtures.slice(0, 2));
+  await expect(page.getByTestId('file-list').getByRole('listitem')).toHaveCount(2);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('upload multiple attachments', async ({ page }) => {
+  await page.goto('/tickets/new');
+
+  const fixtures = ['doc1.pdf', 'doc2.pdf', 'screenshot.png'].map(
+    (f) => path.join(__dirname, '../fixtures', f)
+  );
+
+  await page.getByLabel('Attachments').setInputFiles(fixtures);
+  await expect(page.getByTestId('file-list').getByRole('listitem')).toHaveCount(3);
+
+  await page.getByLabel('Attachments').setInputFiles(fixtures.slice(0, 2));
+  await expect(page.getByTestId('file-list').getByRole('listitem')).toHaveCount(2);
+});
+```
+
+### File Chooser Dialog
+
+**Use when**: The upload is triggered by a button click that opens the native file picker, not by a visible `<input type="file">`. Common with drag-and-drop libraries and custom upload components.
+**Avoid when**: There is a visible `<input type="file">` — use `setInputFiles` directly.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('upload via file chooser dialog', async ({ page }) => {
+  await page.goto('/documents');
+
+  // Register the listener BEFORE the click that opens the dialog
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Upload document' }).click();
+  const fileChooser = await fileChooserPromise;
+
+  // Verify dialog properties
+  expect(fileChooser.isMultiple()).toBe(false);
+
+  await fileChooser.setFiles('fixtures/report.pdf');
+  await expect(page.getByText('report.pdf')).toBeVisible();
+});
+
+test('upload multiple via file chooser', async ({ page }) => {
+  await page.goto('/gallery');
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Add photos' }).click();
+  const fileChooser = await fileChooserPromise;
+
+  expect(fileChooser.isMultiple()).toBe(true);
+  await fileChooser.setFiles(['fixtures/photo1.jpg', 'fixtures/photo2.jpg']);
+
+  await expect(page.getByRole('img')).toHaveCount(2);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('upload via file chooser dialog', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Upload document' }).click();
+  const fileChooser = await fileChooserPromise;
+
+  expect(fileChooser.isMultiple()).toBe(false);
+
+  await fileChooser.setFiles('fixtures/report.pdf');
+  await expect(page.getByText('report.pdf')).toBeVisible();
+});
+
+test('upload multiple via file chooser', async ({ page }) => {
+  await page.goto('/gallery');
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Add photos' }).click();
+  const fileChooser = await fileChooserPromise;
+
+  expect(fileChooser.isMultiple()).toBe(true);
+  await fileChooser.setFiles(['fixtures/photo1.jpg', 'fixtures/photo2.jpg']);
+
+  await expect(page.getByRole('img')).toHaveCount(2);
+});
+```
+
+### Drag-and-Drop File Upload
+
+**Use when**: The UI has a drop zone that accepts files via the HTML5 Drag and Drop API and has no `<input type="file">` fallback.
+**Avoid when**: A file input exists — even hidden ones work with `setInputFiles`.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+test('drop file onto upload zone', async ({ page }) => {
+  await page.goto('/upload');
+
+  // Read the file into a buffer
+  const filePath = path.join(__dirname, '../fixtures/data.csv');
+  const buffer = fs.readFileSync(filePath);
+
+  // Create a DataTransfer with the file and dispatch drop event
+  const dropZone = page.getByTestId('drop-zone');
+
+  await dropZone.dispatchEvent('drop', {
+    dataTransfer: {
+      files: [
+        { name: 'data.csv', mimeType: 'text/csv', buffer },
+      ],
+    },
+  });
+
+  await expect(page.getByText('data.csv')).toBeVisible();
+  await expect(page.getByText('Upload complete')).toBeVisible();
+});
+
+test('drag-and-drop with hidden input fallback', async ({ page }) => {
+  await page.goto('/upload');
+
+  // Many drag-and-drop libraries still use a hidden <input type="file">
+  // Check for it first — this is more reliable than simulating DnD events
+  const hiddenInput = page.locator('input[type="file"]');
+
+  if (await hiddenInput.count() > 0) {
+    await hiddenInput.setInputFiles('fixtures/data.csv');
+  }
+
+  await expect(page.getByText('data.csv')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+test('drop file onto upload zone', async ({ page }) => {
+  await page.goto('/upload');
+
+  const filePath = path.join(__dirname, '../fixtures/data.csv');
+  const buffer = fs.readFileSync(filePath);
+
+  const dropZone = page.getByTestId('drop-zone');
+
+  await dropZone.dispatchEvent('drop', {
+    dataTransfer: {
+      files: [
+        { name: 'data.csv', mimeType: 'text/csv', buffer },
+      ],
+    },
+  });
+
+  await expect(page.getByText('data.csv')).toBeVisible();
+  await expect(page.getByText('Upload complete')).toBeVisible();
+});
+
+test('drag-and-drop with hidden input fallback', async ({ page }) => {
+  await page.goto('/upload');
+
+  const hiddenInput = page.locator('input[type="file"]');
+
+  if (await hiddenInput.count() > 0) {
+    await hiddenInput.setInputFiles('fixtures/data.csv');
+  }
+
+  await expect(page.getByText('data.csv')).toBeVisible();
+});
+```
+
+### File Download — Wait and Verify
+
+**Use when**: Testing export buttons, report generation, or any action that triggers a browser download.
+**Avoid when**: The file is served as a page navigation (opens in a new tab). Use multi-tab patterns instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+test('download and verify file content', async ({ page }) => {
+  await page.goto('/reports');
+
+  // Register BEFORE the click that triggers the download
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export CSV' }).click();
+  const download = await downloadPromise;
+
+  // Verify download metadata
+  expect(download.suggestedFilename()).toBe('report-2025.csv');
+
+  // Save to a known location
+  const savePath = 'test-results/report.csv';
+  await download.saveAs(savePath);
+
+  // Read and verify content
+  const content = fs.readFileSync(savePath, 'utf-8');
+  expect(content).toContain('Name,Email,Status');
+  expect(content).toContain('Jane Doe,jane@example.com,Active');
+
+  // Verify file size is reasonable
+  const stats = fs.statSync(savePath);
+  expect(stats.size).toBeGreaterThan(100);
+});
+
+test('download triggered by a link', async ({ page }) => {
+  await page.goto('/files');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download invoice' }).click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toMatch(/invoice-\d+\.pdf/);
+
+  // Use download.path() for the temp file path
+  const tempPath = await download.path();
+  expect(tempPath).toBeTruthy();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+
+test('download and verify file content', async ({ page }) => {
+  await page.goto('/reports');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export CSV' }).click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe('report-2025.csv');
+
+  const savePath = 'test-results/report.csv';
+  await download.saveAs(savePath);
+
+  const content = fs.readFileSync(savePath, 'utf-8');
+  expect(content).toContain('Name,Email,Status');
+  expect(content).toContain('Jane Doe,jane@example.com,Active');
+
+  const stats = fs.statSync(savePath);
+  expect(stats.size).toBeGreaterThan(100);
+});
+
+test('download triggered by a link', async ({ page }) => {
+  await page.goto('/files');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download invoice' }).click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toMatch(/invoice-\d+\.pdf/);
+
+  const tempPath = await download.path();
+  expect(tempPath).toBeTruthy();
+});
+```
+
+### Configuring Download Paths
+
+**Use when**: You need downloads to go to a specific directory, or you need to disable the download dialog prompt.
+**Avoid when**: Default temp paths via `download.path()` or `download.saveAs()` are sufficient.
+
+**TypeScript**
+```typescript
+// playwright.config.ts — global download behavior
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    // Accept all downloads without prompting
+    acceptDownloads: true, // default is true
+  },
+});
+```
+
+```typescript
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+// Per-test download directory via a custom fixture
+const downloadTest = test.extend<{ downloadDir: string }>({
+  downloadDir: async ({}, use, testInfo) => {
+    const dir = path.join('test-results', 'downloads', testInfo.title.replace(/\s+/g, '-'));
+    fs.mkdirSync(dir, { recursive: true });
+    await use(dir);
+  },
+});
+
+downloadTest('save downloads to organized directories', async ({ page, downloadDir }) => {
+  await page.goto('/exports');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export' }).click();
+  const download = await downloadPromise;
+
+  const savePath = path.join(downloadDir, download.suggestedFilename());
+  await download.saveAs(savePath);
+
+  expect(fs.existsSync(savePath)).toBe(true);
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    acceptDownloads: true,
+  },
+});
+```
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const downloadTest = test.extend({
+  downloadDir: async ({}, use, testInfo) => {
+    const dir = path.join('test-results', 'downloads', testInfo.title.replace(/\s+/g, '-'));
+    fs.mkdirSync(dir, { recursive: true });
+    await use(dir);
+  },
+});
+
+downloadTest('save downloads to organized directories', async ({ page, downloadDir }) => {
+  await page.goto('/exports');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export' }).click();
+  const download = await downloadPromise;
+
+  const savePath = path.join(downloadDir, download.suggestedFilename());
+  await download.saveAs(savePath);
+
+  expect(fs.existsSync(savePath)).toBe(true);
+});
+```
+
+### File Type Validation
+
+**Use when**: Testing that the application rejects invalid file types and accepts valid ones.
+**Avoid when**: The application does no client-side validation and relies entirely on server-side checks (test via API instead).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('rejects unsupported file types', async ({ page }) => {
+  await page.goto('/upload');
+
+  // Upload an invalid file type
+  await page.getByLabel('Upload image').setInputFiles({
+    name: 'malware.exe',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from('fake-exe-content'),
+  });
+
+  await expect(page.getByText('Only JPG, PNG, and GIF files are allowed')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeDisabled();
+});
+
+test('accepts valid file types', async ({ page }) => {
+  await page.goto('/upload');
+
+  await page.getByLabel('Upload image').setInputFiles({
+    name: 'photo.jpg',
+    mimeType: 'image/jpeg',
+    buffer: Buffer.from('fake-jpg-content'),
+  });
+
+  await expect(page.getByText('photo.jpg')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
+});
+
+test('validates file size limits', async ({ page }) => {
+  await page.goto('/upload');
+
+  // Create a buffer that exceeds the 5MB limit
+  const largeBuffer = Buffer.alloc(6 * 1024 * 1024, 'x');
+
+  await page.getByLabel('Upload document').setInputFiles({
+    name: 'huge-file.pdf',
+    mimeType: 'application/pdf',
+    buffer: largeBuffer,
+  });
+
+  await expect(page.getByText('File size must be under 5MB')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('rejects unsupported file types', async ({ page }) => {
+  await page.goto('/upload');
+
+  await page.getByLabel('Upload image').setInputFiles({
+    name: 'malware.exe',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from('fake-exe-content'),
+  });
+
+  await expect(page.getByText('Only JPG, PNG, and GIF files are allowed')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeDisabled();
+});
+
+test('accepts valid file types', async ({ page }) => {
+  await page.goto('/upload');
+
+  await page.getByLabel('Upload image').setInputFiles({
+    name: 'photo.jpg',
+    mimeType: 'image/jpeg',
+    buffer: Buffer.from('fake-jpg-content'),
+  });
+
+  await expect(page.getByText('photo.jpg')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
+});
+
+test('validates file size limits', async ({ page }) => {
+  await page.goto('/upload');
+
+  const largeBuffer = Buffer.alloc(6 * 1024 * 1024, 'x');
+
+  await page.getByLabel('Upload document').setInputFiles({
+    name: 'huge-file.pdf',
+    mimeType: 'application/pdf',
+    buffer: largeBuffer,
+  });
+
+  await expect(page.getByText('File size must be under 5MB')).toBeVisible();
+});
+```
+
+### Large File Handling
+
+**Use when**: Testing uploads or downloads of large files where timeouts and progress indicators matter.
+**Avoid when**: Every test. Large file tests are slow. Run them in a separate suite or tag them for nightly runs.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+test.describe('large file operations', () => {
+  // Increase timeout for the entire describe block
+  test.slow(); // Triples the default timeout
+
+  test('upload large file with progress tracking', async ({ page }) => {
+    await page.goto('/upload');
+
+    // Create a test file on disk (avoid Buffer.alloc for very large files)
+    const largePath = path.join('test-results', 'large-test-file.bin');
+    const stream = fs.createWriteStream(largePath);
+    for (let i = 0; i < 100; i++) {
+      stream.write(Buffer.alloc(1024 * 1024, 'a')); // 100MB total
+    }
+    stream.end();
+    await new Promise((resolve) => stream.on('finish', resolve));
+
+    await page.getByLabel('Upload file').setInputFiles(largePath);
+
+    // Wait for progress indicator
+    await expect(page.getByRole('progressbar')).toBeVisible();
+
+    // Wait for completion — extended timeout
+    await expect(page.getByText('Upload complete')).toBeVisible({ timeout: 120_000 });
+
+    // Cleanup
+    fs.unlinkSync(largePath);
+  });
+
+  test('download large file', async ({ page }) => {
+    await page.goto('/exports');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export full dataset' }).click();
+    const download = await downloadPromise;
+
+    const savePath = 'test-results/large-export.zip';
+    await download.saveAs(savePath);
+
+    // Verify file size is reasonable (at least 10MB)
+    const stats = fs.statSync(savePath);
+    expect(stats.size).toBeGreaterThan(10 * 1024 * 1024);
+
+    fs.unlinkSync(savePath);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+test.describe('large file operations', () => {
+  test.slow();
+
+  test('upload large file with progress tracking', async ({ page }) => {
+    await page.goto('/upload');
+
+    const largePath = path.join('test-results', 'large-test-file.bin');
+    const stream = fs.createWriteStream(largePath);
+    for (let i = 0; i < 100; i++) {
+      stream.write(Buffer.alloc(1024 * 1024, 'a'));
+    }
+    stream.end();
+    await new Promise((resolve) => stream.on('finish', resolve));
+
+    await page.getByLabel('Upload file').setInputFiles(largePath);
+
+    await expect(page.getByRole('progressbar')).toBeVisible();
+    await expect(page.getByText('Upload complete')).toBeVisible({ timeout: 120_000 });
+
+    fs.unlinkSync(largePath);
+  });
+
+  test('download large file', async ({ page }) => {
+    await page.goto('/exports');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export full dataset' }).click();
+    const download = await downloadPromise;
+
+    const savePath = 'test-results/large-export.zip';
+    await download.saveAs(savePath);
+
+    const stats = fs.statSync(savePath);
+    expect(stats.size).toBeGreaterThan(10 * 1024 * 1024);
+
+    fs.unlinkSync(savePath);
+  });
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Key API |
+|---|---|---|
+| Standard `<input type="file">` | `setInputFiles()` on the locator | `locator.setInputFiles(path)` |
+| Hidden file input | Find the input even if hidden, call `setInputFiles()` | `page.locator('input[type="file"]').setInputFiles()` |
+| Custom button opens file picker | Listen for `filechooser` event before clicking | `page.waitForEvent('filechooser')` |
+| Drag-and-drop zone with no input | Dispatch `drop` event with `DataTransfer` | `locator.dispatchEvent('drop', ...)` |
+| DnD zone with hidden input fallback | Prefer `setInputFiles()` on the hidden input | Check `input[type="file"]` count first |
+| Multiple files at once | Pass array to `setInputFiles()` | `setInputFiles([path1, path2])` |
+| In-memory test file (no disk) | Pass object with `name`, `mimeType`, `buffer` | `setInputFiles({ name, mimeType, buffer })` |
+| Download — verify filename | `download.suggestedFilename()` | `page.waitForEvent('download')` |
+| Download — verify content | `download.saveAs()` then read with `fs` | `fs.readFileSync()` |
+| Download — temp file only | `download.path()` returns temp location | Auto-deleted after test |
+| Large file upload/download | Use `test.slow()`, increase assertion timeouts | `{ timeout: 120_000 }` |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `await page.waitForTimeout(3000)` after upload | Arbitrary delay; flaky | `await expect(page.getByText('Upload complete')).toBeVisible()` |
+| `await page.setInputFiles('#file', path)` using CSS selector | Fragile selector; breaks on ID changes | `await page.getByLabel('Upload').setInputFiles(path)` |
+| Clicking download then immediately reading the file | Race condition; file may not be written yet | Use `page.waitForEvent('download')` then `download.saveAs()` |
+| Creating large test files in `beforeAll` and never cleaning up | Fills disk in CI, slows down subsequent runs | Clean up in `afterAll` or use fixture teardown |
+| Using `page.on('filechooser')` for every upload | Unnecessary complexity when `<input type="file">` exists | Use `setInputFiles()` directly |
+| Hardcoding absolute file paths | Breaks across machines and CI | Use `path.join(__dirname, ...)` or relative to project root |
+| Testing file upload with empty buffer | Does not test real validation behavior | Use realistic file content or minimum valid file size |
+| Using `download.path()` for permanent storage | Temp files are cleaned up after test context closes | Use `download.saveAs()` for permanent paths |
+| Uploading real 100MB files in every test run | Slows entire suite, wastes CI resources | Tag large file tests separately; run on schedule, not every PR |
+
+## Troubleshooting
+
+### "FileChooser event was not emitted"
+
+**Cause**: The click did not open a native file picker dialog. The upload component may use a different mechanism.
+
+```typescript
+// Debug: check if there is a hidden <input type="file"> you can target directly
+const fileInputCount = await page.locator('input[type="file"]').count();
+console.log(`Found ${fileInputCount} file inputs`);
+
+// If input exists, skip the file chooser approach entirely
+if (fileInputCount > 0) {
+  await page.locator('input[type="file"]').setInputFiles('fixtures/file.pdf');
+}
+```
+
+### "Download event was not emitted"
+
+**Cause**: The link opens in a new tab or navigates to the file URL instead of triggering a download.
+
+```typescript
+// Fix 1: Ensure acceptDownloads is true in config
+// Fix 2: Check if the link opens a new tab — handle it as a new page
+const pagePromise = page.context().waitForEvent('page');
+await page.getByRole('link', { name: 'Download' }).click();
+const newPage = await pagePromise;
+// Then wait for the download event on the new page
+const download = await newPage.waitForEvent('download');
+```
+
+### Upload works locally but fails in CI
+
+**Cause**: File paths are wrong in CI, or the fixture files are not included in the repo/build.
+
+```typescript
+// Fix: always resolve paths relative to the test file
+import path from 'path';
+const fixturePath = path.join(__dirname, '..', 'fixtures', 'test-file.pdf');
+
+// Verify the file exists before uploading
+import fs from 'fs';
+if (!fs.existsSync(fixturePath)) {
+  throw new Error(`Fixture file missing: ${fixturePath}`);
+}
+```
+
+### `setInputFiles` does nothing — no file appears
+
+**Cause**: The input element is detached, inside a Shadow DOM, or in an iframe.
+
+```typescript
+// Check for iframe
+const frame = page.frameLocator('iframe[title="Upload"]');
+await frame.locator('input[type="file"]').setInputFiles('fixtures/file.pdf');
+
+// Check for Shadow DOM — Playwright pierces open shadow roots automatically
+// but the input may be in a closed shadow root (rare). Use the file chooser approach instead.
+```
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategies for finding upload/download elements
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- assertion patterns for verifying upload/download results
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- creating reusable download directory fixtures
+- [core/network-mocking.md](network-mocking.md) -- mocking upload endpoints for faster tests
+- [core/error-and-edge-cases.md](error-and-edge-cases.md) -- testing upload failure states and error handling

--- a/engineering-team/playwright skill/core/file-upload-download.md
+++ b/engineering-team/playwright skill/core/file-upload-download.md
@@ -1,0 +1,982 @@
+# File Upload and Download Recipes
+
+> **When to use**: You need to test file uploads (single, multiple, drag-and-drop), file downloads (verify content, filename, type), upload progress, or file type restrictions.
+
+---
+
+## Recipe 1: Single File Upload via Input
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('uploads a single file via file input', async ({ page }) => {
+  await page.goto('/documents');
+
+  // Click the upload button which triggers the hidden file input
+  const fileInput = page.locator('input[type="file"]');
+
+  // Upload a file from the test fixtures directory
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/report.pdf'));
+
+  // Verify the file name appears in the UI
+  await expect(page.getByText('report.pdf')).toBeVisible();
+
+  // Click the submit/upload button
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  // Wait for the upload to complete
+  await expect(page.getByRole('alert')).toContainText('File uploaded successfully');
+
+  // Verify the file appears in the documents list
+  await expect(page.getByRole('link', { name: 'report.pdf' })).toBeVisible();
+});
+
+test('uploads a file created in-memory (no fixture file needed)', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Create a file from a buffer -- no fixture file required
+  await fileInput.setInputFiles({
+    name: 'test-data.csv',
+    mimeType: 'text/csv',
+    buffer: Buffer.from('name,email,role\nJane,jane@example.com,admin\nBob,bob@example.com,user'),
+  });
+
+  await expect(page.getByText('test-data.csv')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('File uploaded successfully');
+});
+
+test('clears a selected file before uploading', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Select a file
+  await fileInput.setInputFiles({
+    name: 'wrong-file.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('wrong content'),
+  });
+
+  await expect(page.getByText('wrong-file.txt')).toBeVisible();
+
+  // Clear the selection
+  await fileInput.setInputFiles([]);
+
+  // Or click a "Remove" button in the UI
+  // await page.getByRole('button', { name: 'Remove' }).click();
+
+  await expect(page.getByText('wrong-file.txt')).not.toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('uploads a single file via file input', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/report.pdf'));
+
+  await expect(page.getByText('report.pdf')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('File uploaded successfully');
+  await expect(page.getByRole('link', { name: 'report.pdf' })).toBeVisible();
+});
+
+test('uploads a file created in-memory', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles({
+    name: 'test-data.csv',
+    mimeType: 'text/csv',
+    buffer: Buffer.from('name,email,role\nJane,jane@example.com,admin'),
+  });
+
+  await expect(page.getByText('test-data.csv')).toBeVisible();
+  await page.getByRole('button', { name: 'Upload' }).click();
+  await expect(page.getByRole('alert')).toContainText('File uploaded successfully');
+});
+```
+
+---
+
+## Recipe 2: Multiple File Upload
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('uploads multiple files at once', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Pass an array to upload multiple files
+  await fileInput.setInputFiles([
+    path.resolve(__dirname, '../fixtures/report.pdf'),
+    path.resolve(__dirname, '../fixtures/photo.jpg'),
+    path.resolve(__dirname, '../fixtures/data.csv'),
+  ]);
+
+  // Verify all file names appear
+  await expect(page.getByText('report.pdf')).toBeVisible();
+  await expect(page.getByText('photo.jpg')).toBeVisible();
+  await expect(page.getByText('data.csv')).toBeVisible();
+
+  // Verify the count indicator
+  await expect(page.getByText('3 files selected')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload all' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('3 files uploaded');
+});
+
+test('uploads multiple files with in-memory buffers', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles([
+    {
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('Meeting notes for Q4 planning'),
+    },
+    {
+      name: 'config.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify({ theme: 'dark', lang: 'en' })),
+    },
+  ]);
+
+  await expect(page.getByText('notes.txt')).toBeVisible();
+  await expect(page.getByText('config.json')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload all' }).click();
+  await expect(page.getByRole('alert')).toContainText('2 files uploaded');
+});
+
+test('removes one file from a multi-file selection', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles([
+    { name: 'keep.txt', mimeType: 'text/plain', buffer: Buffer.from('keep') },
+    { name: 'remove.txt', mimeType: 'text/plain', buffer: Buffer.from('remove') },
+    { name: 'also-keep.txt', mimeType: 'text/plain', buffer: Buffer.from('keep') },
+  ]);
+
+  // Remove a specific file from the preview list
+  const removeItem = page.getByText('remove.txt').locator('..');
+  await removeItem.getByRole('button', { name: /remove|delete|×/i }).click();
+
+  await expect(page.getByText('remove.txt')).not.toBeVisible();
+  await expect(page.getByText('keep.txt')).toBeVisible();
+  await expect(page.getByText('also-keep.txt')).toBeVisible();
+  await expect(page.getByText('2 files selected')).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('uploads multiple files at once', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles([
+    path.resolve(__dirname, '../fixtures/report.pdf'),
+    path.resolve(__dirname, '../fixtures/photo.jpg'),
+    path.resolve(__dirname, '../fixtures/data.csv'),
+  ]);
+
+  await expect(page.getByText('report.pdf')).toBeVisible();
+  await expect(page.getByText('photo.jpg')).toBeVisible();
+  await expect(page.getByText('data.csv')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload all' }).click();
+  await expect(page.getByRole('alert')).toContainText('3 files uploaded');
+});
+```
+
+---
+
+## Recipe 3: Drag-and-Drop File Upload
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('uploads a file via drag-and-drop zone', async ({ page }) => {
+  await page.goto('/documents');
+
+  const dropZone = page.locator('[data-testid="drop-zone"]');
+  await expect(dropZone).toContainText(/drag.*here|drop.*files/i);
+
+  // Drag-and-drop from the OS is not natively supported in Playwright,
+  // but drop zones always have an underlying input[type=file] -- use that
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/report.pdf'));
+
+  // File preview should appear in the drop zone
+  await expect(dropZone.getByText('report.pdf')).toBeVisible();
+
+  // Trigger upload
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('uploaded successfully');
+});
+
+test('shows visual feedback during drag-over', async ({ page }) => {
+  await page.goto('/documents');
+
+  const dropZone = page.locator('[data-testid="drop-zone"]');
+
+  // Simulate dragenter to show visual feedback
+  await dropZone.dispatchEvent('dragenter', {
+    dataTransfer: { types: ['Files'], files: [] },
+  });
+
+  // Drop zone should show an active state
+  await expect(dropZone).toHaveClass(/active|highlight|drag-over/);
+  await expect(dropZone).toContainText(/release|drop now/i);
+
+  // Simulate dragleave to reset
+  await dropZone.dispatchEvent('dragleave');
+
+  await expect(dropZone).not.toHaveClass(/active|highlight|drag-over/);
+});
+
+test('handles multiple files dropped at once', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles([
+    { name: 'image1.png', mimeType: 'image/png', buffer: Buffer.from('fake-png-1') },
+    { name: 'image2.png', mimeType: 'image/png', buffer: Buffer.from('fake-png-2') },
+    { name: 'image3.png', mimeType: 'image/png', buffer: Buffer.from('fake-png-3') },
+  ]);
+
+  await expect(page.getByText('image1.png')).toBeVisible();
+  await expect(page.getByText('image2.png')).toBeVisible();
+  await expect(page.getByText('image3.png')).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('uploads a file via drag-and-drop zone', async ({ page }) => {
+  await page.goto('/documents');
+
+  const dropZone = page.locator('[data-testid="drop-zone"]');
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/report.pdf'));
+
+  await expect(dropZone.getByText('report.pdf')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+  await expect(page.getByRole('alert')).toContainText('uploaded successfully');
+});
+```
+
+---
+
+## Recipe 4: Download and Verify File Content
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+test('downloads a file and verifies its content', async ({ page }) => {
+  await page.goto('/documents');
+
+  // Start waiting for the download event BEFORE clicking
+  const downloadPromise = page.waitForEvent('download');
+
+  await page.getByRole('link', { name: 'report.csv' }).click();
+
+  const download = await downloadPromise;
+
+  // Save to a temporary location
+  const downloadPath = path.join(__dirname, '../downloads', download.suggestedFilename());
+  await download.saveAs(downloadPath);
+
+  // Read and verify the content
+  const content = fs.readFileSync(downloadPath, 'utf-8');
+
+  expect(content).toContain('name,email,role');
+  expect(content).toContain('Jane,jane@example.com,admin');
+
+  // Verify line count
+  const lines = content.trim().split('\n');
+  expect(lines.length).toBeGreaterThan(1); // header + at least one data row
+
+  // Clean up
+  fs.unlinkSync(downloadPath);
+});
+
+test('downloads a JSON file and verifies structure', async ({ page }) => {
+  await page.goto('/api-docs');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export API spec' }).click();
+
+  const download = await downloadPromise;
+  const downloadPath = path.join(__dirname, '../downloads', download.suggestedFilename());
+  await download.saveAs(downloadPath);
+
+  const content = JSON.parse(fs.readFileSync(downloadPath, 'utf-8'));
+
+  expect(content).toHaveProperty('openapi');
+  expect(content.paths).toBeDefined();
+  expect(Object.keys(content.paths).length).toBeGreaterThan(0);
+
+  fs.unlinkSync(downloadPath);
+});
+
+test('downloads a file via the stream (no disk save needed)', async ({ page }) => {
+  await page.goto('/documents');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'report.csv' }).click();
+
+  const download = await downloadPromise;
+
+  // Read directly from the download stream without saving to disk
+  const readable = await download.createReadStream();
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of readable!) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  const content = Buffer.concat(chunks).toString('utf-8');
+  expect(content).toContain('name,email,role');
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+test('downloads a file and verifies its content', async ({ page }) => {
+  await page.goto('/documents');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'report.csv' }).click();
+
+  const download = await downloadPromise;
+
+  const downloadPath = path.join(__dirname, '../downloads', download.suggestedFilename());
+  await download.saveAs(downloadPath);
+
+  const content = fs.readFileSync(downloadPath, 'utf-8');
+  expect(content).toContain('name,email,role');
+  expect(content).toContain('Jane,jane@example.com,admin');
+
+  fs.unlinkSync(downloadPath);
+});
+
+test('downloads a file via the stream', async ({ page }) => {
+  await page.goto('/documents');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'report.csv' }).click();
+
+  const download = await downloadPromise;
+
+  const readable = await download.createReadStream();
+  const chunks = [];
+
+  for await (const chunk of readable) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  const content = Buffer.concat(chunks).toString('utf-8');
+  expect(content).toContain('name,email,role');
+});
+```
+
+---
+
+## Recipe 5: Download and Verify Filename
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('download has correct filename and extension', async ({ page }) => {
+  await page.goto('/reports');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export as PDF' }).click();
+
+  const download = await downloadPromise;
+
+  // Verify filename pattern
+  expect(download.suggestedFilename()).toMatch(/^report-\d{4}-\d{2}-\d{2}\.pdf$/);
+});
+
+test('download filename changes based on selected format', async ({ page }) => {
+  await page.goto('/reports');
+
+  // Select CSV format
+  await page.getByLabel('Export format').selectOption('csv');
+
+  const csvDownload = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download' }).click();
+  const csv = await csvDownload;
+  expect(csv.suggestedFilename()).toMatch(/\.csv$/);
+
+  // Select Excel format
+  await page.getByLabel('Export format').selectOption('xlsx');
+
+  const xlsxDownload = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download' }).click();
+  const xlsx = await xlsxDownload;
+  expect(xlsx.suggestedFilename()).toMatch(/\.xlsx$/);
+});
+
+test('download has correct MIME type via response headers', async ({ page }) => {
+  await page.goto('/reports');
+
+  // Intercept the download request to check response headers
+  const responsePromise = page.waitForResponse('**/api/reports/export**');
+  const downloadPromise = page.waitForEvent('download');
+
+  await page.getByRole('button', { name: 'Export as PDF' }).click();
+
+  const response = await responsePromise;
+  expect(response.headers()['content-type']).toContain('application/pdf');
+  expect(response.headers()['content-disposition']).toContain('attachment');
+
+  await downloadPromise; // Consume the download event
+});
+
+test('download failure shows error to user', async ({ page }) => {
+  // Mock the download endpoint to fail
+  await page.route('**/api/reports/export**', async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Report generation failed' }),
+    });
+  });
+
+  await page.goto('/reports');
+  await page.getByRole('button', { name: 'Export as PDF' }).click();
+
+  await expect(page.getByRole('alert')).toContainText(/failed|error/i);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('download has correct filename and extension', async ({ page }) => {
+  await page.goto('/reports');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export as PDF' }).click();
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/^report-\d{4}-\d{2}-\d{2}\.pdf$/);
+});
+
+test('download filename changes based on selected format', async ({ page }) => {
+  await page.goto('/reports');
+
+  await page.getByLabel('Export format').selectOption('csv');
+
+  const csvDownload = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download' }).click();
+  const csv = await csvDownload;
+  expect(csv.suggestedFilename()).toMatch(/\.csv$/);
+});
+```
+
+---
+
+## Recipe 6: Large File Upload with Progress
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('shows upload progress for a large file', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Create a large in-memory file (5 MB)
+  const largeBuffer = Buffer.alloc(5 * 1024 * 1024, 'x');
+
+  await fileInput.setInputFiles({
+    name: 'large-dataset.bin',
+    mimeType: 'application/octet-stream',
+    buffer: largeBuffer,
+  });
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  // Verify progress bar appears
+  const progressBar = page.getByRole('progressbar');
+  await expect(progressBar).toBeVisible();
+
+  // Verify progress percentage updates
+  // Use polling to check that progress increases
+  await expect(async () => {
+    const value = await progressBar.getAttribute('aria-valuenow');
+    expect(Number(value)).toBeGreaterThan(0);
+  }).toPass({ timeout: 10000 });
+
+  // Wait for upload to complete
+  await expect(progressBar).not.toBeVisible({ timeout: 60000 });
+  await expect(page.getByRole('alert')).toContainText('uploaded successfully');
+});
+
+test('cancels an in-progress upload', async ({ page }) => {
+  // Slow down the upload API to simulate a long upload
+  await page.route('**/api/documents/upload', async (route) => {
+    // Delay for 10 seconds to give us time to cancel
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+    await route.continue();
+  });
+
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+  const largeBuffer = Buffer.alloc(5 * 1024 * 1024, 'x');
+
+  await fileInput.setInputFiles({
+    name: 'large-file.bin',
+    mimeType: 'application/octet-stream',
+    buffer: largeBuffer,
+  });
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  // Wait for upload to start
+  await expect(page.getByRole('progressbar')).toBeVisible();
+
+  // Cancel the upload
+  await page.getByRole('button', { name: 'Cancel upload' }).click();
+
+  // Verify upload was cancelled
+  await expect(page.getByRole('progressbar')).not.toBeVisible();
+  await expect(page.getByText(/cancelled|aborted/i)).toBeVisible();
+
+  // Verify the file did not appear in the documents list
+  await expect(page.getByRole('link', { name: 'large-file.bin' })).not.toBeVisible();
+});
+
+test('retries a failed upload', async ({ page }) => {
+  let attempt = 0;
+
+  await page.route('**/api/documents/upload', async (route) => {
+    attempt++;
+    if (attempt === 1) {
+      // First attempt fails
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Server error' }),
+      });
+    } else {
+      // Second attempt succeeds
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: '123', name: 'data.csv' }),
+      });
+    }
+  });
+
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles({
+    name: 'data.csv',
+    mimeType: 'text/csv',
+    buffer: Buffer.from('col1,col2\nval1,val2'),
+  });
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  // First attempt fails
+  await expect(page.getByText(/upload failed|error/i)).toBeVisible();
+
+  // Retry
+  await page.getByRole('button', { name: /retry/i }).click();
+
+  // Second attempt succeeds
+  await expect(page.getByRole('alert')).toContainText('uploaded successfully');
+  expect(attempt).toBe(2);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('shows upload progress for a large file', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  const largeBuffer = Buffer.alloc(5 * 1024 * 1024, 'x');
+
+  await fileInput.setInputFiles({
+    name: 'large-dataset.bin',
+    mimeType: 'application/octet-stream',
+    buffer: largeBuffer,
+  });
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  const progressBar = page.getByRole('progressbar');
+  await expect(progressBar).toBeVisible();
+
+  await expect(progressBar).not.toBeVisible({ timeout: 60000 });
+  await expect(page.getByRole('alert')).toContainText('uploaded successfully');
+});
+
+test('cancels an in-progress upload', async ({ page }) => {
+  await page.route('**/api/documents/upload', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+    await route.continue();
+  });
+
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles({
+    name: 'large-file.bin',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.alloc(5 * 1024 * 1024, 'x'),
+  });
+
+  await page.getByRole('button', { name: 'Upload' }).click();
+  await expect(page.getByRole('progressbar')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Cancel upload' }).click();
+
+  await expect(page.getByRole('progressbar')).not.toBeVisible();
+  await expect(page.getByText(/cancelled|aborted/i)).toBeVisible();
+});
+```
+
+---
+
+## Recipe 7: Testing File Type Restrictions
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('accepts allowed file types', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Verify the accept attribute on the file input
+  await expect(fileInput).toHaveAttribute('accept', /\.pdf|\.doc|\.docx|\.txt/);
+
+  // Upload an allowed file type
+  await fileInput.setInputFiles({
+    name: 'valid-document.pdf',
+    mimeType: 'application/pdf',
+    buffer: Buffer.from('fake-pdf-content'),
+  });
+
+  // Should be accepted without error
+  await expect(page.getByText('valid-document.pdf')).toBeVisible();
+  await expect(page.getByText(/not allowed|invalid/i)).not.toBeVisible();
+});
+
+test('rejects disallowed file types with clear error message', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Upload a disallowed file type
+  // Note: setInputFiles bypasses the browser's accept attribute filter,
+  // so the app's JavaScript validation is what we are testing here
+  await fileInput.setInputFiles({
+    name: 'script.exe',
+    mimeType: 'application/x-msdownload',
+    buffer: Buffer.from('fake-exe-content'),
+  });
+
+  // App should show a rejection message
+  await expect(page.getByRole('alert')).toContainText(
+    /not allowed|unsupported file type|only .pdf, .doc/i
+  );
+
+  // File should not appear in the upload queue
+  await expect(page.getByText('script.exe')).not.toBeVisible();
+});
+
+test('enforces maximum file size', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Create a file that exceeds the max size (e.g., 11 MB when limit is 10 MB)
+  const oversizedBuffer = Buffer.alloc(11 * 1024 * 1024, 'x');
+
+  await fileInput.setInputFiles({
+    name: 'huge-file.pdf',
+    mimeType: 'application/pdf',
+    buffer: oversizedBuffer,
+  });
+
+  await expect(page.getByRole('alert')).toContainText(/file.*too large|exceeds.*10 ?MB/i);
+  await expect(page.getByText('huge-file.pdf')).not.toBeVisible();
+});
+
+test('enforces maximum number of files', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Try to upload more files than the limit (e.g., limit is 5)
+  const files = Array.from({ length: 6 }, (_, i) => ({
+    name: `file-${i + 1}.txt`,
+    mimeType: 'text/plain' as const,
+    buffer: Buffer.from(`content ${i + 1}`),
+  }));
+
+  await fileInput.setInputFiles(files);
+
+  await expect(page.getByRole('alert')).toContainText(/maximum.*5 files|too many files/i);
+});
+
+test('validates image dimensions for avatar upload', async ({ page }) => {
+  await page.goto('/settings/profile');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  // Create a tiny 1x1 PNG (valid format but too small)
+  // Minimal PNG buffer
+  const tinyPng = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    'base64'
+  );
+
+  await fileInput.setInputFiles({
+    name: 'tiny-avatar.png',
+    mimeType: 'image/png',
+    buffer: tinyPng,
+  });
+
+  await expect(page.getByRole('alert')).toContainText(/minimum.*dimensions|too small/i);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('rejects disallowed file types with clear error message', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles({
+    name: 'script.exe',
+    mimeType: 'application/x-msdownload',
+    buffer: Buffer.from('fake-exe-content'),
+  });
+
+  await expect(page.getByRole('alert')).toContainText(
+    /not allowed|unsupported file type|only .pdf, .doc/i
+  );
+  await expect(page.getByText('script.exe')).not.toBeVisible();
+});
+
+test('enforces maximum file size', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  const oversizedBuffer = Buffer.alloc(11 * 1024 * 1024, 'x');
+
+  await fileInput.setInputFiles({
+    name: 'huge-file.pdf',
+    mimeType: 'application/pdf',
+    buffer: oversizedBuffer,
+  });
+
+  await expect(page.getByRole('alert')).toContainText(/file.*too large|exceeds.*10 ?MB/i);
+});
+
+test('enforces maximum number of files', async ({ page }) => {
+  await page.goto('/documents');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  const files = Array.from({ length: 6 }, (_, i) => ({
+    name: `file-${i + 1}.txt`,
+    mimeType: 'text/plain',
+    buffer: Buffer.from(`content ${i + 1}`),
+  }));
+
+  await fileInput.setInputFiles(files);
+
+  await expect(page.getByRole('alert')).toContainText(/maximum.*5 files|too many files/i);
+});
+```
+
+---
+
+## Variations
+
+### Upload via File Chooser Dialog
+
+```typescript
+test('uploads via the native file chooser dialog', async ({ page }) => {
+  await page.goto('/documents');
+
+  // Listen for the file chooser event before clicking the trigger
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Choose file' }).click();
+
+  const fileChooser = await fileChooserPromise;
+
+  // Verify it accepts only certain types
+  expect(fileChooser.isMultiple()).toBe(false);
+
+  await fileChooser.setFiles({
+    name: 'chosen-file.pdf',
+    mimeType: 'application/pdf',
+    buffer: Buffer.from('pdf-content'),
+  });
+
+  await expect(page.getByText('chosen-file.pdf')).toBeVisible();
+});
+```
+
+### Upload with Image Preview
+
+```typescript
+test('shows image preview after selecting a file', async ({ page }) => {
+  await page.goto('/settings/profile');
+
+  const fileInput = page.locator('input[type="file"]');
+
+  await fileInput.setInputFiles(path.resolve(__dirname, '../fixtures/avatar.jpg'));
+
+  // Verify the image preview is displayed
+  const preview = page.getByRole('img', { name: /preview|avatar/i });
+  await expect(preview).toBeVisible();
+
+  // Verify the preview src is a blob or data URL
+  const src = await preview.getAttribute('src');
+  expect(src).toMatch(/^(blob:|data:image)/);
+});
+```
+
+### Download with Authentication
+
+```typescript
+test('downloads a file that requires authentication', async ({ page, request }) => {
+  // Some downloads go through an API that needs auth cookies
+  await page.goto('/documents');
+
+  // The UI download works because the browser sends cookies
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'confidential-report.pdf' }).click();
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe('confidential-report.pdf');
+
+  // Alternatively, verify via API request (which carries the auth context)
+  const response = await request.get('/api/documents/123/download');
+  expect(response.ok()).toBeTruthy();
+  expect(response.headers()['content-type']).toContain('application/pdf');
+});
+```
+
+---
+
+## Tips
+
+1. **Use `setInputFiles` for upload testing**. Even if the UI uses a drag-and-drop zone, there is always an underlying `input[type="file"]` element. Target it directly with `setInputFiles()` instead of trying to simulate OS-level drag events.
+
+2. **Prefer in-memory buffers over fixture files**. Creating files with `Buffer.from()` keeps tests self-contained and eliminates dependencies on external fixture files. Use fixture files only when you need real file content (e.g., a valid PDF that your app parses).
+
+3. **Always set up the download listener before clicking**. Call `page.waitForEvent('download')` before the click that triggers the download. If you click first, you may miss the event.
+
+4. **Use `createReadStream()` to verify content without disk I/O**. The `download.createReadStream()` method lets you read file content directly in memory, which is faster and avoids cleanup of temporary files.
+
+5. **Test the accept attribute AND the JavaScript validation separately**. The HTML `accept` attribute only filters the OS file dialog -- it does not prevent uploads via other means. Your app's JavaScript validation is the real gatekeeper, and `setInputFiles()` bypasses the `accept` filter, which is exactly what you want to test.
+
+---
+
+## Related
+
+- [Playwright Upload Docs](https://playwright.dev/docs/input#upload-files)
+- [Playwright Download Docs](https://playwright.dev/docs/downloads)
+- `recipes/drag-and-drop.md` -- General drag and drop patterns
+- `recipes/crud-testing.md` -- File uploads as part of resource creation
+- `foundations/actions.md` -- Input interaction fundamentals

--- a/engineering-team/playwright skill/core/fixtures-and-hooks.md
+++ b/engineering-team/playwright skill/core/fixtures-and-hooks.md
@@ -1,0 +1,1014 @@
+# Fixtures and Hooks
+
+> **When to use**: Whenever tests need shared setup, teardown, reusable resources, or configurable context. Fixtures are Playwright's killer feature — prefer them over hooks in every situation where both could work.
+
+## Quick Reference
+
+| Mechanism | Scope | Cleanup guaranteed? | Parallelism-safe? | Use for |
+|---|---|---|---|---|
+| `test.extend()` fixture | per-test | Yes (via `use()` callback) | Yes | Most setup/teardown needs |
+| Worker-scoped fixture | per-worker | Yes | Yes (isolated per worker) | Expensive resources: DB connections, auth state |
+| Auto fixture | per-test or per-worker | Yes | Yes | Side effects that must always run: blocking analytics, logging |
+| `beforeEach` / `afterEach` | per-test | No (`afterEach` skipped on crash) | Yes | Simple, one-off setup that doesn't need cleanup |
+| `beforeAll` / `afterAll` | per-worker | No (`afterAll` skipped on crash) | Dangerous if mutating shared state | One-time worker setup with no cleanup needs |
+
+**The rule**: If it needs cleanup, use a fixture. If it doesn't need cleanup and is simple, a hook is acceptable. When in doubt, use a fixture.
+
+## Patterns
+
+### 1. Custom Test Fixture
+
+**Use when**: Tests need a resource with guaranteed setup and teardown.
+**Avoid when**: The setup is a single line with no teardown — a `beforeEach` is fine.
+
+Fixtures use a `use()` callback. Everything before `use()` is setup; everything after is teardown. Teardown runs even if the test crashes.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect } from '@playwright/test';
+
+type TodoFixtures = {
+  todoPage: TodoPage;
+};
+
+class TodoPage {
+  constructor(private page: import('@playwright/test').Page) {}
+
+  async addTodo(text: string) {
+    await this.page.getByPlaceholder('What needs to be done?').fill(text);
+    await this.page.getByPlaceholder('What needs to be done?').press('Enter');
+  }
+
+  async todos() {
+    return this.page.getByTestId('todo-item');
+  }
+}
+
+export const test = base.extend<TodoFixtures>({
+  todoPage: async ({ page }, use) => {
+    // Setup
+    await page.goto('/todos');
+    const todoPage = new TodoPage(page);
+
+    // Hand the fixture to the test
+    await use(todoPage);
+
+    // Teardown — runs even if test fails or crashes
+    await page.evaluate(() => localStorage.clear());
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// todos.spec.ts
+import { test, expect } from './fixtures';
+
+test('add a todo item', async ({ todoPage, page }) => {
+  await todoPage.addTodo('Buy milk');
+  await expect(await todoPage.todos()).toHaveCount(1);
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+class TodoPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async addTodo(text) {
+    await this.page.getByPlaceholder('What needs to be done?').fill(text);
+    await this.page.getByPlaceholder('What needs to be done?').press('Enter');
+  }
+
+  async todos() {
+    return this.page.getByTestId('todo-item');
+  }
+}
+
+const test = base.extend({
+  todoPage: async ({ page }, use) => {
+    await page.goto('/todos');
+    const todoPage = new TodoPage(page);
+    await use(todoPage);
+    await page.evaluate(() => localStorage.clear());
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### 2. Worker-Scoped Fixtures
+
+**Use when**: A resource is expensive to create and safe to share across tests in the same worker (database connections, auth tokens, compiled assets).
+**Avoid when**: Tests mutate the resource — each test must get its own copy.
+
+Worker-scoped fixtures are created once per worker process, not once per test. They cannot depend on test-scoped fixtures (`page`, `context`, `request`).
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base } from '@playwright/test';
+
+type WorkerFixtures = {
+  dbConnection: DatabaseClient;
+  authToken: string;
+};
+
+export const test = base.extend<{}, WorkerFixtures>({
+  dbConnection: [async ({}, use) => {
+    const db = await DatabaseClient.connect(process.env.DB_URL!);
+    await use(db);
+    await db.disconnect();
+  }, { scope: 'worker' }],
+
+  authToken: [async ({}, use) => {
+    const response = await fetch(`${process.env.API_URL}/auth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: 'test-user',
+        password: process.env.TEST_PASSWORD,
+      }),
+    });
+    const { token } = await response.json();
+    await use(token);
+    // No teardown needed — token expires on its own
+  }, { scope: 'worker' }],
+});
+
+export { expect } from '@playwright/test';
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  dbConnection: [async ({}, use) => {
+    const db = await DatabaseClient.connect(process.env.DB_URL);
+    await use(db);
+    await db.disconnect();
+  }, { scope: 'worker' }],
+
+  authToken: [async ({}, use) => {
+    const response = await fetch(`${process.env.API_URL}/auth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: 'test-user',
+        password: process.env.TEST_PASSWORD,
+      }),
+    });
+    const { token } = await response.json();
+    await use(token);
+  }, { scope: 'worker' }],
+});
+
+module.exports = { test, expect };
+```
+
+**Important**: The second type parameter in `base.extend<TestFixtures, WorkerFixtures>` is for worker-scoped fixtures. Always put worker fixtures in the second generic argument.
+
+### 3. Auto Fixtures
+
+**Use when**: Something must run for every test without being explicitly requested — blocking analytics, capturing console errors, injecting feature flags.
+**Avoid when**: Tests need to opt out. Auto fixtures always run; there is no per-test escape hatch.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect } from '@playwright/test';
+
+type AutoFixtures = {
+  blockAnalytics: void;
+  consoleErrors: string[];
+};
+
+export const test = base.extend<AutoFixtures>({
+  // Blocks all analytics/tracking requests in every test
+  blockAnalytics: [async ({ page }, use) => {
+    await page.route(/google-analytics|segment|hotjar|mixpanel/, (route) =>
+      route.abort()
+    );
+    await use();
+  }, { auto: true }],
+
+  // Captures console errors — fail test if unexpected errors appear
+  consoleErrors: [async ({ page }, use) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+    await use(errors);
+    // Teardown: assert no unexpected console errors
+    const unexpected = errors.filter(
+      (e) => !e.includes('Expected warning')
+    );
+    if (unexpected.length > 0) {
+      throw new Error(
+        `Unexpected console errors:\n${unexpected.join('\n')}`
+      );
+    }
+  }, { auto: true }],
+});
+
+export { expect };
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  blockAnalytics: [async ({ page }, use) => {
+    await page.route(/google-analytics|segment|hotjar|mixpanel/, (route) =>
+      route.abort()
+    );
+    await use();
+  }, { auto: true }],
+
+  consoleErrors: [async ({ page }, use) => {
+    const errors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+    await use(errors);
+    const unexpected = errors.filter(
+      (e) => !e.includes('Expected warning')
+    );
+    if (unexpected.length > 0) {
+      throw new Error(
+        `Unexpected console errors:\n${unexpected.join('\n')}`
+      );
+    }
+  }, { auto: true }],
+});
+
+module.exports = { test, expect };
+```
+
+Auto fixtures can also be worker-scoped with `{ auto: true, scope: 'worker' }` for things like starting a dev server once per worker.
+
+### 4. Fixture Composition with `mergeTests()`
+
+**Use when**: You have multiple fixture files (auth fixtures, API fixtures, UI fixtures) and tests need several of them.
+**Avoid when**: You only have one fixture file. Don't over-engineer.
+
+`mergeTests()` combines multiple extended `test` objects into one. Each fixture file defines its own concerns.
+
+**TypeScript**
+```typescript
+// fixtures/auth.ts
+import { test as base } from '@playwright/test';
+
+type AuthFixtures = {
+  authenticatedPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<AuthFixtures>({
+  authenticatedPage: async ({ page }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await use(page);
+  },
+});
+```
+
+```typescript
+// fixtures/api.ts
+import { test as base, APIRequestContext } from '@playwright/test';
+
+type ApiFixtures = {
+  apiClient: APIRequestContext;
+};
+
+export const test = base.extend<ApiFixtures>({
+  apiClient: async ({ playwright }, use) => {
+    const api = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+      extraHTTPHeaders: { Authorization: `Bearer ${process.env.API_TOKEN}` },
+    });
+    await use(api);
+    await api.dispose();
+  },
+});
+```
+
+```typescript
+// fixtures/index.ts
+import { mergeTests } from '@playwright/test';
+import { test as authTest } from './auth';
+import { test as apiTest } from './api';
+
+export const test = mergeTests(authTest, apiTest);
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// dashboard.spec.ts
+import { test, expect } from './fixtures';
+
+test('dashboard loads user data', async ({ authenticatedPage, apiClient }) => {
+  // Both fixtures are available
+  const data = await apiClient.get('/users/me');
+  await expect(authenticatedPage.getByRole('heading')).toContainText('Dashboard');
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures/auth.js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  authenticatedPage: async ({ page }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await use(page);
+  },
+});
+
+module.exports = { test };
+```
+
+```javascript
+// fixtures/api.js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  apiClient: async ({ playwright }, use) => {
+    const api = await playwright.request.newContext({
+      baseURL: 'https://api.example.com',
+      extraHTTPHeaders: { Authorization: `Bearer ${process.env.API_TOKEN}` },
+    });
+    await use(api);
+    await api.dispose();
+  },
+});
+
+module.exports = { test };
+```
+
+```javascript
+// fixtures/index.js
+const { mergeTests } = require('@playwright/test');
+const { test: authTest } = require('./auth');
+const { test: apiTest } = require('./api');
+
+const test = mergeTests(authTest, apiTest);
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+### 5. Parameterized Fixtures (Option Fixtures)
+
+**Use when**: A fixture's behavior should be configurable per-project or per-describe block (locale, viewport, user role, feature flags).
+**Avoid when**: The value never changes — just hardcode it in the fixture.
+
+Option fixtures are declared with `{ option: true }` and can be overridden in `playwright.config` under `use` or with `test.use()` in test files.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect } from '@playwright/test';
+
+type OptionFixtures = {
+  userRole: 'admin' | 'editor' | 'viewer';
+  locale: string;
+};
+
+type DerivedFixtures = {
+  authenticatedPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<OptionFixtures & DerivedFixtures>({
+  // Option fixtures — configurable per project or describe block
+  userRole: ['viewer', { option: true }],
+  locale: ['en-US', { option: true }],
+
+  // Derived fixture — uses the option values
+  authenticatedPage: async ({ page, userRole, locale }, use) => {
+    await page.goto(`/login?locale=${locale}`);
+    const credentials = {
+      admin: { email: 'admin@test.com', password: 'admin-pass' },
+      editor: { email: 'editor@test.com', password: 'editor-pass' },
+      viewer: { email: 'viewer@test.com', password: 'viewer-pass' },
+    };
+    const { email, password } = credentials[userRole];
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await use(page);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// playwright.config.ts (override per project)
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'admin-tests',
+      testDir: './tests/admin',
+      use: { userRole: 'admin', locale: 'en-US' },
+    },
+    {
+      name: 'viewer-tests',
+      testDir: './tests/viewer',
+      use: { userRole: 'viewer', locale: 'fr-FR' },
+    },
+  ],
+});
+```
+
+```typescript
+// admin-settings.spec.ts (override per describe block)
+import { test, expect } from './fixtures';
+
+test.describe('admin settings', () => {
+  test.use({ userRole: 'admin' });
+
+  test('can access settings page', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/settings');
+    await expect(authenticatedPage.getByRole('heading')).toHaveText('Admin Settings');
+  });
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  userRole: ['viewer', { option: true }],
+  locale: ['en-US', { option: true }],
+
+  authenticatedPage: async ({ page, userRole, locale }, use) => {
+    await page.goto(`/login?locale=${locale}`);
+    const credentials = {
+      admin: { email: 'admin@test.com', password: 'admin-pass' },
+      editor: { email: 'editor@test.com', password: 'editor-pass' },
+      viewer: { email: 'viewer@test.com', password: 'viewer-pass' },
+    };
+    const { email, password } = credentials[userRole];
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await use(page);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### 6. Fixture Dependencies
+
+**Use when**: One fixture needs the output of another fixture. Playwright automatically resolves the dependency graph.
+**Avoid when**: You are tempted to nest fixtures more than 3 levels deep — flatten the design instead.
+
+Request fixtures by name in the destructured first argument. Playwright handles ordering and lifecycle.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect } from '@playwright/test';
+
+type Fixtures = {
+  apiContext: import('@playwright/test').APIRequestContext;
+  testUser: { id: string; email: string };
+  userPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<Fixtures>({
+  apiContext: async ({ playwright }, use) => {
+    const ctx = await playwright.request.newContext({
+      baseURL: process.env.API_URL,
+    });
+    await use(ctx);
+    await ctx.dispose();
+  },
+
+  // Depends on apiContext — Playwright creates apiContext first
+  testUser: async ({ apiContext }, use) => {
+    const response = await apiContext.post('/test/users', {
+      data: { email: `user-${Date.now()}@test.com`, role: 'editor' },
+    });
+    const user = await response.json();
+    await use(user);
+    // Teardown: delete the test user
+    await apiContext.delete(`/test/users/${user.id}`);
+  },
+
+  // Depends on page AND testUser — both are ready before this runs
+  userPage: async ({ page, testUser }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(testUser.email);
+    await page.getByLabel('Password').fill('default-test-password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await use(page);
+  },
+});
+
+export { expect };
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  apiContext: async ({ playwright }, use) => {
+    const ctx = await playwright.request.newContext({
+      baseURL: process.env.API_URL,
+    });
+    await use(ctx);
+    await ctx.dispose();
+  },
+
+  testUser: async ({ apiContext }, use) => {
+    const response = await apiContext.post('/test/users', {
+      data: { email: `user-${Date.now()}@test.com`, role: 'editor' },
+    });
+    const user = await response.json();
+    await use(user);
+    await apiContext.delete(`/test/users/${user.id}`);
+  },
+
+  userPage: async ({ page, testUser }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(testUser.email);
+    await page.getByLabel('Password').fill('default-test-password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+    await use(page);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+Teardown runs in reverse dependency order: `userPage` tears down first, then `testUser` (which deletes the user), then `apiContext`.
+
+### 7. Overriding Built-in Fixtures
+
+**Use when**: Every test needs the same modification to `page`, `context`, or `browser` — custom headers, viewport, locale, route blocking.
+**Avoid when**: Only some tests need the override. Use a new named fixture instead to keep the default `page` available.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect } from '@playwright/test';
+
+export const test = base.extend({
+  // Override the built-in context fixture to add custom headers
+  context: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      extraHTTPHeaders: {
+        'X-Test-ID': `test-${Date.now()}`,
+        'Accept-Language': 'en-US',
+      },
+      permissions: ['geolocation'],
+      geolocation: { latitude: 37.7749, longitude: -122.4194 },
+    });
+    await use(context);
+    await context.close();
+  },
+
+  // Override the built-in page fixture to block third-party scripts
+  page: async ({ context }, use) => {
+    const page = await context.newPage();
+    await page.route('**/*.{png,jpg,jpeg,gif,svg}', (route) => route.abort());
+    await use(page);
+    // No need to close page — context.close() handles it
+  },
+});
+
+export { expect };
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  context: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      extraHTTPHeaders: {
+        'X-Test-ID': `test-${Date.now()}`,
+        'Accept-Language': 'en-US',
+      },
+      permissions: ['geolocation'],
+      geolocation: { latitude: 37.7749, longitude: -122.4194 },
+    });
+    await use(context);
+    await context.close();
+  },
+
+  page: async ({ context }, use) => {
+    const page = await context.newPage();
+    await page.route('**/*.{png,jpg,jpeg,gif,svg}', (route) => route.abort());
+    await use(page);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### 8. beforeEach / afterEach — When Hooks Are Acceptable
+
+**Use when**: Simple, stateless setup with no teardown needed. Navigation to a starting URL is the canonical example.
+**Avoid when**: The setup creates something that must be cleaned up. Use a fixture instead.
+
+**TypeScript**
+```typescript
+// acceptable-hooks.spec.ts
+import { test, expect } from '@playwright/test';
+
+// Acceptable: simple navigation, no teardown needed
+test.beforeEach(async ({ page }) => {
+  await page.goto('/dashboard');
+});
+
+test('shows welcome message', async ({ page }) => {
+  await expect(page.getByRole('heading')).toHaveText('Welcome');
+});
+
+test('shows navigation sidebar', async ({ page }) => {
+  await expect(page.getByRole('navigation')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// acceptable-hooks.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/dashboard');
+});
+
+test('shows welcome message', async ({ page }) => {
+  await expect(page.getByRole('heading')).toHaveText('Welcome');
+});
+
+test('shows navigation sidebar', async ({ page }) => {
+  await expect(page.getByRole('navigation')).toBeVisible();
+});
+```
+
+Hooks can use fixtures in their argument list — `beforeEach(async ({ page, context })` works. But hooks cannot *define* fixtures.
+
+### 9. beforeAll / afterAll — Worker-Level Hooks
+
+**Use when**: One-time setup that all tests in a file share and that has no cleanup needs, such as logging a diagnostic or checking a precondition.
+**Avoid when**: You are creating resources that need cleanup (use worker-scoped fixtures) or storing mutable state (this breaks parallelism).
+
+**TypeScript**
+```typescript
+// health-check.spec.ts
+import { test, expect } from '@playwright/test';
+
+// Good: read-only check, no mutable state
+test.beforeAll(async ({ request }) => {
+  const response = await request.get('/api/health');
+  expect(response.ok()).toBeTruthy();
+});
+
+test('homepage loads', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/My App/);
+});
+```
+
+**JavaScript**
+```javascript
+// health-check.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.beforeAll(async ({ request }) => {
+  const response = await request.get('/api/health');
+  expect(response.ok()).toBeTruthy();
+});
+
+test('homepage loads', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/My App/);
+});
+```
+
+`beforeAll` / `afterAll` receive only worker-scoped fixtures: `request`, `browser`, and any custom worker fixtures. They do **not** receive `page` or `context` (those are per-test).
+
+### 10. Typed Fixtures in TypeScript
+
+Always define an interface for your fixtures. This gives you autocomplete, catches typos at compile time, and documents the fixture contract.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect, Page, APIRequestContext } from '@playwright/test';
+
+// Define fixture types explicitly
+interface TestFixtures {
+  adminPage: Page;
+  editorPage: Page;
+  apiClient: APIRequestContext;
+}
+
+interface WorkerFixtures {
+  sharedToken: string;
+}
+
+export const test = base.extend<TestFixtures, WorkerFixtures>({
+  sharedToken: [async ({}, use) => {
+    const res = await fetch(`${process.env.API_URL}/auth/service-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ secret: process.env.SERVICE_SECRET }),
+    });
+    const { token } = await res.json();
+    await use(token);
+  }, { scope: 'worker' }],
+
+  apiClient: async ({ playwright, sharedToken }, use) => {
+    const ctx = await playwright.request.newContext({
+      baseURL: process.env.API_URL,
+      extraHTTPHeaders: { Authorization: `Bearer ${sharedToken}` },
+    });
+    await use(ctx);
+    await ctx.dispose();
+  },
+
+  adminPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: 'auth/admin.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+
+  editorPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: 'auth/editor.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+});
+
+export { expect };
+```
+
+## Decision Guide
+
+```
+I need to set up something before tests run.
+│
+├── Does it create a resource that MUST be cleaned up?
+│   │
+│   ├── YES → Use a fixture (setup before `use()`, teardown after)
+│   │   │
+│   │   ├── Is the resource expensive and safe to share across tests?
+│   │   │   ├── YES → Worker-scoped fixture: { scope: 'worker' }
+│   │   │   └── NO  → Test-scoped fixture (default)
+│   │   │
+│   │   ├── Should every test get this automatically?
+│   │   │   ├── YES → Auto fixture: { auto: true }
+│   │   │   └── NO  → Regular fixture (test declares it in args)
+│   │   │
+│   │   └── Should the value be configurable per project?
+│   │       ├── YES → Option fixture: { option: true }
+│   │       └── NO  → Regular fixture with hardcoded setup
+│   │
+│   └── NO → Hook is acceptable
+│       │
+│       ├── Per-test setup?
+│       │   └── beforeEach
+│       │
+│       └── One-time per worker?
+│           └── beforeAll (but only for read-only / diagnostic checks)
+│
+└── Am I combining fixtures from multiple domains?
+    └── YES → mergeTests() from separate fixture files
+```
+
+## Anti-Patterns
+
+### 1. Global Mutable State in `beforeAll`
+
+```typescript
+// BAD: Mutable state shared across parallel tests
+let testUser: { id: string; email: string };
+
+test.beforeAll(async ({ request }) => {
+  const res = await request.post('/api/users', { data: { email: 'shared@test.com' } });
+  testUser = await res.json(); // Shared mutable state!
+});
+
+test.afterAll(async ({ request }) => {
+  await request.delete(`/api/users/${testUser.id}`); // Cleanup may not run
+});
+
+test('test 1', async ({ page }) => {
+  // Uses testUser — but what if another worker also has a testUser?
+});
+```
+
+```typescript
+// GOOD: Worker-scoped fixture — isolated per worker, guaranteed cleanup
+import { test as base } from '@playwright/test';
+
+export const test = base.extend<{ testUser: { id: string; email: string } }>({
+  testUser: async ({ request }, use) => {
+    const res = await request.post('/api/users', {
+      data: { email: `user-${Date.now()}@test.com` },
+    });
+    const user = await res.json();
+    await use(user);
+    await request.delete(`/api/users/${user.id}`);
+  },
+});
+```
+
+### 2. Cleanup in `afterEach` Instead of Fixture Teardown
+
+```typescript
+// BAD: afterEach is not guaranteed to run on crash
+test.beforeEach(async ({ page }) => {
+  await page.evaluate(() => localStorage.setItem('debug', 'true'));
+});
+
+test.afterEach(async ({ page }) => {
+  // This might NOT run if the test crashes or times out
+  await page.evaluate(() => localStorage.clear());
+});
+```
+
+```typescript
+// GOOD: Fixture teardown always runs
+export const test = base.extend<{ debugMode: void }>({
+  debugMode: async ({ page }, use) => {
+    await page.evaluate(() => localStorage.setItem('debug', 'true'));
+    await use();
+    await page.evaluate(() => localStorage.clear()); // Guaranteed
+  },
+});
+```
+
+### 3. Fixtures That Do Too Many Things
+
+```typescript
+// BAD: One fixture doing setup for unrelated concerns
+export const test = base.extend({
+  everything: async ({ page }, use) => {
+    // Logs in
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('user@test.com');
+    await page.getByLabel('Password').fill('password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    // Creates test data
+    await page.request.post('/api/products', { data: { name: 'Widget' } });
+    // Blocks analytics
+    await page.route(/analytics/, (r) => r.abort());
+    // Sets locale
+    await page.evaluate(() => localStorage.setItem('locale', 'en'));
+    await use(page);
+  },
+});
+```
+
+```typescript
+// GOOD: Separate fixtures, each with one responsibility
+export const test = base.extend({
+  authenticatedPage: async ({ page }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('user@test.com');
+    await page.getByLabel('Password').fill('password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await use(page);
+  },
+
+  testProduct: async ({ request }, use) => {
+    const res = await request.post('/api/products', { data: { name: 'Widget' } });
+    const product = await res.json();
+    await use(product);
+    await request.delete(`/api/products/${product.id}`);
+  },
+
+  blockAnalytics: [async ({ page }, use) => {
+    await page.route(/analytics/, (r) => r.abort());
+    await use();
+  }, { auto: true }],
+});
+```
+
+### 4. Over-Abstracting Fixtures
+
+```typescript
+// BAD: Fixture factory with layers of indirection nobody can follow
+const createFixture = (role, permissions, options) =>
+  base.extend({
+    [`${role}Page`]: async ({ page }, use) => {
+      await setupRole(page, role, permissions, options);
+      await use(page);
+    },
+  });
+
+const adminTest = createFixture('admin', ['read', 'write', 'delete'], { mfa: true });
+const editorTest = createFixture('editor', ['read', 'write'], { mfa: false });
+// Good luck debugging which fixture ran
+```
+
+```typescript
+// GOOD: Explicit fixtures — boring but readable
+export const test = base.extend({
+  adminPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: 'auth/admin.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+
+  editorPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: 'auth/editor.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+});
+```
+
+### 5. Not Typing Fixtures in TypeScript
+
+```typescript
+// BAD: No type parameter — no autocomplete, no compile-time errors
+export const test = base.extend({
+  myFixture: async ({ page }, use) => {
+    await use({ count: 42 });
+  },
+});
+// test('example', async ({ myFixture }) => {
+//   myFixture.cont // No autocomplete, no type safety
+// });
+```
+
+```typescript
+// GOOD: Explicit type interface
+interface MyFixtures {
+  myFixture: { count: number };
+}
+
+export const test = base.extend<MyFixtures>({
+  myFixture: async ({ page }, use) => {
+    await use({ count: 42 });
+  },
+});
+// test('example', async ({ myFixture }) => {
+//   myFixture.count // Autocomplete works, typos caught at compile time
+// });
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Cannot use a test-scoped fixture in a worker-scoped fixture` | Worker fixture depends on `page`, `context`, or test-scoped custom fixture | Worker fixtures can only depend on other worker fixtures or built-in worker fixtures (`browser`, `playwright`) |
+| `Fixture "X" has already been registered` | Two fixture files define the same fixture name and are both extended | Use `mergeTests()` instead of chaining `.extend()` calls, or rename one fixture |
+| Fixture teardown not running | You used `afterEach` instead of the `use()` callback pattern | Move cleanup code after the `await use()` call inside the fixture |
+| `beforeAll` can't access `page` | `page` is test-scoped; `beforeAll` only gets worker-scoped fixtures | Use a worker-scoped fixture, or move logic to `beforeEach` |
+| Test hangs inside fixture | `await use()` was never called — Playwright waits indefinitely for the fixture to yield | Ensure every fixture code path calls `await use(value)` exactly once |
+| Fixture runs but test doesn't see the value | Fixture not declared in the test's destructured arguments | Add the fixture name to the test function signature: `test('name', async ({ myFixture }) => { ... })` |
+| Option fixture value ignored | `test.use()` called inside `test()` instead of `test.describe()` | `test.use()` must be at the top level of a `describe` block or file, not inside a test |
+| Auto fixture not running | Fixture file not imported — the custom `test` is not used | Import and use the `test` from your fixture file, not from `@playwright/test` |
+
+## Related
+
+- [pom/page-object-model.md](../pom/page-object-model.md) — Page objects are typically consumed via fixtures
+- [core/test-organization.md](test-organization.md) — Where to put fixture files in the project tree
+- [core/configuration.md](configuration.md) — Option fixtures are configured in `playwright.config`
+- [core/authentication.md](authentication.md) — Auth state is the most common worker-scoped fixture
+- [ci/global-setup-teardown.md](../ci/global-setup-teardown.md) — For truly global (all-workers) setup, not per-worker
+- [pom/pom-vs-fixtures-vs-helpers.md](../pom/pom-vs-fixtures-vs-helpers.md) — When to use each abstraction

--- a/engineering-team/playwright skill/core/flaky-tests.md
+++ b/engineering-team/playwright skill/core/flaky-tests.md
@@ -1,0 +1,834 @@
+# Flaky Tests
+
+> **When to use**: A test passes sometimes and fails other times. You need to diagnose the root cause, fix it, and prevent it from happening again.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```bash
+# Burn-in test — run 10 times to expose flakiness
+npx playwright test tests/checkout.spec.ts --repeat-each=10
+
+# Run with retries to catch intermittent failures
+npx playwright test --retries=3
+
+# Run single test in isolation to rule out state leaks
+npx playwright test tests/checkout.spec.ts --grep "adds item" --workers=1
+
+# Run with tracing on every attempt for comparison
+npx playwright test --retries=3 --trace=on
+
+# Run in fully parallel mode to expose isolation issues
+npx playwright test --fully-parallel --workers=4
+
+# List flaky tests (tests that failed then passed on retry)
+npx playwright test --retries=2 --reporter=json | jq '.suites[].specs[] | select(.ok == true and (.tests[].results | length > 1))'
+```
+
+## Patterns
+
+### Flakiness Taxonomy
+
+Every flaky test falls into one of four categories. Identify the category first, then apply the matching fix.
+
+| Category | Symptom | Typical Root Cause | Diagnosis Method |
+|---|---|---|---|
+| **Timing / Async** | Fails intermittently everywhere | Race conditions, missing `await`, arbitrary waits | Fails locally with `--repeat-each=20` |
+| **Test Isolation** | Fails only when run with other tests, passes alone | Shared mutable state, data collisions, test ordering dependency | Passes with `--workers=1 --grep "this test"`, fails in full suite |
+| **Environment** | Fails only in CI, passes locally | Different OS, viewport, fonts, network latency, missing dependencies | Compare CI screenshots/traces with local; run in Docker locally |
+| **Infrastructure** | Random failures unrelated to test logic | Browser crash, OOM, DNS resolution, file system race | Failures have no pattern; error messages reference browser internals |
+
+### Diagnosis Flowchart
+
+Follow this decision tree to identify which category your flaky test belongs to.
+
+```
+Test is flaky
+|
++-- Does it fail locally with --repeat-each=20?
+|   |
+|   +-- YES --> TIMING / ASYNC issue
+|   |           - Missing await
+|   |           - Using waitForTimeout instead of assertions
+|   |           - Race condition between action and assertion
+|   |           - Not waiting for network response before asserting
+|   |
+|   +-- NO --> Does it fail only in CI?
+|       |
+|       +-- YES --> ENVIRONMENT issue
+|       |           - Different viewport/screen size
+|       |           - Missing fonts causing layout shift
+|       |           - Slower CI machines hitting timeouts
+|       |           - External services unavailable
+|       |
+|       +-- NO --> Does it fail only when run with other tests?
+|           |
+|           +-- YES --> ISOLATION issue
+|           |           - Shared mutable state (module-level variables)
+|           |           - Database/API state from previous test
+|           |           - localStorage/cookies leaking between tests
+|           |           - Parallel tests colliding on unique constraints
+|           |
+|           +-- NO --> INFRASTRUCTURE issue
+|                       - Browser process crash
+|                       - Out of memory
+|                       - File system or network instability
+|                       - Flaky third-party service
+```
+
+### Fix: Timing and Async Issues
+
+**Use when**: The test fails locally with `--repeat-each=20`, or you see `waitForTimeout`, missing `await`, or race conditions.
+
+The most common source of flakiness. The fix is always the same: replace arbitrary waits and manual checks with Playwright's auto-retrying mechanisms.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// ---- FIX 1: Replace waitForTimeout with assertions ----
+
+// BAD — arbitrary delay, fails on slow machines, wastes time on fast ones
+test('bad: uses arbitrary wait', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.waitForTimeout(3000); // hoping data loads in 3s
+  await expect(page.getByTestId('data-table')).toBeVisible();
+});
+
+// GOOD — auto-retrying assertion waits exactly as long as needed
+test('good: uses auto-retrying assertion', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByTestId('data-table')).toBeVisible();
+});
+
+// ---- FIX 2: Wait for network responses before asserting ----
+
+// BAD — clicks button and immediately asserts, but data comes from API
+test('bad: does not wait for API response', async ({ page }) => {
+  await page.goto('/users');
+  await page.getByRole('button', { name: 'Load More' }).click();
+  // Flaky: API response may not have arrived yet
+  await expect(page.getByRole('listitem')).toHaveCount(20);
+});
+
+// GOOD — waits for the specific API response that populates the data
+test('good: waits for API response', async ({ page }) => {
+  await page.goto('/users');
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('/api/users') && resp.status() === 200
+  );
+  await page.getByRole('button', { name: 'Load More' }).click();
+  await responsePromise;
+
+  await expect(page.getByRole('listitem')).toHaveCount(20);
+});
+
+// ---- FIX 3: Handle animations and transitions ----
+
+// BAD — element exists but is mid-animation, click lands on wrong target
+test('bad: clicks during animation', async ({ page }) => {
+  await page.goto('/modal-demo');
+  await page.getByRole('button', { name: 'Open' }).click();
+  // Modal is animating in — click may miss the button inside it
+  await page.getByRole('button', { name: 'Confirm' }).click();
+});
+
+// GOOD — wait for the modal to be fully stable before interacting
+test('good: waits for stable state', async ({ page }) => {
+  await page.goto('/modal-demo');
+  await page.getByRole('button', { name: 'Open' }).click();
+  // toBeVisible auto-waits for stability (no animation in progress)
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.getByRole('button', { name: 'Confirm' }).click();
+});
+
+// ---- FIX 4: Use toPass() for multi-step assertions that must succeed together ----
+
+test('good: retry entire assertion block', async ({ page }) => {
+  await page.goto('/search');
+
+  await expect(async () => {
+    await page.getByLabel('Search').fill('playwright');
+    await page.getByRole('button', { name: 'Search' }).click();
+    await expect(page.getByTestId('result-count')).toHaveText('10 results');
+  }).toPass({
+    timeout: 15_000,
+    intervals: [1_000, 2_000, 5_000],
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// FIX 1: Replace waitForTimeout with assertions
+test('good: uses auto-retrying assertion', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByTestId('data-table')).toBeVisible();
+});
+
+// FIX 2: Wait for network responses before asserting
+test('good: waits for API response', async ({ page }) => {
+  await page.goto('/users');
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('/api/users') && resp.status() === 200
+  );
+  await page.getByRole('button', { name: 'Load More' }).click();
+  await responsePromise;
+
+  await expect(page.getByRole('listitem')).toHaveCount(20);
+});
+
+// FIX 3: Handle animations and transitions
+test('good: waits for stable state', async ({ page }) => {
+  await page.goto('/modal-demo');
+  await page.getByRole('button', { name: 'Open' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.getByRole('button', { name: 'Confirm' }).click();
+});
+
+// FIX 4: Use toPass() for multi-step assertions
+test('good: retry entire assertion block', async ({ page }) => {
+  await page.goto('/search');
+
+  await expect(async () => {
+    await page.getByLabel('Search').fill('playwright');
+    await page.getByRole('button', { name: 'Search' }).click();
+    await expect(page.getByTestId('result-count')).toHaveText('10 results');
+  }).toPass({
+    timeout: 15_000,
+    intervals: [1_000, 2_000, 5_000],
+  });
+});
+```
+
+### Fix: Test Isolation Issues
+
+**Use when**: The test passes when run alone (`--grep "test name"`) but fails when run with other tests, or fails only in parallel mode.
+
+Isolation issues come from shared state: module-level variables, database rows, localStorage, cookies, or file system artifacts.
+
+**TypeScript**
+```typescript
+import { test as base, expect } from '@playwright/test';
+
+// ---- FIX 1: Unique test data per test ----
+
+// BAD — all parallel tests use the same email, causing unique constraint violations
+test('bad: hardcoded data', async ({ page }) => {
+  await page.goto('/register');
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByRole('button', { name: 'Register' }).click();
+  await expect(page.getByText('Welcome')).toBeVisible();
+});
+
+// GOOD — unique email per test run
+test('good: unique data per test', async ({ page }) => {
+  const email = `test-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByRole('button', { name: 'Register' }).click();
+  await expect(page.getByText('Welcome')).toBeVisible();
+});
+
+// ---- FIX 2: Worker-scoped fixtures for shared expensive resources ----
+
+type WorkerFixtures = {
+  workerAccount: { email: string; id: string };
+};
+
+export const test = base.extend<{}, WorkerFixtures>({
+  workerAccount: [async ({ request }, use) => {
+    const email = `worker-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+    const response = await request.post('/api/users', {
+      data: { email, password: 'TestP@ss123!' },
+    });
+    const account = await response.json();
+
+    await use({ email, id: account.id });
+
+    // Cleanup after all tests in this worker are done
+    await request.delete(`/api/users/${account.id}`);
+  }, { scope: 'worker' }],
+});
+
+// ---- FIX 3: Clean up state in fixture teardown ----
+
+export const testWithCleanup = base.extend({
+  cleanPage: async ({ page }, use) => {
+    await use(page);
+
+    // Teardown: clear all client-side state
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await page.context().clearCookies();
+  },
+});
+
+// ---- FIX 4: Isolate tests that cannot run in parallel ----
+
+import { test } from '@playwright/test';
+
+// Use serial mode ONLY for tests that genuinely depend on shared state
+// (e.g., a multi-step wizard where each test is one step)
+test.describe.serial('checkout wizard', () => {
+  test('step 1: add items', async ({ page }) => {
+    await page.goto('/shop');
+    await page.getByRole('button', { name: 'Add Widget' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+
+  test('step 2: enter shipping', async ({ page }) => {
+    await page.goto('/checkout/shipping');
+    await page.getByLabel('Address').fill('123 Test St');
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test: base, expect } = require('@playwright/test');
+
+// FIX 1: Unique test data per test
+test('good: unique data per test', async ({ page }) => {
+  const email = `test-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByRole('button', { name: 'Register' }).click();
+  await expect(page.getByText('Welcome')).toBeVisible();
+});
+
+// FIX 2: Worker-scoped fixtures for shared expensive resources
+const test = base.extend({
+  workerAccount: [async ({ request }, use) => {
+    const email = `worker-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+    const response = await request.post('/api/users', {
+      data: { email, password: 'TestP@ss123!' },
+    });
+    const account = await response.json();
+
+    await use({ email, id: account.id });
+
+    await request.delete(`/api/users/${account.id}`);
+  }, { scope: 'worker' }],
+});
+
+module.exports = { test, expect };
+```
+
+### Fix: Environment Issues
+
+**Use when**: The test passes locally but fails in CI, or fails on certain operating systems, viewports, or machines.
+
+Environment flakiness stems from differences in rendering, timing, available resources, or external service availability between your local machine and CI.
+
+**TypeScript**
+```typescript
+// playwright.config.ts — environment-consistent configuration
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  // ---- FIX 1: Disable animations for deterministic behavior ----
+  use: {
+    // Disable CSS animations and transitions
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
+  },
+
+  // ---- FIX 2: Consistent viewport across environments ----
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Explicit viewport prevents layout differences between local and CI
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+
+  // ---- FIX 3: Use webServer to start app in CI ----
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+
+  // ---- FIX 4: Higher timeouts for slower CI machines ----
+  timeout: process.env.CI ? 60_000 : 30_000,
+  expect: {
+    timeout: process.env.CI ? 10_000 : 5_000,
+  },
+});
+```
+
+```typescript
+// tests/fixtures/stub-externals.ts — stub external services
+import { test as base, expect } from '@playwright/test';
+
+export const test = base.extend({
+  // Auto fixture: block all external services in every test
+  stubExternals: [async ({ page }, use) => {
+    // Block third-party scripts that vary between environments
+    await page.route(/google-analytics|segment|hotjar|intercom/, (route) =>
+      route.abort()
+    );
+
+    // Stub flaky external API with consistent response
+    await page.route('**/api.external-service.com/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', data: [] }),
+      })
+    );
+
+    await use();
+  }, { auto: true }],
+});
+
+export { expect };
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  timeout: process.env.CI ? 60_000 : 30_000,
+  expect: {
+    timeout: process.env.CI ? 10_000 : 5_000,
+  },
+});
+```
+
+```javascript
+// tests/fixtures/stub-externals.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  stubExternals: [async ({ page }, use) => {
+    await page.route(/google-analytics|segment|hotjar|intercom/, (route) =>
+      route.abort()
+    );
+
+    await page.route('**/api.external-service.com/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', data: [] }),
+      })
+    );
+
+    await use();
+  }, { auto: true }],
+});
+
+module.exports = { test, expect };
+```
+
+### Detection Strategies
+
+**Use when**: You suspect flakiness but the test does not fail consistently, or you want to validate a fix actually eliminated the flakiness.
+
+**TypeScript**
+```typescript
+// ---- Strategy 1: Burn-in testing with --repeat-each ----
+// Run a test 20 times. If it fails even once, it has a flakiness bug.
+// npx playwright test tests/checkout.spec.ts --repeat-each=20
+
+// ---- Strategy 2: Retry configuration to catch intermittent failures ----
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  // Retries in CI surface flaky tests in the report
+  retries: process.env.CI ? 2 : 0,
+
+  // Reporter shows which tests needed retries
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['json', { outputFile: 'results.json' }]]
+    : [['html', { open: 'on-failure' }]],
+});
+
+// ---- Strategy 3: Custom reporter to track flaky test metrics ----
+// flaky-reporter.ts
+import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+
+class FlakyReporter implements Reporter {
+  private flakyTests: { name: string; file: string; retries: number }[] = [];
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    if (result.retry > 0 && result.status === 'passed') {
+      this.flakyTests.push({
+        name: test.title,
+        file: test.location.file,
+        retries: result.retry,
+      });
+    }
+  }
+
+  onEnd() {
+    if (this.flakyTests.length > 0) {
+      console.log('\n--- FLAKY TESTS ---');
+      for (const t of this.flakyTests) {
+        console.log(`  ${t.file} > "${t.name}" (needed ${t.retries} retries)`);
+      }
+      console.log(`Total flaky: ${this.flakyTests.length}`);
+    }
+  }
+}
+
+export default FlakyReporter;
+```
+
+```typescript
+// playwright.config.ts — register custom flaky reporter
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  reporter: [
+    ['html'],
+    ['./flaky-reporter.ts'],
+  ],
+});
+```
+
+**JavaScript**
+```javascript
+// flaky-reporter.js
+class FlakyReporter {
+  constructor() {
+    this.flakyTests = [];
+  }
+
+  onTestEnd(test, result) {
+    if (result.retry > 0 && result.status === 'passed') {
+      this.flakyTests.push({
+        name: test.title,
+        file: test.location.file,
+        retries: result.retry,
+      });
+    }
+  }
+
+  onEnd() {
+    if (this.flakyTests.length > 0) {
+      console.log('\n--- FLAKY TESTS ---');
+      for (const t of this.flakyTests) {
+        console.log(`  ${t.file} > "${t.name}" (needed ${t.retries} retries)`);
+      }
+      console.log(`Total flaky: ${this.flakyTests.length}`);
+    }
+  }
+}
+
+module.exports = FlakyReporter;
+```
+
+### Quarantine Strategy
+
+**Use when**: A test is known-flaky and you cannot fix it immediately. Quarantine it so it does not block CI, but track it so it does not rot.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// ---- Option 1: test.fixme() — skips the test with a reason ----
+test.fixme('checkout with promo code applies discount', async ({ page }) => {
+  // TODO(JIRA-1234): Flaky due to race condition in promo service
+  // Fails ~10% of runs. Root cause: /api/promo responds after rendering
+  await page.goto('/checkout');
+  await page.getByLabel('Promo code').fill('SAVE20');
+  await page.getByRole('button', { name: 'Apply' }).click();
+  await expect(page.getByTestId('discount')).toHaveText('-$20.00');
+});
+
+// ---- Option 2: test.fail() — inverts: test passes only if it fails ----
+// Use this when you KNOW the test fails and want CI to alert you when it starts passing
+test.fail('known broken: export to PDF', async ({ page }) => {
+  // When this test starts passing, the .fail() annotation will make it fail,
+  // reminding you to remove the annotation
+  await page.goto('/reports');
+  await page.getByRole('button', { name: 'Export PDF' }).click();
+  await expect(page.getByText('PDF ready')).toBeVisible({ timeout: 10_000 });
+});
+
+// ---- Option 3: Skip by tag — quarantine with a grep filter ----
+test('@flaky checkout race condition', async ({ page }) => {
+  // In CI, exclude flaky-tagged tests: npx playwright test --grep-invert @flaky
+  // Run ONLY flaky tests nightly: npx playwright test --grep @flaky --retries=5
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Place Order' }).click();
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// Option 1: test.fixme() — skips the test with a reason
+test.fixme('checkout with promo code applies discount', async ({ page }) => {
+  // TODO(JIRA-1234): Flaky due to race condition in promo service
+  await page.goto('/checkout');
+  await page.getByLabel('Promo code').fill('SAVE20');
+  await page.getByRole('button', { name: 'Apply' }).click();
+  await expect(page.getByTestId('discount')).toHaveText('-$20.00');
+});
+
+// Option 2: test.fail() — inverts: test passes only if it fails
+test.fail('known broken: export to PDF', async ({ page }) => {
+  await page.goto('/reports');
+  await page.getByRole('button', { name: 'Export PDF' }).click();
+  await expect(page.getByText('PDF ready')).toBeVisible({ timeout: 10_000 });
+});
+
+// Option 3: Skip by tag
+test('@flaky checkout race condition', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Place Order' }).click();
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**CI configuration for quarantine:**
+
+```yaml
+# .github/workflows/tests.yml
+jobs:
+  e2e-tests:
+    steps:
+      - name: Run stable tests
+        run: npx playwright test --grep-invert @flaky
+
+  flaky-monitoring:
+    # Runs nightly, not on every PR
+    schedule:
+      - cron: '0 3 * * *'
+    steps:
+      - name: Run flaky tests with retries
+        run: npx playwright test --grep @flaky --retries=5 --reporter=json
+      - name: Report flaky test results
+        run: node scripts/report-flaky-metrics.js
+```
+
+### Prevention Checklist
+
+Apply these rules from the start to prevent flakiness from entering your test suite.
+
+**TypeScript**
+```typescript
+// playwright.config.ts — flake-resistant configuration
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  // RULE 1: Run tests fully parallel to expose isolation issues early
+  fullyParallel: true,
+
+  // RULE 2: Fail CI if test.only() is left in code
+  forbidOnly: !!process.env.CI,
+
+  // RULE 3: Use retries in CI to surface (not hide) flaky tests
+  retries: process.env.CI ? 2 : 0,
+
+  // RULE 4: Reasonable timeouts — not too high, not too low
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+
+  use: {
+    // RULE 5: Always capture traces on retry for debugging
+    trace: 'on-first-retry',
+
+    // RULE 6: Use baseURL — never hardcode full URLs in tests
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+
+    // RULE 7: Disable animations for deterministic behavior
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
+
+    // RULE 8: Explicit viewport — same locally and in CI
+    viewport: { width: 1280, height: 720 },
+  },
+
+  // RULE 9: Start the app automatically in CI
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+```typescript
+// tests/example-stable-test.spec.ts — applying all rules in a test
+import { test, expect } from '@playwright/test';
+
+test.describe('user profile', () => {
+  test('updates display name', async ({ page }) => {
+    // RULE 10: Unique data per test
+    const newName = `User-${Date.now()}`;
+
+    // RULE 11: Use baseURL — relative paths only
+    await page.goto('/profile');
+
+    // RULE 12: Role-based locators — resilient to implementation changes
+    await page.getByRole('textbox', { name: 'Display name' }).fill(newName);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // RULE 13: Auto-retrying assertions — never manual waits
+    await expect(page.getByRole('alert')).toHaveText('Profile updated');
+
+    // RULE 14: Assert on the result, not intermediate states
+    await expect(page.getByRole('textbox', { name: 'Display name' })).toHaveValue(newName);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    trace: 'on-first-retry',
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
+    viewport: { width: 1280, height: 720 },
+  },
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+```javascript
+// tests/example-stable-test.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe('user profile', () => {
+  test('updates display name', async ({ page }) => {
+    const newName = `User-${Date.now()}`;
+
+    await page.goto('/profile');
+    await page.getByRole('textbox', { name: 'Display name' }).fill(newName);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByRole('alert')).toHaveText('Profile updated');
+    await expect(page.getByRole('textbox', { name: 'Display name' })).toHaveValue(newName);
+  });
+});
+```
+
+## Decision Guide
+
+```
+My test is flaky. What do I do?
+|
++-- Step 1: Reproduce locally
+|   |
+|   +-- npx playwright test <file> --repeat-each=20
+|   +-- Fails? --> TIMING issue. Fix with auto-retrying assertions.
+|   +-- Does not fail? --> Continue to Step 2.
+|
++-- Step 2: Isolate from other tests
+|   |
+|   +-- npx playwright test --grep "exact test name" --workers=1
+|   +-- Passes alone? --> ISOLATION issue. Fix with unique data + fixtures.
+|   +-- Fails alone? --> Continue to Step 3.
+|
++-- Step 3: Compare environments
+|   |
+|   +-- Download CI trace, compare with local trace
+|   +-- Different? --> ENVIRONMENT issue. Fix with explicit viewport,
+|   |                  reducedMotion, webServer config, stub externals.
+|   +-- Same? --> Continue to Step 4.
+|
++-- Step 4: Check infrastructure
+|   |
+|   +-- Error mentions browser crash, OOM, DNS, ECONNREFUSED?
+|   +-- YES --> INFRASTRUCTURE issue. Fix with Docker, retry config,
+|   |           health checks before test run.
+|   +-- NO --> Re-examine. Enable trace: 'on' and retries to collect
+|              more data. Compare passing and failing traces side by side.
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Increase timeout to 120s to "fix" flakiness | Masks the real issue. Tests become unbearably slow when they fail. Slows the entire CI pipeline. | Diagnose the root cause. Fix the race condition, not the timeout. |
+| Use `page.waitForTimeout(N)` | Arbitrary delays are too slow on fast machines and too fast on slow ones. The #1 cause of flakiness. | Use `expect(locator).toBeVisible()`, `page.waitForResponse()`, or `expect.poll()`. |
+| Ignore flaky tests ("it works if you run it again") | Flaky tests erode trust in the entire suite. People stop reading failures. Real bugs slip through. | Diagnose immediately. If you cannot fix now, quarantine with `test.fixme()` and a tracking ticket. |
+| Add `--retries=3` and call it fixed | Retries do not fix flakiness, they hide it. A test that needs retries is a test with a bug. | Use retries to **detect** flakiness (check the retry count in reports), not to paper over it. |
+| Use `test.describe.serial()` to fix ordering-dependent tests | Serial mode forces all tests in the block to run sequentially. It hides isolation bugs and slows the suite. | Fix the isolation issue. Each test should pass regardless of execution order. |
+| Mock everything to prevent environment differences | Over-mocking removes confidence that the real system works. Tests pass but the app is broken. | Mock only external/third-party services. Test your own API for real. |
+| Run `--repeat-each=100` in CI on every commit | Multiplies CI time by 100x. Wastes resources. | Run burn-in locally or in a nightly job, not on every PR. |
+
+## Troubleshooting
+
+| Symptom | Category | Fix |
+|---|---|---|
+| Test fails with "Timeout 5000ms" intermittently | Timing | Increase `expect.timeout` to 10s, or add `page.waitForResponse()` before the assertion |
+| Test passes alone, fails in full suite run | Isolation | Check for module-level `let` variables, shared database rows, or localStorage leaks |
+| Test passes locally, fails in CI | Environment | Compare traces. Check viewport, fonts, `reducedMotion`, and external service availability |
+| Test fails with "Target closed" or "Browser closed" | Infrastructure | Check CI memory limits. Add `--workers=50%` to reduce parallel load. Add health check in `beforeAll` |
+| Test fails differently every time | Timing + Isolation | Enable `trace: 'on'` and compare multiple failing traces. The inconsistency itself is a clue |
+| Flaky test passes 99/100 times | Timing (rare race) | Use `--repeat-each=200` locally. Add `page.waitForResponse()` or `expect.poll()` for the specific race |
+| Visual comparison test is flaky | Environment | Use `maxDiffPixelRatio` threshold. Set explicit fonts with `@font-face`. Use Docker for consistent rendering |
+| Tests flake only on WebKit | Environment | WebKit has different timing behavior. Add WebKit-specific assertions or increase timeouts per project |
+
+## Related
+
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-retrying assertions and explicit waits
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- fixture teardown for test isolation
+- [core/test-data-management.md](test-data-management.md) -- unique data per test, factory functions
+- [core/configuration.md](configuration.md) -- retry, timeout, and trace configuration
+- [core/debugging.md](debugging.md) -- trace viewer, UI mode, and Inspector for diagnosing failures
+- [core/common-pitfalls.md](common-pitfalls.md) -- common mistakes that cause flakiness

--- a/engineering-team/playwright skill/core/forms-and-validation.md
+++ b/engineering-team/playwright skill/core/forms-and-validation.md
@@ -1,0 +1,1056 @@
+# Forms and Validation
+
+> **When to use**: Testing form filling, submission, validation messages, multi-step wizards, dynamic fields, and auto-complete interactions.
+> **Prerequisites**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Reference
+
+```typescript
+// Text input
+await page.getByLabel('Name').fill('Jane Doe');
+
+// Select dropdown
+await page.getByLabel('Country').selectOption('US');
+await page.getByLabel('Country').selectOption({ label: 'United States' });
+
+// Checkbox and radio
+await page.getByLabel('Remember me').check();
+await page.getByLabel('Express shipping').click();
+
+// Date input
+await page.getByLabel('Start date').fill('2025-03-15');
+
+// Clear a field
+await page.getByLabel('Name').clear();
+
+// Submit
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Verify validation error
+await expect(page.getByText('Email is required')).toBeVisible();
+```
+
+## Patterns
+
+### Filling Basic Form Fields
+
+**Use when**: Testing any form with standard HTML inputs — text, email, password, number, textarea, select, checkbox, radio.
+**Avoid when**: Never. This is the foundation pattern.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('fill and submit a registration form', async ({ page }) => {
+  await page.goto('/register');
+
+  // Text inputs — use fill() which clears first, not type()
+  await page.getByLabel('First name').fill('Jane');
+  await page.getByLabel('Last name').fill('Doe');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('S3cureP@ss!');
+  await page.getByLabel('Confirm password').fill('S3cureP@ss!');
+
+  // Textarea
+  await page.getByLabel('Bio').fill('Software engineer with 10 years of experience.');
+
+  // Number input
+  await page.getByLabel('Age').fill('32');
+
+  // Native <select>
+  await page.getByLabel('Country').selectOption('US');
+
+  // Select by visible label text (when value differs from display text)
+  await page.getByLabel('State').selectOption({ label: 'California' });
+
+  // Multi-select
+  await page.getByLabel('Interests').selectOption(['coding', 'testing', 'devops']);
+
+  // Checkbox — use check() not click() (idempotent: won't uncheck if already checked)
+  await page.getByLabel('I agree to the terms').check();
+  await expect(page.getByLabel('I agree to the terms')).toBeChecked();
+
+  // Radio button
+  await page.getByLabel('Monthly billing').check();
+  await expect(page.getByLabel('Monthly billing')).toBeChecked();
+
+  // Submit
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('fill and submit a registration form', async ({ page }) => {
+  await page.goto('/register');
+
+  await page.getByLabel('First name').fill('Jane');
+  await page.getByLabel('Last name').fill('Doe');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('S3cureP@ss!');
+  await page.getByLabel('Confirm password').fill('S3cureP@ss!');
+
+  await page.getByLabel('Bio').fill('Software engineer with 10 years of experience.');
+  await page.getByLabel('Age').fill('32');
+  await page.getByLabel('Country').selectOption('US');
+  await page.getByLabel('State').selectOption({ label: 'California' });
+  await page.getByLabel('Interests').selectOption(['coding', 'testing', 'devops']);
+
+  await page.getByLabel('I agree to the terms').check();
+  await expect(page.getByLabel('I agree to the terms')).toBeChecked();
+
+  await page.getByLabel('Monthly billing').check();
+  await expect(page.getByLabel('Monthly billing')).toBeChecked();
+
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+});
+```
+
+### Date and Time Inputs
+
+**Use when**: Testing native `<input type="date">`, `<input type="time">`, `<input type="datetime-local">`, or third-party date pickers.
+**Avoid when**: The date picker is a simple text field with no special input type. Just use `fill()`.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('fill native date and time inputs', async ({ page }) => {
+  await page.goto('/booking');
+
+  // Native date input — use ISO format YYYY-MM-DD
+  await page.getByLabel('Check-in date').fill('2025-06-15');
+  await expect(page.getByLabel('Check-in date')).toHaveValue('2025-06-15');
+
+  // Native time input — use HH:MM format
+  await page.getByLabel('Arrival time').fill('14:30');
+
+  // datetime-local — use YYYY-MM-DDTHH:MM format
+  await page.getByLabel('Event start').fill('2025-06-15T09:00');
+});
+
+test('interact with a third-party date picker', async ({ page }) => {
+  await page.goto('/booking');
+
+  // Click to open the date picker
+  await page.getByLabel('Departure date').click();
+
+  // Navigate months if needed
+  await page.getByRole('button', { name: 'Next month' }).click();
+
+  // Select a specific day
+  await page.getByRole('gridcell', { name: '20' }).click();
+
+  // Verify the selected date appears in the input
+  await expect(page.getByLabel('Departure date')).toHaveValue(/2025/);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('fill native date and time inputs', async ({ page }) => {
+  await page.goto('/booking');
+
+  await page.getByLabel('Check-in date').fill('2025-06-15');
+  await expect(page.getByLabel('Check-in date')).toHaveValue('2025-06-15');
+
+  await page.getByLabel('Arrival time').fill('14:30');
+  await page.getByLabel('Event start').fill('2025-06-15T09:00');
+});
+
+test('interact with a third-party date picker', async ({ page }) => {
+  await page.goto('/booking');
+
+  await page.getByLabel('Departure date').click();
+  await page.getByRole('button', { name: 'Next month' }).click();
+  await page.getByRole('gridcell', { name: '20' }).click();
+
+  await expect(page.getByLabel('Departure date')).toHaveValue(/2025/);
+});
+```
+
+### Required Field Validation
+
+**Use when**: Testing that the form shows appropriate error messages when required fields are empty.
+**Avoid when**: You only care about the happy path. Validation tests should complement, not replace, success path tests.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('shows validation errors for empty required fields', async ({ page }) => {
+  await page.goto('/contact');
+
+  // Submit without filling anything
+  await page.getByRole('button', { name: 'Send message' }).click();
+
+  // Verify all required field errors appear
+  await expect(page.getByText('Name is required')).toBeVisible();
+  await expect(page.getByText('Email is required')).toBeVisible();
+  await expect(page.getByText('Message is required')).toBeVisible();
+
+  // Verify the form was NOT submitted (still on the same page)
+  await expect(page).toHaveURL(/\/contact/);
+});
+
+test('clears validation errors when fields are filled', async ({ page }) => {
+  await page.goto('/contact');
+
+  // Trigger errors
+  await page.getByRole('button', { name: 'Send message' }).click();
+  await expect(page.getByText('Name is required')).toBeVisible();
+
+  // Fill the field — error should disappear
+  await page.getByLabel('Name').fill('Jane Doe');
+
+  // Use tab or click away to trigger blur validation
+  await page.getByLabel('Email').focus();
+
+  await expect(page.getByText('Name is required')).not.toBeVisible();
+});
+
+test('native HTML5 validation with required attribute', async ({ page }) => {
+  await page.goto('/simple-form');
+
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  // Check for native validation message via the :invalid pseudo-class
+  const emailInput = page.getByLabel('Email');
+  const validationMessage = await emailInput.evaluate(
+    (el: HTMLInputElement) => el.validationMessage
+  );
+  expect(validationMessage).toBeTruthy();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('shows validation errors for empty required fields', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByRole('button', { name: 'Send message' }).click();
+
+  await expect(page.getByText('Name is required')).toBeVisible();
+  await expect(page.getByText('Email is required')).toBeVisible();
+  await expect(page.getByText('Message is required')).toBeVisible();
+
+  await expect(page).toHaveURL(/\/contact/);
+});
+
+test('clears validation errors when fields are filled', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByRole('button', { name: 'Send message' }).click();
+  await expect(page.getByText('Name is required')).toBeVisible();
+
+  await page.getByLabel('Name').fill('Jane Doe');
+  await page.getByLabel('Email').focus();
+
+  await expect(page.getByText('Name is required')).not.toBeVisible();
+});
+
+test('native HTML5 validation with required attribute', async ({ page }) => {
+  await page.goto('/simple-form');
+
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const emailInput = page.getByLabel('Email');
+  const validationMessage = await emailInput.evaluate(
+    (el) => el.validationMessage
+  );
+  expect(validationMessage).toBeTruthy();
+});
+```
+
+### Format Validation and Custom Rules
+
+**Use when**: Testing email format, phone number format, password strength, and business-specific validation rules.
+**Avoid when**: The validation is purely server-side with no client-side feedback. Test via API instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('validates email format', async ({ page }) => {
+  await page.goto('/register');
+
+  const emailField = page.getByLabel('Email');
+
+  // Invalid formats
+  const invalidEmails = ['not-an-email', 'missing@', '@no-local.com', 'spaces in@email.com'];
+
+  for (const email of invalidEmails) {
+    await emailField.fill(email);
+    await emailField.blur();
+    await expect(page.getByText('Please enter a valid email')).toBeVisible();
+  }
+
+  // Valid format clears the error
+  await emailField.fill('valid@example.com');
+  await emailField.blur();
+  await expect(page.getByText('Please enter a valid email')).not.toBeVisible();
+});
+
+test('validates password strength rules', async ({ page }) => {
+  await page.goto('/register');
+
+  const passwordField = page.getByLabel('Password', { exact: true });
+
+  // Too short
+  await passwordField.fill('Ab1!');
+  await passwordField.blur();
+  await expect(page.getByText('At least 8 characters')).toBeVisible();
+
+  // Missing uppercase
+  await passwordField.fill('abcdefg1!');
+  await passwordField.blur();
+  await expect(page.getByText('At least one uppercase letter')).toBeVisible();
+
+  // Strong password — all checks pass
+  await passwordField.fill('Str0ngP@ss!');
+  await passwordField.blur();
+  await expect(page.getByText(/At least/)).not.toBeVisible();
+});
+
+test('validates custom business rule — age range', async ({ page }) => {
+  await page.goto('/insurance/quote');
+
+  await page.getByLabel('Age').fill('15');
+  await page.getByLabel('Age').blur();
+  await expect(page.getByText('Must be 18 or older')).toBeVisible();
+
+  await page.getByLabel('Age').fill('150');
+  await page.getByLabel('Age').blur();
+  await expect(page.getByText('Please enter a valid age')).toBeVisible();
+
+  await page.getByLabel('Age').fill('30');
+  await page.getByLabel('Age').blur();
+  await expect(page.getByText(/Must be|valid age/)).not.toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('validates email format', async ({ page }) => {
+  await page.goto('/register');
+
+  const emailField = page.getByLabel('Email');
+
+  const invalidEmails = ['not-an-email', 'missing@', '@no-local.com', 'spaces in@email.com'];
+
+  for (const email of invalidEmails) {
+    await emailField.fill(email);
+    await emailField.blur();
+    await expect(page.getByText('Please enter a valid email')).toBeVisible();
+  }
+
+  await emailField.fill('valid@example.com');
+  await emailField.blur();
+  await expect(page.getByText('Please enter a valid email')).not.toBeVisible();
+});
+
+test('validates password strength rules', async ({ page }) => {
+  await page.goto('/register');
+
+  const passwordField = page.getByLabel('Password', { exact: true });
+
+  await passwordField.fill('Ab1!');
+  await passwordField.blur();
+  await expect(page.getByText('At least 8 characters')).toBeVisible();
+
+  await passwordField.fill('abcdefg1!');
+  await passwordField.blur();
+  await expect(page.getByText('At least one uppercase letter')).toBeVisible();
+
+  await passwordField.fill('Str0ngP@ss!');
+  await passwordField.blur();
+  await expect(page.getByText(/At least/)).not.toBeVisible();
+});
+
+test('validates custom business rule — age range', async ({ page }) => {
+  await page.goto('/insurance/quote');
+
+  await page.getByLabel('Age').fill('15');
+  await page.getByLabel('Age').blur();
+  await expect(page.getByText('Must be 18 or older')).toBeVisible();
+
+  await page.getByLabel('Age').fill('150');
+  await page.getByLabel('Age').blur();
+  await expect(page.getByText('Please enter a valid age')).toBeVisible();
+
+  await page.getByLabel('Age').fill('30');
+  await page.getByLabel('Age').blur();
+  await expect(page.getByText(/Must be|valid age/)).not.toBeVisible();
+});
+```
+
+### Multi-Step Forms and Wizards
+
+**Use when**: The form spans multiple pages or steps, with next/previous navigation and per-step validation.
+**Avoid when**: The form is a single page. Use the basic form filling pattern.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('complete a multi-step checkout wizard', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Step 1: Shipping
+  await test.step('fill shipping information', async () => {
+    await expect(page.getByRole('heading', { name: 'Shipping' })).toBeVisible();
+
+    await page.getByLabel('Address').fill('123 Main St');
+    await page.getByLabel('City').fill('Portland');
+    await page.getByLabel('State').selectOption('OR');
+    await page.getByLabel('ZIP code').fill('97201');
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+
+  // Step 2: Payment
+  await test.step('fill payment details', async () => {
+    await expect(page.getByRole('heading', { name: 'Payment' })).toBeVisible();
+
+    await page.getByLabel('Card number').fill('4242424242424242');
+    await page.getByLabel('Expiration').fill('12/28');
+    await page.getByLabel('CVC').fill('123');
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+
+  // Step 3: Review
+  await test.step('review and confirm order', async () => {
+    await expect(page.getByRole('heading', { name: 'Review' })).toBeVisible();
+
+    // Verify data from previous steps is shown
+    await expect(page.getByText('123 Main St')).toBeVisible();
+    await expect(page.getByText('ending in 4242')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Place order' }).click();
+  });
+
+  // Confirmation
+  await expect(page.getByRole('heading', { name: 'Order confirmed' })).toBeVisible();
+});
+
+test('wizard validates each step before proceeding', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Try to skip step 1 without filling required fields
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Should stay on step 1 with validation errors
+  await expect(page.getByRole('heading', { name: 'Shipping' })).toBeVisible();
+  await expect(page.getByText('Address is required')).toBeVisible();
+});
+
+test('wizard supports going back without losing data', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Fill step 1
+  await page.getByLabel('Address').fill('123 Main St');
+  await page.getByLabel('City').fill('Portland');
+  await page.getByLabel('State').selectOption('OR');
+  await page.getByLabel('ZIP code').fill('97201');
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Go back from step 2
+  await page.getByRole('button', { name: 'Back' }).click();
+
+  // Verify step 1 data is preserved
+  await expect(page.getByLabel('Address')).toHaveValue('123 Main St');
+  await expect(page.getByLabel('City')).toHaveValue('Portland');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('complete a multi-step checkout wizard', async ({ page }) => {
+  await page.goto('/checkout');
+
+  await test.step('fill shipping information', async () => {
+    await expect(page.getByRole('heading', { name: 'Shipping' })).toBeVisible();
+
+    await page.getByLabel('Address').fill('123 Main St');
+    await page.getByLabel('City').fill('Portland');
+    await page.getByLabel('State').selectOption('OR');
+    await page.getByLabel('ZIP code').fill('97201');
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+
+  await test.step('fill payment details', async () => {
+    await expect(page.getByRole('heading', { name: 'Payment' })).toBeVisible();
+
+    await page.getByLabel('Card number').fill('4242424242424242');
+    await page.getByLabel('Expiration').fill('12/28');
+    await page.getByLabel('CVC').fill('123');
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+  });
+
+  await test.step('review and confirm order', async () => {
+    await expect(page.getByRole('heading', { name: 'Review' })).toBeVisible();
+
+    await expect(page.getByText('123 Main St')).toBeVisible();
+    await expect(page.getByText('ending in 4242')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Place order' }).click();
+  });
+
+  await expect(page.getByRole('heading', { name: 'Order confirmed' })).toBeVisible();
+});
+
+test('wizard validates each step before proceeding', async ({ page }) => {
+  await page.goto('/checkout');
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Shipping' })).toBeVisible();
+  await expect(page.getByText('Address is required')).toBeVisible();
+});
+
+test('wizard supports going back without losing data', async ({ page }) => {
+  await page.goto('/checkout');
+
+  await page.getByLabel('Address').fill('123 Main St');
+  await page.getByLabel('City').fill('Portland');
+  await page.getByLabel('State').selectOption('OR');
+  await page.getByLabel('ZIP code').fill('97201');
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.getByRole('button', { name: 'Back' }).click();
+
+  await expect(page.getByLabel('Address')).toHaveValue('123 Main St');
+  await expect(page.getByLabel('City')).toHaveValue('Portland');
+});
+```
+
+### Auto-Complete and Typeahead Fields
+
+**Use when**: Testing search fields, address lookups, mention pickers, or any input that shows suggestions as the user types.
+**Avoid when**: The field is a plain text input with no suggestions.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('select from auto-complete suggestions', async ({ page }) => {
+  await page.goto('/search');
+
+  const searchField = page.getByRole('combobox', { name: 'Search' });
+
+  // Type slowly enough for suggestions to appear
+  // pressSequentially simulates real keystrokes (triggers keydown/keyup/input events)
+  await searchField.pressSequentially('playw', { delay: 100 });
+
+  // Wait for the suggestion list to appear
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  // Select a specific suggestion
+  await suggestions.getByRole('option', { name: 'Playwright Testing' }).click();
+
+  // Verify the selection populated the field
+  await expect(searchField).toHaveValue('Playwright Testing');
+});
+
+test('auto-complete with API-driven suggestions', async ({ page }) => {
+  await page.goto('/address-form');
+
+  const addressField = page.getByLabel('Address');
+  await addressField.pressSequentially('123 Ma', { delay: 50 });
+
+  // Wait for the API-driven suggestion list
+  const responsePromise = page.waitForResponse('**/api/address-suggest*');
+  await responsePromise;
+
+  await page.getByRole('option', { name: /123 Main St/ }).click();
+
+  // Verify dependent fields were auto-populated
+  await expect(page.getByLabel('City')).toHaveValue('Portland');
+  await expect(page.getByLabel('State')).toHaveValue('OR');
+  await expect(page.getByLabel('ZIP code')).toHaveValue('97201');
+});
+
+test('dismiss auto-complete and use custom value', async ({ page }) => {
+  await page.goto('/tags');
+
+  const tagInput = page.getByLabel('Add tag');
+  await tagInput.pressSequentially('custom-tag');
+
+  // Dismiss suggestions with Escape
+  await tagInput.press('Escape');
+  await expect(page.getByRole('listbox')).not.toBeVisible();
+
+  // Submit custom value with Enter
+  await tagInput.press('Enter');
+  await expect(page.getByText('custom-tag')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('select from auto-complete suggestions', async ({ page }) => {
+  await page.goto('/search');
+
+  const searchField = page.getByRole('combobox', { name: 'Search' });
+  await searchField.pressSequentially('playw', { delay: 100 });
+
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  await suggestions.getByRole('option', { name: 'Playwright Testing' }).click();
+  await expect(searchField).toHaveValue('Playwright Testing');
+});
+
+test('auto-complete with API-driven suggestions', async ({ page }) => {
+  await page.goto('/address-form');
+
+  const addressField = page.getByLabel('Address');
+  await addressField.pressSequentially('123 Ma', { delay: 50 });
+
+  const responsePromise = page.waitForResponse('**/api/address-suggest*');
+  await responsePromise;
+
+  await page.getByRole('option', { name: /123 Main St/ }).click();
+
+  await expect(page.getByLabel('City')).toHaveValue('Portland');
+  await expect(page.getByLabel('State')).toHaveValue('OR');
+  await expect(page.getByLabel('ZIP code')).toHaveValue('97201');
+});
+
+test('dismiss auto-complete and use custom value', async ({ page }) => {
+  await page.goto('/tags');
+
+  const tagInput = page.getByLabel('Add tag');
+  await tagInput.pressSequentially('custom-tag');
+
+  await tagInput.press('Escape');
+  await expect(page.getByRole('listbox')).not.toBeVisible();
+
+  await tagInput.press('Enter');
+  await expect(page.getByText('custom-tag')).toBeVisible();
+});
+```
+
+### Dynamic Forms — Conditional Fields
+
+**Use when**: Form fields appear, disappear, or change based on the value of other fields.
+**Avoid when**: All fields are always visible. Use the basic form filling pattern.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('conditional fields appear based on selection', async ({ page }) => {
+  await page.goto('/insurance/apply');
+
+  // Selecting "Business" shows additional fields
+  await page.getByLabel('Account type').selectOption('business');
+
+  // Wait for conditional fields to appear
+  await expect(page.getByLabel('Company name')).toBeVisible();
+  await expect(page.getByLabel('Tax ID')).toBeVisible();
+
+  await page.getByLabel('Company name').fill('Acme Corp');
+  await page.getByLabel('Tax ID').fill('12-3456789');
+
+  // Switching back to "Personal" hides them
+  await page.getByLabel('Account type').selectOption('personal');
+  await expect(page.getByLabel('Company name')).not.toBeVisible();
+  await expect(page.getByLabel('Tax ID')).not.toBeVisible();
+});
+
+test('checkbox toggles additional section', async ({ page }) => {
+  await page.goto('/shipping');
+
+  // "Different billing address" reveals billing fields
+  await page.getByLabel('Use different billing address').check();
+
+  const billingSection = page.getByRole('group', { name: 'Billing address' });
+  await expect(billingSection).toBeVisible();
+
+  await billingSection.getByLabel('Street').fill('456 Oak Ave');
+  await billingSection.getByLabel('City').fill('Seattle');
+
+  // Unchecking hides the section
+  await page.getByLabel('Use different billing address').uncheck();
+  await expect(billingSection).not.toBeVisible();
+});
+
+test('dependent dropdown chains', async ({ page }) => {
+  await page.goto('/location-picker');
+
+  // Country selection populates the state dropdown
+  await page.getByLabel('Country').selectOption('US');
+
+  // Wait for the dependent dropdown to be populated
+  const stateDropdown = page.getByLabel('State');
+  await expect(stateDropdown.getByRole('option')).not.toHaveCount(0);
+
+  await stateDropdown.selectOption('CA');
+
+  // State selection populates the city dropdown
+  const cityDropdown = page.getByLabel('City');
+  await expect(cityDropdown.getByRole('option')).not.toHaveCount(0);
+
+  await cityDropdown.selectOption({ label: 'Los Angeles' });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('conditional fields appear based on selection', async ({ page }) => {
+  await page.goto('/insurance/apply');
+
+  await page.getByLabel('Account type').selectOption('business');
+
+  await expect(page.getByLabel('Company name')).toBeVisible();
+  await expect(page.getByLabel('Tax ID')).toBeVisible();
+
+  await page.getByLabel('Company name').fill('Acme Corp');
+  await page.getByLabel('Tax ID').fill('12-3456789');
+
+  await page.getByLabel('Account type').selectOption('personal');
+  await expect(page.getByLabel('Company name')).not.toBeVisible();
+  await expect(page.getByLabel('Tax ID')).not.toBeVisible();
+});
+
+test('checkbox toggles additional section', async ({ page }) => {
+  await page.goto('/shipping');
+
+  await page.getByLabel('Use different billing address').check();
+
+  const billingSection = page.getByRole('group', { name: 'Billing address' });
+  await expect(billingSection).toBeVisible();
+
+  await billingSection.getByLabel('Street').fill('456 Oak Ave');
+  await billingSection.getByLabel('City').fill('Seattle');
+
+  await page.getByLabel('Use different billing address').uncheck();
+  await expect(billingSection).not.toBeVisible();
+});
+
+test('dependent dropdown chains', async ({ page }) => {
+  await page.goto('/location-picker');
+
+  await page.getByLabel('Country').selectOption('US');
+
+  const stateDropdown = page.getByLabel('State');
+  await expect(stateDropdown.getByRole('option')).not.toHaveCount(0);
+
+  await stateDropdown.selectOption('CA');
+
+  const cityDropdown = page.getByLabel('City');
+  await expect(cityDropdown.getByRole('option')).not.toHaveCount(0);
+
+  await cityDropdown.selectOption({ label: 'Los Angeles' });
+});
+```
+
+### Form Submission and Response Handling
+
+**Use when**: Testing what happens after a form is submitted — success messages, redirects, error responses from the server, and loading states during submission.
+**Avoid when**: You only care about client-side validation. Test submission separately from validation.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('successful form submission shows confirmation', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Name').fill('Jane Doe');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Hello from Playwright');
+
+  // Wait for the API response during submission
+  const responsePromise = page.waitForResponse('**/api/contact');
+  await page.getByRole('button', { name: 'Send message' }).click();
+  const response = await responsePromise;
+
+  expect(response.status()).toBe(200);
+  await expect(page.getByText('Message sent successfully')).toBeVisible();
+});
+
+test('form submission shows server-side validation errors', async ({ page }) => {
+  await page.goto('/register');
+
+  await page.getByLabel('Email').fill('taken@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('ValidP@ss1');
+  await page.getByRole('button', { name: 'Register' }).click();
+
+  // Server responds with a 409 — email already taken
+  await expect(page.getByText('An account with this email already exists')).toBeVisible();
+});
+
+test('form shows loading state during submission', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Name').fill('Jane');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Test');
+
+  await page.getByRole('button', { name: 'Send message' }).click();
+
+  // Button should be disabled during submission
+  await expect(page.getByRole('button', { name: /Sending/ })).toBeDisabled();
+
+  // After completion, button returns to normal
+  await expect(page.getByRole('button', { name: 'Send message' })).toBeEnabled();
+});
+
+test('form redirects after successful submission', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Verify redirect
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('successful form submission shows confirmation', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Name').fill('Jane Doe');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Hello from Playwright');
+
+  const responsePromise = page.waitForResponse('**/api/contact');
+  await page.getByRole('button', { name: 'Send message' }).click();
+  const response = await responsePromise;
+
+  expect(response.status()).toBe(200);
+  await expect(page.getByText('Message sent successfully')).toBeVisible();
+});
+
+test('form submission shows server-side validation errors', async ({ page }) => {
+  await page.goto('/register');
+
+  await page.getByLabel('Email').fill('taken@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('ValidP@ss1');
+  await page.getByRole('button', { name: 'Register' }).click();
+
+  await expect(page.getByText('An account with this email already exists')).toBeVisible();
+});
+
+test('form shows loading state during submission', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Name').fill('Jane');
+  await page.getByLabel('Email').fill('jane@example.com');
+  await page.getByLabel('Message').fill('Test');
+
+  await page.getByRole('button', { name: 'Send message' }).click();
+
+  await expect(page.getByRole('button', { name: /Sending/ })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Send message' })).toBeEnabled();
+});
+
+test('form redirects after successful submission', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+### Form Reset Testing
+
+**Use when**: Testing "clear form" or "reset" functionality, verifying that fields return to their default values.
+**Avoid when**: The form has no reset mechanism.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('reset button clears all fields to defaults', async ({ page }) => {
+  await page.goto('/settings');
+
+  // Change fields from defaults
+  await page.getByLabel('Display name').fill('New Name');
+  await page.getByLabel('Theme').selectOption('dark');
+  await page.getByLabel('Notifications').uncheck();
+
+  // Click reset
+  await page.getByRole('button', { name: 'Reset' }).click();
+
+  // Verify fields returned to original values
+  await expect(page.getByLabel('Display name')).toHaveValue('');
+  await expect(page.getByLabel('Theme')).toHaveValue('light');
+  await expect(page.getByLabel('Notifications')).toBeChecked();
+});
+
+test('confirmation dialog before resetting a dirty form', async ({ page }) => {
+  await page.goto('/editor');
+
+  await page.getByLabel('Title').fill('Draft post');
+
+  // Reset triggers a confirmation dialog
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.getByRole('button', { name: 'Discard changes' }).click();
+
+  await expect(page.getByLabel('Title')).toHaveValue('');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('reset button clears all fields to defaults', async ({ page }) => {
+  await page.goto('/settings');
+
+  await page.getByLabel('Display name').fill('New Name');
+  await page.getByLabel('Theme').selectOption('dark');
+  await page.getByLabel('Notifications').uncheck();
+
+  await page.getByRole('button', { name: 'Reset' }).click();
+
+  await expect(page.getByLabel('Display name')).toHaveValue('');
+  await expect(page.getByLabel('Theme')).toHaveValue('light');
+  await expect(page.getByLabel('Notifications')).toBeChecked();
+});
+
+test('confirmation dialog before resetting a dirty form', async ({ page }) => {
+  await page.goto('/editor');
+
+  await page.getByLabel('Title').fill('Draft post');
+
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.getByRole('button', { name: 'Discard changes' }).click();
+
+  await expect(page.getByLabel('Title')).toHaveValue('');
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Key API |
+|---|---|---|
+| Standard text input | `fill()` (clears, then types) | `page.getByLabel('Name').fill('Jane')` |
+| Need keystroke events (autocomplete) | `pressSequentially()` with delay | `locator.pressSequentially('text', { delay: 100 })` |
+| Native `<select>` dropdown | `selectOption()` by value or label | `locator.selectOption('US')` or `{ label: 'United States' }` |
+| Custom dropdown (ARIA listbox) | Click trigger, then select option role | `getByRole('option', { name: '...' }).click()` |
+| Checkbox | `check()` / `uncheck()` (idempotent) | `locator.check()` — safe to call even if already checked |
+| Radio button | `check()` on the target radio | `page.getByLabel('Express').check()` |
+| Date input (native) | `fill()` with ISO format | `locator.fill('2025-03-15')` |
+| Date picker (third-party) | Click to open, navigate, select day | `getByRole('gridcell', { name: '15' }).click()` |
+| Validation errors | Submit, then assert error text | `expect(page.getByText('Required')).toBeVisible()` |
+| Multi-step wizard | `test.step()` per step, assert heading | `await test.step('Step 1', async () => { ... })` |
+| Conditional/dynamic fields | Change trigger field, assert new field visibility | `expect(locator).toBeVisible()` / `.not.toBeVisible()` |
+| Form submission | `waitForResponse` + click submit | Register response listener before click |
+| Auto-complete | `pressSequentially()`, wait for listbox, select option | `getByRole('option', { name }).click()` |
+| Form reset | Click reset, assert default values | `expect(locator).toHaveValue('')` |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `await page.getByLabel('Name').type('Jane')` | `type()` appends to existing content; does not clear first | `await page.getByLabel('Name').fill('Jane')` |
+| `await page.getByLabel('Agree').click()` | `click()` toggles — if already checked, it unchecks | `await page.getByLabel('Agree').check()` |
+| `await page.fill('#email', 'test@test.com')` | CSS selector is fragile | `await page.getByLabel('Email').fill('test@test.com')` |
+| `await page.selectOption('select', 'US')` without label | Targets first `<select>` on page; ambiguous | `await page.getByLabel('Country').selectOption('US')` |
+| Testing every invalid input in one test | Test becomes huge, slow, and hard to debug | One test per validation rule or group related rules |
+| `expect(await input.inputValue()).toBe('Jane')` | Resolves once — no retry. Race condition. | `await expect(input).toHaveValue('Jane')` |
+| Filling fields with `page.evaluate()` | Bypasses event handlers (no `input`, `change` events fire) | Use `fill()` or `pressSequentially()` |
+| Not waiting for conditional fields before filling | `fill()` fails on hidden/detached elements | `await expect(field).toBeVisible()` first |
+| Hardcoding wait after selecting a dropdown | `waitForTimeout(500)` is flaky and slow | Wait for the dependent element to appear |
+| Skipping server-side validation tests | Client-side validation can be bypassed | Test both client-side UX and server response |
+
+## Troubleshooting
+
+### `fill()` does nothing or clears but doesn't type
+
+**Cause**: The input field uses a contenteditable div (rich text editors), not a real `<input>` or `<textarea>`.
+
+```typescript
+// Check if it is contenteditable
+const isContentEditable = await page.getByTestId('editor').evaluate(
+  (el) => el.getAttribute('contenteditable')
+);
+
+// For contenteditable, use pressSequentially or type
+if (isContentEditable) {
+  await page.getByTestId('editor').click();
+  await page.getByTestId('editor').pressSequentially('Hello world');
+}
+```
+
+### Date picker does not accept `fill()` value
+
+**Cause**: Third-party date pickers often render custom UI over a hidden input. `fill()` sets the hidden input but the UI does not update.
+
+```typescript
+// Interact with the date picker UI instead
+await page.getByLabel('Date').click();  // Opens the picker
+await page.getByRole('button', { name: 'Next month' }).click();
+await page.getByRole('gridcell', { name: '15' }).click();
+
+// Alternatively, if the library reads from the input on change:
+await page.getByLabel('Date').fill('2025-06-15');
+await page.getByLabel('Date').dispatchEvent('change');
+```
+
+### `selectOption()` throws "not a <select> element"
+
+**Cause**: The dropdown is a custom component (ARIA listbox), not a native `<select>`.
+
+```typescript
+// For custom dropdowns: click to open, then select from the listbox
+await page.getByRole('combobox', { name: 'Country' }).click();
+await page.getByRole('option', { name: 'United States' }).click();
+```
+
+### Validation errors do not appear after `fill()` and submit
+
+**Cause**: The validation triggers on `blur` (focus leaving the field), but `fill()` does not trigger blur automatically.
+
+```typescript
+// Trigger blur explicitly
+await page.getByLabel('Email').fill('invalid');
+await page.getByLabel('Email').blur();
+await expect(page.getByText('Please enter a valid email')).toBeVisible();
+
+// Or move focus to the next field
+await page.getByLabel('Password').focus();
+```
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategies for finding form elements
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- assertion patterns for verifying form state
+- [core/file-operations.md](file-operations.md) -- file upload fields in forms
+- [core/error-and-edge-cases.md](error-and-edge-cases.md) -- testing form error states and edge cases
+- [core/accessibility.md](accessibility.md) -- ensuring forms are accessible (label associations, ARIA attributes)
+- [core/network-mocking.md](network-mocking.md) -- mocking form submission API responses

--- a/engineering-team/playwright skill/core/i18n-and-localization.md
+++ b/engineering-team/playwright skill/core/i18n-and-localization.md
@@ -1,0 +1,622 @@
+# Internationalization and Localization Testing
+
+> **When to use**: Verifying your application works correctly across locales, languages, text directions, date/number formats, and timezones. Catches layout breaks, missing translations, and format errors before they reach international users.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```typescript
+// Set locale and timezone per context
+const context = await browser.newContext({
+  locale: 'de-DE',
+  timezoneId: 'Europe/Berlin',
+});
+
+// Or in playwright.config.ts for project-level locale testing
+projects: [
+  { name: 'english', use: { locale: 'en-US', timezoneId: 'America/New_York' } },
+  { name: 'german',  use: { locale: 'de-DE', timezoneId: 'Europe/Berlin' } },
+  { name: 'arabic',  use: { locale: 'ar-SA', timezoneId: 'Asia/Riyadh' } },
+],
+```
+
+## Patterns
+
+### Setting Browser Locale
+
+**Use when**: Testing locale-dependent rendering -- date formats, number formatting, currency, sorting, and browser-level localization.
+**Avoid when**: Your app does not use the browser locale and instead relies on a user preference stored server-side.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('locale-specific formatting', () => {
+  test('US locale formats dates as MM/DD/YYYY', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'en-US' });
+    const page = await context.newPage();
+    await page.goto('/dashboard');
+
+    // Verify date format matches US convention
+    await expect(page.getByTestId('last-updated')).toHaveText(/\d{1,2}\/\d{1,2}\/\d{4}/);
+    await context.close();
+  });
+
+  test('German locale formats dates as DD.MM.YYYY', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'de-DE' });
+    const page = await context.newPage();
+    await page.goto('/dashboard');
+
+    await expect(page.getByTestId('last-updated')).toHaveText(/\d{1,2}\.\d{1,2}\.\d{4}/);
+    await context.close();
+  });
+
+  test('Japanese locale formats numbers with commas', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'ja-JP' });
+    const page = await context.newPage();
+    await page.goto('/pricing');
+
+    // Japanese yen: no decimal places, uses comma grouping
+    await expect(page.getByTestId('price')).toHaveText(/[\d,]+円/);
+    await context.close();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('German locale formats dates as DD.MM.YYYY', async ({ browser }) => {
+  const context = await browser.newContext({ locale: 'de-DE' });
+  const page = await context.newPage();
+  await page.goto('/dashboard');
+
+  await expect(page.getByTestId('last-updated')).toHaveText(/\d{1,2}\.\d{1,2}\.\d{4}/);
+  await context.close();
+});
+```
+
+### Multi-Locale Project Configuration
+
+**Use when**: Running the full test suite across multiple locales in CI.
+**Avoid when**: You only need to test a single locale or the app does not vary by locale.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'en-US',
+      use: {
+        locale: 'en-US',
+        timezoneId: 'America/New_York',
+      },
+    },
+    {
+      name: 'de-DE',
+      use: {
+        locale: 'de-DE',
+        timezoneId: 'Europe/Berlin',
+      },
+    },
+    {
+      name: 'ar-SA',
+      use: {
+        locale: 'ar-SA',
+        timezoneId: 'Asia/Riyadh',
+      },
+    },
+    {
+      name: 'ja-JP',
+      use: {
+        locale: 'ja-JP',
+        timezoneId: 'Asia/Tokyo',
+      },
+    },
+  ],
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    { name: 'en-US', use: { locale: 'en-US', timezoneId: 'America/New_York' } },
+    { name: 'de-DE', use: { locale: 'de-DE', timezoneId: 'Europe/Berlin' } },
+    { name: 'ar-SA', use: { locale: 'ar-SA', timezoneId: 'Asia/Riyadh' } },
+    { name: 'ja-JP', use: { locale: 'ja-JP', timezoneId: 'Asia/Tokyo' } },
+  ],
+});
+```
+
+### RTL Layout Testing
+
+**Use when**: Your app supports right-to-left languages (Arabic, Hebrew, Persian, Urdu) and you need to verify layout direction, text alignment, and mirrored UI.
+**Avoid when**: Your app has no RTL support.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('RTL layout', () => {
+  test('Arabic locale renders RTL layout', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'ar-SA' });
+    const page = await context.newPage();
+    await page.goto('/');
+
+    // Verify the document direction
+    const dir = await page.getAttribute('html', 'dir');
+    expect(dir).toBe('rtl');
+
+    // Verify navigation is right-aligned
+    const nav = page.getByRole('navigation', { name: 'Main' });
+    const navBox = await nav.boundingBox();
+    const viewportWidth = page.viewportSize()!.width;
+    // Nav should start from the right side
+    expect(navBox!.x + navBox!.width).toBeGreaterThan(viewportWidth * 0.5);
+
+    // Verify text alignment
+    const heading = page.getByRole('heading', { level: 1 });
+    const textAlign = await heading.evaluate((el) =>
+      window.getComputedStyle(el).textAlign
+    );
+    expect(textAlign).toMatch(/right|start/);
+
+    await context.close();
+  });
+
+  test('RTL layout does not cause horizontal overflow', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'ar-SA' });
+    const page = await context.newPage();
+    await page.goto('/dashboard');
+
+    // Check for horizontal scrollbar (content overflow)
+    const hasHorizontalOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasHorizontalOverflow).toBe(false);
+
+    await context.close();
+  });
+
+  test('icons and directional elements are mirrored in RTL', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'ar-SA' });
+    const page = await context.newPage();
+    await page.goto('/dashboard');
+
+    // Back arrow should point right in RTL
+    const backButton = page.getByRole('button', { name: /back|رجوع/i });
+    const transform = await backButton.evaluate((el) =>
+      window.getComputedStyle(el).transform
+    );
+    // CSS transform for horizontal flip: matrix(-1, 0, 0, 1, 0, 0) or scaleX(-1)
+    // Or check the logical property direction
+    expect(transform).not.toBe('none');
+
+    await context.close();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('Arabic locale renders RTL layout', async ({ browser }) => {
+  const context = await browser.newContext({ locale: 'ar-SA' });
+  const page = await context.newPage();
+  await page.goto('/');
+
+  const dir = await page.getAttribute('html', 'dir');
+  expect(dir).toBe('rtl');
+
+  const hasHorizontalOverflow = await page.evaluate(() =>
+    document.documentElement.scrollWidth > document.documentElement.clientWidth
+  );
+  expect(hasHorizontalOverflow).toBe(false);
+
+  await context.close();
+});
+```
+
+### Date, Number, and Currency Format Verification
+
+**Use when**: Your app uses `Intl.DateTimeFormat`, `Intl.NumberFormat`, or similar locale-sensitive APIs.
+**Avoid when**: Formats are hardcoded and do not depend on locale.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const FORMAT_EXPECTATIONS = {
+  'en-US': {
+    date: /\d{1,2}\/\d{1,2}\/\d{4}/,            // 1/15/2025
+    number: /1,234,567\.89/,                       // 1,234,567.89
+    currency: /\$[\d,]+\.\d{2}/,                   // $1,234.56
+  },
+  'de-DE': {
+    date: /\d{1,2}\.\d{1,2}\.\d{4}/,             // 15.1.2025
+    number: /1\.234\.567,89/,                      // 1.234.567,89
+    currency: /[\d.,]+\s?€/,                       // 1.234,56 €
+  },
+  'ja-JP': {
+    date: /\d{4}\/\d{1,2}\/\d{1,2}/,             // 2025/1/15
+    number: /1,234,567\.89/,                       // 1,234,567.89
+    currency: /[¥￥][\d,]+/,                        // ¥1,235
+  },
+} as const;
+
+for (const [locale, expected] of Object.entries(FORMAT_EXPECTATIONS)) {
+  test.describe(`${locale} formatting`, () => {
+    test(`dates match ${locale} format`, async ({ browser }) => {
+      const context = await browser.newContext({ locale });
+      const page = await context.newPage();
+      await page.goto('/account');
+
+      const dateText = await page.getByTestId('member-since').textContent();
+      expect(dateText).toMatch(expected.date);
+      await context.close();
+    });
+
+    test(`currency matches ${locale} format`, async ({ browser }) => {
+      const context = await browser.newContext({ locale });
+      const page = await context.newPage();
+      await page.goto('/pricing');
+
+      const priceText = await page.getByTestId('monthly-price').textContent();
+      expect(priceText).toMatch(expected.currency);
+      await context.close();
+    });
+  });
+}
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const locales = [
+  { locale: 'en-US', datePattern: /\d{1,2}\/\d{1,2}\/\d{4}/, currencyPattern: /\$[\d,]+\.\d{2}/ },
+  { locale: 'de-DE', datePattern: /\d{1,2}\.\d{1,2}\.\d{4}/, currencyPattern: /[\d.,]+\s?€/ },
+];
+
+for (const { locale, datePattern, currencyPattern } of locales) {
+  test(`${locale} date format`, async ({ browser }) => {
+    const context = await browser.newContext({ locale });
+    const page = await context.newPage();
+    await page.goto('/account');
+
+    const dateText = await page.getByTestId('member-since').textContent();
+    expect(dateText).toMatch(datePattern);
+    await context.close();
+  });
+}
+```
+
+### Language Switcher Testing
+
+**Use when**: Your app has an in-app language selector that changes the UI language without depending on browser locale.
+**Avoid when**: Language is determined purely by browser locale with no user override.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('language switcher changes UI language', async ({ page }) => {
+  await page.goto('/');
+
+  // Default language
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('Welcome');
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+
+  // Switch to French
+  await page.getByRole('combobox', { name: /language|langue/i }).selectOption('fr');
+
+  // UI should update to French
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('Bienvenue');
+  await expect(page.getByRole('button', { name: 'Se connecter' })).toBeVisible();
+
+  // Verify language persists after navigation
+  await page.getByRole('link', { name: /about|à propos/i }).click();
+  await expect(page.getByRole('heading', { level: 1 })).not.toContainText('About');
+});
+
+test('language preference persists across sessions', async ({ page, context }) => {
+  await page.goto('/');
+  await page.getByRole('combobox', { name: /language/i }).selectOption('es');
+  await expect(page.getByRole('button', { name: 'Iniciar sesión' })).toBeVisible();
+
+  // Reload page — language should persist (cookie/localStorage)
+  await page.reload();
+  await expect(page.getByRole('button', { name: 'Iniciar sesión' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('language switcher changes UI language', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('Welcome');
+
+  await page.getByRole('combobox', { name: /language/i }).selectOption('fr');
+
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('Bienvenue');
+  await expect(page.getByRole('button', { name: 'Se connecter' })).toBeVisible();
+});
+```
+
+### Translation Completeness Checks
+
+**Use when**: Verifying that all visible UI strings are translated and no fallback keys leak into the UI.
+**Avoid when**: You have a build-time translation validation step that already catches missing keys.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const LANGUAGES = ['en', 'fr', 'de', 'es', 'ja'];
+const PAGES_TO_CHECK = ['/', '/login', '/dashboard', '/settings', '/pricing'];
+
+for (const lang of LANGUAGES) {
+  test.describe(`${lang} translation completeness`, () => {
+    for (const pagePath of PAGES_TO_CHECK) {
+      test(`no missing translations on ${pagePath}`, async ({ page }) => {
+        // Set language via URL param, cookie, or language switcher
+        await page.goto(`${pagePath}?lang=${lang}`);
+
+        // Check for common translation key leak patterns
+        const pageText = await page.textContent('body');
+
+        // Translation keys typically look like: key.subkey, UPPER_SNAKE_CASE, or {{key}}
+        expect(pageText).not.toMatch(/\b[a-z]+\.[a-z]+\.[a-z]+\b/); // dot.notation.keys
+        expect(pageText).not.toContain('{{');                          // Unresolved templates
+        expect(pageText).not.toContain('}}');
+        expect(pageText).not.toMatch(/\bTODO\b/i);                    // Placeholder text
+
+        // Check for untranslated English text when in non-English locale
+        if (lang !== 'en') {
+          // These common English strings should be translated
+          const untranslated = ['Sign in', 'Log out', 'Settings', 'Dashboard', 'Submit'];
+          for (const text of untranslated) {
+            const count = await page.getByText(text, { exact: true }).count();
+            // Allow 0 matches (element not on page) but flag exact English matches
+            if (count > 0) {
+              console.warn(`Possible untranslated text "${text}" found on ${pagePath} for ${lang}`);
+            }
+          }
+        }
+      });
+    }
+  });
+}
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const LANGUAGES = ['en', 'fr', 'de'];
+const PAGES = ['/', '/login', '/dashboard'];
+
+for (const lang of LANGUAGES) {
+  for (const pagePath of PAGES) {
+    test(`${lang}: no missing translations on ${pagePath}`, async ({ page }) => {
+      await page.goto(`${pagePath}?lang=${lang}`);
+
+      const pageText = await page.textContent('body');
+      expect(pageText).not.toMatch(/\b[a-z]+\.[a-z]+\.[a-z]+\b/);
+      expect(pageText).not.toContain('{{');
+      expect(pageText).not.toContain('}}');
+    });
+  }
+}
+```
+
+### Timezone Testing
+
+**Use when**: Your app displays time-sensitive data (event times, deadlines, scheduling) and you need to verify correct timezone rendering.
+**Avoid when**: All times are displayed in UTC with no local conversion.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('timezone rendering', () => {
+  test('event times adjust to user timezone', async ({ browser }) => {
+    // Event stored as 2025-03-15T14:00:00Z (2 PM UTC)
+    const contextNY = await browser.newContext({
+      locale: 'en-US',
+      timezoneId: 'America/New_York', // UTC-5 in March (EST)
+    });
+    const pageNY = await contextNY.newPage();
+    await pageNY.goto('/events/123');
+    // Should display 9:00 AM
+    await expect(pageNY.getByTestId('event-time')).toContainText('9:00 AM');
+    await contextNY.close();
+
+    const contextTokyo = await browser.newContext({
+      locale: 'en-US',
+      timezoneId: 'Asia/Tokyo', // UTC+9
+    });
+    const pageTokyo = await contextTokyo.newPage();
+    await pageTokyo.goto('/events/123');
+    // Should display 11:00 PM
+    await expect(pageTokyo.getByTestId('event-time')).toContainText('11:00 PM');
+    await contextTokyo.close();
+  });
+
+  test('deadline displays correctly across DST boundary', async ({ browser }) => {
+    const context = await browser.newContext({
+      locale: 'en-US',
+      timezoneId: 'America/Los_Angeles',
+    });
+    const page = await context.newPage();
+
+    // Test a deadline that crosses DST (March second Sunday)
+    await page.goto('/tasks?deadline=2025-03-10T07:00:00Z');
+    // Before DST: UTC-8, so 11 PM on March 9
+    await expect(page.getByTestId('deadline')).toContainText('Mar 9');
+
+    await context.close();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('event times adjust to user timezone', async ({ browser }) => {
+  const context = await browser.newContext({
+    locale: 'en-US',
+    timezoneId: 'America/New_York',
+  });
+  const page = await context.newPage();
+  await page.goto('/events/123');
+  await expect(page.getByTestId('event-time')).toContainText('9:00 AM');
+  await context.close();
+});
+```
+
+### Multi-Language Screenshot Comparison
+
+**Use when**: Catching visual layout regressions caused by text expansion, RTL mirroring, or font rendering differences across locales.
+**Avoid when**: Visual regression testing is handled separately and locale is not a layout risk.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const LOCALES_TO_SCREENSHOT = [
+  { locale: 'en-US', name: 'english' },
+  { locale: 'de-DE', name: 'german' },     // German text is ~30% longer than English
+  { locale: 'ja-JP', name: 'japanese' },    // CJK characters, different font metrics
+  { locale: 'ar-SA', name: 'arabic' },      // RTL layout
+];
+
+for (const { locale, name } of LOCALES_TO_SCREENSHOT) {
+  test(`visual snapshot for ${name} (${locale})`, async ({ browser }) => {
+    const context = await browser.newContext({
+      locale,
+      viewport: { width: 1280, height: 720 },
+    });
+    const page = await context.newPage();
+    await page.goto('/');
+
+    // Wait for fonts and images to load
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveScreenshot(`homepage-${name}.png`, {
+      maxDiffPixelRatio: 0.02, // Allow 2% pixel difference for font rendering
+      fullPage: true,
+    });
+
+    await context.close();
+  });
+}
+
+test('long German text does not overflow buttons', async ({ browser }) => {
+  const context = await browser.newContext({ locale: 'de-DE' });
+  const page = await context.newPage();
+  await page.goto('/dashboard');
+
+  // Check that no button has overflowing text
+  const buttons = page.getByRole('button');
+  const count = await buttons.count();
+  for (let i = 0; i < count; i++) {
+    const button = buttons.nth(i);
+    const overflow = await button.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return el.scrollWidth > el.clientWidth && style.overflow !== 'hidden';
+    });
+    if (overflow) {
+      const text = await button.textContent();
+      expect(overflow, `Button "${text}" overflows in German`).toBe(false);
+    }
+  }
+
+  await context.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const LOCALES = [
+  { locale: 'en-US', name: 'english' },
+  { locale: 'de-DE', name: 'german' },
+  { locale: 'ar-SA', name: 'arabic' },
+];
+
+for (const { locale, name } of LOCALES) {
+  test(`visual snapshot for ${name}`, async ({ browser }) => {
+    const context = await browser.newContext({ locale, viewport: { width: 1280, height: 720 } });
+    const page = await context.newPage();
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveScreenshot(`homepage-${name}.png`, {
+      maxDiffPixelRatio: 0.02,
+      fullPage: true,
+    });
+    await context.close();
+  });
+}
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Test locale-dependent formatting | Set `locale` in browser context | Playwright sets `navigator.language` and affects `Intl` APIs |
+| Test app language switcher | Interact with the switcher UI directly | Tests the actual user workflow, not just browser locale |
+| Test timezone rendering | Set `timezoneId` in browser context | Overrides `Date` and `Intl.DateTimeFormat` timezone |
+| Catch text overflow from long translations | Visual regression + bounding box checks | German/Finnish text is 30-40% longer than English |
+| Verify RTL layout | Set Arabic/Hebrew locale + assert `dir="rtl"` | Tests both browser signal and app response |
+| Catch missing translations | Scan page text for key patterns (`{{`, dot notation) | Catches build/deploy issues where translation files are missing |
+| Compare layouts across locales | `toHaveScreenshot` per locale with project-based config | Captures visual differences automatically |
+| Test DST edge cases | Set specific `timezoneId` + known date boundaries | DST boundaries cause the most timezone bugs |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Hardcoding translated text in assertions | Breaks when translations change | Use `getByRole` with `name` regex, or test IDs for locale-independent selection |
+| Testing only `en-US` | Misses RTL, text overflow, and format bugs | Test at least one LTR, one RTL, and one CJK locale |
+| Setting `locale` on the page instead of context | `locale` is a context-level option, not page-level | Set locale when creating the context or in project config |
+| Ignoring text expansion for German/Finnish | Buttons and labels overflow in longer languages | Use visual regression or bounding box assertions |
+| Using `toHaveScreenshot` without `maxDiffPixelRatio` | Font rendering differs slightly across OS/CI | Set `maxDiffPixelRatio: 0.02` or higher for cross-platform tolerance |
+| Testing timezone only in UTC | Masks timezone conversion bugs | Test with at least 3 timezones: UTC-negative, UTC, UTC-positive |
+| Relying on browser locale for app language | Many apps use server-side or cookie-based language | Test via the app's own language switching mechanism |
+| Not testing DST boundaries | Time displayed can be off by 1 hour at transitions | Test dates near DST transitions for your target timezones |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `locale` option has no effect | App ignores `navigator.language` and uses server-side locale | Set locale through the app's own mechanism (cookie, URL param, API) |
+| Date format does not change with locale | App hardcodes date format instead of using `Intl.DateTimeFormat` | This is an app bug to fix, not a test issue |
+| RTL page still renders LTR | App checks locale but does not set `dir="rtl"` | Verify the app's RTL detection logic; may need to set `Accept-Language` header |
+| Visual screenshots fail across OS | Font rendering differs between macOS, Linux, Windows | Run visual tests in Docker for consistency, or increase `maxDiffPixelRatio` |
+| `timezoneId` does not affect page | App uses server time, not client `Date` | Timezone testing only works for client-side date rendering |
+| Translation key appears briefly then disappears | Translation files load asynchronously | Wait for `networkidle` or a specific translated element before asserting |
+| Character encoding issues (garbled text) | Incorrect charset in HTML or missing font | Verify `<meta charset="utf-8">` and that CJK/Arabic fonts are available |
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategies that work across locales
+- [core/configuration.md](configuration.md) -- project-level locale and timezone configuration
+- [core/visual-regression.md](visual-regression.md) -- screenshot comparison fundamentals
+- [core/clock-and-time-mocking.md](clock-and-time-mocking.md) -- mocking time for date-dependent testing
+- [ci/docker-and-containers.md](../ci/docker-and-containers.md) -- consistent font rendering in CI with Docker

--- a/engineering-team/playwright skill/core/iframes-and-shadow-dom.md
+++ b/engineering-team/playwright skill/core/iframes-and-shadow-dom.md
@@ -1,0 +1,488 @@
+# Iframes and Shadow DOM
+
+> **When to use**: When your application embeds content in `<iframe>` elements (payment widgets, third-party embeds, legacy modules) or uses Web Components with Shadow DOM (design systems, custom elements, Salesforce Lightning).
+> **Prerequisites**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Reference
+
+```typescript
+// Iframes — use frameLocator to reach inside
+const frame = page.frameLocator('iframe[title="Payment"]');
+await frame.getByLabel('Card number').fill('4242424242424242');
+
+// Nested iframes — chain frameLocator calls
+const inner = page.frameLocator('#outer').frameLocator('#inner');
+await inner.getByRole('button', { name: 'Submit' }).click();
+
+// Shadow DOM — Playwright pierces open shadow roots automatically
+await page.getByRole('button', { name: 'Toggle' }).click();       // auto-pierces
+await page.locator('my-component').getByText('Hello').click();     // auto-pierces
+```
+
+## Patterns
+
+### Basic iframe Interaction with `frameLocator()`
+
+**Use when**: You need to interact with content inside an `<iframe>` -- payment forms, embedded editors, captchas, third-party widgets.
+**Avoid when**: The content is in the main frame. Never use `frameLocator` for Shadow DOM.
+
+`frameLocator()` returns a locator-like object scoped to the iframe's document. All standard locator methods work inside it.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('complete payment inside Stripe iframe', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Locate the iframe by its title, name, or a CSS selector
+  const paymentFrame = page.frameLocator('iframe[title="Secure payment"]');
+
+  // Use normal locators inside the frame
+  await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+  await paymentFrame.getByLabel('Expiry').fill('12/28');
+  await paymentFrame.getByLabel('CVC').fill('123');
+  await paymentFrame.getByRole('button', { name: 'Pay' }).click();
+
+  // Assertion on content inside the iframe
+  await expect(paymentFrame.getByText('Payment successful')).toBeVisible();
+
+  // Assertion on the parent page (outside the iframe)
+  await expect(page.getByRole('heading', { name: 'Order confirmed' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('complete payment inside Stripe iframe', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const paymentFrame = page.frameLocator('iframe[title="Secure payment"]');
+  await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+  await paymentFrame.getByLabel('Expiry').fill('12/28');
+  await paymentFrame.getByLabel('CVC').fill('123');
+  await paymentFrame.getByRole('button', { name: 'Pay' }).click();
+
+  await expect(paymentFrame.getByText('Payment successful')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Order confirmed' })).toBeVisible();
+});
+```
+
+### Selecting the Right iframe
+
+**Use when**: Multiple iframes exist on the page or the iframe has no obvious identifier.
+**Avoid when**: There is only one iframe and a simple `page.frameLocator('iframe')` works.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('interact with the correct iframe among many', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // By title attribute (best — accessible and stable)
+  const chatFrame = page.frameLocator('iframe[title="Live chat"]');
+
+  // By name attribute
+  const reportFrame = page.frameLocator('iframe[name="analytics-report"]');
+
+  // By src URL pattern
+  const adFrame = page.frameLocator('iframe[src*="ads.example.com"]');
+
+  // By index — when nothing else works (0-indexed)
+  const thirdFrame = page.frameLocator('iframe').nth(2);
+
+  // By parent container — scope to a section first
+  const sidebar = page.getByRole('complementary');
+  const sidebarFrame = sidebar.frameLocator('iframe');
+
+  await chatFrame.getByRole('textbox', { name: 'Message' }).fill('Help');
+  await expect(reportFrame.getByRole('heading')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('interact with the correct iframe among many', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const chatFrame = page.frameLocator('iframe[title="Live chat"]');
+  const reportFrame = page.frameLocator('iframe[name="analytics-report"]');
+  const adFrame = page.frameLocator('iframe[src*="ads.example.com"]');
+  const thirdFrame = page.frameLocator('iframe').nth(2);
+
+  await chatFrame.getByRole('textbox', { name: 'Message' }).fill('Help');
+  await expect(reportFrame.getByRole('heading')).toBeVisible();
+});
+```
+
+### Nested Iframes
+
+**Use when**: An iframe contains another iframe (common in complex widget hierarchies, ad containers, or embedded third-party tools).
+**Avoid when**: There is only one level of iframe nesting.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('interact with deeply nested iframe content', async ({ page }) => {
+  await page.goto('/embed-page');
+
+  // Chain frameLocator calls for each level of nesting
+  const outerFrame = page.frameLocator('#widget-container');
+  const innerFrame = outerFrame.frameLocator('#payment-form');
+
+  await innerFrame.getByLabel('Amount').fill('99.99');
+  await innerFrame.getByRole('button', { name: 'Confirm' }).click();
+
+  // Three levels deep
+  const deepFrame = page
+    .frameLocator('#level-1')
+    .frameLocator('#level-2')
+    .frameLocator('#level-3');
+  await expect(deepFrame.getByText('Success')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('interact with deeply nested iframe content', async ({ page }) => {
+  await page.goto('/embed-page');
+
+  const outerFrame = page.frameLocator('#widget-container');
+  const innerFrame = outerFrame.frameLocator('#payment-form');
+
+  await innerFrame.getByLabel('Amount').fill('99.99');
+  await innerFrame.getByRole('button', { name: 'Confirm' }).click();
+
+  const deepFrame = page
+    .frameLocator('#level-1')
+    .frameLocator('#level-2')
+    .frameLocator('#level-3');
+  await expect(deepFrame.getByText('Success')).toBeVisible();
+});
+```
+
+### Cross-Origin Iframes
+
+**Use when**: The iframe loads content from a different domain (payment providers, OAuth flows, third-party embeds).
+**Avoid when**: The iframe is same-origin.
+
+Playwright handles cross-origin iframes transparently. `frameLocator()` works regardless of origin. No special configuration is needed.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('complete OAuth login in cross-origin iframe', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+
+  // The OAuth provider renders in a cross-origin iframe or popup
+  // For iframes:
+  const oauthFrame = page.frameLocator('iframe[src*="accounts.google.com"]');
+  await oauthFrame.getByLabel('Email').fill('user@gmail.com');
+  await oauthFrame.getByRole('button', { name: 'Next' }).click();
+});
+
+test('cross-origin payment widget', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Stripe, PayPal, etc. load in cross-origin iframes
+  const stripeFrame = page.frameLocator('iframe[src*="js.stripe.com"]');
+
+  // All locator methods work across origins
+  await stripeFrame.getByLabel('Card number').fill('4242424242424242');
+  await stripeFrame.getByLabel('MM / YY').fill('12 / 28');
+  await stripeFrame.getByLabel('CVC').fill('123');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('cross-origin payment widget', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const stripeFrame = page.frameLocator('iframe[src*="js.stripe.com"]');
+  await stripeFrame.getByLabel('Card number').fill('4242424242424242');
+  await stripeFrame.getByLabel('MM / YY').fill('12 / 28');
+  await stripeFrame.getByLabel('CVC').fill('123');
+});
+```
+
+### Using the Frame API for Advanced Scenarios
+
+**Use when**: You need to access the frame's URL, wait for frame navigation, or run `evaluate` inside the frame.
+**Avoid when**: `frameLocator()` covers your needs. It is simpler and auto-waits.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('use Frame API for URL checks and evaluate', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Get the Frame object (not FrameLocator)
+  const frame = page.frame({ url: /analytics\.example\.com/ });
+  expect(frame).not.toBeNull();
+
+  // Check the frame's URL
+  expect(frame!.url()).toContain('analytics.example.com');
+
+  // Run JavaScript inside the frame
+  const title = await frame!.evaluate(() => document.title);
+  expect(title).toBe('Analytics Dashboard');
+
+  // Wait for a frame to navigate
+  const frameNavPromise = page.waitForEvent('framenavigated', {
+    predicate: (f) => f.url().includes('/reports'),
+  });
+  await page.frameLocator('iframe[name="analytics"]')
+    .getByRole('link', { name: 'Reports' }).click();
+  await frameNavPromise;
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('use Frame API for URL checks and evaluate', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const frame = page.frame({ url: /analytics\.example\.com/ });
+  expect(frame).not.toBeNull();
+
+  expect(frame.url()).toContain('analytics.example.com');
+
+  const title = await frame.evaluate(() => document.title);
+  expect(title).toBe('Analytics Dashboard');
+});
+```
+
+### Shadow DOM -- Automatic Piercing
+
+**Use when**: Your app uses Web Components with open Shadow DOM. This is the default behavior -- no special configuration needed.
+**Avoid when**: The shadow root is closed (see workaround below).
+
+Playwright's `locator()`, `getByRole()`, `getByText()`, and all semantic locators pierce open Shadow DOM by default.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('interact with web components using Shadow DOM', async ({ page }) => {
+  await page.goto('/design-system-demo');
+
+  // getByRole pierces shadow roots automatically
+  await page.getByRole('button', { name: 'Open menu' }).click();
+
+  // locator() with CSS also pierces
+  await page.locator('my-dropdown').getByRole('option', { name: 'Settings' }).click();
+
+  // Nested web components — each shadow root is pierced
+  await page
+    .locator('my-app')
+    .locator('my-sidebar')
+    .getByRole('link', { name: 'Dashboard' })
+    .click();
+
+  // Assertions pierce too
+  await expect(page.locator('my-card').getByText('Welcome back')).toBeVisible();
+
+  // getByTestId pierces shadow DOM
+  await expect(page.getByTestId('user-avatar')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('interact with web components using Shadow DOM', async ({ page }) => {
+  await page.goto('/design-system-demo');
+
+  await page.getByRole('button', { name: 'Open menu' }).click();
+  await page.locator('my-dropdown').getByRole('option', { name: 'Settings' }).click();
+
+  await page
+    .locator('my-app')
+    .locator('my-sidebar')
+    .getByRole('link', { name: 'Dashboard' })
+    .click();
+
+  await expect(page.locator('my-card').getByText('Welcome back')).toBeVisible();
+});
+```
+
+### Closed Shadow DOM Workaround
+
+**Use when**: A third-party component uses `attachShadow({ mode: 'closed' })`, which blocks Playwright's auto-piercing.
+**Avoid when**: The shadow root is open (the default). Auto-piercing handles open roots.
+
+Override `attachShadow` before the page loads to force open mode.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('access closed shadow DOM by forcing open mode', async ({ page }) => {
+  // Intercept attachShadow before the page scripts run
+  await page.addInitScript(() => {
+    const originalAttachShadow = Element.prototype.attachShadow;
+    Element.prototype.attachShadow = function (init: ShadowRootInit) {
+      return originalAttachShadow.call(this, { ...init, mode: 'open' });
+    };
+  });
+
+  await page.goto('/third-party-widget');
+
+  // Now the previously closed shadow root is accessible
+  await page.locator('closed-component').getByRole('button', { name: 'Action' }).click();
+  await expect(page.locator('closed-component').getByText('Done')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('access closed shadow DOM by forcing open mode', async ({ page }) => {
+  await page.addInitScript(() => {
+    const originalAttachShadow = Element.prototype.attachShadow;
+    Element.prototype.attachShadow = function (init) {
+      return originalAttachShadow.call(this, { ...init, mode: 'open' });
+    };
+  });
+
+  await page.goto('/third-party-widget');
+
+  await page.locator('closed-component').getByRole('button', { name: 'Action' }).click();
+  await expect(page.locator('closed-component').getByText('Done')).toBeVisible();
+});
+```
+
+### Web Components with Slots and Custom Events
+
+**Use when**: Testing web components that use `<slot>` for content projection or dispatch custom events.
+**Avoid when**: The component does not use slots or custom events.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('slotted content is visible through web component', async ({ page }) => {
+  await page.goto('/components-demo');
+
+  // Content projected into a <slot> is in the light DOM (not shadow)
+  // Playwright sees it at its original location
+  const card = page.locator('my-card');
+  await expect(card.getByRole('heading', { name: 'Product Title' })).toBeVisible();
+  await expect(card.getByText('Product description here')).toBeVisible();
+});
+
+test('listen for custom events from web components', async ({ page }) => {
+  await page.goto('/components-demo');
+
+  // Set up a listener for a custom event
+  const eventPromise = page.evaluate(() => {
+    return new Promise<{ detail: unknown }>((resolve) => {
+      document.querySelector('my-color-picker')!.addEventListener(
+        'color-change',
+        (e: Event) => resolve({ detail: (e as CustomEvent).detail }),
+        { once: true }
+      );
+    });
+  });
+
+  // Trigger the event by interacting with the component
+  await page.locator('my-color-picker').getByRole('button', { name: 'Red' }).click();
+
+  const event = await eventPromise;
+  expect(event.detail).toEqual({ color: '#ff0000' });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('slotted content is visible through web component', async ({ page }) => {
+  await page.goto('/components-demo');
+
+  const card = page.locator('my-card');
+  await expect(card.getByRole('heading', { name: 'Product Title' })).toBeVisible();
+  await expect(card.getByText('Product description here')).toBeVisible();
+});
+
+test('listen for custom events from web components', async ({ page }) => {
+  await page.goto('/components-demo');
+
+  const eventPromise = page.evaluate(() => {
+    return new Promise((resolve) => {
+      document.querySelector('my-color-picker').addEventListener(
+        'color-change',
+        (e) => resolve({ detail: e.detail }),
+        { once: true }
+      );
+    });
+  });
+
+  await page.locator('my-color-picker').getByRole('button', { name: 'Red' }).click();
+
+  const event = await eventPromise;
+  expect(event.detail).toEqual({ color: '#ff0000' });
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Content inside `<iframe>` | `page.frameLocator('selector')` | Returns a scoped locator for the iframe document |
+| Multiple iframes on page | Use `title`, `name`, or `src` attribute selectors | More stable than index-based `nth()` |
+| Nested iframes | Chain `frameLocator().frameLocator()` | Each call scopes one level deeper |
+| Cross-origin iframe | Same as any iframe -- `frameLocator()` | Playwright handles cross-origin transparently |
+| URL check or `evaluate` inside frame | `page.frame({ url })` (Frame API) | FrameLocator does not expose URL or evaluate |
+| Open Shadow DOM | Standard locators -- no changes needed | Playwright pierces open shadow roots by default |
+| Closed Shadow DOM | `addInitScript` to override `attachShadow` | Forces closed roots to open before page loads |
+| Slotted content in Web Components | Locate within the custom element tag | Slotted content is light DOM, accessible normally |
+| Non-piercing CSS (rare) | `css:light=selector` | Explicitly restricts to light DOM only |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.locator('#element-inside-iframe')` | Locators do not cross iframe boundaries | `page.frameLocator('iframe').locator('#element')` |
+| `page.frameLocator('iframe').frameLocator('iframe')` without specific selectors | Matches wrong iframes when multiple exist | Use specific attributes: `frameLocator('iframe[title="..."]')` |
+| `page.$('>>> .shadow-element')` | `>>>` piercing selector is not standard in Playwright | Use `page.locator('host-element').getByRole(...)` -- auto-piercing works |
+| Using `contentFrame()` on a locator for routine interactions | More complex API than `frameLocator` for simple cases | Use `frameLocator()` -- simpler, auto-waits |
+| `page.evaluate` to query inside shadow DOM | Bypasses Playwright's auto-waiting and retry logic | Use `page.locator()` which auto-pierces |
+| Hardcoding iframe index (`nth(0)`) when attributes are available | Index changes when iframes are added/removed | Use `title`, `name`, or `src` pattern |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Locator times out inside iframe | Using `page.locator()` instead of `frameLocator().locator()` | Switch to `page.frameLocator('selector').locator(...)` |
+| `frameLocator` returns no elements | Iframe not yet loaded when locator resolves | `frameLocator` auto-waits; check that the iframe selector matches |
+| Cross-origin iframe content inaccessible | Rare: specific browser security policy | Playwright handles cross-origin; ensure you are not using `page.frame()` with wrong URL |
+| Shadow DOM element not found with `locator()` | Shadow root is closed (`mode: 'closed'`) | Use `addInitScript` to override `attachShadow` to force open mode |
+| `getByRole` finds elements from wrong shadow root | Multiple web components have elements with the same role and name | Scope the locator: `page.locator('my-specific-component').getByRole(...)` |
+| Slotted content not found | Searching inside shadow root instead of light DOM | Slotted content stays in light DOM; locate it through the parent custom element |
+| `frame.evaluate()` returns null | Frame navigated away or was removed from DOM | Re-acquire the frame reference after navigation |
+
+## Related
+
+- [core/locators.md](locators.md) -- locator fundamentals including frame and shadow DOM basics
+- [core/browser-apis.md](browser-apis.md) -- testing browser APIs that may live inside iframes
+- [core/canvas-and-webgl.md](canvas-and-webgl.md) -- canvas elements inside iframes or web components
+- [core/debugging.md](debugging.md) -- using Playwright Inspector to identify iframe boundaries and shadow roots

--- a/engineering-team/playwright skill/core/locator-strategy.md
+++ b/engineering-team/playwright skill/core/locator-strategy.md
@@ -1,0 +1,586 @@
+# Choosing a Locator Strategy
+
+> **When to use**: When deciding which Playwright locator method to use for an element
+
+## Quick Answer
+
+Use `getByRole()` for everything that has a semantic HTML role (buttons, links, headings, form fields, dialogs). Fall back to `getByLabel()` for form fields, `getByText()` for plain content, and `getByTestId()` only as a last resort for custom components with no accessible role.
+
+## Decision Flowchart
+
+```
+Start: You need to locate an element
+  |
+  v
+Does the element have a semantic role?
+(button, link, heading, textbox, checkbox, combobox, dialog, img, row, cell, navigation...)
+  |
+  +-- YES --> Use getByRole('role', { name: 'accessible name' })
+  |             |
+  |             +-- Need to narrow scope? Chain from a parent role locator:
+  |                   getByRole('navigation').getByRole('link', { name: '...' })
+  |
+  +-- NO
+       |
+       v
+     Is it a form field with a visible <label>?
+       |
+       +-- YES --> Use getByLabel('label text')
+       |
+       +-- NO
+            |
+            v
+          Is it static text content (paragraph, span, div with text)?
+            |
+            +-- YES --> Use getByText('text content')
+            |             Prefer { exact: true } when text is short or common
+            |
+            +-- NO
+                 |
+                 v
+               Does it have a placeholder?
+                 |
+                 +-- YES --> Use getByPlaceholder('placeholder text')
+                 |             (Less preferred -- placeholders disappear on input)
+                 |
+                 +-- NO
+                      |
+                      v
+                    Does it have a title attribute or alt text?
+                      |
+                      +-- YES --> Use getByTitle('...') or getByAltText('...')
+                      |
+                      +-- NO
+                           |
+                           v
+                         Add data-testid="..." to the markup
+                         Use getByTestId('identifier')
+                         |
+                         +--> NEVER fall back to CSS selectors or XPath.
+                              Fix the markup instead.
+```
+
+## Decision Matrix
+
+| Element Type | Recommended Locator | Fallback | Example |
+|---|---|---|---|
+| Button | `getByRole('button', { name })` | `getByText()` if role missing | `getByRole('button', { name: 'Submit' })` |
+| Link | `getByRole('link', { name })` | `getByText()` for anchor text | `getByRole('link', { name: 'Sign up' })` |
+| Text input | `getByLabel('...')` | `getByRole('textbox', { name })` | `getByLabel('Email address')` |
+| Checkbox | `getByRole('checkbox', { name })` | `getByLabel()` | `getByRole('checkbox', { name: 'Accept terms' })` |
+| Radio button | `getByRole('radio', { name })` | `getByLabel()` | `getByRole('radio', { name: 'Express shipping' })` |
+| Dropdown / Select | `getByRole('combobox', { name })` | `getByLabel()` | `getByLabel('Country')` |
+| Heading | `getByRole('heading', { name, level })` | `getByText()` | `getByRole('heading', { name: 'Dashboard', level: 1 })` |
+| Nav link | chain: `getByRole('navigation').getByRole('link', { name })` | scope with `locator('nav')` | see detailed example below |
+| Table cell | chain: `getByRole('row').filter().getByRole('cell')` | `locator('td')` scoped | see detailed example below |
+| Image | `getByRole('img', { name })` | `getByAltText()` | `getByRole('img', { name: 'Company logo' })` |
+| Modal / Dialog | `getByRole('dialog')` then chain within | `locator('[role="dialog"]')` | `getByRole('dialog').getByRole('button', { name: 'Confirm' })` |
+| Dynamic list item | `.filter({ hasText })` or `.filter({ has })` | `nth()` as last resort | `getByRole('listitem').filter({ hasText: 'Milk' })` |
+| Custom component | `getByTestId('...')` | Add `data-testid` to markup | `getByTestId('color-picker')` |
+
+## Detailed Analysis
+
+### Tier 1: `getByRole()` -- Use by Default
+
+The strongest locator. It mirrors how assistive technology and real users perceive the page.
+
+**Pros**
+- Resilient to markup refactors (class names, tag changes)
+- Enforces accessible markup -- if the locator breaks, your accessibility broke too
+- Works across frameworks (React, Vue, Angular, plain HTML)
+- Supports filtering by `name`, `level`, `checked`, `pressed`, `expanded`, `selected`
+
+**Cons**
+- Requires the element to have a valid ARIA role (implicit or explicit)
+- Can match multiple elements when names are duplicated -- scope with chaining
+
+**When it fails**: Custom components with `<div>` soup and no ARIA roles. Fix the component first; add `getByTestId()` only if you cannot change the markup.
+
+---
+
+### Tier 2: `getByLabel()` -- Form Fields
+
+Queries by the associated `<label>` text. This is often the most readable locator for form fields.
+
+**Pros**
+- Extremely readable: `getByLabel('Password')` tells you exactly what field
+- Works with `<label for="...">`, wrapping `<label>`, and `aria-labelledby`
+
+**Cons**
+- Only works for form elements with labels
+- Breaks if someone changes label text (but that is usually intentional)
+
+**Use over `getByRole('textbox')`** when the label text is clear and unique. Use `getByRole()` when you need to differentiate between multiple fields with similar labels by role type.
+
+---
+
+### Tier 3: `getByText()` -- Static Content
+
+Finds elements by their visible text content.
+
+**Pros**
+- Intuitive for non-interactive text (paragraphs, spans, badges, status messages)
+- Supports exact and substring matching
+
+**Cons**
+- Fragile if text is dynamic, translated, or duplicated
+- Can match parent elements unintentionally -- use `{ exact: true }` or scope the query
+
+**Rule of thumb**: Use `getByText()` for assertions and content verification, not for interactive elements. Interactive elements should use `getByRole()`.
+
+---
+
+### Tier 4: `getByPlaceholder()` -- Inputs Without Labels
+
+Locates by placeholder attribute value.
+
+**Pros**
+- Works when labels are missing (search bars, minimal UIs)
+
+**Cons**
+- Placeholders disappear when the user types -- poor UX foundation
+- Signals missing accessibility (no label)
+
+**Treat as a yellow flag**: If you use this, consider filing a ticket to add a proper label.
+
+---
+
+### Tier 5: `getByTestId()` -- Last Resort
+
+Locates by `data-testid` attribute.
+
+**Pros**
+- Fully decoupled from user-facing text and structure
+- Stable under UI redesigns
+
+**Cons**
+- Invisible to users and assistive technology
+- Pollutes production markup (unless stripped in build)
+- Tells you nothing about what the element looks like or does
+
+**Use only when**: The component has no semantic role, no label, no text, and you cannot change the markup. Common cases: canvas elements, third-party widgets, complex custom components.
+
+---
+
+### Never Use: Raw CSS Selectors or XPath
+
+```
+// DO NOT do this
+page.locator('.btn-primary');           // class names change
+page.locator('#submit-btn');            // IDs are brittle
+page.locator('div > span:nth-child(2)'); // structure changes break this
+page.locator('xpath=//div[@class="foo"]'); // unreadable, fragile
+```
+
+If you are reaching for a CSS selector, stop. Walk back up the flowchart and find a semantic locator. If none exists, add `data-testid`.
+
+## Real-World Examples
+
+### 1. Buttons
+
+```typescript
+// TypeScript
+// Standard button
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Icon-only button (uses aria-label)
+await page.getByRole('button', { name: 'Close' }).click();
+
+// Button inside a specific section
+await page.getByRole('region', { name: 'Billing' })
+  .getByRole('button', { name: 'Update' }).click();
+```
+
+```javascript
+// JavaScript
+// Standard button
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Icon-only button (uses aria-label)
+await page.getByRole('button', { name: 'Close' }).click();
+
+// Button inside a specific section
+await page.getByRole('region', { name: 'Billing' })
+  .getByRole('button', { name: 'Update' }).click();
+```
+
+---
+
+### 2. Links
+
+```typescript
+// TypeScript
+// Standard link
+await page.getByRole('link', { name: 'Sign up' }).click();
+
+// Link inside navigation
+await page.getByRole('navigation')
+  .getByRole('link', { name: 'Pricing' }).click();
+
+// Link with exact match (avoid partial hits)
+await page.getByRole('link', { name: 'Log in', exact: true }).click();
+```
+
+```javascript
+// JavaScript
+await page.getByRole('link', { name: 'Sign up' }).click();
+
+await page.getByRole('navigation')
+  .getByRole('link', { name: 'Pricing' }).click();
+
+await page.getByRole('link', { name: 'Log in', exact: true }).click();
+```
+
+---
+
+### 3. Text Inputs
+
+```typescript
+// TypeScript
+// Input with a visible label -- preferred
+await page.getByLabel('Email address').fill('user@example.com');
+
+// When multiple textboxes exist and you need role specificity
+await page.getByRole('textbox', { name: 'Email address' }).fill('user@example.com');
+
+// Textarea
+await page.getByLabel('Message').fill('Hello, world');
+
+// Search input (role = searchbox)
+await page.getByRole('searchbox', { name: 'Search' }).fill('playwright');
+```
+
+```javascript
+// JavaScript
+await page.getByLabel('Email address').fill('user@example.com');
+
+await page.getByRole('textbox', { name: 'Email address' }).fill('user@example.com');
+
+await page.getByLabel('Message').fill('Hello, world');
+
+await page.getByRole('searchbox', { name: 'Search' }).fill('playwright');
+```
+
+---
+
+### 4. Checkboxes and Radios
+
+```typescript
+// TypeScript
+// Checkbox
+await page.getByRole('checkbox', { name: 'Accept terms' }).check();
+
+// Verify checked state
+await expect(page.getByRole('checkbox', { name: 'Accept terms' })).toBeChecked();
+
+// Radio button
+await page.getByRole('radio', { name: 'Express shipping' }).check();
+
+// Radio within a group (fieldset with legend)
+await page.getByRole('group', { name: 'Shipping method' })
+  .getByRole('radio', { name: 'Express' }).check();
+```
+
+```javascript
+// JavaScript
+await page.getByRole('checkbox', { name: 'Accept terms' }).check();
+
+await expect(page.getByRole('checkbox', { name: 'Accept terms' })).toBeChecked();
+
+await page.getByRole('radio', { name: 'Express shipping' }).check();
+
+await page.getByRole('group', { name: 'Shipping method' })
+  .getByRole('radio', { name: 'Express' }).check();
+```
+
+---
+
+### 5. Dropdowns and Selects
+
+```typescript
+// TypeScript
+// Native <select> element
+await page.getByLabel('Country').selectOption('Canada');
+
+// Custom combobox (ARIA combobox role)
+await page.getByRole('combobox', { name: 'Country' }).click();
+await page.getByRole('option', { name: 'Canada' }).click();
+
+// Listbox pattern
+await page.getByRole('combobox', { name: 'Font size' }).click();
+await page.getByRole('listbox').getByRole('option', { name: '16px' }).click();
+```
+
+```javascript
+// JavaScript
+await page.getByLabel('Country').selectOption('Canada');
+
+await page.getByRole('combobox', { name: 'Country' }).click();
+await page.getByRole('option', { name: 'Canada' }).click();
+
+await page.getByRole('combobox', { name: 'Font size' }).click();
+await page.getByRole('listbox').getByRole('option', { name: '16px' }).click();
+```
+
+---
+
+### 6. Headings
+
+```typescript
+// TypeScript
+// Specific heading level
+await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+// Any heading with that name (when level does not matter)
+await expect(page.getByRole('heading', { name: 'Recent activity' })).toBeVisible();
+
+// Heading within a section
+await page.getByRole('region', { name: 'Sidebar' })
+  .getByRole('heading', { name: 'Categories' });
+```
+
+```javascript
+// JavaScript
+await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+await expect(page.getByRole('heading', { name: 'Recent activity' })).toBeVisible();
+
+await page.getByRole('region', { name: 'Sidebar' })
+  .getByRole('heading', { name: 'Categories' });
+```
+
+---
+
+### 7. Navigation Items
+
+```typescript
+// TypeScript
+// Link inside the main nav
+await page.getByRole('navigation')
+  .getByRole('link', { name: 'Pricing' }).click();
+
+// When there are multiple navs, narrow by aria-label
+await page.getByRole('navigation', { name: 'Main menu' })
+  .getByRole('link', { name: 'Pricing' }).click();
+
+// Breadcrumb navigation
+await page.getByRole('navigation', { name: 'Breadcrumb' })
+  .getByRole('link', { name: 'Products' }).click();
+```
+
+```javascript
+// JavaScript
+await page.getByRole('navigation')
+  .getByRole('link', { name: 'Pricing' }).click();
+
+await page.getByRole('navigation', { name: 'Main menu' })
+  .getByRole('link', { name: 'Pricing' }).click();
+
+await page.getByRole('navigation', { name: 'Breadcrumb' })
+  .getByRole('link', { name: 'Products' }).click();
+```
+
+---
+
+### 8. Table Cells
+
+```typescript
+// TypeScript
+// Find a cell in a specific row
+await page.getByRole('row', { name: /Jane Smith/ })
+  .getByRole('cell', { name: '$120.00' });
+
+// Click an action button in a specific row
+await page.getByRole('row', { name: /Jane Smith/ })
+  .getByRole('button', { name: 'Edit' }).click();
+
+// Filter rows using .filter() for complex matching
+const row = page.getByRole('row').filter({ hasText: 'Pending' });
+await row.getByRole('button', { name: 'Approve' }).click();
+
+// Verify table header exists
+await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+```
+
+```javascript
+// JavaScript
+await page.getByRole('row', { name: /Jane Smith/ })
+  .getByRole('cell', { name: '$120.00' });
+
+await page.getByRole('row', { name: /Jane Smith/ })
+  .getByRole('button', { name: 'Edit' }).click();
+
+const row = page.getByRole('row').filter({ hasText: 'Pending' });
+await row.getByRole('button', { name: 'Approve' }).click();
+
+await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+```
+
+---
+
+### 9. Images
+
+```typescript
+// TypeScript
+// Image with alt text
+await expect(page.getByRole('img', { name: 'Company logo' })).toBeVisible();
+
+// Alternative: getByAltText (same result, less preferred)
+await expect(page.getByAltText('Company logo')).toBeVisible();
+
+// Avatar image inside a card
+await page.locator('article').filter({ hasText: 'Jane Smith' })
+  .getByRole('img', { name: "Jane Smith's avatar" });
+```
+
+```javascript
+// JavaScript
+await expect(page.getByRole('img', { name: 'Company logo' })).toBeVisible();
+
+await expect(page.getByAltText('Company logo')).toBeVisible();
+
+await page.locator('article').filter({ hasText: 'Jane Smith' })
+  .getByRole('img', { name: "Jane Smith's avatar" });
+```
+
+---
+
+### 10. Custom Components (No ARIA Role)
+
+```typescript
+// TypeScript
+// Third-party color picker with no semantic role
+await page.getByTestId('color-picker').click();
+
+// Custom drag-and-drop zone
+await page.getByTestId('drop-zone').dispatchEvent('drop', { dataTransfer });
+
+// Canvas-based chart
+const chart = page.getByTestId('revenue-chart');
+await expect(chart).toBeVisible();
+```
+
+```javascript
+// JavaScript
+await page.getByTestId('color-picker').click();
+
+await page.getByTestId('drop-zone').dispatchEvent('drop', { dataTransfer });
+
+const chart = page.getByTestId('revenue-chart');
+await expect(chart).toBeVisible();
+```
+
+**Before reaching for `getByTestId`, ask yourself**: Can I add `role` and `aria-label` to this component instead? If yes, do that and use `getByRole()`.
+
+---
+
+### 11. Dynamic Lists
+
+```typescript
+// TypeScript
+// Filter a list item by text
+const item = page.getByRole('listitem').filter({ hasText: 'Milk' });
+await item.getByRole('button', { name: 'Remove' }).click();
+
+// Filter by a child locator
+const card = page.locator('.product-card').filter({
+  has: page.getByText('Out of stock'),
+});
+await expect(card).toHaveCount(3);
+
+// Count items in a list
+await expect(page.getByRole('listitem')).toHaveCount(5);
+
+// Iterate over list items for complex assertions
+for (const item of await page.getByRole('listitem').all()) {
+  await expect(item).toContainText('$');
+}
+```
+
+```javascript
+// JavaScript
+const item = page.getByRole('listitem').filter({ hasText: 'Milk' });
+await item.getByRole('button', { name: 'Remove' }).click();
+
+const card = page.locator('.product-card').filter({
+  has: page.getByText('Out of stock'),
+});
+await expect(card).toHaveCount(3);
+
+await expect(page.getByRole('listitem')).toHaveCount(5);
+
+for (const item of await page.getByRole('listitem').all()) {
+  await expect(item).toContainText('$');
+}
+```
+
+---
+
+### 12. Modals and Dialogs
+
+```typescript
+// TypeScript
+// Wait for dialog to appear, then interact within it
+const dialog = page.getByRole('dialog', { name: 'Confirm deletion' });
+await expect(dialog).toBeVisible();
+await dialog.getByRole('button', { name: 'Delete' }).click();
+
+// Fill a form inside a dialog
+const modal = page.getByRole('dialog', { name: 'Edit profile' });
+await modal.getByLabel('Display name').fill('Jane');
+await modal.getByRole('button', { name: 'Save' }).click();
+
+// Verify dialog closed
+await expect(dialog).toBeHidden();
+```
+
+```javascript
+// JavaScript
+const dialog = page.getByRole('dialog', { name: 'Confirm deletion' });
+await expect(dialog).toBeVisible();
+await dialog.getByRole('button', { name: 'Delete' }).click();
+
+const modal = page.getByRole('dialog', { name: 'Edit profile' });
+await modal.getByLabel('Display name').fill('Jane');
+await modal.getByRole('button', { name: 'Save' }).click();
+
+await expect(dialog).toBeHidden();
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It Fails | Use Instead |
+|---|---|---|
+| `page.locator('.btn-primary')` | Class names change during refactors and redesigns | `getByRole('button', { name: '...' })` |
+| `page.locator('#email-input')` | IDs are implementation details, not user-visible | `getByLabel('Email')` |
+| `page.locator('div > form > input:first-child')` | Any structural change breaks the selector | `getByLabel('...')` or `getByRole('textbox', { name: '...' })` |
+| `page.locator('[data-testid="submit"]')` | Raw CSS for test IDs -- use the built-in method | `getByTestId('submit')` |
+| `page.getByText('Submit')` for a button | Matches any element with that text, not just the button | `getByRole('button', { name: 'Submit' })` |
+| `page.locator('button').nth(2)` | Index-based -- breaks when order changes | `getByRole('button', { name: '...' })` |
+
+## Scoping Strategy: When Multiple Elements Match
+
+When a locator matches more than one element, narrow scope rather than using `nth()`:
+
+```typescript
+// BAD: fragile index
+page.getByRole('button', { name: 'Edit' }).nth(0);
+
+// GOOD: scope to a parent section
+page.getByRole('region', { name: 'Billing' })
+  .getByRole('button', { name: 'Edit' });
+
+// GOOD: scope to a table row
+page.getByRole('row', { name: /Order #1234/ })
+  .getByRole('button', { name: 'Edit' });
+
+// GOOD: scope with filter
+page.locator('article').filter({ hasText: 'Draft' })
+  .getByRole('button', { name: 'Edit' });
+```
+
+## Related
+
+- [Playwright Locators documentation](https://playwright.dev/docs/locators)
+- [Playwright Best Practices](https://playwright.dev/docs/best-practices)
+- [ARIA Roles reference (MDN)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)

--- a/engineering-team/playwright skill/core/locators.md
+++ b/engineering-team/playwright skill/core/locators.md
@@ -1,0 +1,634 @@
+# Locators
+
+> **When to use**: Every time you need to find an element on the page. Start here before reaching for CSS or XPath.
+> **Prerequisites**: [core/configuration.md](configuration.md)
+
+## Quick Reference
+
+```typescript
+// Priority order — use the first one that works:
+page.getByRole('button', { name: 'Submit' })        // 1. Role (default)
+page.getByLabel('Email address')                     // 2. Label (form fields)
+page.getByText('Welcome back')                       // 3. Text (non-interactive)
+page.getByPlaceholder('Search...')                    // 4. Placeholder
+page.getByAltText('Company logo')                    // 5. Alt text (images)
+page.getByTitle('Close dialog')                      // 6. Title attribute
+page.getByTestId('checkout-summary')                 // 7. Test ID (last semantic option)
+page.locator('css=.legacy-widget >> internal:role=button') // 8. CSS/XPath (last resort)
+```
+
+## Patterns
+
+### Role-Based Locators (Default Choice)
+
+**Use when**: Always. This is your starting point for every element.
+**Avoid when**: The element has no ARIA role and adding one is outside your control.
+
+Role-based locators mirror how assistive technology sees your page. They survive refactors, class renames, and component library swaps.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('role-based locators cover most UI elements', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Buttons — matches <button>, <input type="submit">, role="button"
+  await page.getByRole('button', { name: 'Save changes' }).click();
+
+  // Links — matches <a href>
+  await page.getByRole('link', { name: 'View profile' }).click();
+
+  // Headings — use level to target specific h1-h6
+  await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+  // Text inputs — match by accessible name (label association)
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+  // Checkboxes and radios
+  await page.getByRole('checkbox', { name: 'Remember me' }).check();
+  await page.getByRole('radio', { name: 'Monthly billing' }).click();
+
+  // Dropdowns — <select> elements
+  await page.getByRole('combobox', { name: 'Country' }).selectOption('US');
+
+  // Navigation landmarks
+  const nav = page.getByRole('navigation', { name: 'Main' });
+  await expect(nav.getByRole('link', { name: 'Settings' })).toBeVisible();
+
+  // Tables
+  const table = page.getByRole('table', { name: 'Recent orders' });
+  await expect(table.getByRole('row')).toHaveCount(5);
+
+  // Dialogs
+  const dialog = page.getByRole('dialog', { name: 'Confirm deletion' });
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  // Exact matching — prevents "Log" from matching "Log out"
+  await page.getByRole('button', { name: 'Log', exact: true }).click();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('role-based locators cover most UI elements', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await page.getByRole('button', { name: 'Save changes' }).click();
+  await page.getByRole('link', { name: 'View profile' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('checkbox', { name: 'Remember me' }).check();
+  await page.getByRole('radio', { name: 'Monthly billing' }).click();
+  await page.getByRole('combobox', { name: 'Country' }).selectOption('US');
+
+  const nav = page.getByRole('navigation', { name: 'Main' });
+  await expect(nav.getByRole('link', { name: 'Settings' })).toBeVisible();
+
+  const dialog = page.getByRole('dialog', { name: 'Confirm deletion' });
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+
+  await page.getByRole('button', { name: 'Log', exact: true }).click();
+});
+```
+
+### Label-Based Locators
+
+**Use when**: Targeting form fields that have associated `<label>` elements or `aria-label`.
+**Avoid when**: The element is not a form control. Use `getByRole` with the accessible name instead — it covers labels too.
+
+`getByLabel` is a shortcut for form fields. It matches `<label for="">`, wrapping `<label>`, and `aria-label` / `aria-labelledby`.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('fill a registration form using labels', async ({ page }) => {
+  await page.goto('/register');
+
+  await page.getByLabel('First name').fill('Jane');
+  await page.getByLabel('Last name').fill('Doe');
+  await page.getByLabel('Email address').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('s3cure!Pass');
+  await page.getByLabel('Confirm password').fill('s3cure!Pass');
+  await page.getByLabel('I agree to the terms').check();
+
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('fill a registration form using labels', async ({ page }) => {
+  await page.goto('/register');
+
+  await page.getByLabel('First name').fill('Jane');
+  await page.getByLabel('Last name').fill('Doe');
+  await page.getByLabel('Email address').fill('jane@example.com');
+  await page.getByLabel('Password', { exact: true }).fill('s3cure!Pass');
+  await page.getByLabel('Confirm password').fill('s3cure!Pass');
+  await page.getByLabel('I agree to the terms').check();
+
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+});
+```
+
+### Text-Based Locators
+
+**Use when**: Targeting non-interactive content — status messages, paragraphs, banners, labels outside forms.
+**Avoid when**: The element is a button, link, heading, or form field. Use `getByRole` instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('verify text content on the page', async ({ page }) => {
+  await page.goto('/order/confirmation');
+
+  // Substring match (default)
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+
+  // Exact match — use when substring hits multiple elements
+  await expect(page.getByText('Order #12345', { exact: true })).toBeVisible();
+
+  // Regex match — for dynamic content patterns
+  await expect(page.getByText(/Order #\d+/)).toBeVisible();
+
+  // DO NOT use getByText for buttons or links:
+  // Bad:  page.getByText('Submit')
+  // Good: page.getByRole('button', { name: 'Submit' })
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('verify text content on the page', async ({ page }) => {
+  await page.goto('/order/confirmation');
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+  await expect(page.getByText('Order #12345', { exact: true })).toBeVisible();
+  await expect(page.getByText(/Order #\d+/)).toBeVisible();
+});
+```
+
+### Test ID Locators
+
+**Use when**: No semantic locator works — the element has no accessible role, label, or stable text. Common with custom canvas-rendered components, complex data grids, or third-party widgets.
+**Avoid when**: Any semantic locator (`getByRole`, `getByLabel`, `getByText`) can identify the element. Test IDs are invisible to users and assistive technology.
+
+Configure the attribute name once in `playwright.config`:
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    testIdAttribute: 'data-testid', // default; change to match your codebase
+  },
+});
+```
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('interact with a custom widget using test IDs', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // Only when the chart component exposes no accessible roles
+  const chart = page.getByTestId('revenue-chart');
+  await expect(chart).toBeVisible();
+  await chart.click({ position: { x: 150, y: 75 } });
+
+  await expect(page.getByTestId('chart-tooltip')).toContainText('$12,400');
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    testIdAttribute: 'data-testid',
+  },
+});
+```
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('interact with a custom widget using test IDs', async ({ page }) => {
+  await page.goto('/analytics');
+
+  const chart = page.getByTestId('revenue-chart');
+  await expect(chart).toBeVisible();
+  await chart.click({ position: { x: 150, y: 75 } });
+
+  await expect(page.getByTestId('chart-tooltip')).toContainText('$12,400');
+});
+```
+
+### CSS/XPath — Last Resort
+
+**Use when**: You have zero control over the markup, no test IDs, no accessible names, and no way to add them. Legacy apps with generated class names and no semantic HTML.
+**Avoid when**: Any other locator type works. Always.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('legacy app with no semantic markup', async ({ page }) => {
+  await page.goto('/legacy-admin');
+
+  // CSS — prefer short, structural selectors over fragile class chains
+  await page.locator('table.report-grid td:has-text("Overdue")').first().click();
+
+  // XPath — only when CSS cannot express the query (e.g., text + ancestor traversal)
+  await page.locator('xpath=//td[contains(text(),"Overdue")]/ancestor::tr//button').click();
+
+  // Combine CSS with Playwright pseudo-selectors for resilience
+  await page.locator('.sidebar >> role=button[name="Expand"]').click();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('legacy app with no semantic markup', async ({ page }) => {
+  await page.goto('/legacy-admin');
+
+  await page.locator('table.report-grid td:has-text("Overdue")').first().click();
+  await page.locator('xpath=//td[contains(text(),"Overdue")]/ancestor::tr//button').click();
+  await page.locator('.sidebar >> role=button[name="Expand"]').click();
+});
+```
+
+### Locator Chaining and Filtering
+
+**Use when**: A single locator matches multiple elements and you need to narrow down by context, content, or position.
+**Avoid when**: A direct `getByRole` with `name` already uniquely identifies the element.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('chaining and filtering locators', async ({ page }) => {
+  await page.goto('/products');
+
+  // Chain: scope a locator within another
+  const productCard = page.getByRole('listitem').filter({ hasText: 'Running Shoes' });
+  await productCard.getByRole('button', { name: 'Add to cart' }).click();
+
+  // Filter by child locator — more precise than hasText
+  const row = page.getByRole('row').filter({
+    has: page.getByRole('cell', { name: 'Premium Plan' }),
+  });
+  await row.getByRole('button', { name: 'Upgrade' }).click();
+
+  // Filter with hasNot — exclude elements containing a child
+  const availableItems = page.getByRole('listitem').filter({
+    hasNot: page.getByText('Sold out'),
+  });
+  await expect(availableItems).toHaveCount(3);
+
+  // Filter with hasNotText — exclude by text content
+  const nonFeatured = page.getByRole('listitem').filter({
+    hasNotText: 'Featured',
+  });
+
+  // Positional: nth, first, last — use sparingly, only when order is stable
+  const thirdItem = page.getByRole('listitem').nth(2); // 0-indexed
+  const firstItem = page.getByRole('listitem').first();
+  const lastItem = page.getByRole('listitem').last();
+
+  // Combining multiple filters
+  const activeAdminRow = page
+    .getByRole('row')
+    .filter({ has: page.getByRole('cell', { name: 'Admin' }) })
+    .filter({ has: page.getByText('Active') });
+  await expect(activeAdminRow).toHaveCount(1);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('chaining and filtering locators', async ({ page }) => {
+  await page.goto('/products');
+
+  const productCard = page.getByRole('listitem').filter({ hasText: 'Running Shoes' });
+  await productCard.getByRole('button', { name: 'Add to cart' }).click();
+
+  const row = page.getByRole('row').filter({
+    has: page.getByRole('cell', { name: 'Premium Plan' }),
+  });
+  await row.getByRole('button', { name: 'Upgrade' }).click();
+
+  const availableItems = page.getByRole('listitem').filter({
+    hasNot: page.getByText('Sold out'),
+  });
+  await expect(availableItems).toHaveCount(3);
+
+  const thirdItem = page.getByRole('listitem').nth(2);
+  const firstItem = page.getByRole('listitem').first();
+  const lastItem = page.getByRole('listitem').last();
+
+  const activeAdminRow = page
+    .getByRole('row')
+    .filter({ has: page.getByRole('cell', { name: 'Admin' }) })
+    .filter({ has: page.getByText('Active') });
+  await expect(activeAdminRow).toHaveCount(1);
+});
+```
+
+### Frame Locators
+
+**Use when**: Interacting with content inside `<iframe>` or `<frame>` elements — payment widgets, embedded editors, third-party widgets.
+**Avoid when**: The content is in the main frame or a Shadow DOM (use piercing instead).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('interact with content inside an iframe', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Locate the iframe, then use normal locators inside it
+  const paymentFrame = page.frameLocator('iframe[title="Payment"]');
+  await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+  await paymentFrame.getByLabel('Expiration').fill('12/28');
+  await paymentFrame.getByLabel('CVC').fill('123');
+  await paymentFrame.getByRole('button', { name: 'Pay' }).click();
+
+  // Nested iframes — chain frameLocator calls
+  const nestedFrame = page
+    .frameLocator('#outer-frame')
+    .frameLocator('#inner-frame');
+  await expect(nestedFrame.getByText('Payment confirmed')).toBeVisible();
+
+  // Frame by nth index — when no better selector exists
+  const secondFrame = page.frameLocator('iframe').nth(1);
+  await expect(secondFrame.getByRole('heading')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('interact with content inside an iframe', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const paymentFrame = page.frameLocator('iframe[title="Payment"]');
+  await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+  await paymentFrame.getByLabel('Expiration').fill('12/28');
+  await paymentFrame.getByLabel('CVC').fill('123');
+  await paymentFrame.getByRole('button', { name: 'Pay' }).click();
+
+  const nestedFrame = page
+    .frameLocator('#outer-frame')
+    .frameLocator('#inner-frame');
+  await expect(nestedFrame.getByText('Payment confirmed')).toBeVisible();
+
+  const secondFrame = page.frameLocator('iframe').nth(1);
+  await expect(secondFrame.getByRole('heading')).toBeVisible();
+});
+```
+
+### Shadow DOM Piercing
+
+**Use when**: Targeting elements inside web components that use Shadow DOM (custom elements, design system components, Salesforce Lightning).
+**Avoid when**: The element is in a regular DOM or iframe.
+
+Playwright pierces open Shadow DOM automatically with `locator()`. The `getByRole` / `getByText` family also pierces shadow roots by default.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('interact with Shadow DOM elements', async ({ page }) => {
+  await page.goto('/design-system-demo');
+
+  // getByRole automatically pierces open Shadow DOM — just use it normally
+  await page.getByRole('button', { name: 'Toggle menu' }).click();
+
+  // locator() with CSS also pierces shadow roots by default
+  await page.locator('my-dropdown').getByRole('option', { name: 'Settings' }).click();
+
+  // Chain into nested shadow DOMs
+  await page
+    .locator('my-app')
+    .locator('my-sidebar')
+    .getByRole('link', { name: 'Profile' })
+    .click();
+
+  // If you explicitly need non-piercing behavior (rare), use css=light/
+  // await page.locator('css:light=.outer-only').click();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('interact with Shadow DOM elements', async ({ page }) => {
+  await page.goto('/design-system-demo');
+
+  await page.getByRole('button', { name: 'Toggle menu' }).click();
+  await page.locator('my-dropdown').getByRole('option', { name: 'Settings' }).click();
+
+  await page
+    .locator('my-app')
+    .locator('my-sidebar')
+    .getByRole('link', { name: 'Profile' })
+    .click();
+});
+```
+
+### Dynamic Content — Waiting for Elements
+
+**Use when**: Elements appear after API calls, animations, lazy loading, or route transitions.
+**Avoid when**: The element is already on the page. Playwright auto-waits on actions, so explicit waits are rarely needed.
+
+Never use `page.waitForTimeout()`. Use auto-waiting assertions or explicit event waits.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('handle dynamic content without manual waits', async ({ page }) => {
+  await page.goto('/search');
+
+  // Auto-waiting: actions like click(), fill() wait for the element automatically
+  await page.getByRole('textbox', { name: 'Search' }).fill('playwright');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  // Web-first assertion: auto-retries until timeout (default 5s)
+  await expect(page.getByRole('listitem')).toHaveCount(10);
+
+  // Wait for a specific element to appear after an async operation
+  await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+
+  // Wait for loading indicators to disappear
+  await expect(page.getByRole('progressbar')).toBeHidden();
+
+  // Wait for network-dependent content: wait for response then assert
+  const responsePromise = page.waitForResponse('**/api/search*');
+  await page.getByRole('button', { name: 'Load more' }).click();
+  await responsePromise;
+  await expect(page.getByRole('listitem')).toHaveCount(20);
+
+  // Wait for URL change after navigation
+  await page.getByRole('link', { name: 'First result' }).click();
+  await page.waitForURL('**/results/**');
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('handle dynamic content without manual waits', async ({ page }) => {
+  await page.goto('/search');
+
+  await page.getByRole('textbox', { name: 'Search' }).fill('playwright');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  await expect(page.getByRole('listitem')).toHaveCount(10);
+  await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+  await expect(page.getByRole('progressbar')).toBeHidden();
+
+  const responsePromise = page.waitForResponse('**/api/search*');
+  await page.getByRole('button', { name: 'Load more' }).click();
+  await responsePromise;
+  await expect(page.getByRole('listitem')).toHaveCount(20);
+
+  await page.getByRole('link', { name: 'First result' }).click();
+  await page.waitForURL('**/results/**');
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+});
+```
+
+## Decision Guide
+
+| Element Type | Recommended Locator | Example | Why |
+|---|---|---|---|
+| Button | `getByRole('button', { name })` | `getByRole('button', { name: 'Submit' })` | Matches `<button>`, `<input type="submit">`, `role="button"` |
+| Link | `getByRole('link', { name })` | `getByRole('link', { name: 'Home' })` | Matches any `<a href>` regardless of styling |
+| Text input | `getByRole('textbox', { name })` | `getByRole('textbox', { name: 'Email' })` | Matches by accessible name (label) |
+| Password input | `getByLabel()` | `getByLabel('Password')` | Password fields have no distinct role; label is the best match |
+| Checkbox | `getByRole('checkbox', { name })` | `getByRole('checkbox', { name: 'Agree' })` | Also use `.check()` / `.uncheck()` instead of `.click()` |
+| Radio button | `getByRole('radio', { name })` | `getByRole('radio', { name: 'Express' })` | Group radios with `getByRole('radiogroup')` |
+| Select/dropdown | `getByRole('combobox', { name })` | `getByRole('combobox', { name: 'Country' })` | Native `<select>` maps to combobox role |
+| Custom dropdown | `getByRole('listbox')` + `getByRole('option')` | Click trigger, then `getByRole('option', { name })` | ARIA listbox pattern for custom dropdowns |
+| Heading | `getByRole('heading', { name, level })` | `getByRole('heading', { name: 'Dashboard', level: 2 })` | Use `level` to distinguish h1-h6 |
+| Table | `getByRole('table', { name })` | `getByRole('table', { name: 'Users' })` | Chain with `getByRole('row')`, `getByRole('cell')` |
+| Table row | `getByRole('row').filter({ has })` | `.filter({ has: getByRole('cell', { name: 'Jane' }) })` | Filter rows by cell content |
+| Navigation | `getByRole('navigation', { name })` | `getByRole('navigation', { name: 'Main' })` | Matches `<nav>` with `aria-label` |
+| Dialog/modal | `getByRole('dialog', { name })` | `getByRole('dialog', { name: 'Confirm' })` | Scope all dialog interactions under this |
+| Tab | `getByRole('tab', { name })` | `getByRole('tab', { name: 'Settings' })` | Use with `getByRole('tabpanel')` |
+| Image | `getByAltText()` | `getByAltText('User avatar')` | Matches the `alt` attribute |
+| Form field (any) | `getByLabel()` | `getByLabel('Date of birth')` | Fallback when role is ambiguous (date pickers, custom inputs) |
+| Static text | `getByText()` | `getByText('No results found')` | Non-interactive content only |
+| No semantic markup | `getByTestId()` | `getByTestId('sparkline-chart')` | Last semantic option before CSS |
+| Iframe content | `frameLocator()` then any locator | `frameLocator('#payment').getByLabel('Card')` | Required for cross-frame access |
+| Shadow DOM | `getByRole()` / `locator()` | Works automatically | Playwright pierces open shadow roots by default |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.locator('.btn-primary')` | Breaks when CSS classes change (renames, CSS modules, Tailwind) | `page.getByRole('button', { name: 'Save' })` |
+| `page.locator('#submit-btn')` | IDs are implementation details; often auto-generated | `page.getByRole('button', { name: 'Submit' })` |
+| `page.locator('div > span:nth-child(3)')` | Breaks on any DOM restructure | `page.getByText('Expected content')` or `getByTestId()` |
+| `page.locator('xpath=//div[@class="form"]//input[2]')` | Fragile, unreadable, position-dependent | `page.getByLabel('Last name')` |
+| `page.getByText('Submit')` for a button | Text locators don't assert the element is interactive | `page.getByRole('button', { name: 'Submit' })` |
+| `page.locator('.item').nth(0)` on dynamic lists | Index changes when items are added/removed/reordered | `.filter({ hasText: 'Specific item' })` |
+| `page.getByText('Aceptar')` hardcoded i18n text | Fails when locale changes | `page.getByRole('button', { name: /accept/i })` or `getByTestId('confirm-btn')` |
+| `await page.waitForTimeout(3000)` | Arbitrary delay; too slow in fast environments, too short in slow ones | `await expect(locator).toBeVisible()` |
+| `page.locator('.card').locator('.card-title').locator('a')` | Deep CSS chaining breaks on any structural change | `page.getByRole('link', { name: 'Card title text' })` |
+| `page.$('selector')` (ElementHandle API) | Returns a snapshot, not auto-waiting; deprecated pattern | `page.locator('selector')` — locators are lazy and auto-wait |
+| `page.locator('text=Click here')` | Legacy text selector syntax | `page.getByText('Click here')` or `getByRole` with name |
+| Multiple locators for one element in sequence | Each `locator()` call in a chain restarts the search | Store as variable: `const btn = page.getByRole('button', { name: 'Save' })` |
+
+## Troubleshooting
+
+### "strict mode violation" — locator matches multiple elements
+
+**Cause**: Your locator is not specific enough and Playwright refuses to pick one for you.
+
+```typescript
+// Error: locator.click: strict mode violation, getByRole('button') resolved to 5 elements
+await page.getByRole('button').click(); // Too broad
+
+// Fix 1: Add a name filter
+await page.getByRole('button', { name: 'Save' }).click();
+
+// Fix 2: Scope within a parent
+await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+
+// Fix 3: Use exact matching when names are substrings of each other
+await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+// Fix 4: Use filter to narrow down
+await page.getByRole('button').filter({ hasText: 'Save draft' }).click();
+
+// Debug: see what matched
+console.log(await page.getByRole('button').all()); // list all matches
+```
+
+### Element exists but locator times out
+
+**Cause**: The element is inside an iframe, Shadow DOM, or is obscured/hidden.
+
+```typescript
+// Check if element is inside an iframe
+const frame = page.frameLocator('iframe');
+await frame.getByRole('button', { name: 'Submit' }).click();
+
+// Check if element is in a Shadow DOM — getByRole pierces automatically,
+// but page.$() and CSS selectors may not. Switch to getByRole.
+
+// Check if element is hidden (display: none, visibility: hidden, opacity: 0)
+// Use toBeVisible() to confirm, or toBeAttached() if hidden is expected
+await expect(page.getByRole('button', { name: 'Submit' })).toBeAttached();
+```
+
+### `getByRole` doesn't find the element
+
+**Cause**: The element's implicit ARIA role doesn't match what you expect, or it has no role.
+
+```typescript
+// Debug: inspect the accessibility tree
+const snapshot = await page.accessibility.snapshot();
+console.log(JSON.stringify(snapshot, null, 2));
+
+// Common mismatches:
+// - <div onclick="..."> has no button role → add role="button" or use <button>
+// - <input type="text"> with no label has no accessible name → add <label> or aria-label
+// - <a> without href has no link role → add href or role="link"
+
+// Fallback chain: try getByLabel → getByText → getByTestId → locator()
+```
+
+## Related
+
+- [core/locator-strategy.md](locator-strategy.md) — deep-dive decision framework for choosing locator strategies at the project level
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) — pair locators with web-first assertions
+- [pom/page-object-model.md](../pom/page-object-model.md) — encapsulate locators in page objects
+- [core/iframes-and-shadow-dom.md](iframes-and-shadow-dom.md) — advanced iframe and Shadow DOM patterns
+- [core/i18n-and-localization.md](i18n-and-localization.md) — locator strategies for internationalized apps

--- a/engineering-team/playwright skill/core/mobile-and-responsive.md
+++ b/engineering-team/playwright skill/core/mobile-and-responsive.md
@@ -1,0 +1,1669 @@
+# Mobile and Responsive Testing
+
+> **When to use**: Testing how your application behaves on phones, tablets, and across viewport sizes. Covers device emulation, touch interactions, geolocation, orientation changes, and mobile-specific UI patterns.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```typescript
+import { devices } from '@playwright/test';
+
+// Predefined device profiles (viewport, userAgent, touch, deviceScaleFactor)
+devices['iPhone 14']           // 390x844, touch, Safari mobile UA
+devices['iPhone 14 Pro Max']   // 430x932, touch, Safari mobile UA
+devices['Pixel 7']             // 412x915, touch, Chrome mobile UA
+devices['iPad Pro 11']         // 834x1194, touch, Safari tablet UA
+devices['Galaxy S9+']          // 320x658, touch, Chrome mobile UA
+devices['Desktop Chrome']      // 1280x720, no touch, Chrome desktop UA
+devices['Desktop Safari']      // 1280x720, no touch, Safari desktop UA
+
+// Landscape variants
+devices['iPhone 14 landscape'] // 844x390, touch, Safari mobile UA
+devices['iPad Pro 11 landscape'] // 1194x834, touch, Safari tablet UA
+```
+
+```bash
+# Run mobile project only
+npx playwright test --project=mobile-chrome
+npx playwright test --project=mobile-safari
+
+# Run all projects (desktop + mobile in parallel)
+npx playwright test
+
+# List available device names
+npx playwright test --list-devices 2>/dev/null || node -e "const {devices}=require('@playwright/test');console.log(Object.keys(devices).join('\n'))"
+```
+
+## Patterns
+
+### 1. Device Emulation
+
+**Use when**: Testing your app as it appears on a specific real-world device -- iPhone, Pixel, iPad. Applies the correct viewport, user agent, device scale factor, and touch support in one shot.
+**Avoid when**: You only need to test a specific viewport width (use custom viewports instead). Device emulation is not a substitute for real device testing when pixel-perfect rendering matters.
+
+#### TypeScript
+
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    {
+      name: 'Desktop Chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 14'] },
+    },
+    {
+      name: 'Tablet',
+      use: { ...devices['iPad Pro 11'] },
+    },
+  ],
+});
+```
+
+```typescript
+// tests/mobile-navigation.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('mobile user can navigate via hamburger menu', async ({ page, isMobile }) => {
+  await page.goto('/');
+
+  if (isMobile) {
+    // Mobile: hamburger menu is visible, desktop nav is hidden
+    await expect(page.getByRole('button', { name: 'Menu' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeHidden();
+
+    // Open hamburger menu
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('**/products');
+  } else {
+    // Desktop: nav links are directly visible
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('**/products');
+  }
+
+  await expect(page.getByRole('heading', { name: 'Products', level: 1 })).toBeVisible();
+});
+```
+
+#### JavaScript
+
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  projects: [
+    {
+      name: 'Desktop Chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 14'] },
+    },
+    {
+      name: 'Tablet',
+      use: { ...devices['iPad Pro 11'] },
+    },
+  ],
+});
+```
+
+```javascript
+// tests/mobile-navigation.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('mobile user can navigate via hamburger menu', async ({ page, isMobile }) => {
+  await page.goto('/');
+
+  if (isMobile) {
+    await expect(page.getByRole('button', { name: 'Menu' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('**/products');
+  } else {
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('**/products');
+  }
+
+  await expect(page.getByRole('heading', { name: 'Products', level: 1 })).toBeVisible();
+});
+```
+
+### 2. Custom Viewports
+
+**Use when**: Testing responsive layouts at specific breakpoints without full device emulation. Ideal for verifying CSS media queries fire at the right widths.
+**Avoid when**: You need realistic mobile behavior (touch events, mobile user agent, device scale factor). Use device emulation instead.
+
+#### TypeScript
+
+```typescript
+// tests/responsive-layout.spec.ts
+import { test, expect } from '@playwright/test';
+
+const breakpoints = [
+  { name: 'mobile-small', width: 320, height: 568 },
+  { name: 'mobile', width: 375, height: 667 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1024, height: 768 },
+  { name: 'desktop-large', width: 1440, height: 900 },
+];
+
+for (const bp of breakpoints) {
+  test(`layout adapts correctly at ${bp.name} (${bp.width}px)`, async ({ page }) => {
+    await page.setViewportSize({ width: bp.width, height: bp.height });
+    await page.goto('/');
+
+    if (bp.width < 768) {
+      // Mobile layout: stacked, hamburger menu visible
+      await expect(page.getByRole('button', { name: 'Menu' })).toBeVisible();
+      await expect(page.getByTestId('sidebar')).toBeHidden();
+    } else if (bp.width < 1024) {
+      // Tablet layout: collapsible sidebar
+      await expect(page.getByRole('button', { name: 'Menu' })).toBeHidden();
+      await expect(page.getByTestId('sidebar')).toBeVisible();
+    } else {
+      // Desktop layout: full sidebar, no hamburger
+      await expect(page.getByRole('button', { name: 'Menu' })).toBeHidden();
+      await expect(page.getByTestId('sidebar')).toBeVisible();
+      await expect(page.getByTestId('sidebar')).toHaveCSS('width', '280px');
+    }
+  });
+}
+```
+
+```typescript
+// Per-file viewport override (applies to all tests in this file)
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test('mobile checkout flow fits on small screen', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Verify no horizontal scrollbar
+  const hasHorizontalScroll = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+  );
+  expect(hasHorizontalScroll).toBe(false);
+
+  // Verify all form fields are visible without horizontal scroll
+  await expect(page.getByLabel('Card number')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Pay now' })).toBeVisible();
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/responsive-layout.spec.js
+const { test, expect } = require('@playwright/test');
+
+const breakpoints = [
+  { name: 'mobile-small', width: 320, height: 568 },
+  { name: 'mobile', width: 375, height: 667 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1024, height: 768 },
+  { name: 'desktop-large', width: 1440, height: 900 },
+];
+
+for (const bp of breakpoints) {
+  test(`layout adapts correctly at ${bp.name} (${bp.width}px)`, async ({ page }) => {
+    await page.setViewportSize({ width: bp.width, height: bp.height });
+    await page.goto('/');
+
+    if (bp.width < 768) {
+      await expect(page.getByRole('button', { name: 'Menu' })).toBeVisible();
+      await expect(page.getByTestId('sidebar')).toBeHidden();
+    } else if (bp.width < 1024) {
+      await expect(page.getByRole('button', { name: 'Menu' })).toBeHidden();
+      await expect(page.getByTestId('sidebar')).toBeVisible();
+    } else {
+      await expect(page.getByRole('button', { name: 'Menu' })).toBeHidden();
+      await expect(page.getByTestId('sidebar')).toBeVisible();
+      await expect(page.getByTestId('sidebar')).toHaveCSS('width', '280px');
+    }
+  });
+}
+```
+
+```javascript
+// Per-file viewport override
+const { test, expect } = require('@playwright/test');
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test('mobile checkout flow fits on small screen', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const hasHorizontalScroll = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+  );
+  expect(hasHorizontalScroll).toBe(false);
+
+  await expect(page.getByLabel('Card number')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Pay now' })).toBeVisible();
+});
+```
+
+### 3. Touch Events
+
+**Use when**: Testing touch-specific interactions -- tap, swipe, pinch. Required for mobile-only gestures that have no mouse equivalent.
+**Avoid when**: The feature works identically with mouse clicks. Playwright's `click()` dispatches touch events automatically on touch-enabled device profiles.
+
+#### TypeScript
+
+```typescript
+// tests/touch-interactions.spec.ts
+import { test, expect, devices } from '@playwright/test';
+
+test.use({ ...devices['iPhone 14'] });
+
+test('tap to select an item', async ({ page }) => {
+  await page.goto('/gallery');
+
+  // tap() dispatches touchstart → touchend → click
+  // Only available when hasTouch is true (device profiles set this)
+  await page.getByRole('img', { name: 'Sunset photo' }).tap();
+  await expect(page.getByText('Selected: Sunset photo')).toBeVisible();
+});
+
+test('swipe to dismiss a card', async ({ page }) => {
+  await page.goto('/notifications');
+
+  const card = page.getByTestId('notification-card').first();
+  const box = await card.boundingBox();
+
+  if (box) {
+    // Simulate a left swipe: touchstart on right side, touchmove to left, touchend
+    await page.touchscreen.tap(box.x + box.width - 20, box.y + box.height / 2);
+
+    // Swipe gesture using mouse (touch events are synthesized from mouse on emulated devices)
+    await card.hover({ position: { x: box.width - 20, y: box.height / 2 } });
+    await page.mouse.down();
+    await page.mouse.move(box.x - 100, box.y + box.height / 2, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(card).toBeHidden();
+  }
+});
+
+test('long press to open context menu', async ({ page }) => {
+  await page.goto('/files');
+
+  const file = page.getByRole('listitem').filter({ hasText: 'Report.pdf' });
+
+  // Long press: dispatch pointerdown, wait, then pointerup
+  await file.click({ delay: 800 }); // delay in ms simulates long press
+  await expect(page.getByRole('menu')).toBeVisible();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+});
+
+test('pinch to zoom on a map', async ({ page }) => {
+  await page.goto('/map');
+
+  // Pinch-to-zoom requires dispatching multi-touch events via JavaScript
+  const mapElement = page.getByTestId('map-container');
+
+  await mapElement.evaluate((el) => {
+    // Simulate pinch-out (zoom in) with two touch points moving apart
+    const center = { x: el.clientWidth / 2, y: el.clientHeight / 2 };
+
+    const touch1 = new Touch({
+      identifier: 0,
+      target: el,
+      clientX: center.x - 50,
+      clientY: center.y,
+    });
+    const touch2 = new Touch({
+      identifier: 1,
+      target: el,
+      clientX: center.x + 50,
+      clientY: center.y,
+    });
+
+    el.dispatchEvent(new TouchEvent('touchstart', {
+      touches: [touch1, touch2],
+      changedTouches: [touch1, touch2],
+      bubbles: true,
+    }));
+
+    const touch1Moved = new Touch({
+      identifier: 0,
+      target: el,
+      clientX: center.x - 120,
+      clientY: center.y,
+    });
+    const touch2Moved = new Touch({
+      identifier: 1,
+      target: el,
+      clientX: center.x + 120,
+      clientY: center.y,
+    });
+
+    el.dispatchEvent(new TouchEvent('touchmove', {
+      touches: [touch1Moved, touch2Moved],
+      changedTouches: [touch1Moved, touch2Moved],
+      bubbles: true,
+    }));
+
+    el.dispatchEvent(new TouchEvent('touchend', {
+      touches: [],
+      changedTouches: [touch1Moved, touch2Moved],
+      bubbles: true,
+    }));
+  });
+
+  // Verify zoom level changed
+  await expect(page.getByTestId('zoom-level')).not.toHaveText('1x');
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/touch-interactions.spec.js
+const { test, expect, devices } = require('@playwright/test');
+
+test.use({ ...devices['iPhone 14'] });
+
+test('tap to select an item', async ({ page }) => {
+  await page.goto('/gallery');
+
+  await page.getByRole('img', { name: 'Sunset photo' }).tap();
+  await expect(page.getByText('Selected: Sunset photo')).toBeVisible();
+});
+
+test('swipe to dismiss a card', async ({ page }) => {
+  await page.goto('/notifications');
+
+  const card = page.getByTestId('notification-card').first();
+  const box = await card.boundingBox();
+
+  if (box) {
+    await card.hover({ position: { x: box.width - 20, y: box.height / 2 } });
+    await page.mouse.down();
+    await page.mouse.move(box.x - 100, box.y + box.height / 2, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(card).toBeHidden();
+  }
+});
+
+test('long press to open context menu', async ({ page }) => {
+  await page.goto('/files');
+
+  const file = page.getByRole('listitem').filter({ hasText: 'Report.pdf' });
+  await file.click({ delay: 800 });
+  await expect(page.getByRole('menu')).toBeVisible();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+});
+```
+
+### 4. Mobile-Specific UI
+
+**Use when**: Testing UI components that only appear on mobile -- hamburger menus, bottom sheets, pull-to-refresh, sticky mobile headers, floating action buttons.
+**Avoid when**: The component renders identically on desktop and mobile.
+
+#### TypeScript
+
+```typescript
+// tests/mobile-ui.spec.ts
+import { test, expect, devices } from '@playwright/test';
+
+test.use({ ...devices['iPhone 14'] });
+
+test('hamburger menu opens and closes', async ({ page }) => {
+  await page.goto('/');
+
+  const menuButton = page.getByRole('button', { name: 'Menu' });
+  const nav = page.getByRole('navigation', { name: 'Main' });
+
+  // Menu starts closed
+  await expect(nav).toBeHidden();
+
+  // Open menu
+  await menuButton.click();
+  await expect(nav).toBeVisible();
+
+  // Verify all nav items are visible
+  await expect(nav.getByRole('link', { name: 'Home' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Products' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Account' })).toBeVisible();
+
+  // Close menu by tapping outside (overlay)
+  await page.getByTestId('menu-overlay').click();
+  await expect(nav).toBeHidden();
+});
+
+test('bottom sheet slides up on mobile', async ({ page }) => {
+  await page.goto('/products/1');
+
+  await page.getByRole('button', { name: 'Add to cart' }).click();
+
+  // Bottom sheet appears with cart summary
+  const bottomSheet = page.getByTestId('bottom-sheet');
+  await expect(bottomSheet).toBeVisible();
+  await expect(bottomSheet).toContainText('Added to cart');
+
+  // Dismiss by swiping down
+  const box = await bottomSheet.boundingBox();
+  if (box) {
+    const startX = box.x + box.width / 2;
+    const startY = box.y + 20;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX, startY + 300, { steps: 10 });
+    await page.mouse.up();
+  }
+
+  await expect(bottomSheet).toBeHidden();
+});
+
+test('pull to refresh reloads content', async ({ page }) => {
+  await page.goto('/feed');
+
+  // Store initial first item text
+  const firstItem = page.getByRole('listitem').first();
+  const initialText = await firstItem.textContent();
+
+  // Pull-to-refresh: swipe down from top of scrollable area
+  const feed = page.getByTestId('feed-container');
+  const box = await feed.boundingBox();
+
+  if (box) {
+    await page.mouse.move(box.x + box.width / 2, box.y + 10);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2, box.y + 250, { steps: 15 });
+    await page.mouse.up();
+  }
+
+  // Wait for refresh indicator and then content reload
+  await expect(page.getByTestId('refresh-spinner')).toBeVisible();
+  await expect(page.getByTestId('refresh-spinner')).toBeHidden();
+});
+
+test('sticky mobile header remains visible on scroll', async ({ page }) => {
+  await page.goto('/products');
+
+  const header = page.getByRole('banner');
+
+  // Scroll down significantly
+  await page.evaluate(() => window.scrollTo(0, 2000));
+
+  // Header should remain visible (sticky positioning)
+  await expect(header).toBeVisible();
+  await expect(header).toBeInViewport();
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/mobile-ui.spec.js
+const { test, expect, devices } = require('@playwright/test');
+
+test.use({ ...devices['iPhone 14'] });
+
+test('hamburger menu opens and closes', async ({ page }) => {
+  await page.goto('/');
+
+  const menuButton = page.getByRole('button', { name: 'Menu' });
+  const nav = page.getByRole('navigation', { name: 'Main' });
+
+  await expect(nav).toBeHidden();
+  await menuButton.click();
+  await expect(nav).toBeVisible();
+
+  await expect(nav.getByRole('link', { name: 'Home' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Products' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Account' })).toBeVisible();
+
+  await page.getByTestId('menu-overlay').click();
+  await expect(nav).toBeHidden();
+});
+
+test('bottom sheet slides up on mobile', async ({ page }) => {
+  await page.goto('/products/1');
+
+  await page.getByRole('button', { name: 'Add to cart' }).click();
+
+  const bottomSheet = page.getByTestId('bottom-sheet');
+  await expect(bottomSheet).toBeVisible();
+  await expect(bottomSheet).toContainText('Added to cart');
+
+  const box = await bottomSheet.boundingBox();
+  if (box) {
+    const startX = box.x + box.width / 2;
+    const startY = box.y + 20;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX, startY + 300, { steps: 10 });
+    await page.mouse.up();
+  }
+
+  await expect(bottomSheet).toBeHidden();
+});
+
+test('sticky mobile header remains visible on scroll', async ({ page }) => {
+  await page.goto('/products');
+
+  const header = page.getByRole('banner');
+  await page.evaluate(() => window.scrollTo(0, 2000));
+  await expect(header).toBeVisible();
+  await expect(header).toBeInViewport();
+});
+```
+
+### 5. Geolocation
+
+**Use when**: Testing location-dependent features -- store finders, delivery zones, weather widgets, location-based pricing.
+**Avoid when**: The feature does not use the Geolocation API. If it uses IP-based location, mock the API response instead.
+
+#### TypeScript
+
+```typescript
+// playwright.config.ts -- set geolocation per project
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    {
+      name: 'mobile-nyc',
+      use: {
+        ...devices['iPhone 14'],
+        geolocation: { latitude: 40.7128, longitude: -74.0060 },
+        permissions: ['geolocation'],
+      },
+    },
+    {
+      name: 'mobile-london',
+      use: {
+        ...devices['iPhone 14'],
+        geolocation: { latitude: 51.5074, longitude: -0.1278 },
+        permissions: ['geolocation'],
+        locale: 'en-GB',
+        timezoneId: 'Europe/London',
+      },
+    },
+  ],
+});
+```
+
+```typescript
+// tests/store-locator.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('shows nearby stores based on geolocation', async ({ page, context }) => {
+  // Geolocation is already set via project config above.
+  // To override in a specific test:
+  await context.setGeolocation({ latitude: 34.0522, longitude: -118.2437 }); // Los Angeles
+
+  await page.goto('/store-locator');
+  await page.getByRole('button', { name: 'Use my location' }).click();
+
+  // Verify the app uses the mocked location
+  await expect(page.getByText('Stores near Los Angeles')).toBeVisible();
+  await expect(page.getByRole('listitem')).toHaveCount(5); // nearest 5 stores
+});
+
+test('geolocation updates in real time', async ({ page, context }) => {
+  await context.setGeolocation({ latitude: 40.7128, longitude: -74.0060 });
+  await page.goto('/delivery-tracker');
+
+  await expect(page.getByText('New York')).toBeVisible();
+
+  // Simulate user moving to a new location
+  await context.setGeolocation({ latitude: 40.7580, longitude: -73.9855 }); // Times Square
+
+  // Trigger a location refresh (app-specific)
+  await page.getByRole('button', { name: 'Refresh location' }).click();
+  await expect(page.getByText('Times Square')).toBeVisible();
+});
+
+test('handles geolocation permission denied', async ({ page, context }) => {
+  // Clear geolocation permissions to simulate denial
+  await context.clearPermissions();
+  await page.goto('/store-locator');
+
+  await page.getByRole('button', { name: 'Use my location' }).click();
+
+  // App should show fallback UI
+  await expect(page.getByText('Location access denied')).toBeVisible();
+  await expect(page.getByLabel('Enter your zip code')).toBeVisible();
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/store-locator.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('shows nearby stores based on geolocation', async ({ page, context }) => {
+  await context.setGeolocation({ latitude: 34.0522, longitude: -118.2437 });
+
+  await page.goto('/store-locator');
+  await page.getByRole('button', { name: 'Use my location' }).click();
+
+  await expect(page.getByText('Stores near Los Angeles')).toBeVisible();
+  await expect(page.getByRole('listitem')).toHaveCount(5);
+});
+
+test('geolocation updates in real time', async ({ page, context }) => {
+  await context.setGeolocation({ latitude: 40.7128, longitude: -74.0060 });
+  await page.goto('/delivery-tracker');
+
+  await expect(page.getByText('New York')).toBeVisible();
+
+  await context.setGeolocation({ latitude: 40.7580, longitude: -73.9855 });
+  await page.getByRole('button', { name: 'Refresh location' }).click();
+  await expect(page.getByText('Times Square')).toBeVisible();
+});
+
+test('handles geolocation permission denied', async ({ page, context }) => {
+  await context.clearPermissions();
+  await page.goto('/store-locator');
+
+  await page.getByRole('button', { name: 'Use my location' }).click();
+
+  await expect(page.getByText('Location access denied')).toBeVisible();
+  await expect(page.getByLabel('Enter your zip code')).toBeVisible();
+});
+```
+
+### 6. Multi-Project Responsive Testing
+
+**Use when**: Running the same tests across desktop and mobile browsers in parallel. The standard approach for responsive apps.
+**Avoid when**: Your app is desktop-only or mobile-only.
+
+#### TypeScript
+
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+
+  projects: [
+    // ── Desktop ────────────────────────────────────────────
+    {
+      name: 'desktop-chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'desktop-firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'desktop-safari',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    // ── Mobile ─────────────────────────────────────────────
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 14'] },
+    },
+
+    // ── Tablet ─────────────────────────────────────────────
+    {
+      name: 'tablet',
+      use: { ...devices['iPad Pro 11'] },
+    },
+  ],
+});
+```
+
+```typescript
+// tests/responsive-checkout.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('checkout works across all viewports', async ({ page, isMobile }) => {
+  await page.goto('/products');
+
+  // Add item -- same action on all viewports
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+
+  // Navigate to cart
+  if (isMobile) {
+    // Mobile: cart link may be in hamburger or bottom nav
+    await page.getByRole('link', { name: 'Cart' }).click();
+  } else {
+    // Desktop: cart icon in header
+    await page.getByRole('link', { name: /Cart \(\d+\)/ }).click();
+  }
+
+  await page.waitForURL('**/cart');
+  await expect(page.getByRole('heading', { name: 'Your cart' })).toBeVisible();
+
+  // Proceed to checkout
+  await page.getByRole('link', { name: 'Checkout' }).click();
+  await page.waitForURL('**/checkout');
+
+  // Fill form -- same fields on all viewports
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByLabel('Card number').fill('4242424242424242');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+```bash
+# Run desktop projects only
+npx playwright test --project=desktop-chrome --project=desktop-firefox --project=desktop-safari
+
+# Run mobile projects only
+npx playwright test --project=mobile-chrome --project=mobile-safari
+
+# Run specific test file on all projects
+npx playwright test tests/responsive-checkout.spec.ts
+
+# CI optimization: mobile + desktop-chrome on PRs, all browsers on main
+# In CI config:
+# PR:   npx playwright test --project=desktop-chrome --project=mobile-chrome --project=mobile-safari
+# Main: npx playwright test
+```
+
+#### JavaScript
+
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+
+  projects: [
+    {
+      name: 'desktop-chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'desktop-firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'desktop-safari',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 14'] },
+    },
+    {
+      name: 'tablet',
+      use: { ...devices['iPad Pro 11'] },
+    },
+  ],
+});
+```
+
+```javascript
+// tests/responsive-checkout.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('checkout works across all viewports', async ({ page, isMobile }) => {
+  await page.goto('/products');
+
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+
+  if (isMobile) {
+    await page.getByRole('link', { name: 'Cart' }).click();
+  } else {
+    await page.getByRole('link', { name: /Cart \(\d+\)/ }).click();
+  }
+
+  await page.waitForURL('**/cart');
+  await expect(page.getByRole('heading', { name: 'Your cart' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Checkout' }).click();
+  await page.waitForURL('**/checkout');
+
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByLabel('Card number').fill('4242424242424242');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+### 7. Responsive Breakpoint Testing
+
+**Use when**: Systematically verifying layout behavior at every major CSS breakpoint. Best used alongside visual regression testing.
+**Avoid when**: You only need one or two viewport sizes -- just use `test.use()` overrides instead.
+
+#### TypeScript
+
+```typescript
+// tests/fixtures/responsive.fixture.ts
+import { test as base, expect } from '@playwright/test';
+
+type Breakpoint = {
+  name: string;
+  width: number;
+  height: number;
+  isMobileExpected: boolean;
+};
+
+const BREAKPOINTS: Breakpoint[] = [
+  { name: 'xs',  width: 320,  height: 568, isMobileExpected: true },
+  { name: 'sm',  width: 640,  height: 800, isMobileExpected: true },
+  { name: 'md',  width: 768,  height: 1024, isMobileExpected: false },
+  { name: 'lg',  width: 1024, height: 768, isMobileExpected: false },
+  { name: 'xl',  width: 1280, height: 800, isMobileExpected: false },
+  { name: '2xl', width: 1440, height: 900, isMobileExpected: false },
+];
+
+// Custom fixture that runs a test at every breakpoint
+export const test = base.extend<{ forEachBreakpoint: void }>({
+  forEachBreakpoint: [async ({ page }, use, testInfo) => {
+    // This fixture is used as a tag -- actual breakpoint iteration is done via test.describe
+    await use();
+  }, { auto: false }],
+});
+
+// Helper: create a describe block that tests every breakpoint
+export function describeBreakpoints(
+  title: string,
+  fn: (bp: Breakpoint) => void
+) {
+  for (const bp of BREAKPOINTS) {
+    base.describe(`${title} @ ${bp.name} (${bp.width}px)`, () => {
+      base.use({ viewport: { width: bp.width, height: bp.height } });
+      fn(bp);
+    });
+  }
+}
+
+export { expect, BREAKPOINTS };
+```
+
+```typescript
+// tests/responsive-grid.spec.ts
+import { test, expect, describeBreakpoints } from './fixtures/responsive.fixture';
+
+describeBreakpoints('product grid', (bp) => {
+  test('shows correct number of columns', async ({ page }) => {
+    await page.goto('/products');
+
+    const grid = page.getByTestId('product-grid');
+    const columns = await grid.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return style.gridTemplateColumns.split(' ').length;
+    });
+
+    if (bp.width < 640) {
+      expect(columns).toBe(1);     // xs: single column
+    } else if (bp.width < 1024) {
+      expect(columns).toBe(2);     // sm-md: two columns
+    } else {
+      expect(columns).toBe(4);     // lg+: four columns
+    }
+  });
+
+  test('no content overflow', async ({ page }) => {
+    await page.goto('/products');
+
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasOverflow).toBe(false);
+  });
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/fixtures/responsive.fixture.js
+const { test: base, expect } = require('@playwright/test');
+
+const BREAKPOINTS = [
+  { name: 'xs',  width: 320,  height: 568, isMobileExpected: true },
+  { name: 'sm',  width: 640,  height: 800, isMobileExpected: true },
+  { name: 'md',  width: 768,  height: 1024, isMobileExpected: false },
+  { name: 'lg',  width: 1024, height: 768, isMobileExpected: false },
+  { name: 'xl',  width: 1280, height: 800, isMobileExpected: false },
+  { name: '2xl', width: 1440, height: 900, isMobileExpected: false },
+];
+
+function describeBreakpoints(title, fn) {
+  for (const bp of BREAKPOINTS) {
+    base.describe(`${title} @ ${bp.name} (${bp.width}px)`, () => {
+      base.use({ viewport: { width: bp.width, height: bp.height } });
+      fn(bp);
+    });
+  }
+}
+
+module.exports = { test: base, expect, BREAKPOINTS, describeBreakpoints };
+```
+
+```javascript
+// tests/responsive-grid.spec.js
+const { test, expect, describeBreakpoints } = require('./fixtures/responsive.fixture');
+
+describeBreakpoints('product grid', (bp) => {
+  test('shows correct number of columns', async ({ page }) => {
+    await page.goto('/products');
+
+    const grid = page.getByTestId('product-grid');
+    const columns = await grid.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return style.gridTemplateColumns.split(' ').length;
+    });
+
+    if (bp.width < 640) {
+      expect(columns).toBe(1);
+    } else if (bp.width < 1024) {
+      expect(columns).toBe(2);
+    } else {
+      expect(columns).toBe(4);
+    }
+  });
+
+  test('no content overflow', async ({ page }) => {
+    await page.goto('/products');
+
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasOverflow).toBe(false);
+  });
+});
+```
+
+### 8. Orientation Testing
+
+**Use when**: Testing portrait vs landscape layouts. Critical for tablet apps, media players, dashboards, and any app that adapts to orientation.
+**Avoid when**: Your app does not change layout based on orientation (purely responsive to width only -- test with custom viewports instead).
+
+#### TypeScript
+
+```typescript
+// tests/orientation.spec.ts
+import { test, expect, devices } from '@playwright/test';
+
+test.describe('iPad orientation changes', () => {
+  test.use({ ...devices['iPad Pro 11'] });
+
+  test('dashboard adjusts layout in landscape', async ({ page }) => {
+    // Start in portrait (834x1194 -- default for iPad Pro 11)
+    await page.goto('/dashboard');
+
+    // Portrait: sidebar collapses, chart stacks vertically
+    await expect(page.getByTestId('sidebar')).toHaveCSS('position', 'fixed');
+
+    // Switch to landscape by changing viewport
+    await page.setViewportSize({ width: 1194, height: 834 });
+
+    // Landscape: sidebar visible inline, charts side-by-side
+    await expect(page.getByTestId('sidebar')).toHaveCSS('position', 'relative');
+  });
+
+  test('video player switches to fullscreen in landscape', async ({ page }) => {
+    await page.goto('/videos/1');
+
+    // Portrait: video in inline player
+    const player = page.getByTestId('video-player');
+    const portraitBox = await player.boundingBox();
+
+    // Switch to landscape
+    await page.setViewportSize({ width: 1194, height: 834 });
+
+    // Video should expand to fill width
+    const landscapeBox = await player.boundingBox();
+    expect(landscapeBox!.width).toBeGreaterThan(portraitBox!.width);
+  });
+});
+
+test.describe('iPhone orientation changes', () => {
+  test('portrait mode', () => {
+    test.use({ ...devices['iPhone 14'] }); // 390x844
+  });
+
+  test('landscape mode', () => {
+    test.use({ ...devices['iPhone 14 landscape'] }); // 844x390
+  });
+});
+
+// Test both orientations with a loop
+const orientations = [
+  { name: 'portrait', device: devices['iPad Pro 11'] },
+  { name: 'landscape', device: devices['iPad Pro 11 landscape'] },
+];
+
+for (const { name, device } of orientations) {
+  test.describe(`form usability in ${name}`, () => {
+    test.use({ ...device });
+
+    test('all form fields are visible without scrolling', async ({ page }) => {
+      await page.goto('/contact');
+
+      const form = page.getByRole('form');
+      await expect(form).toBeVisible();
+
+      // Check form fits within viewport
+      const formBox = await form.boundingBox();
+      const viewport = page.viewportSize()!;
+      expect(formBox!.width).toBeLessThanOrEqual(viewport.width);
+    });
+  });
+}
+```
+
+#### JavaScript
+
+```javascript
+// tests/orientation.spec.js
+const { test, expect, devices } = require('@playwright/test');
+
+test.describe('iPad orientation changes', () => {
+  test.use({ ...devices['iPad Pro 11'] });
+
+  test('dashboard adjusts layout in landscape', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await expect(page.getByTestId('sidebar')).toHaveCSS('position', 'fixed');
+
+    await page.setViewportSize({ width: 1194, height: 834 });
+
+    await expect(page.getByTestId('sidebar')).toHaveCSS('position', 'relative');
+  });
+
+  test('video player switches to fullscreen in landscape', async ({ page }) => {
+    await page.goto('/videos/1');
+
+    const player = page.getByTestId('video-player');
+    const portraitBox = await player.boundingBox();
+
+    await page.setViewportSize({ width: 1194, height: 834 });
+
+    const landscapeBox = await player.boundingBox();
+    expect(landscapeBox.width).toBeGreaterThan(portraitBox.width);
+  });
+});
+
+const orientations = [
+  { name: 'portrait', device: devices['iPad Pro 11'] },
+  { name: 'landscape', device: devices['iPad Pro 11 landscape'] },
+];
+
+for (const { name, device } of orientations) {
+  test.describe(`form usability in ${name}`, () => {
+    test.use({ ...device });
+
+    test('all form fields are visible without scrolling', async ({ page }) => {
+      await page.goto('/contact');
+
+      const form = page.getByRole('form');
+      await expect(form).toBeVisible();
+
+      const formBox = await form.boundingBox();
+      const viewport = page.viewportSize();
+      expect(formBox.width).toBeLessThanOrEqual(viewport.width);
+    });
+  });
+}
+```
+
+### 9. Mobile Performance
+
+**Use when**: Simulating real-world mobile conditions -- slow 3G networks, underpowered CPUs. Critical for testing loading states, skeleton screens, and timeout handling.
+**Avoid when**: Testing functional correctness only. Performance throttling slows down your test suite significantly.
+
+#### TypeScript
+
+```typescript
+// tests/mobile-performance.spec.ts
+import { test, expect, devices } from '@playwright/test';
+
+test.describe('mobile on slow network', () => {
+  test.use({ ...devices['Pixel 7'] });
+
+  test('shows skeleton loader on slow 3G', async ({ page }) => {
+    // Get the CDP session for network throttling (Chromium only)
+    const cdpSession = await page.context().newCDPSession(page);
+
+    // Simulate slow 3G: 500kbps download, 500kbps upload, 400ms RTT
+    await cdpSession.send('Network.emulateNetworkConditions', {
+      offline: false,
+      downloadThroughput: (500 * 1024) / 8,  // bytes per second
+      uploadThroughput: (500 * 1024) / 8,
+      latency: 400,                            // ms
+    });
+
+    await page.goto('/products');
+
+    // Skeleton screen should appear while content loads
+    await expect(page.getByTestId('product-skeleton')).toBeVisible();
+
+    // Eventually, real content replaces skeleton
+    await expect(page.getByRole('listitem')).toHaveCount(12, { timeout: 30_000 });
+    await expect(page.getByTestId('product-skeleton')).toBeHidden();
+  });
+
+  test('shows offline message when network drops', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+    // Drop network entirely
+    await page.context().setOffline(true);
+
+    // Try to navigate -- should show offline message
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await expect(page.getByText(/you.*offline|no.*connection/i)).toBeVisible();
+
+    // Restore network
+    await page.context().setOffline(false);
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+  });
+
+  test('images lazy-load on slow connections', async ({ page }) => {
+    const cdpSession = await page.context().newCDPSession(page);
+    await cdpSession.send('Network.emulateNetworkConditions', {
+      offline: false,
+      downloadThroughput: (1000 * 1024) / 8,
+      uploadThroughput: (500 * 1024) / 8,
+      latency: 200,
+    });
+
+    await page.goto('/gallery');
+
+    // Images below the fold should have loading="lazy" and not load immediately
+    const belowFoldImages = page.locator('img[loading="lazy"]');
+    const count = await belowFoldImages.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Scroll to trigger lazy loading
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(belowFoldImages.first()).toHaveJSProperty('complete', true);
+  });
+
+  test('CPU throttling shows performance impact', async ({ page }) => {
+    const cdpSession = await page.context().newCDPSession(page);
+
+    // Simulate 4x CPU slowdown (typical mid-range mobile device)
+    await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+    await page.goto('/');
+
+    // Measure time to interactive
+    const tti = await page.evaluate(() => {
+      const entries = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+      return entries[0]?.domInteractive ?? 0;
+    });
+
+    // Assert TTI is within acceptable range for throttled mobile
+    expect(tti).toBeLessThan(5000);
+
+    // Reset throttling
+    await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+  });
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/mobile-performance.spec.js
+const { test, expect, devices } = require('@playwright/test');
+
+test.describe('mobile on slow network', () => {
+  test.use({ ...devices['Pixel 7'] });
+
+  test('shows skeleton loader on slow 3G', async ({ page }) => {
+    const cdpSession = await page.context().newCDPSession(page);
+
+    await cdpSession.send('Network.emulateNetworkConditions', {
+      offline: false,
+      downloadThroughput: (500 * 1024) / 8,
+      uploadThroughput: (500 * 1024) / 8,
+      latency: 400,
+    });
+
+    await page.goto('/products');
+
+    await expect(page.getByTestId('product-skeleton')).toBeVisible();
+    await expect(page.getByRole('listitem')).toHaveCount(12, { timeout: 30_000 });
+    await expect(page.getByTestId('product-skeleton')).toBeHidden();
+  });
+
+  test('shows offline message when network drops', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+    await page.context().setOffline(true);
+
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await expect(page.getByText(/you.*offline|no.*connection/i)).toBeVisible();
+
+    await page.context().setOffline(false);
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+  });
+
+  test('CPU throttling shows performance impact', async ({ page }) => {
+    const cdpSession = await page.context().newCDPSession(page);
+
+    await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+    await page.goto('/');
+
+    const tti = await page.evaluate(() => {
+      const entries = performance.getEntriesByType('navigation');
+      return entries[0]?.domInteractive ?? 0;
+    });
+
+    expect(tti).toBeLessThan(5000);
+    await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+  });
+});
+```
+
+### 10. PWA Mobile Testing
+
+**Use when**: Testing Progressive Web App features -- service workers, install prompts, offline mode, push notifications on mobile.
+**Avoid when**: Your app is not a PWA. For general offline testing, see the network offline pattern in Pattern 9.
+
+#### TypeScript
+
+```typescript
+// tests/pwa-mobile.spec.ts
+import { test, expect, devices } from '@playwright/test';
+
+test.use({ ...devices['Pixel 7'] });
+
+test('service worker registers and caches resources', async ({ page }) => {
+  await page.goto('/');
+
+  // Wait for service worker to register
+  const swRegistered = await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    return registration.active?.state === 'activated';
+  });
+  expect(swRegistered).toBe(true);
+
+  // Verify critical resources are cached
+  const cacheContents = await page.evaluate(async () => {
+    const cache = await caches.open('app-shell-v1');
+    const keys = await cache.keys();
+    return keys.map((req) => new URL(req.url).pathname);
+  });
+
+  expect(cacheContents).toContain('/');
+  expect(cacheContents).toContain('/offline.html');
+});
+
+test('app works offline after initial load', async ({ page }) => {
+  // Load the app online first -- service worker caches resources
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+
+  // Wait for service worker to finish caching
+  await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    // Wait for the service worker to activate
+    if (registration.active?.state !== 'activated') {
+      await new Promise<void>((resolve) => {
+        registration.active?.addEventListener('statechange', () => {
+          if (registration.active?.state === 'activated') resolve();
+        });
+      });
+    }
+  });
+
+  // Go offline
+  await page.context().setOffline(true);
+
+  // Navigate to a cached page
+  await page.goto('/about');
+
+  // Cached page should render
+  await expect(page.getByRole('heading', { name: 'About' })).toBeVisible();
+});
+
+test('offline fallback page shows when uncached route is accessed', async ({ page }) => {
+  await page.goto('/');
+
+  // Wait for service worker
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  // Go offline and navigate to an uncached route
+  await page.context().setOffline(true);
+  await page.goto('/uncached-page');
+
+  // Should show the offline fallback page
+  await expect(page.getByText(/offline|no.*connection/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+});
+
+test('app prompts to install on mobile', async ({ page, context }) => {
+  // Listen for the beforeinstallprompt event
+  await page.goto('/');
+
+  const installPromptFired = await page.evaluate(() => {
+    return new Promise<boolean>((resolve) => {
+      // Check if the event has already fired
+      window.addEventListener('beforeinstallprompt', (e) => {
+        e.preventDefault(); // Prevent auto-prompt
+        resolve(true);
+      });
+
+      // If PWA criteria are met, the event fires automatically
+      // Timeout after 5s if it doesn't fire
+      setTimeout(() => resolve(false), 5000);
+    });
+  });
+
+  // Note: beforeinstallprompt only fires in Chromium and when PWA criteria are met
+  // This test validates the event handler, not the browser chrome UI
+  if (installPromptFired) {
+    // App should show a custom install banner
+    await expect(page.getByTestId('install-banner')).toBeVisible();
+    await page.getByRole('button', { name: 'Install app' }).click();
+  }
+});
+
+test('push notification permission request on mobile', async ({ page, context }) => {
+  // Grant notification permission
+  await context.grantPermissions(['notifications']);
+
+  await page.goto('/settings/notifications');
+
+  await page.getByRole('button', { name: 'Enable notifications' }).click();
+
+  // Verify the app registered for push
+  const pushSubscription = await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription !== null;
+  });
+
+  expect(pushSubscription).toBe(true);
+  await expect(page.getByText('Notifications enabled')).toBeVisible();
+});
+```
+
+#### JavaScript
+
+```javascript
+// tests/pwa-mobile.spec.js
+const { test, expect, devices } = require('@playwright/test');
+
+test.use({ ...devices['Pixel 7'] });
+
+test('service worker registers and caches resources', async ({ page }) => {
+  await page.goto('/');
+
+  const swRegistered = await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    return registration.active?.state === 'activated';
+  });
+  expect(swRegistered).toBe(true);
+
+  const cacheContents = await page.evaluate(async () => {
+    const cache = await caches.open('app-shell-v1');
+    const keys = await cache.keys();
+    return keys.map((req) => new URL(req.url).pathname);
+  });
+
+  expect(cacheContents).toContain('/');
+  expect(cacheContents).toContain('/offline.html');
+});
+
+test('app works offline after initial load', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.ready;
+  });
+
+  await page.context().setOffline(true);
+  await page.goto('/about');
+
+  await expect(page.getByRole('heading', { name: 'About' })).toBeVisible();
+});
+
+test('offline fallback page shows when uncached route is accessed', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  await page.context().setOffline(true);
+  await page.goto('/uncached-page');
+
+  await expect(page.getByText(/offline|no.*connection/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+});
+
+test('push notification permission request on mobile', async ({ page, context }) => {
+  await context.grantPermissions(['notifications']);
+
+  await page.goto('/settings/notifications');
+
+  await page.getByRole('button', { name: 'Enable notifications' }).click();
+
+  const pushSubscription = await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription !== null;
+  });
+
+  expect(pushSubscription).toBe(true);
+  await expect(page.getByText('Notifications enabled')).toBeVisible();
+});
+```
+
+## Decision Guide
+
+| Question | Answer | Approach |
+|---|---|---|
+| Need to test how app looks on iPhone 14? | Yes | Use `devices['iPhone 14']` -- gets viewport, UA, touch, scale factor in one shot |
+| Need to test a CSS breakpoint at 768px? | Yes | Use `test.use({ viewport: { width: 768, height: 1024 } })` -- simpler, no UA change |
+| Need to test both portrait and landscape? | Yes | Use named device + landscape variant: `devices['iPad Pro 11']` and `devices['iPad Pro 11 landscape']` |
+| Need realistic mobile performance? | Yes | Use CDP `Network.emulateNetworkConditions` + `Emulation.setCPUThrottlingRate` (Chromium only) |
+| Need to test touch gestures? | Yes | Use device profile with `hasTouch: true`, then use `tap()`, mouse gestures for swipe |
+| Need to test geolocation? | Yes | Set `geolocation` and `permissions: ['geolocation']` in context options |
+| Need pixel-perfect mobile testing? | No -- use real devices | Playwright emulation approximates; font rendering and native UI differ from real hardware |
+| Which devices to test by default? | Start with 3 | `Desktop Chrome` + `Pixel 7` (Android) + `iPhone 14` (iOS). Add tablet if your app has a tablet layout. |
+| When to add more device projects? | When bugs escape | If users report device-specific bugs, add that device profile permanently |
+| Run all devices on every PR? | No | Run desktop + one mobile on PRs. Run all devices on main branch merges. |
+| Device emulation vs custom viewport? | Depends on goal | Emulation: testing real-world device behavior. Custom viewport: testing CSS breakpoints. |
+| Should I test every screen size? | No | Test your actual CSS breakpoints, plus smallest (320px) and largest (1440px+) supported sizes |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Only testing at 1280x720 desktop | Misses all mobile and tablet layout bugs; most web traffic is mobile | Add at least `Pixel 7` and `iPhone 14` projects |
+| Using device emulation for pixel-perfect testing | Emulation approximates real devices -- font rendering, sub-pixel antialiasing, and native browser chrome differ | Use emulation for layout and interaction testing; use real device labs (BrowserStack, Sauce Labs) for pixel-perfect validation |
+| Ignoring touch interactions | Mobile users tap, swipe, and long-press; `click()` alone may not trigger touch-specific event handlers | Use `tap()` on touch device profiles; test swipe gestures with mouse move sequences |
+| Not testing orientation changes | Users rotate tablets and phones; layouts may break in landscape | Test both portrait and landscape with device variants or `page.setViewportSize()` |
+| `page.setViewportSize()` without `hasTouch: true` | Viewport is small but browser reports no touch support -- `@media (hover: hover)` still matches desktop | Use device profiles or explicitly set `hasTouch: true` in `test.use()` |
+| Hardcoding `isMobile` checks in every test | Duplicates logic, hard to maintain; tests become brittle | Use page objects that abstract mobile vs desktop behavior behind methods |
+| Testing mobile layout with `visibility: hidden` checks only | Element may still take up space; CSS may use `display: none` or `transform: translateX(-100%)` | Use `toBeHidden()` (checks not visible) or `toHaveCSS('display', 'none')` for specific CSS behavior |
+| Running 10+ device projects on every CI run | Massive CI time and cost with diminishing returns beyond 3-4 devices | Pick representative devices: one Android phone, one iPhone, one tablet, and desktop browsers |
+| Network throttling in every test | Slows entire suite dramatically for minimal extra coverage | Create a separate `mobile-perf` project or tag performance tests with `@slow` and run them separately |
+| `await page.waitForTimeout(2000)` after orientation change | Arbitrary delay; layout reflow may be faster or slower | `await expect(locator).toHaveCSS('property', 'value')` -- assertion auto-retries until layout settles |
+| Testing geolocation without setting permissions | Browser blocks geolocation silently; test sees no location data and passes incorrectly | Always set `permissions: ['geolocation']` alongside `geolocation` coordinates |
+| CDP throttling on Firefox or WebKit | CDP sessions are Chromium-only; test will throw on other browsers | Guard CDP calls with a browser check or use Chromium-only projects for performance tests |
+
+## Troubleshooting
+
+### `tap()` throws "Page.tap: Not supported" error
+
+**Cause**: The browser context was created without `hasTouch: true`. Device profiles set this automatically, but custom viewport configurations do not.
+
+```typescript
+// Wrong -- custom viewport without touch support
+test.use({ viewport: { width: 375, height: 667 } });
+test('tap fails', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button').tap(); // Error: Not supported
+});
+
+// Fix -- enable touch explicitly
+test.use({
+  viewport: { width: 375, height: 667 },
+  hasTouch: true,
+});
+test('tap works', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button').tap(); // Works
+});
+
+// Or use a device profile that includes hasTouch
+test.use({ ...devices['iPhone 14'] });
+```
+
+### `isMobile` is always `false`
+
+**Cause**: `isMobile` is set by the device profile's `isMobile` property, not by viewport size. Custom viewports do not set it.
+
+```typescript
+// isMobile is false here -- no device profile used
+test.use({ viewport: { width: 375, height: 667 } });
+
+test('isMobile is false', async ({ page, isMobile }) => {
+  console.log(isMobile); // false
+});
+
+// Fix: use a device profile, or set isMobile explicitly
+test.use({
+  viewport: { width: 375, height: 667 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+test('isMobile is true', async ({ page, isMobile }) => {
+  console.log(isMobile); // true
+});
+```
+
+### Geolocation not working -- location remains default
+
+**Cause**: Missing `permissions: ['geolocation']` in context options. The browser silently denies the Geolocation API without this permission.
+
+```typescript
+// Wrong -- geolocation set but no permission granted
+test.use({
+  geolocation: { latitude: 40.7128, longitude: -74.0060 },
+  // Missing: permissions: ['geolocation']
+});
+
+// Fix
+test.use({
+  geolocation: { latitude: 40.7128, longitude: -74.0060 },
+  permissions: ['geolocation'],
+});
+```
+
+### CDP session throws on Firefox/WebKit
+
+**Cause**: `page.context().newCDPSession(page)` is Chromium-only. Firefox and WebKit do not support CDP.
+
+```typescript
+// Wrong -- crashes on Firefox and WebKit
+test('throttle network', async ({ page }) => {
+  const cdp = await page.context().newCDPSession(page); // Throws on non-Chromium
+});
+
+// Fix -- guard with browser name check
+test('throttle network', async ({ page, browserName }) => {
+  test.skip(browserName !== 'chromium', 'CDP throttling is Chromium-only');
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Network.emulateNetworkConditions', {
+    offline: false,
+    downloadThroughput: (500 * 1024) / 8,
+    uploadThroughput: (500 * 1024) / 8,
+    latency: 400,
+  });
+});
+
+// Alternative -- use context.setOffline() which works on all browsers
+test('offline mode', async ({ page }) => {
+  await page.context().setOffline(true); // Works everywhere
+});
+```
+
+### Viewport change does not trigger CSS media queries
+
+**Cause**: `page.setViewportSize()` changes the viewport but does not trigger `resize` or `orientationchange` events in some frameworks that rely on JavaScript-based responsive logic rather than CSS media queries.
+
+```typescript
+// If media queries don't fire after setViewportSize, dispatch manually
+await page.setViewportSize({ width: 375, height: 667 });
+await page.evaluate(() => window.dispatchEvent(new Event('resize')));
+
+// Better: use the viewport in test.use() so it's set before page load
+test.use({ viewport: { width: 375, height: 667 } });
+```
+
+### Service worker not registering in tests
+
+**Cause**: Service workers require HTTPS or localhost. Playwright's default `baseURL` of `http://localhost:3000` works, but other HTTP origins do not.
+
+```typescript
+// Ensure your baseURL is localhost or HTTPS
+// playwright.config.ts
+export default defineConfig({
+  use: {
+    baseURL: 'http://localhost:3000',          // Works for service workers
+    // baseURL: 'http://192.168.1.100:3000',   // Does NOT work -- not localhost
+  },
+});
+
+// If testing against a non-localhost server, use HTTPS
+// or use serviceWorkers: 'allow' (default) in context options
+```
+
+## Related
+
+- [core/configuration.md](configuration.md) -- project setup with device profiles and multi-project config
+- [core/visual-regression.md](visual-regression.md) -- combine responsive testing with screenshot comparison across viewports
+- [core/network-mocking.md](network-mocking.md) -- mock API responses alongside mobile testing
+- [core/service-workers-and-pwa.md](service-workers-and-pwa.md) -- in-depth PWA testing beyond mobile context
+- [core/performance-testing.md](performance-testing.md) -- comprehensive performance testing including mobile metrics
+- [core/browser-apis.md](browser-apis.md) -- geolocation, permissions, and other browser APIs in detail
+- [ci/projects-and-dependencies.md](../ci/projects-and-dependencies.md) -- advanced multi-project patterns for responsive testing matrices

--- a/engineering-team/playwright skill/core/multi-context-and-popups.md
+++ b/engineering-team/playwright skill/core/multi-context-and-popups.md
@@ -1,0 +1,526 @@
+# Multi-Context, Popups, and New Windows
+
+> **When to use**: Handling popup windows, new tabs, OAuth authorization flows, payment gateway redirects, multi-tab coordination, and any scenario where your application opens additional browser windows or tabs.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+// Catch a popup triggered by a click
+const popupPromise = page.waitForEvent('popup');
+await page.getByRole('button', { name: 'Open preview' }).click();
+const popup = await popupPromise;
+await popup.waitForLoadState();
+await expect(popup.getByRole('heading')).toContainText('Preview');
+
+// List all open pages in a context
+const allPages = context.pages();
+console.log(`Open tabs: ${allPages.length}`);
+```
+
+**Key concept**: In Playwright, a "popup" is any new page opened by `window.open()`, `target="_blank"` links, or JavaScript-triggered new windows. They all fire the `popup` event on the originating page.
+
+## Patterns
+
+### Handling Basic Popups
+
+**Use when**: A user action opens a new tab or window and you need to interact with it.
+**Avoid when**: The "popup" is actually a modal dialog within the same page -- use `getByRole('dialog')` instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('handle popup opened by target="_blank" link', async ({ page }) => {
+  await page.goto('/help');
+
+  // Set up the popup listener BEFORE the action that triggers it
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Documentation' }).click();
+  const popup = await popupPromise;
+
+  // Wait for the popup to load
+  await popup.waitForLoadState();
+
+  // Interact with the popup
+  await expect(popup.getByRole('heading', { level: 1 })).toContainText('Documentation');
+  expect(popup.url()).toContain('/docs');
+
+  // Close the popup when done
+  await popup.close();
+});
+
+test('handle popup opened by window.open()', async ({ page }) => {
+  await page.goto('/reports');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Print report' }).click();
+  const popup = await popupPromise;
+
+  await popup.waitForLoadState();
+  await expect(popup.getByTestId('print-preview')).toBeVisible();
+
+  // The original page is still accessible
+  await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('handle popup opened by target="_blank" link', async ({ page }) => {
+  await page.goto('/help');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Documentation' }).click();
+  const popup = await popupPromise;
+
+  await popup.waitForLoadState();
+  await expect(popup.getByRole('heading', { level: 1 })).toContainText('Documentation');
+
+  await popup.close();
+});
+```
+
+### OAuth Popup Flows
+
+**Use when**: Your app opens a third-party OAuth window (Google, GitHub, Microsoft, etc.) for authentication.
+**Avoid when**: You can bypass OAuth entirely by injecting auth tokens directly -- see [core/authentication.md](authentication.md).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('Google OAuth popup flow', async ({ page }) => {
+  await page.goto('/login');
+
+  // Listen for the popup before clicking the OAuth button
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+  const oauthPopup = await popupPromise;
+
+  // Wait for the OAuth provider page to load
+  await oauthPopup.waitForLoadState();
+  expect(oauthPopup.url()).toContain('accounts.google.com');
+
+  // Fill in credentials on the OAuth provider page
+  await oauthPopup.getByLabel('Email or phone').fill('testuser@gmail.com');
+  await oauthPopup.getByRole('button', { name: 'Next' }).click();
+  await oauthPopup.getByLabel('Enter your password').fill('test-password');
+  await oauthPopup.getByRole('button', { name: 'Next' }).click();
+
+  // The popup closes automatically after authorization
+  // Wait for the original page to receive the auth callback
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+
+test('GitHub OAuth popup flow', async ({ page }) => {
+  await page.goto('/login');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Sign in with GitHub' }).click();
+  const popup = await popupPromise;
+
+  await popup.waitForLoadState();
+  expect(popup.url()).toContain('github.com');
+
+  await popup.getByLabel('Username or email address').fill('testuser');
+  await popup.getByLabel('Password').fill('test-password');
+  await popup.getByRole('button', { name: 'Sign in' }).click();
+
+  // Authorize the app if prompted
+  const authorizeButton = popup.getByRole('button', { name: 'Authorize' });
+  if (await authorizeButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await authorizeButton.click();
+  }
+
+  // Popup closes, original page redirects
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText(/Welcome/)).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('GitHub OAuth popup flow', async ({ page }) => {
+  await page.goto('/login');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Sign in with GitHub' }).click();
+  const popup = await popupPromise;
+
+  await popup.waitForLoadState();
+  await popup.getByLabel('Username or email address').fill('testuser');
+  await popup.getByLabel('Password').fill('test-password');
+  await popup.getByRole('button', { name: 'Sign in' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText(/Welcome/)).toBeVisible();
+});
+```
+
+### Payment Gateway Popups
+
+**Use when**: Checkout flows open a payment provider in a new window (PayPal, 3D Secure verification).
+**Avoid when**: The payment gateway loads in an iframe on the same page -- use `frameLocator` instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('PayPal popup checkout flow', async ({ page }) => {
+  await page.goto('/checkout');
+
+  await page.getByLabel('Email').fill('buyer@example.com');
+  await page.getByRole('button', { name: 'Proceed to payment' }).click();
+
+  // PayPal opens in a popup
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Pay with PayPal' }).click();
+  const paypalPopup = await popupPromise;
+
+  await paypalPopup.waitForLoadState();
+  expect(paypalPopup.url()).toContain('paypal.com');
+
+  // Complete PayPal flow
+  await paypalPopup.getByLabel('Email').fill('buyer@paypal-test.com');
+  await paypalPopup.getByRole('button', { name: 'Next' }).click();
+  await paypalPopup.getByLabel('Password').fill('test-password');
+  await paypalPopup.getByRole('button', { name: 'Log In' }).click();
+  await paypalPopup.getByRole('button', { name: 'Complete Purchase' }).click();
+
+  // Popup closes, return to original page
+  await page.waitForURL('/order/confirmation');
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('3D Secure verification popup', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Card number').fill('4000000000003220'); // 3DS test card
+  await page.getByLabel('Expiry').fill('12/28');
+  await page.getByLabel('CVC').fill('123');
+  await page.getByRole('button', { name: 'Pay' }).click();
+
+  // 3DS challenge opens in popup or iframe -- handle both
+  const popupPromise = page.waitForEvent('popup', { timeout: 5000 }).catch(() => null);
+  const popup = await popupPromise;
+
+  if (popup) {
+    await popup.waitForLoadState();
+    await popup.getByRole('button', { name: 'Complete authentication' }).click();
+  } else {
+    // Fallback: 3DS in iframe
+    const frame = page.frameLocator('iframe[name*="challenge"]');
+    await frame.getByRole('button', { name: 'Complete authentication' }).click();
+  }
+
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('PayPal popup checkout flow', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Proceed to payment' }).click();
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Pay with PayPal' }).click();
+  const paypalPopup = await popupPromise;
+
+  await paypalPopup.waitForLoadState();
+  await paypalPopup.getByLabel('Email').fill('buyer@paypal-test.com');
+  await paypalPopup.getByRole('button', { name: 'Next' }).click();
+  await paypalPopup.getByLabel('Password').fill('test-password');
+  await paypalPopup.getByRole('button', { name: 'Log In' }).click();
+  await paypalPopup.getByRole('button', { name: 'Complete Purchase' }).click();
+
+  await page.waitForURL('/order/confirmation');
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+```
+
+### Multi-Tab Coordination
+
+**Use when**: Testing scenarios where multiple tabs share state -- real-time collaboration, shopping cart sync, or session management across tabs.
+**Avoid when**: Each tab is independent and can be tested in separate test cases.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('cart updates reflect across tabs', async ({ context }) => {
+  // Open two tabs in the same context (shared cookies/storage)
+  const page1 = await context.newPage();
+  const page2 = await context.newPage();
+
+  await page1.goto('/products');
+  await page2.goto('/cart');
+
+  // Add item in tab 1
+  await page1.getByRole('button', { name: 'Add to cart' }).first().click();
+
+  // Tab 2 should reflect the update (via WebSocket, polling, or storage event)
+  await expect(page2.getByTestId('cart-count')).toHaveText('1', { timeout: 5000 });
+});
+
+test('logout in one tab logs out all tabs', async ({ context }) => {
+  const page1 = await context.newPage();
+  const page2 = await context.newPage();
+
+  // Both tabs are on authenticated pages
+  await page1.goto('/dashboard');
+  await page2.goto('/settings');
+
+  // Log out from tab 1
+  await page1.getByRole('button', { name: 'Log out' }).click();
+  await page1.waitForURL('/login');
+
+  // Tab 2 should redirect to login on next action or automatically
+  await page2.reload();
+  expect(page2.url()).toContain('/login');
+});
+
+test('manage multiple tabs with context.pages()', async ({ context, page }) => {
+  await page.goto('/dashboard');
+
+  // Open several new tabs
+  const popupPromise1 = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Report A' }).click();
+  const tab1 = await popupPromise1;
+
+  const popupPromise2 = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Report B' }).click();
+  const tab2 = await popupPromise2;
+
+  // List all pages in this context
+  const allPages = context.pages();
+  expect(allPages).toHaveLength(3); // original + 2 popups
+
+  // Interact with specific tabs
+  await tab1.waitForLoadState();
+  await expect(tab1.getByRole('heading')).toContainText('Report A');
+
+  await tab2.waitForLoadState();
+  await expect(tab2.getByRole('heading')).toContainText('Report B');
+
+  // Close tabs when done
+  await tab2.close();
+  await tab1.close();
+  expect(context.pages()).toHaveLength(1);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('cart updates reflect across tabs', async ({ context }) => {
+  const page1 = await context.newPage();
+  const page2 = await context.newPage();
+
+  await page1.goto('/products');
+  await page2.goto('/cart');
+
+  await page1.getByRole('button', { name: 'Add to cart' }).first().click();
+  await expect(page2.getByTestId('cart-count')).toHaveText('1', { timeout: 5000 });
+});
+
+test('manage tabs with context.pages()', async ({ context, page }) => {
+  await page.goto('/dashboard');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Report A' }).click();
+  const newTab = await popupPromise;
+
+  expect(context.pages()).toHaveLength(2);
+  await newTab.close();
+  expect(context.pages()).toHaveLength(1);
+});
+```
+
+### Download Triggers in New Tabs
+
+**Use when**: A download is triggered by opening a new tab (e.g., PDF generation that opens in a new window before downloading).
+**Avoid when**: The download starts directly without opening a new tab -- use `page.waitForEvent('download')` directly.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('PDF download from new tab', async ({ page }) => {
+  await page.goto('/invoices');
+
+  // Some apps open the PDF in a new tab, which then triggers a download
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Download Invoice #123' }).click();
+  const popup = await popupPromise;
+
+  // The popup may directly trigger a download
+  const downloadPromise = popup.waitForEvent('download');
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toContain('invoice');
+  const path = await download.path();
+  expect(path).toBeTruthy();
+
+  await popup.close();
+});
+
+test('export opens in new tab then auto-downloads', async ({ page }) => {
+  await page.goto('/reports');
+
+  // Handle both: popup that downloads AND popup that shows content
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Export CSV' }).click();
+  const popup = await popupPromise;
+
+  // Try to catch a download; if no download, the popup has the content
+  try {
+    const download = await popup.waitForEvent('download', { timeout: 5000 });
+    const filename = download.suggestedFilename();
+    expect(filename).toMatch(/\.csv$/);
+    await download.saveAs(`./downloads/${filename}`);
+  } catch {
+    // No download event — content displayed in the popup
+    const content = await popup.textContent('body');
+    expect(content).toContain('Report Data');
+  }
+
+  await popup.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('PDF download from new tab', async ({ page }) => {
+  await page.goto('/invoices');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Download Invoice #123' }).click();
+  const popup = await popupPromise;
+
+  const downloadPromise = popup.waitForEvent('download');
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toContain('invoice');
+  await popup.close();
+});
+```
+
+### Multi-Context for Isolated Sessions
+
+**Use when**: Testing interactions between different users (e.g., admin and regular user, two chat participants).
+**Avoid when**: You only need a single user perspective -- a single context is sufficient.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('admin sees user changes in real-time', async ({ browser }) => {
+  // Create separate contexts for two users (separate sessions)
+  const adminContext = await browser.newContext();
+  const userContext = await browser.newContext();
+
+  const adminPage = await adminContext.newPage();
+  const userPage = await userContext.newPage();
+
+  // Admin logs in and watches the user list
+  await adminPage.goto('/admin/users');
+
+  // User signs up
+  await userPage.goto('/register');
+  await userPage.getByLabel('Name').fill('New User');
+  await userPage.getByLabel('Email').fill('newuser@example.com');
+  await userPage.getByLabel('Password').fill('password123');
+  await userPage.getByRole('button', { name: 'Register' }).click();
+
+  // Admin should see the new user appear
+  await expect(adminPage.getByText('newuser@example.com')).toBeVisible({ timeout: 10000 });
+
+  await adminContext.close();
+  await userContext.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('admin sees user changes in real-time', async ({ browser }) => {
+  const adminContext = await browser.newContext();
+  const userContext = await browser.newContext();
+
+  const adminPage = await adminContext.newPage();
+  const userPage = await userContext.newPage();
+
+  await adminPage.goto('/admin/users');
+
+  await userPage.goto('/register');
+  await userPage.getByLabel('Name').fill('New User');
+  await userPage.getByLabel('Email').fill('newuser@example.com');
+  await userPage.getByLabel('Password').fill('password123');
+  await userPage.getByRole('button', { name: 'Register' }).click();
+
+  await expect(adminPage.getByText('newuser@example.com')).toBeVisible({ timeout: 10000 });
+
+  await adminContext.close();
+  await userContext.close();
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| `target="_blank"` link | `page.waitForEvent('popup')` | Playwright fires `popup` for all new windows/tabs |
+| `window.open()` call | `page.waitForEvent('popup')` | Same mechanism regardless of how the window opens |
+| OAuth login popup | `waitForEvent('popup')` + interact + wait for close | OAuth providers redirect back and close the popup |
+| Payment popup (PayPal) | `waitForEvent('popup')` + complete flow | Same as OAuth but with payment-specific UI |
+| Download in new tab | `popup.waitForEvent('download')` | Catch the download event on the popup page |
+| Multiple tabs, same user | Open pages in the same `context` | Shared cookies, localStorage, session |
+| Multiple users (separate sessions) | Create separate `browser.newContext()` per user | Isolated cookies, storage, auth state |
+| Tab sync testing | Multiple `context.newPage()` + assert shared state | Tests real-time state synchronization |
+| Popup that may or may not appear | `waitForEvent('popup', { timeout })` with try/catch | Graceful handling of conditional popups |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Clicking then calling `waitForEvent('popup')` | Popup may open before listener is registered (race condition) | Set up `waitForEvent` BEFORE the click |
+| Using `context.pages()[1]` to get a popup | Index order is not guaranteed; brittle | Use `waitForEvent('popup')` which returns the exact page |
+| Forgetting `popup.waitForLoadState()` | Popup page may not be loaded when you interact with it | Always call `waitForLoadState()` after receiving the popup |
+| Not closing popups after test | Leaked pages consume memory and may affect subsequent tests | Close popups with `popup.close()` in the test or use fixtures |
+| Using separate `browser.newContext()` when tabs should share state | Separate contexts have separate cookies/sessions | Use `context.newPage()` for tabs in the same session |
+| Using `context.newPage()` for isolated users | Pages in the same context share state | Use `browser.newContext()` for separate user sessions |
+| `page.waitForTimeout()` after popup trigger | Popup timing is unpredictable | Use `page.waitForEvent('popup')` which resolves when the popup opens |
+| Catching popup on the wrong page | Popup event fires on the page that triggered it | Listen for `popup` on the page where the click/action happens |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `waitForEvent('popup')` times out | The action did not open a new window; it navigated in the same tab | Check if the link has `target="_blank"` or if `window.open` is called |
+| Popup opens but is blank | Popup is still loading; you interacted too early | Add `await popup.waitForLoadState()` before interacting |
+| Popup URL is `about:blank` | Popup is created empty, then navigated by JavaScript | Wait for `popup.waitForURL()` with the expected URL pattern |
+| OAuth popup is blocked by browser | Pop-up blocker is active | Playwright disables pop-up blocking by default; check if a browser arg re-enables it |
+| Two popups open but only one is caught | `waitForEvent` resolves for the first event only | Use `page.on('popup', callback)` to catch all popups, or chain two `waitForEvent` calls |
+| `context.pages()` returns unexpected count | Previous test left pages open | Close all extra pages in `afterEach` or use per-test contexts |
+| Popup closes before interaction completes | The app or OAuth provider auto-closes after timeout | Increase test speed or remove `slowMo`; interact with the popup immediately |
+| Cross-origin popup interaction fails | Popup navigated to a different origin | Playwright handles cross-origin popups; ensure you are not setting `--disable-web-security` |
+
+## Related
+
+- [core/authentication.md](authentication.md) -- bypassing OAuth popups with stored auth state
+- [core/multi-user-and-collaboration.md](multi-user-and-collaboration.md) -- multi-user real-time collaboration testing
+- [core/file-operations.md](file-operations.md) -- file download handling without popups
+- [core/third-party-integrations.md](third-party-integrations.md) -- mocking OAuth providers to avoid real popups
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- fixtures for multi-context setups

--- a/engineering-team/playwright skill/core/multi-user-and-collaboration.md
+++ b/engineering-team/playwright skill/core/multi-user-and-collaboration.md
@@ -1,0 +1,477 @@
+# Multi-User and Collaboration Testing
+
+> **When to use**: When your application involves real-time collaboration, multi-user workflows, or any scenario where two or more users interact with the same resource simultaneously -- chat apps, shared documents, multiplayer features, admin-and-user flows.
+> **Prerequisites**: [core/fixtures-and-hooks.md](fixtures-and-hooks.md), [core/configuration.md](configuration.md)
+
+## Quick Reference
+
+```typescript
+// Two independent browser contexts in one test = two users
+const alice = await browser.newContext({ storageState: 'auth/alice.json' });
+const bob = await browser.newContext({ storageState: 'auth/bob.json' });
+const alicePage = await alice.newPage();
+const bobPage = await bob.newPage();
+
+// Each operates independently — different cookies, sessions, localStorage
+await alicePage.goto('/chat/room-1');
+await bobPage.goto('/chat/room-1');
+```
+
+## Patterns
+
+### Two Users in One Test via Browser Contexts
+
+**Use when**: You need to verify that actions by one user are visible to another in real time.
+**Avoid when**: You only need to test a single user's flow. One context per test is the default.
+
+Each `browser.newContext()` creates a fully isolated session -- separate cookies, localStorage, and network state. This is how you simulate two logged-in users in a single test without launching a second browser.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('alice sends a message and bob sees it', async ({ browser }) => {
+  // Create two isolated contexts
+  const aliceContext = await browser.newContext({ storageState: 'auth/alice.json' });
+  const bobContext = await browser.newContext({ storageState: 'auth/bob.json' });
+
+  const alicePage = await aliceContext.newPage();
+  const bobPage = await bobContext.newPage();
+
+  // Both navigate to the same chat room
+  await alicePage.goto('/chat/general');
+  await bobPage.goto('/chat/general');
+
+  // Alice sends a message
+  await alicePage.getByRole('textbox', { name: 'Message' }).fill('Hello Bob!');
+  await alicePage.getByRole('button', { name: 'Send' }).click();
+
+  // Bob sees it in real time
+  await expect(bobPage.getByText('Hello Bob!')).toBeVisible();
+
+  // Alice also sees her own message
+  await expect(alicePage.getByText('Hello Bob!')).toBeVisible();
+
+  // Cleanup
+  await aliceContext.close();
+  await bobContext.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('alice sends a message and bob sees it', async ({ browser }) => {
+  const aliceContext = await browser.newContext({ storageState: 'auth/alice.json' });
+  const bobContext = await browser.newContext({ storageState: 'auth/bob.json' });
+
+  const alicePage = await aliceContext.newPage();
+  const bobPage = await bobContext.newPage();
+
+  await alicePage.goto('/chat/general');
+  await bobPage.goto('/chat/general');
+
+  await alicePage.getByRole('textbox', { name: 'Message' }).fill('Hello Bob!');
+  await alicePage.getByRole('button', { name: 'Send' }).click();
+
+  await expect(bobPage.getByText('Hello Bob!')).toBeVisible();
+  await expect(alicePage.getByText('Hello Bob!')).toBeVisible();
+
+  await aliceContext.close();
+  await bobContext.close();
+});
+```
+
+### Multi-User Fixture for Reusability
+
+**Use when**: Multiple tests need two-user setups. Wrap context creation in a fixture to avoid boilerplate.
+**Avoid when**: Only one test needs multi-user logic.
+
+**TypeScript**
+```typescript
+// fixtures.ts
+import { test as base, expect, BrowserContext, Page } from '@playwright/test';
+
+type MultiUserFixtures = {
+  aliceContext: BrowserContext;
+  alicePage: Page;
+  bobContext: BrowserContext;
+  bobPage: Page;
+};
+
+export const test = base.extend<MultiUserFixtures>({
+  aliceContext: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: 'auth/alice.json' });
+    await use(context);
+    await context.close();
+  },
+  alicePage: async ({ aliceContext }, use) => {
+    const page = await aliceContext.newPage();
+    await use(page);
+  },
+  bobContext: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: 'auth/bob.json' });
+    await use(context);
+    await context.close();
+  },
+  bobPage: async ({ bobContext }, use) => {
+    const page = await bobContext.newPage();
+    await use(page);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// collaboration.spec.ts
+import { test, expect } from './fixtures';
+
+test('both users see shared document title', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/docs/shared-doc');
+  await bobPage.goto('/docs/shared-doc');
+
+  await alicePage.getByRole('textbox', { name: 'Title' }).fill('Project Plan');
+
+  await expect(bobPage.getByRole('textbox', { name: 'Title' })).toHaveValue('Project Plan');
+});
+```
+
+**JavaScript**
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  aliceContext: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: 'auth/alice.json' });
+    await use(context);
+    await context.close();
+  },
+  alicePage: async ({ aliceContext }, use) => {
+    const page = await aliceContext.newPage();
+    await use(page);
+  },
+  bobContext: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: 'auth/bob.json' });
+    await use(context);
+    await context.close();
+  },
+  bobPage: async ({ bobContext }, use) => {
+    const page = await bobContext.newPage();
+    await use(page);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### Collaborative Editing with Conflict Detection
+
+**Use when**: Testing real-time collaborative editors (Google Docs-style) where both users edit the same content.
+**Avoid when**: Your app does not support concurrent editing.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('concurrent edits merge without data loss', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/docs/shared-doc');
+  await bobPage.goto('/docs/shared-doc');
+
+  // Wait for both to be connected
+  await expect(alicePage.getByTestId('connection-status')).toHaveText('Connected');
+  await expect(bobPage.getByTestId('connection-status')).toHaveText('Connected');
+
+  // Alice types at the beginning
+  const aliceEditor = alicePage.getByRole('textbox', { name: 'Editor' });
+  await aliceEditor.pressSequentially('Alice was here. ');
+
+  // Bob types at the end (simultaneously)
+  const bobEditor = bobPage.getByRole('textbox', { name: 'Editor' });
+  await bobEditor.press('End');
+  await bobEditor.pressSequentially('Bob was here.');
+
+  // Both edits should be visible to both users
+  await expect(aliceEditor).toContainText('Alice was here.');
+  await expect(aliceEditor).toContainText('Bob was here.');
+  await expect(bobEditor).toContainText('Alice was here.');
+  await expect(bobEditor).toContainText('Bob was here.');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('concurrent edits merge without data loss', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/docs/shared-doc');
+  await bobPage.goto('/docs/shared-doc');
+
+  await expect(alicePage.getByTestId('connection-status')).toHaveText('Connected');
+  await expect(bobPage.getByTestId('connection-status')).toHaveText('Connected');
+
+  const aliceEditor = alicePage.getByRole('textbox', { name: 'Editor' });
+  await aliceEditor.pressSequentially('Alice was here. ');
+
+  const bobEditor = bobPage.getByRole('textbox', { name: 'Editor' });
+  await bobEditor.press('End');
+  await bobEditor.pressSequentially('Bob was here.');
+
+  await expect(aliceEditor).toContainText('Alice was here.');
+  await expect(aliceEditor).toContainText('Bob was here.');
+  await expect(bobEditor).toContainText('Alice was here.');
+  await expect(bobEditor).toContainText('Bob was here.');
+});
+```
+
+### Shared State Verification (Presence, Cursors, Indicators)
+
+**Use when**: Verifying that one user's presence or activity is reflected in the other user's UI -- online indicators, typing indicators, cursor positions.
+**Avoid when**: Presence is not a feature of your app.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('bob sees alice typing indicator', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/chat/general');
+  await bobPage.goto('/chat/general');
+
+  // Alice starts typing
+  await alicePage.getByRole('textbox', { name: 'Message' }).pressSequentially('Hel', { delay: 100 });
+
+  // Bob sees the typing indicator
+  await expect(bobPage.getByText('Alice is typing...')).toBeVisible();
+
+  // Alice stops typing — indicator disappears after debounce
+  await expect(bobPage.getByText('Alice is typing...')).toBeHidden({ timeout: 5000 });
+});
+
+test('online users list updates when user joins', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/chat/general');
+
+  // Alice sees only herself
+  await expect(alicePage.getByTestId('online-users').getByText('Alice')).toBeVisible();
+  await expect(alicePage.getByTestId('online-users').getByText('Bob')).toBeHidden();
+
+  // Bob joins
+  await bobPage.goto('/chat/general');
+
+  // Alice now sees Bob in the online list
+  await expect(alicePage.getByTestId('online-users').getByText('Bob')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('bob sees alice typing indicator', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/chat/general');
+  await bobPage.goto('/chat/general');
+
+  await alicePage.getByRole('textbox', { name: 'Message' }).pressSequentially('Hel', { delay: 100 });
+  await expect(bobPage.getByText('Alice is typing...')).toBeVisible();
+  await expect(bobPage.getByText('Alice is typing...')).toBeHidden({ timeout: 5000 });
+});
+
+test('online users list updates when user joins', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/chat/general');
+  await expect(alicePage.getByTestId('online-users').getByText('Alice')).toBeVisible();
+
+  await bobPage.goto('/chat/general');
+  await expect(alicePage.getByTestId('online-users').getByText('Bob')).toBeVisible();
+});
+```
+
+### Race Condition Testing Between Users
+
+**Use when**: You need to verify that simultaneous actions (two users clicking "buy" on the last item, or two users editing the same field) are handled correctly.
+**Avoid when**: Your app has no shared mutable resources.
+
+**TypeScript**
+```typescript
+import { test, expect } from './fixtures';
+
+test('only one user can claim the last item', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/store/limited-item');
+  await bobPage.goto('/store/limited-item');
+
+  // Both see the item is available
+  await expect(alicePage.getByText('1 remaining')).toBeVisible();
+  await expect(bobPage.getByText('1 remaining')).toBeVisible();
+
+  // Both click buy at approximately the same time
+  const aliceBuy = alicePage.getByRole('button', { name: 'Buy now' }).click();
+  const bobBuy = bobPage.getByRole('button', { name: 'Buy now' }).click();
+  await Promise.all([aliceBuy, bobBuy]);
+
+  // One succeeds, one fails — verify the app handles the race
+  const aliceResult = await alicePage.getByTestId('purchase-result').textContent();
+  const bobResult = await bobPage.getByTestId('purchase-result').textContent();
+
+  const results = [aliceResult, bobResult];
+  expect(results).toContain('Purchase successful');
+  expect(results).toContain('Item no longer available');
+});
+
+test('simultaneous form submissions do not create duplicates', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/admin/settings');
+  await bobPage.goto('/admin/settings');
+
+  // Both change the same setting
+  await alicePage.getByLabel('Company name').fill('Alice Corp');
+  await bobPage.getByLabel('Company name').fill('Bob Inc');
+
+  // Submit simultaneously
+  await Promise.all([
+    alicePage.getByRole('button', { name: 'Save' }).click(),
+    bobPage.getByRole('button', { name: 'Save' }).click(),
+  ]);
+
+  // Reload both pages — one value should win, no corruption
+  await alicePage.reload();
+  const finalValue = await alicePage.getByLabel('Company name').inputValue();
+  expect(['Alice Corp', 'Bob Inc']).toContain(finalValue);
+
+  // The "loser" should see a conflict notification or the updated value
+  await bobPage.reload();
+  await expect(bobPage.getByLabel('Company name')).toHaveValue(finalValue);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('./fixtures');
+
+test('only one user can claim the last item', async ({ alicePage, bobPage }) => {
+  await alicePage.goto('/store/limited-item');
+  await bobPage.goto('/store/limited-item');
+
+  await expect(alicePage.getByText('1 remaining')).toBeVisible();
+  await expect(bobPage.getByText('1 remaining')).toBeVisible();
+
+  const aliceBuy = alicePage.getByRole('button', { name: 'Buy now' }).click();
+  const bobBuy = bobPage.getByRole('button', { name: 'Buy now' }).click();
+  await Promise.all([aliceBuy, bobBuy]);
+
+  const aliceResult = await alicePage.getByTestId('purchase-result').textContent();
+  const bobResult = await bobPage.getByTestId('purchase-result').textContent();
+
+  const results = [aliceResult, bobResult];
+  expect(results).toContain('Purchase successful');
+  expect(results).toContain('Item no longer available');
+});
+```
+
+### N Users with Dynamic Context Creation
+
+**Use when**: You need more than two users, or the number of users is variable (load-like collaboration tests).
+**Avoid when**: Two users suffice. Keep it simple.
+
+**TypeScript**
+```typescript
+import { test, expect, Browser, Page } from '@playwright/test';
+
+async function createUser(browser: Browser, name: string, room: string): Promise<Page> {
+  const context = await browser.newContext({ storageState: `auth/${name}.json` });
+  const page = await context.newPage();
+  await page.goto(`/chat/${room}`);
+  return page;
+}
+
+test('five users in a chat room all see each other', async ({ browser }) => {
+  const names = ['alice', 'bob', 'charlie', 'diana', 'eve'];
+  const pages = await Promise.all(
+    names.map((name) => createUser(browser, name, 'team-room'))
+  );
+
+  // First user sends a message
+  await pages[0].getByRole('textbox', { name: 'Message' }).fill('Hello everyone!');
+  await pages[0].getByRole('button', { name: 'Send' }).click();
+
+  // All users see the message
+  for (const page of pages) {
+    await expect(page.getByText('Hello everyone!')).toBeVisible();
+  }
+
+  // Cleanup
+  for (const page of pages) {
+    await page.context().close();
+  }
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+async function createUser(browser, name, room) {
+  const context = await browser.newContext({ storageState: `auth/${name}.json` });
+  const page = await context.newPage();
+  await page.goto(`/chat/${room}`);
+  return page;
+}
+
+test('five users in a chat room all see each other', async ({ browser }) => {
+  const names = ['alice', 'bob', 'charlie', 'diana', 'eve'];
+  const pages = await Promise.all(
+    names.map((name) => createUser(browser, name, 'team-room'))
+  );
+
+  await pages[0].getByRole('textbox', { name: 'Message' }).fill('Hello everyone!');
+  await pages[0].getByRole('button', { name: 'Send' }).click();
+
+  for (const page of pages) {
+    await expect(page.getByText('Hello everyone!')).toBeVisible();
+  }
+
+  for (const page of pages) {
+    await page.context().close();
+  }
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Two users interact in real time | Two `browser.newContext()` in one test | Fully isolated sessions, same test timeline |
+| Same multi-user setup across many tests | Custom fixture per user context | Eliminates boilerplate, guarantees cleanup |
+| Testing presence/typing indicators | Sequential actions, assert on other page | Order matters -- act on one, assert on the other |
+| Race condition (simultaneous clicks) | `Promise.all([action1, action2])` | Fires both as close to simultaneously as possible |
+| Admin performs action, user sees result | Two contexts with different `storageState` | Different auth roles, same browser instance |
+| 3+ users in one test | Loop with `browser.newContext()` per user | Each context is cheap; browser is shared |
+| Cross-browser multi-user (Chrome + Firefox) | Separate browser launches in `beforeAll` | Rarely needed; contexts within one browser suffice |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Use one context with two pages for two users | Pages in the same context share cookies and localStorage | Use `browser.newContext()` per user |
+| Open a second browser for the second user | Wastes memory and startup time | Use a second `browser.newContext()` -- contexts are lightweight |
+| `await page.waitForTimeout(2000)` for real-time sync | Arbitrary delay; flaky in CI, slow in dev | `await expect(bobPage.getByText('msg')).toBeVisible()` |
+| Share mutable state via `let` variables between contexts | Test order and timing become implicit dependencies | Each context is independent; assert via UI |
+| Put multi-user setup in `beforeAll` | `beforeAll` cannot access `page` or `context` | Use test-scoped fixtures or inline `browser.newContext()` |
+| Forget to close extra contexts | Leaks memory and may cause port exhaustion | Always close contexts in fixture teardown or `finally` |
+| Assert on both pages without waiting | The second page may not have received the update yet | Use `expect` with auto-retry on the receiving page |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Second user sees stale data | Context created before server state was ready | Navigate the second page after the first user's action completes |
+| `storageState` file not found | Auth setup project has not run, or path is wrong | Run auth setup first via `dependencies` in `playwright.config` |
+| Both users have the same session | Reusing the same `storageState` file for both | Create distinct auth state files per user role |
+| Real-time updates never arrive on second page | WebSocket/SSE connection not established before assertion | Wait for a connection indicator before asserting: `await expect(page.getByTestId('connected')).toBeVisible()` |
+| Test is slow with many contexts | Too many contexts in a single test (10+) | Limit to 3-5 contexts per test; use API setup to reduce page interactions |
+| `Promise.all` race test always has same winner | Network/event loop makes one always faster | This is expected in testing -- assert that the app handles both outcomes, not which user wins |
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- wrap multi-user contexts in fixtures
+- [core/websockets-and-realtime.md](websockets-and-realtime.md) -- test the transport layer beneath collaboration features
+- [core/test-data-management.md](test-data-management.md) -- set up shared resources (rooms, documents) before multi-user tests
+- [core/configuration.md](configuration.md) -- configure `storageState` per project for different user roles

--- a/engineering-team/playwright skill/core/network-mocking.md
+++ b/engineering-team/playwright skill/core/network-mocking.md
@@ -1,0 +1,1329 @@
+# Network Mocking
+
+> **When to use**: Isolating your frontend from external services, simulating error states, testing loading/empty/error UI, speeding up tests by avoiding real network calls, and testing against APIs that don't exist yet.
+> **Prerequisites**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Reference
+
+```typescript
+// Intercept and return fake data
+await page.route('**/api/users', (route) =>
+  route.fulfill({ json: [{ id: 1, name: 'Jane' }] })
+);
+
+// Modify a real response before it reaches the browser
+await page.route('**/api/users', async (route) => {
+  const response = await route.fetch();
+  const json = await response.json();
+  json.push({ id: 999, name: 'Injected' });
+  await route.fulfill({ response, json });
+});
+
+// Block third-party scripts
+await page.route('**/*.{png,jpg,svg}', (route) => route.abort());
+
+// Wait for a specific request/response
+const responsePromise = page.waitForResponse('**/api/users');
+await page.getByRole('button', { name: 'Load' }).click();
+await responsePromise;
+
+// HAR replay — serve recorded responses
+await page.routeFromHAR('tests/data/api.har', { url: '**/api/**' });
+```
+
+## Patterns
+
+### Route Interception Basics
+
+**Use when**: You need to intercept any HTTP request made by the page to fulfill, modify, or block it.
+**Avoid when**: You want to test the real integration between frontend and backend (use real API calls instead).
+
+`page.route()` registers a handler that runs for every request matching a URL pattern. Each handler must call exactly one of `route.fulfill()`, `route.continue()`, or `route.abort()`.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('route interception basics', async ({ page }) => {
+  // Intercept before navigating — routes must be set up first
+  await page.route('**/api/users', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 1, name: 'Alice' }]),
+    });
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByText('Alice')).toBeVisible();
+
+  // Remove the route when done (important for cleanup)
+  await page.unroute('**/api/users');
+});
+
+test('context-level routes apply to all pages', async ({ context, page }) => {
+  // Routes on the context apply to every page in that context
+  await context.route('**/api/config', (route) =>
+    route.fulfill({ json: { theme: 'dark', locale: 'en' } })
+  );
+
+  await page.goto('/settings');
+  await expect(page.getByText('Dark')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('route interception basics', async ({ page }) => {
+  await page.route('**/api/users', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 1, name: 'Alice' }]),
+    });
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByText('Alice')).toBeVisible();
+
+  await page.unroute('**/api/users');
+});
+
+test('context-level routes apply to all pages', async ({ context, page }) => {
+  await context.route('**/api/config', (route) =>
+    route.fulfill({ json: { theme: 'dark', locale: 'en' } })
+  );
+
+  await page.goto('/settings');
+  await expect(page.getByText('Dark')).toBeVisible();
+});
+```
+
+### Mocking REST Responses
+
+**Use when**: Your frontend depends on a REST API and you want deterministic, instant responses with controlled data.
+**Avoid when**: You need to verify that your frontend sends the correct request body or headers to the real API (use `route.continue()` with `waitForRequest` instead).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const mockUsers = [
+  { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin' },
+  { id: 2, name: 'Bob', email: 'bob@example.com', role: 'user' },
+];
+
+test('mock a GET endpoint with JSON', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({ json: mockUsers })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(3); // header + 2 data rows
+});
+
+test('mock a POST endpoint and verify the request', async ({ page }) => {
+  await page.route('**/api/users', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 201,
+        json: { id: 3, name: 'Charlie', email: 'charlie@example.com' },
+      });
+    }
+    // Let other methods through
+    return route.continue();
+  });
+
+  await page.goto('/users/new');
+  await page.getByLabel('Name').fill('Charlie');
+  await page.getByLabel('Email').fill('charlie@example.com');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByText('Charlie')).toBeVisible();
+});
+
+test('mock with custom headers and status', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-total-count': '42',
+        'x-request-id': 'test-abc-123',
+      },
+      body: JSON.stringify(mockUsers),
+    })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('42 total')).toBeVisible();
+});
+
+test('mock empty state', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({ json: [] })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('No users found')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const mockUsers = [
+  { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin' },
+  { id: 2, name: 'Bob', email: 'bob@example.com', role: 'user' },
+];
+
+test('mock a GET endpoint with JSON', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({ json: mockUsers })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(3);
+});
+
+test('mock a POST endpoint and verify the request', async ({ page }) => {
+  await page.route('**/api/users', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 201,
+        json: { id: 3, name: 'Charlie', email: 'charlie@example.com' },
+      });
+    }
+    return route.continue();
+  });
+
+  await page.goto('/users/new');
+  await page.getByLabel('Name').fill('Charlie');
+  await page.getByLabel('Email').fill('charlie@example.com');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByText('Charlie')).toBeVisible();
+});
+
+test('mock empty state', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({ json: [] })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('No users found')).toBeVisible();
+});
+```
+
+### Mocking GraphQL
+
+**Use when**: Your frontend uses GraphQL and you want to mock specific queries or mutations by operation name.
+**Avoid when**: The GraphQL endpoint is part of your own backend and you want full integration coverage.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('mock a GraphQL query by operation name', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    const request = route.request();
+    const postData = request.postDataJSON();
+
+    if (postData.operationName === 'GetUsers') {
+      return route.fulfill({
+        json: {
+          data: {
+            users: [
+              { id: '1', name: 'Alice', email: 'alice@example.com' },
+              { id: '2', name: 'Bob', email: 'bob@example.com' },
+            ],
+          },
+        },
+      });
+    }
+
+    if (postData.operationName === 'GetUser') {
+      return route.fulfill({
+        json: {
+          data: {
+            user: { id: '1', name: 'Alice', email: 'alice@example.com' },
+          },
+        },
+      });
+    }
+
+    // Let unmocked operations through to the real server
+    return route.continue();
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Alice')).toBeVisible();
+  await expect(page.getByText('Bob')).toBeVisible();
+});
+
+test('mock a GraphQL mutation', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    const { operationName, variables } = route.request().postDataJSON();
+
+    if (operationName === 'CreateUser') {
+      return route.fulfill({
+        json: {
+          data: {
+            createUser: {
+              id: '99',
+              name: variables.input.name,
+              email: variables.input.email,
+            },
+          },
+        },
+      });
+    }
+
+    return route.continue();
+  });
+
+  await page.goto('/users/new');
+  await page.getByLabel('Name').fill('Charlie');
+  await page.getByLabel('Email').fill('charlie@example.com');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByText('Charlie')).toBeVisible();
+});
+
+test('mock GraphQL errors', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    const { operationName } = route.request().postDataJSON();
+
+    if (operationName === 'GetUsers') {
+      return route.fulfill({
+        json: {
+          data: null,
+          errors: [
+            {
+              message: 'Not authorized',
+              extensions: { code: 'UNAUTHORIZED' },
+            },
+          ],
+        },
+      });
+    }
+
+    return route.continue();
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Not authorized')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('mock a GraphQL query by operation name', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    const postData = route.request().postDataJSON();
+
+    if (postData.operationName === 'GetUsers') {
+      return route.fulfill({
+        json: {
+          data: {
+            users: [
+              { id: '1', name: 'Alice', email: 'alice@example.com' },
+              { id: '2', name: 'Bob', email: 'bob@example.com' },
+            ],
+          },
+        },
+      });
+    }
+
+    return route.continue();
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Alice')).toBeVisible();
+  await expect(page.getByText('Bob')).toBeVisible();
+});
+
+test('mock a GraphQL mutation', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    const { operationName, variables } = route.request().postDataJSON();
+
+    if (operationName === 'CreateUser') {
+      return route.fulfill({
+        json: {
+          data: {
+            createUser: {
+              id: '99',
+              name: variables.input.name,
+              email: variables.input.email,
+            },
+          },
+        },
+      });
+    }
+
+    return route.continue();
+  });
+
+  await page.goto('/users/new');
+  await page.getByLabel('Name').fill('Charlie');
+  await page.getByLabel('Email').fill('charlie@example.com');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByText('Charlie')).toBeVisible();
+});
+```
+
+### Modifying Responses
+
+**Use when**: You need the real API response but want to tweak specific fields -- inject test data, override feature flags, simulate edge cases in real data.
+**Avoid when**: You can fully mock the response. `route.fetch()` adds a real network round-trip, so it is slower.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('modify a real API response', async ({ page }) => {
+  await page.route('**/api/users', async (route) => {
+    // Fetch the real response from the server
+    const response = await route.fetch();
+    const users = await response.json();
+
+    // Inject a test user into the real data
+    users.push({ id: 999, name: 'Test User', email: 'test@example.com' });
+
+    await route.fulfill({ response, json: users });
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Test User')).toBeVisible();
+});
+
+test('override feature flags from real config', async ({ page }) => {
+  await page.route('**/api/config', async (route) => {
+    const response = await route.fetch();
+    const config = await response.json();
+
+    // Enable a feature flag for testing
+    config.featureFlags = {
+      ...config.featureFlags,
+      newCheckout: true,
+      darkMode: true,
+    };
+
+    await route.fulfill({ response, json: config });
+  });
+
+  await page.goto('/settings');
+  await expect(page.getByRole('switch', { name: 'Dark mode' })).toBeVisible();
+});
+
+test('modify response headers', async ({ page }) => {
+  await page.route('**/api/data', async (route) => {
+    const response = await route.fetch();
+
+    await route.fulfill({
+      response,
+      headers: {
+        ...response.headers(),
+        'cache-control': 'no-cache',
+        'x-test-header': 'injected',
+      },
+    });
+  });
+
+  await page.goto('/data');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('modify a real API response', async ({ page }) => {
+  await page.route('**/api/users', async (route) => {
+    const response = await route.fetch();
+    const users = await response.json();
+
+    users.push({ id: 999, name: 'Test User', email: 'test@example.com' });
+
+    await route.fulfill({ response, json: users });
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Test User')).toBeVisible();
+});
+
+test('override feature flags from real config', async ({ page }) => {
+  await page.route('**/api/config', async (route) => {
+    const response = await route.fetch();
+    const config = await response.json();
+
+    config.featureFlags = {
+      ...config.featureFlags,
+      newCheckout: true,
+      darkMode: true,
+    };
+
+    await route.fulfill({ response, json: config });
+  });
+
+  await page.goto('/settings');
+  await expect(page.getByRole('switch', { name: 'Dark mode' })).toBeVisible();
+});
+```
+
+### Request Blocking
+
+**Use when**: Blocking analytics, ads, third-party scripts, images, or fonts to speed up tests and eliminate flakiness from external dependencies.
+**Avoid when**: The blocked resource is required for the feature under test.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('block analytics and tracking scripts', async ({ page }) => {
+  await page.route(/(google-analytics|segment|hotjar|mixpanel)/, (route) =>
+    route.abort()
+  );
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+
+test('block images to speed up tests', async ({ page }) => {
+  await page.route('**/*.{png,jpg,jpeg,gif,svg,webp}', (route) =>
+    route.abort()
+  );
+
+  await page.goto('/gallery');
+  // Test interactions without waiting for image downloads
+  await page.getByRole('button', { name: 'Next' }).click();
+});
+
+test('block specific third-party domains', async ({ page }) => {
+  const blockedDomains = [
+    'ads.example.com',
+    'tracker.example.com',
+    'cdn.slow-service.com',
+  ];
+
+  await page.route('**/*', (route) => {
+    const url = new URL(route.request().url());
+    if (blockedDomains.includes(url.hostname)) {
+      return route.abort();
+    }
+    return route.continue();
+  });
+
+  await page.goto('/home');
+});
+
+test('block by resource type', async ({ context }) => {
+  // Context-level blocking affects all pages
+  await context.route('**/*', (route) => {
+    const resourceType = route.request().resourceType();
+    if (['image', 'font', 'media'].includes(resourceType)) {
+      return route.abort();
+    }
+    return route.continue();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('block analytics and tracking scripts', async ({ page }) => {
+  await page.route(/(google-analytics|segment|hotjar|mixpanel)/, (route) =>
+    route.abort()
+  );
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+
+test('block images to speed up tests', async ({ page }) => {
+  await page.route('**/*.{png,jpg,jpeg,gif,svg,webp}', (route) =>
+    route.abort()
+  );
+
+  await page.goto('/gallery');
+  await page.getByRole('button', { name: 'Next' }).click();
+});
+
+test('block by resource type', async ({ context }) => {
+  await context.route('**/*', (route) => {
+    const resourceType = route.request().resourceType();
+    if (['image', 'font', 'media'].includes(resourceType)) {
+      return route.abort();
+    }
+    return route.continue();
+  });
+});
+```
+
+### HAR Recording and Replay
+
+**Use when**: You want to capture real network traffic once and replay it in tests for speed and determinism. Great for complex APIs with many endpoints or when API access is limited.
+**Avoid when**: API responses change frequently and stale recordings would cause false passes. Keep HAR files in version control and update them regularly.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Record a HAR file — run once to capture traffic, then replay
+test('record HAR for later replay', async ({ page }) => {
+  // This records all matching network traffic to the HAR file.
+  // If the file already exists and responses match, it serves from HAR.
+  // If a request has no match in the HAR, it falls through to the network
+  // and the new response is appended to the HAR file.
+  await page.routeFromHAR('tests/data/users-api.har', {
+    url: '**/api/**',
+    update: true, // set to true to record, false (or omit) to replay
+  });
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(6);
+});
+
+// Replay from a previously recorded HAR file
+test('replay from HAR', async ({ page }) => {
+  await page.routeFromHAR('tests/data/users-api.har', {
+    url: '**/api/**',
+    // update: false is the default — serves from the HAR file
+  });
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(6);
+});
+
+// HAR with notFound option — control what happens for unmatched requests
+test('HAR replay with fallback behavior', async ({ page }) => {
+  await page.routeFromHAR('tests/data/users-api.har', {
+    url: '**/api/**',
+    notFound: 'abort', // 'abort' fails unmatched requests; 'fallback' lets them through
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+
+// Context-level HAR replay
+test('HAR replay at context level', async ({ context, page }) => {
+  await context.routeFromHAR('tests/data/full-app.har', {
+    url: '**/api/**',
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('record HAR for later replay', async ({ page }) => {
+  await page.routeFromHAR('tests/data/users-api.har', {
+    url: '**/api/**',
+    update: true,
+  });
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(6);
+});
+
+test('replay from HAR', async ({ page }) => {
+  await page.routeFromHAR('tests/data/users-api.har', {
+    url: '**/api/**',
+  });
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(6);
+});
+
+test('HAR replay with fallback behavior', async ({ page }) => {
+  await page.routeFromHAR('tests/data/users-api.har', {
+    url: '**/api/**',
+    notFound: 'abort',
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+```
+
+### Conditional Mocking
+
+**Use when**: You need different responses based on the request method, body, headers, or query parameters. Common for paginated APIs, search endpoints, and role-based access.
+**Avoid when**: Simple static mocking suffices. Don't over-engineer route handlers.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('respond based on request method', async ({ page }) => {
+  await page.route('**/api/users', (route) => {
+    const method = route.request().method();
+
+    switch (method) {
+      case 'GET':
+        return route.fulfill({
+          json: [{ id: 1, name: 'Alice' }],
+        });
+      case 'POST':
+        return route.fulfill({
+          status: 201,
+          json: { id: 2, name: 'Bob' },
+        });
+      case 'DELETE':
+        return route.fulfill({ status: 204, body: '' });
+      default:
+        return route.continue();
+    }
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+
+test('respond based on query parameters', async ({ page }) => {
+  await page.route('**/api/users*', (route) => {
+    const url = new URL(route.request().url());
+    const page_num = parseInt(url.searchParams.get('page') || '1');
+    const role = url.searchParams.get('role');
+
+    const allUsers = [
+      { id: 1, name: 'Alice', role: 'admin' },
+      { id: 2, name: 'Bob', role: 'user' },
+      { id: 3, name: 'Charlie', role: 'user' },
+      { id: 4, name: 'Diana', role: 'admin' },
+    ];
+
+    let filtered = allUsers;
+    if (role) {
+      filtered = allUsers.filter((u) => u.role === role);
+    }
+
+    const perPage = 2;
+    const start = (page_num - 1) * perPage;
+    const paginated = filtered.slice(start, start + perPage);
+
+    return route.fulfill({
+      json: paginated,
+      headers: {
+        'content-type': 'application/json',
+        'x-total-count': String(filtered.length),
+      },
+    });
+  });
+
+  await page.goto('/users');
+  await expect(page.getByRole('row')).toHaveCount(3); // header + 2 rows
+});
+
+test('respond based on request body', async ({ page }) => {
+  await page.route('**/api/search', (route) => {
+    const body = route.request().postDataJSON();
+    const query = body?.query?.toLowerCase() || '';
+
+    const results = {
+      playwright: [{ title: 'Playwright Docs' }, { title: 'Playwright GitHub' }],
+      cypress: [{ title: 'Cypress Docs' }],
+    };
+
+    return route.fulfill({
+      json: results[query] || [],
+    });
+  });
+
+  await page.goto('/search');
+  await page.getByLabel('Search').fill('playwright');
+  await page.getByRole('button', { name: 'Search' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(2);
+});
+
+test('respond based on request headers', async ({ page }) => {
+  await page.route('**/api/users', (route) => {
+    const authHeader = route.request().headers()['authorization'];
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return route.fulfill({
+        status: 401,
+        json: { error: 'Unauthorized' },
+      });
+    }
+
+    return route.fulfill({
+      json: [{ id: 1, name: 'Alice' }],
+    });
+  });
+
+  await page.goto('/login');
+  await expect(page.getByText('Unauthorized')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('respond based on request method', async ({ page }) => {
+  await page.route('**/api/users', (route) => {
+    const method = route.request().method();
+
+    switch (method) {
+      case 'GET':
+        return route.fulfill({ json: [{ id: 1, name: 'Alice' }] });
+      case 'POST':
+        return route.fulfill({ status: 201, json: { id: 2, name: 'Bob' } });
+      case 'DELETE':
+        return route.fulfill({ status: 204, body: '' });
+      default:
+        return route.continue();
+    }
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+
+test('respond based on query parameters', async ({ page }) => {
+  await page.route('**/api/users*', (route) => {
+    const url = new URL(route.request().url());
+    const role = url.searchParams.get('role');
+
+    const allUsers = [
+      { id: 1, name: 'Alice', role: 'admin' },
+      { id: 2, name: 'Bob', role: 'user' },
+      { id: 3, name: 'Charlie', role: 'user' },
+    ];
+
+    const filtered = role ? allUsers.filter((u) => u.role === role) : allUsers;
+
+    return route.fulfill({ json: filtered });
+  });
+
+  await page.goto('/users?role=admin');
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+
+test('respond based on request body', async ({ page }) => {
+  await page.route('**/api/search', (route) => {
+    const body = route.request().postDataJSON();
+    const query = body?.query?.toLowerCase() || '';
+
+    const results = {
+      playwright: [{ title: 'Playwright Docs' }, { title: 'Playwright GitHub' }],
+      cypress: [{ title: 'Cypress Docs' }],
+    };
+
+    return route.fulfill({ json: results[query] || [] });
+  });
+
+  await page.goto('/search');
+  await page.getByLabel('Search').fill('playwright');
+  await page.getByRole('button', { name: 'Search' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(2);
+});
+```
+
+### Network Error Simulation
+
+**Use when**: Testing how your UI handles server errors, timeouts, and connection failures. Essential for verifying error boundaries, retry logic, and degraded-mode UX.
+**Avoid when**: The test is about the happy path. Only introduce errors when testing error handling.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('simulate a 500 server error', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({
+      status: 500,
+      json: { error: 'Internal Server Error' },
+    })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+});
+
+test('simulate a 403 forbidden', async ({ page }) => {
+  await page.route('**/api/admin/**', (route) =>
+    route.fulfill({
+      status: 403,
+      json: { error: 'Forbidden', message: 'Admin access required' },
+    })
+  );
+
+  await page.goto('/admin/settings');
+  await expect(page.getByText('Admin access required')).toBeVisible();
+});
+
+test('simulate a 404 not found', async ({ page }) => {
+  await page.route('**/api/users/999', (route) =>
+    route.fulfill({
+      status: 404,
+      json: { error: 'User not found' },
+    })
+  );
+
+  await page.goto('/users/999');
+  await expect(page.getByText('User not found')).toBeVisible();
+});
+
+test('simulate a network error (connection refused)', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.abort('connectionrefused')
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('Network error')).toBeVisible();
+});
+
+test('simulate a timeout', async ({ page }) => {
+  await page.route('**/api/users', async (route) => {
+    // Delay longer than the app's fetch timeout to trigger a timeout error
+    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    await route.fulfill({ json: [] });
+  });
+
+  await page.goto('/users');
+  // The app should show a timeout message before the route resolves
+  await expect(page.getByText('Request timed out')).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test('simulate intermittent failures then recovery', async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route('**/api/users', (route) => {
+    requestCount++;
+    if (requestCount <= 2) {
+      return route.fulfill({
+        status: 503,
+        json: { error: 'Service Unavailable' },
+      });
+    }
+    return route.fulfill({
+      json: [{ id: 1, name: 'Alice' }],
+    });
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+
+  // Simulate user clicking retry (which makes the 3rd request)
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+
+  // Third attempt succeeds
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('simulate a 500 server error', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.fulfill({
+      status: 500,
+      json: { error: 'Internal Server Error' },
+    })
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+});
+
+test('simulate a network error (connection refused)', async ({ page }) => {
+  await page.route('**/api/users', (route) =>
+    route.abort('connectionrefused')
+  );
+
+  await page.goto('/users');
+  await expect(page.getByText('Network error')).toBeVisible();
+});
+
+test('simulate intermittent failures then recovery', async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route('**/api/users', (route) => {
+    requestCount++;
+    if (requestCount <= 2) {
+      return route.fulfill({
+        status: 503,
+        json: { error: 'Service Unavailable' },
+      });
+    }
+    return route.fulfill({
+      json: [{ id: 1, name: 'Alice' }],
+    });
+  });
+
+  await page.goto('/users');
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText('Alice')).toBeVisible();
+});
+```
+
+**Abort reasons**: `'aborted'`, `'accessdenied'`, `'addressunreachable'`, `'blockedbyclient'`, `'blockedbyresponse'`, `'connectionaborted'`, `'connectionclosed'`, `'connectionfailed'`, `'connectionrefused'`, `'connectionreset'`, `'internetdisconnected'`, `'namenotresolved'`, `'timedout'`, `'failed'`.
+
+### Request Waiting
+
+**Use when**: Synchronizing your test with network activity -- waiting for a request to be sent or a response to arrive before asserting on the UI.
+**Avoid when**: A web-first assertion on a locator is sufficient. Only use request waiting when you need to inspect the request/response itself.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('wait for response and verify UI updates', async ({ page }) => {
+  await page.goto('/users');
+
+  // CRITICAL: set up the wait BEFORE triggering the action
+  const responsePromise = page.waitForResponse('**/api/users');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const response = await responsePromise;
+
+  expect(response.status()).toBe(200);
+  const users = await response.json();
+  expect(users).toHaveLength(5);
+});
+
+test('wait for request and verify payload', async ({ page }) => {
+  await page.goto('/users/new');
+
+  const requestPromise = page.waitForRequest('**/api/users');
+  await page.getByLabel('Name').fill('Alice');
+  await page.getByLabel('Email').fill('alice@example.com');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const request = await requestPromise;
+
+  expect(request.method()).toBe('POST');
+  expect(request.postDataJSON()).toMatchObject({
+    name: 'Alice',
+    email: 'alice@example.com',
+  });
+});
+
+test('wait for response with predicate function', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Wait for a specific response matching custom criteria
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/users') &&
+      response.status() === 200 &&
+      response.request().method() === 'GET'
+  );
+  await page.getByRole('button', { name: 'Load users' }).click();
+  const response = await responsePromise;
+
+  const data = await response.json();
+  expect(data.length).toBeGreaterThan(0);
+});
+
+test('wait for multiple requests in sequence', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Wait for multiple API calls that happen during a flow
+  const [validateResponse, submitResponse] = await Promise.all([
+    page.waitForResponse('**/api/cart/validate'),
+    page.waitForResponse('**/api/orders'),
+    page.getByRole('button', { name: 'Place order' }).click(),
+  ]);
+
+  expect(validateResponse.status()).toBe(200);
+  expect(submitResponse.status()).toBe(201);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('wait for response and verify UI updates', async ({ page }) => {
+  await page.goto('/users');
+
+  const responsePromise = page.waitForResponse('**/api/users');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const response = await responsePromise;
+
+  expect(response.status()).toBe(200);
+  const users = await response.json();
+  expect(users).toHaveLength(5);
+});
+
+test('wait for request and verify payload', async ({ page }) => {
+  await page.goto('/users/new');
+
+  const requestPromise = page.waitForRequest('**/api/users');
+  await page.getByLabel('Name').fill('Alice');
+  await page.getByLabel('Email').fill('alice@example.com');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const request = await requestPromise;
+
+  expect(request.method()).toBe('POST');
+  expect(request.postDataJSON()).toMatchObject({
+    name: 'Alice',
+    email: 'alice@example.com',
+  });
+});
+
+test('wait for multiple requests in sequence', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const [validateResponse, submitResponse] = await Promise.all([
+    page.waitForResponse('**/api/cart/validate'),
+    page.waitForResponse('**/api/orders'),
+    page.getByRole('button', { name: 'Place order' }).click(),
+  ]);
+
+  expect(validateResponse.status()).toBe(200);
+  expect(submitResponse.status()).toBe(201);
+});
+```
+
+### Glob Patterns and URL Matching
+
+**Use when**: You need to match URLs with wildcards, partial paths, or regex. Every `page.route()`, `waitForRequest()`, and `waitForResponse()` accepts glob patterns, strings, or regex.
+**Avoid when**: The URL is known and static. Use the exact string.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('glob pattern examples', async ({ page }) => {
+  // ** matches any path segments (including nested)
+  await page.route('**/api/users', (route) =>
+    route.fulfill({ json: [] })
+  );
+  // Matches: https://example.com/api/users
+  // Matches: https://example.com/v2/api/users
+
+  // * matches any single path segment
+  await page.route('**/api/users/*/orders', (route) =>
+    route.fulfill({ json: [] })
+  );
+  // Matches: /api/users/123/orders
+  // Matches: /api/users/abc/orders
+  // Does NOT match: /api/users/123/456/orders
+
+  // Match file extensions
+  await page.route('**/*.{png,jpg,svg}', (route) => route.abort());
+  // Matches: /images/logo.png, /assets/photo.jpg
+
+  // Match query strings with *
+  await page.route('**/api/search?q=*', (route) =>
+    route.fulfill({ json: [] })
+  );
+  // Matches: /api/search?q=anything
+
+  // Use regex for complex patterns
+  await page.route(/\/api\/users\/\d+$/, (route) =>
+    route.fulfill({ json: { id: 1, name: 'Alice' } })
+  );
+  // Matches: /api/users/123, /api/users/456
+  // Does NOT match: /api/users/abc, /api/users/123/orders
+
+  // Regex with captured groups for dynamic responses
+  await page.route(/\/api\/users\/(\d+)/, (route) => {
+    const match = route.request().url().match(/\/api\/users\/(\d+)/);
+    const userId = match ? match[1] : '0';
+    return route.fulfill({
+      json: { id: parseInt(userId), name: `User ${userId}` },
+    });
+  });
+
+  await page.goto('/users');
+});
+
+test('match all requests on a domain', async ({ page }) => {
+  // Block everything from a specific domain
+  await page.route('https://analytics.example.com/**', (route) =>
+    route.abort()
+  );
+
+  await page.goto('/dashboard');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('glob pattern examples', async ({ page }) => {
+  // ** matches any path segments
+  await page.route('**/api/users', (route) =>
+    route.fulfill({ json: [] })
+  );
+
+  // * matches a single path segment
+  await page.route('**/api/users/*/orders', (route) =>
+    route.fulfill({ json: [] })
+  );
+
+  // Match file extensions
+  await page.route('**/*.{png,jpg,svg}', (route) => route.abort());
+
+  // Regex for complex patterns
+  await page.route(/\/api\/users\/\d+$/, (route) =>
+    route.fulfill({ json: { id: 1, name: 'Alice' } })
+  );
+
+  // Regex with dynamic responses
+  await page.route(/\/api\/users\/(\d+)/, (route) => {
+    const match = route.request().url().match(/\/api\/users\/(\d+)/);
+    const userId = match ? match[1] : '0';
+    return route.fulfill({
+      json: { id: parseInt(userId), name: `User ${userId}` },
+    });
+  });
+
+  await page.goto('/users');
+});
+
+test('match all requests on a domain', async ({ page }) => {
+  await page.route('https://analytics.example.com/**', (route) =>
+    route.abort()
+  );
+
+  await page.goto('/dashboard');
+});
+```
+
+**Pattern reference**:
+
+| Pattern | Matches | Does Not Match |
+|---|---|---|
+| `**/api/users` | `/api/users`, `/v2/api/users` | `/api/users/1` |
+| `**/api/users*` | `/api/users`, `/api/users?page=1` | `/api/users/1` |
+| `**/api/users/**` | `/api/users/1`, `/api/users/1/orders` | `/api/users` |
+| `**/api/users/*/orders` | `/api/users/1/orders` | `/api/users/1/2/orders` |
+| `**/*.{png,jpg}` | `/logo.png`, `/deep/path/img.jpg` | `/file.svg` |
+| `/\/api\/users\/\d+$/` (regex) | `/api/users/123` | `/api/users/abc` |
+
+## Decision Guide
+
+| Scenario | Use | Why |
+|---|---|---|
+| Frontend depends on an external API | `route.fulfill()` | Deterministic data, no external dependency, fast |
+| Need to test real API but tweak one field | `route.fetch()` + modify + `route.fulfill()` | Uses real data as baseline, only overrides what you need |
+| Testing happy path with real backend | `route.continue()` (or no route) | Full integration coverage |
+| Block analytics/ads/third-party noise | `route.abort()` | Faster tests, no flakiness from external services |
+| Complex API with many endpoints | `page.routeFromHAR()` with `update: true` | Record once, replay forever; minimal test code |
+| Testing error handling (500, timeout) | `route.fulfill({ status: 500 })` or `route.abort('timedout')` | Simulate errors deterministically |
+| Verify request payload sent by frontend | `page.waitForRequest()` + assertions | Confirms frontend sends correct data |
+| Verify response data before UI check | `page.waitForResponse()` + assertions | Confirms data arrives before asserting on DOM |
+| Multiple tests need the same mock | `context.route()` or fixture | Share routes across tests without repetition |
+| Testing loading spinners / skeleton UI | `route.fulfill()` with a delay (via `setTimeout`) | Control exact timing of response |
+| Paginated or search-based API | Conditional mock (check query params / body) | Dynamic responses based on request content |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Mocking your own app's pages and static assets | You end up testing a fake app, not your real one | Only mock API/data endpoints, never HTML/JS/CSS served by your app |
+| Hardcoding mock data inline in every test | Duplicated data, hard to update when API changes | Extract mock data into shared fixtures (`tests/data/users.json`) |
+| Never updating mocks when the API changes | Tests pass against stale data; real app breaks | Use HAR recording with periodic `update: true` runs, or validate mock shapes against OpenAPI schemas |
+| Mocking in production-like E2E tests | You lose integration confidence | Keep a separate test suite with real backends for smoke/integration tests; mock only in component and isolated UI tests |
+| Forgetting to call `route.fulfill()`, `route.continue()`, or `route.abort()` | Request hangs, test times out with a confusing error | Every route handler must call exactly one of the three |
+| Setting up routes after `page.goto()` | Requests fire during navigation before the route is registered | Always call `page.route()` before `page.goto()` |
+| Using `waitForResponse` after the triggering action | Race condition: response may arrive before the wait is registered | Always set up the promise before the action: `const p = page.waitForResponse(...); await click(); await p;` |
+| Mocking with `route.continue()` and thinking it mocks | `route.continue()` passes the request to the real server | Use `route.fulfill()` to return fake data |
+| Over-broad glob patterns (`**/*`) without filtering | Catches all requests including HTML, JS, CSS; breaks the app | Be specific: `**/api/**` or filter by `resourceType()` |
+| Forgetting `await` on route setup or fulfillment | Route may not be active when navigation starts | Always `await page.route(...)` and `await route.fulfill(...)` |
+| Not calling `page.unroute()` when swapping mocks mid-test | Old route handler still fires, new one is ignored or both fire | Call `page.unroute()` before registering a new handler for the same pattern |
+| Using `page.on('request')` for mocking | Event listeners are read-only; they cannot modify or fulfill requests | Use `page.route()` for interception; `page.on('request')` only for logging |
+
+## Troubleshooting
+
+### Route handler never fires
+
+**Cause**: The URL pattern does not match the actual request URL. Common when the base URL includes a port number, path prefix, or the request uses a different protocol.
+
+**Fix**:
+- Log all requests to find the exact URL:
+```typescript
+page.on('request', (req) => console.log(req.method(), req.url()));
+```
+- Ensure glob pattern matches. `**/api/users` does not match `http://localhost:3000/api/users?page=1` -- use `**/api/users*` to include query strings.
+- Check that `page.route()` is called before `page.goto()`.
+
+### Route handler fires but test still times out
+
+**Cause**: The handler throws an error or never calls `fulfill`/`continue`/`abort`.
+
+**Fix**:
+- Add error handling inside the route handler.
+- Ensure every code path in the handler ends with one of the three resolution methods.
+```typescript
+await page.route('**/api/users', async (route) => {
+  try {
+    const data = getTestData(); // this might throw
+    await route.fulfill({ json: data });
+  } catch (error) {
+    console.error('Route handler error:', error);
+    await route.abort();
+  }
+});
+```
+
+### Mocked response is ignored -- app shows real data
+
+**Cause**: The route is registered at the page level but the request is made by a service worker or a different browser context.
+
+**Fix**:
+- Use `context.route()` instead of `page.route()` to cover all pages and service workers.
+- Disable service workers in the config if they interfere:
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  use: {
+    serviceWorkers: 'block',
+  },
+});
+```
+
+### `route.fetch()` causes infinite loop
+
+**Cause**: `route.fetch()` re-issues the request, which can re-trigger the same route handler if the URL pattern matches.
+
+**Fix**: Playwright handles this correctly for the same route handler -- `route.fetch()` will not re-enter the handler that called it. But if you have multiple overlapping route handlers, they can interfere. Simplify to a single handler per URL pattern, or use `route.fetch({ url: 'different-url' })` to redirect.
+
+### HAR replay returns wrong responses
+
+**Cause**: HAR files match requests by URL and sometimes by POST body. If the request body changes (e.g., timestamps, CSRF tokens), the match fails.
+
+**Fix**:
+- Re-record the HAR file with `update: true`.
+- Use `notFound: 'fallback'` to let unmatched requests hit the real server.
+- For POST requests with dynamic bodies, consider using `page.route()` with manual matching instead of HAR.
+
+## Related
+
+- [core/when-to-mock.md](when-to-mock.md) -- decision framework for when to mock vs use real services
+- [core/api-testing.md](api-testing.md) -- testing REST and GraphQL APIs directly (without a browser)
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- web-first assertions and `waitForResponse` patterns
+- [core/authentication.md](authentication.md) -- mocking auth tokens and session state
+- [core/error-and-edge-cases.md](error-and-edge-cases.md) -- error state testing patterns beyond network errors
+- [core/service-workers-and-pwa.md](service-workers-and-pwa.md) -- handling service worker caching that interferes with mocks

--- a/engineering-team/playwright skill/core/nextjs.md
+++ b/engineering-team/playwright skill/core/nextjs.md
@@ -1,0 +1,1013 @@
+# Testing Next.js Apps with Playwright
+
+> **When to use**: Testing Next.js applications -- App Router, Pages Router, API routes, middleware, SSR pages, dynamic routes, and server components. This guide covers E2E testing patterns specific to Next.js behavior.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```bash
+# Install Playwright in a Next.js project
+npm init playwright@latest
+
+# Run with Next.js dev server managed by Playwright
+npx playwright test
+
+# Run against a production build (recommended for CI)
+npx playwright test --project=chromium
+
+# Debug a single test with headed browser
+npx playwright test tests/home.spec.ts --headed --debug
+```
+
+```
+# .env.test — loaded by Next.js automatically when NODE_ENV=test
+NEXT_PUBLIC_API_URL=http://localhost:3000/api
+DATABASE_URL=postgresql://localhost:5432/test_db
+NEXTAUTH_SECRET=test-secret-do-not-use-in-production
+NEXTAUTH_URL=http://localhost:3000
+```
+
+## Setup
+
+### Playwright Config for Next.js
+
+The single most important configuration detail: use `webServer` to let Playwright start and manage your Next.js server.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npm run start' // production build in CI
+      : 'npm run dev',                   // dev server locally
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NODE_ENV: process.env.CI ? 'production' : 'test',
+    },
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npm run start'
+      : 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NODE_ENV: process.env.CI ? 'production' : 'test',
+    },
+  },
+});
+```
+
+### Environment Variables with `.env.test`
+
+Next.js loads `.env.test` automatically when `NODE_ENV=test`. Use this for test-specific overrides.
+
+```bash
+# .env.test (commit this -- no real secrets)
+NEXT_PUBLIC_API_URL=http://localhost:3000/api
+NEXT_PUBLIC_FEATURE_FLAG_NEW_CHECKOUT=true
+DATABASE_URL=postgresql://localhost:5432/test_db
+
+# .env.test.local (gitignored -- real test secrets)
+NEXTAUTH_SECRET=test-secret-local
+STRIPE_TEST_KEY=sk_test_xxx
+```
+
+```bash
+# .gitignore
+.env*.local
+playwright-report/
+playwright/.auth/
+test-results/
+```
+
+## Patterns
+
+### Testing App Router Pages
+
+**Use when**: Testing pages built with the Next.js App Router (`app/` directory). App Router pages are server components by default and may include streaming, suspense boundaries, and loading states.
+**Avoid when**: You need to test isolated server component logic -- use unit tests for that. E2E tests verify the rendered result.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('App Router pages', () => {
+  test('home page renders server component content', async ({ page }) => {
+    await page.goto('/');
+
+    // Server components render on the server -- by the time Playwright
+    // sees the page, SSR content is already in the HTML
+    await expect(page.getByRole('heading', { name: 'Welcome', level: 1 })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+  });
+
+  test('loading state shows while data streams in', async ({ page }) => {
+    // Slow down the API to expose the loading state
+    await page.route('**/api/dashboard/stats', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.continue();
+    });
+
+    await page.goto('/dashboard');
+
+    // Verify the loading skeleton appears during streaming
+    await expect(page.getByRole('progressbar')).toBeVisible();
+
+    // Then verify the real content replaces it
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByRole('progressbar')).toBeHidden();
+  });
+
+  test('suspense boundary shows fallback then resolves', async ({ page }) => {
+    await page.goto('/products');
+
+    // The product list may be inside a Suspense boundary
+    // Playwright auto-waits, so just assert the final state
+    await expect(page.getByRole('listitem')).toHaveCount(12);
+  });
+
+  test('nested layouts persist across navigation', async ({ page }) => {
+    await page.goto('/dashboard/analytics');
+
+    // Verify the dashboard layout sidebar is visible
+    const sidebar = page.getByRole('navigation', { name: 'Dashboard' });
+    await expect(sidebar).toBeVisible();
+
+    // Navigate to a sibling route -- layout should persist (no full reload)
+    await sidebar.getByRole('link', { name: 'Settings' }).click();
+    await page.waitForURL('/dashboard/settings');
+
+    // Sidebar is still there -- layout was not re-mounted
+    await expect(sidebar).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('App Router pages', () => {
+  test('home page renders server component content', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Welcome', level: 1 })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+  });
+
+  test('loading state shows while data streams in', async ({ page }) => {
+    await page.route('**/api/dashboard/stats', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.continue();
+    });
+
+    await page.goto('/dashboard');
+
+    await expect(page.getByRole('progressbar')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByRole('progressbar')).toBeHidden();
+  });
+
+  test('suspense boundary shows fallback then resolves', async ({ page }) => {
+    await page.goto('/products');
+
+    await expect(page.getByRole('listitem')).toHaveCount(12);
+  });
+
+  test('nested layouts persist across navigation', async ({ page }) => {
+    await page.goto('/dashboard/analytics');
+
+    const sidebar = page.getByRole('navigation', { name: 'Dashboard' });
+    await expect(sidebar).toBeVisible();
+
+    await sidebar.getByRole('link', { name: 'Settings' }).click();
+    await page.waitForURL('/dashboard/settings');
+
+    await expect(sidebar).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+  });
+});
+```
+
+### Testing Pages Router (getServerSideProps / getStaticProps)
+
+**Use when**: Testing pages built with the Pages Router (`pages/` directory) that use `getServerSideProps` or `getStaticProps` for data fetching.
+**Avoid when**: Testing the data fetching functions directly -- that is a unit test concern. E2E tests verify what the user sees.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Pages Router with SSR', () => {
+  test('page with getServerSideProps renders fetched data', async ({ page }) => {
+    await page.goto('/blog');
+
+    // getServerSideProps fetches posts on the server -- verify they render
+    await expect(page.getByRole('heading', { name: 'Blog', level: 1 })).toBeVisible();
+    await expect(page.getByRole('article')).toHaveCount(10);
+
+    // Verify server-fetched data appears (not a loading skeleton)
+    await expect(page.getByRole('article').first()).toContainText(/\w+/);
+  });
+
+  test('page with getStaticProps shows pre-rendered content', async ({ page }) => {
+    await page.goto('/about');
+
+    // Static pages are pre-rendered at build time -- content is immediate
+    await expect(page.getByRole('heading', { name: 'About Us' })).toBeVisible();
+    await expect(page.getByText('Founded in 2020')).toBeVisible();
+  });
+
+  test('client-side navigation with next/link preserves SPA behavior', async ({ page }) => {
+    await page.goto('/blog');
+
+    // Click a next/link -- this should be a client-side transition, not a full reload
+    const navigationPromise = page.waitForURL('/blog/my-first-post');
+    await page.getByRole('link', { name: 'My First Post' }).click();
+    await navigationPromise;
+
+    await expect(page.getByRole('heading', { name: 'My First Post', level: 1 })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Pages Router with SSR', () => {
+  test('page with getServerSideProps renders fetched data', async ({ page }) => {
+    await page.goto('/blog');
+
+    await expect(page.getByRole('heading', { name: 'Blog', level: 1 })).toBeVisible();
+    await expect(page.getByRole('article')).toHaveCount(10);
+    await expect(page.getByRole('article').first()).toContainText(/\w+/);
+  });
+
+  test('page with getStaticProps shows pre-rendered content', async ({ page }) => {
+    await page.goto('/about');
+
+    await expect(page.getByRole('heading', { name: 'About Us' })).toBeVisible();
+    await expect(page.getByText('Founded in 2020')).toBeVisible();
+  });
+
+  test('client-side navigation with next/link preserves SPA behavior', async ({ page }) => {
+    await page.goto('/blog');
+
+    const navigationPromise = page.waitForURL('/blog/my-first-post');
+    await page.getByRole('link', { name: 'My First Post' }).click();
+    await navigationPromise;
+
+    await expect(page.getByRole('heading', { name: 'My First Post', level: 1 })).toBeVisible();
+  });
+});
+```
+
+### Testing Dynamic Routes (`[slug]`, `[...catchAll]`)
+
+**Use when**: Testing pages with dynamic segments like `/blog/[slug]`, `/products/[id]`, or catch-all routes like `/docs/[...path]`.
+**Avoid when**: The route is static -- no dynamic segments involved.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('dynamic routes', () => {
+  test('dynamic [slug] page renders correct content', async ({ page }) => {
+    await page.goto('/blog/nextjs-testing-guide');
+
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Next.js Testing Guide');
+    // Verify the slug maps to the correct content, not a 404
+    await expect(page.getByText('Page not found')).toBeHidden();
+  });
+
+  test('non-existent slug shows 404 page', async ({ page }) => {
+    const response = await page.goto('/blog/this-post-does-not-exist');
+
+    // Next.js returns 404 for pages that call notFound() or return { notFound: true }
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
+  });
+
+  test('catch-all route handles nested paths', async ({ page }) => {
+    await page.goto('/docs/getting-started/installation');
+
+    await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+
+    // Navigate to a different docs path
+    await page.goto('/docs/api/configuration');
+    await expect(page.getByRole('heading', { name: 'Configuration' })).toBeVisible();
+  });
+
+  test('dynamic route with query parameters', async ({ page }) => {
+    await page.goto('/products?category=electronics&sort=price-asc');
+
+    await expect(page.getByRole('heading', { name: 'Electronics' })).toBeVisible();
+    // Verify sort order is applied
+    const prices = await page.getByTestId('product-price').allTextContents();
+    const numericPrices = prices.map((p) => parseFloat(p.replace('$', '')));
+    expect(numericPrices).toEqual([...numericPrices].sort((a, b) => a - b));
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('dynamic routes', () => {
+  test('dynamic [slug] page renders correct content', async ({ page }) => {
+    await page.goto('/blog/nextjs-testing-guide');
+
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Next.js Testing Guide');
+    await expect(page.getByText('Page not found')).toBeHidden();
+  });
+
+  test('non-existent slug shows 404 page', async ({ page }) => {
+    const response = await page.goto('/blog/this-post-does-not-exist');
+
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
+  });
+
+  test('catch-all route handles nested paths', async ({ page }) => {
+    await page.goto('/docs/getting-started/installation');
+
+    await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+
+    await page.goto('/docs/api/configuration');
+    await expect(page.getByRole('heading', { name: 'Configuration' })).toBeVisible();
+  });
+
+  test('dynamic route with query parameters', async ({ page }) => {
+    await page.goto('/products?category=electronics&sort=price-asc');
+
+    await expect(page.getByRole('heading', { name: 'Electronics' })).toBeVisible();
+    const prices = await page.getByTestId('product-price').allTextContents();
+    const numericPrices = prices.map((p) => parseFloat(p.replace('$', '')));
+    expect(numericPrices).toEqual([...numericPrices].sort((a, b) => a - b));
+  });
+});
+```
+
+### Testing API Routes
+
+**Use when**: Testing Next.js API routes (`app/api/` or `pages/api/`) directly with Playwright's `request` context, or indirectly through UI interactions that call them.
+**Avoid when**: Unit testing API handler logic in isolation -- use a unit testing framework for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('API routes -- direct testing', () => {
+  test('GET /api/products returns product list', async ({ request }) => {
+    const response = await request.get('/api/products');
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.products).toBeInstanceOf(Array);
+    expect(body.products.length).toBeGreaterThan(0);
+    expect(body.products[0]).toHaveProperty('id');
+    expect(body.products[0]).toHaveProperty('name');
+    expect(body.products[0]).toHaveProperty('price');
+  });
+
+  test('POST /api/products creates a new product', async ({ request }) => {
+    const response = await request.post('/api/products', {
+      data: {
+        name: 'Test Product',
+        price: 29.99,
+        description: 'Created by Playwright',
+      },
+    });
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.product.name).toBe('Test Product');
+  });
+
+  test('POST /api/products validates required fields', async ({ request }) => {
+    const response = await request.post('/api/products', {
+      data: { name: '' }, // missing required fields
+    });
+
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContainEqual(
+      expect.objectContaining({ field: 'price' })
+    );
+  });
+});
+
+test.describe('API routes -- indirect through UI', () => {
+  test('form submission calls API and shows result', async ({ page }) => {
+    await page.goto('/products/new');
+
+    await page.getByLabel('Product name').fill('Widget');
+    await page.getByLabel('Price').fill('19.99');
+    await page.getByRole('button', { name: 'Create product' }).click();
+
+    // The UI calls POST /api/products internally
+    await expect(page.getByText('Product created successfully')).toBeVisible();
+    await page.waitForURL('/products/**');
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('API routes -- direct testing', () => {
+  test('GET /api/products returns product list', async ({ request }) => {
+    const response = await request.get('/api/products');
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.products).toBeInstanceOf(Array);
+    expect(body.products.length).toBeGreaterThan(0);
+    expect(body.products[0]).toHaveProperty('id');
+    expect(body.products[0]).toHaveProperty('name');
+    expect(body.products[0]).toHaveProperty('price');
+  });
+
+  test('POST /api/products creates a new product', async ({ request }) => {
+    const response = await request.post('/api/products', {
+      data: {
+        name: 'Test Product',
+        price: 29.99,
+        description: 'Created by Playwright',
+      },
+    });
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.product.name).toBe('Test Product');
+  });
+
+  test('POST /api/products validates required fields', async ({ request }) => {
+    const response = await request.post('/api/products', {
+      data: { name: '' },
+    });
+
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContainEqual(
+      expect.objectContaining({ field: 'price' })
+    );
+  });
+});
+
+test.describe('API routes -- indirect through UI', () => {
+  test('form submission calls API and shows result', async ({ page }) => {
+    await page.goto('/products/new');
+
+    await page.getByLabel('Product name').fill('Widget');
+    await page.getByLabel('Price').fill('19.99');
+    await page.getByRole('button', { name: 'Create product' }).click();
+
+    await expect(page.getByText('Product created successfully')).toBeVisible();
+    await page.waitForURL('/products/**');
+  });
+});
+```
+
+### Testing Middleware
+
+**Use when**: Testing Next.js middleware that handles redirects, rewrites, authentication guards, geolocation-based routing, or header manipulation.
+**Avoid when**: The middleware logic is trivial -- a redirect from `/old` to `/new` can be verified with a simple navigation test.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('middleware', () => {
+  test('unauthenticated user is redirected to login', async ({ page }) => {
+    // Visit a protected page without auth cookies
+    const response = await page.goto('/dashboard');
+
+    // Middleware should redirect to /login
+    expect(page.url()).toContain('/login');
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('middleware redirect preserves the return URL', async ({ page }) => {
+    await page.goto('/dashboard/settings');
+
+    // Should redirect to login with a callbackUrl or returnTo parameter
+    const url = new URL(page.url());
+    expect(url.pathname).toBe('/login');
+    expect(url.searchParams.get('callbackUrl') || url.searchParams.get('returnTo'))
+      .toContain('/dashboard/settings');
+  });
+
+  test('middleware sets security headers', async ({ page }) => {
+    const response = await page.goto('/');
+
+    const headers = response!.headers();
+    expect(headers['x-frame-options']).toBe('DENY');
+    expect(headers['x-content-type-options']).toBe('nosniff');
+    expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+
+  test('middleware rewrites based on locale', async ({ page, context }) => {
+    // Set Accept-Language header to simulate a French user
+    await context.setExtraHTTPHeaders({
+      'Accept-Language': 'fr-FR,fr;q=0.9',
+    });
+
+    await page.goto('/');
+
+    // Middleware should rewrite to the French locale
+    await expect(page.getByText('Bienvenue')).toBeVisible();
+  });
+
+  test('middleware blocks unauthorized API access', async ({ request }) => {
+    // Call a protected API route without authentication
+    const response = await request.get('/api/admin/users');
+
+    expect(response.status()).toBe(401);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('middleware', () => {
+  test('unauthenticated user is redirected to login', async ({ page }) => {
+    const response = await page.goto('/dashboard');
+
+    expect(page.url()).toContain('/login');
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('middleware redirect preserves the return URL', async ({ page }) => {
+    await page.goto('/dashboard/settings');
+
+    const url = new URL(page.url());
+    expect(url.pathname).toBe('/login');
+    expect(url.searchParams.get('callbackUrl') || url.searchParams.get('returnTo'))
+      .toContain('/dashboard/settings');
+  });
+
+  test('middleware sets security headers', async ({ page }) => {
+    const response = await page.goto('/');
+
+    const headers = response.headers();
+    expect(headers['x-frame-options']).toBe('DENY');
+    expect(headers['x-content-type-options']).toBe('nosniff');
+    expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+
+  test('middleware rewrites based on locale', async ({ page, context }) => {
+    await context.setExtraHTTPHeaders({
+      'Accept-Language': 'fr-FR,fr;q=0.9',
+    });
+
+    await page.goto('/');
+
+    await expect(page.getByText('Bienvenue')).toBeVisible();
+  });
+
+  test('middleware blocks unauthorized API access', async ({ request }) => {
+    const response = await request.get('/api/admin/users');
+
+    expect(response.status()).toBe(401);
+  });
+});
+```
+
+### Testing Hydration and SSR/CSR Consistency
+
+**Use when**: Verifying that server-rendered HTML matches the client-side hydrated output. Hydration mismatches cause visual flicker, broken interactivity, or React errors in the console.
+**Avoid when**: The page has no interactive client components -- pure server components do not hydrate.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('hydration', () => {
+  test('no hydration errors in console', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+    // Wait for hydration to complete -- interactive elements become clickable
+    await page.getByRole('button', { name: 'Get started' }).click();
+
+    // Filter for hydration-specific errors
+    const hydrationErrors = consoleErrors.filter(
+      (e) =>
+        e.includes('Hydration') ||
+        e.includes('hydration') ||
+        e.includes('server-rendered') ||
+        e.includes('did not match')
+    );
+    expect(hydrationErrors).toEqual([]);
+  });
+
+  test('interactive elements work after hydration', async ({ page }) => {
+    await page.goto('/');
+
+    // This button relies on a client component event handler
+    // If hydration fails, the click will do nothing
+    const counter = page.getByTestId('counter-value');
+    await expect(counter).toHaveText('0');
+
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await expect(counter).toHaveText('1');
+  });
+
+  test('date/time renders without hydration mismatch', async ({ page }) => {
+    // Dates are a common source of hydration mismatch because server
+    // and client may be in different timezones
+    await page.goto('/dashboard');
+
+    // Verify the date displays without flicker
+    const dateElement = page.getByTestId('current-date');
+    await expect(dateElement).toBeVisible();
+    // Verify it contains a plausible date format, not "undefined" or garbled text
+    await expect(dateElement).toHaveText(/\w+ \d{1,2}, \d{4}/);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('hydration', () => {
+  test('no hydration errors in console', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Get started' }).click();
+
+    const hydrationErrors = consoleErrors.filter(
+      (e) =>
+        e.includes('Hydration') ||
+        e.includes('hydration') ||
+        e.includes('server-rendered') ||
+        e.includes('did not match')
+    );
+    expect(hydrationErrors).toEqual([]);
+  });
+
+  test('interactive elements work after hydration', async ({ page }) => {
+    await page.goto('/');
+
+    const counter = page.getByTestId('counter-value');
+    await expect(counter).toHaveText('0');
+
+    await page.getByRole('button', { name: 'Increment' }).click();
+    await expect(counter).toHaveText('1');
+  });
+
+  test('date/time renders without hydration mismatch', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const dateElement = page.getByTestId('current-date');
+    await expect(dateElement).toBeVisible();
+    await expect(dateElement).toHaveText(/\w+ \d{1,2}, \d{4}/);
+  });
+});
+```
+
+### Testing next/image Optimization
+
+**Use when**: Verifying that `next/image` components render correctly, lazy load offscreen images, and serve optimized formats.
+**Avoid when**: You do not use `next/image` or image optimization is not a concern for your test.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('next/image', () => {
+  test('hero image loads with correct attributes', async ({ page }) => {
+    await page.goto('/');
+
+    const heroImage = page.getByRole('img', { name: 'Hero banner' });
+    await expect(heroImage).toBeVisible();
+
+    // Verify next/image sets srcset for responsive loading
+    const srcset = await heroImage.getAttribute('srcset');
+    expect(srcset).toBeTruthy();
+    expect(srcset).toContain('w='); // next/image adds width descriptors
+
+    // Verify priority images are not lazy-loaded
+    const loading = await heroImage.getAttribute('loading');
+    expect(loading).not.toBe('lazy'); // priority images use eager loading
+  });
+
+  test('offscreen images lazy load on scroll', async ({ page }) => {
+    await page.goto('/gallery');
+
+    // Get an image that is below the fold
+    const offscreenImage = page.getByRole('img', { name: 'Gallery item 20' });
+
+    // Before scroll: image should not have loaded its src yet
+    const initialSrc = await offscreenImage.getAttribute('src');
+    // next/image uses a blur placeholder or empty src for lazy images
+
+    // Scroll the image into view
+    await offscreenImage.scrollIntoViewIfNeeded();
+    await expect(offscreenImage).toBeVisible();
+
+    // Verify the image has loaded (naturalWidth > 0 means the image loaded)
+    const naturalWidth = await offscreenImage.evaluate(
+      (img: HTMLImageElement) => img.naturalWidth
+    );
+    expect(naturalWidth).toBeGreaterThan(0);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('next/image', () => {
+  test('hero image loads with correct attributes', async ({ page }) => {
+    await page.goto('/');
+
+    const heroImage = page.getByRole('img', { name: 'Hero banner' });
+    await expect(heroImage).toBeVisible();
+
+    const srcset = await heroImage.getAttribute('srcset');
+    expect(srcset).toBeTruthy();
+    expect(srcset).toContain('w=');
+
+    const loading = await heroImage.getAttribute('loading');
+    expect(loading).not.toBe('lazy');
+  });
+
+  test('offscreen images lazy load on scroll', async ({ page }) => {
+    await page.goto('/gallery');
+
+    const offscreenImage = page.getByRole('img', { name: 'Gallery item 20' });
+
+    await offscreenImage.scrollIntoViewIfNeeded();
+    await expect(offscreenImage).toBeVisible();
+
+    const naturalWidth = await offscreenImage.evaluate(
+      (img) => img.naturalWidth
+    );
+    expect(naturalWidth).toBeGreaterThan(0);
+  });
+});
+```
+
+### Authentication with NextAuth.js / Auth.js
+
+**Use when**: Testing login flows in Next.js apps using NextAuth.js or Auth.js. Use a setup project to authenticate once, then reuse `storageState` across tests.
+**Avoid when**: Your app does not use session-based authentication.
+
+**TypeScript**
+```typescript
+// playwright.config.ts (auth-specific excerpt)
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'authenticated',
+      use: { storageState: 'playwright/.auth/user.json' },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'unauthenticated',
+      // No storageState -- tests run as logged-out user
+      testMatch: '**/*.unauth.spec.ts',
+    },
+  ],
+});
+```
+
+```typescript
+// tests/auth.setup.ts
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate via credentials', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Wait for the redirect after successful login
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  // Save authentication state (cookies + localStorage)
+  await page.context().storageState({ path: authFile });
+});
+```
+
+```typescript
+// tests/dashboard.spec.ts
+import { test, expect } from '@playwright/test';
+
+// This test runs with the authenticated storageState from the setup project
+test('authenticated user sees dashboard', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // No login redirect -- auth cookies are already set
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(page.getByText('test@example.com')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/auth.setup.js
+const { test: setup, expect } = require('@playwright/test');
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate via credentials', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.context().storageState({ path: authFile });
+});
+```
+
+```javascript
+// tests/dashboard.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('authenticated user sees dashboard', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(page.getByText('test@example.com')).toBeVisible();
+});
+```
+
+## Framework-Specific Tips
+
+### Dev Server vs Production Build
+
+| Scenario | Command | Trade-off |
+|---|---|---|
+| Local development | `npm run dev` | Hot reload, fast iteration, but does not test production behavior (minification, optimization, middleware edge runtime) |
+| CI pipeline | `npm run build && npm run start` | Tests the real production bundle; catches build errors, middleware edge cases |
+| Quick smoke test | `npm run dev` in CI with `reuseExistingServer: false` | Faster CI but misses production-only bugs |
+
+**Recommendation**: Use `npm run dev` locally for fast feedback. Use `npm run build && npm run start` in CI to test the real production artifact.
+
+### Server Components Cannot Be Tested in Isolation
+
+Next.js server components run on the server and produce HTML. Playwright tests the rendered output. You cannot import and render a server component in a Playwright test. Instead:
+
+1. Test the final rendered HTML through navigation (`page.goto`)
+2. Verify that server-fetched data appears on the page
+3. Use API route tests to validate the data layer separately
+
+### Handling Next.js Redirects
+
+Next.js redirects (configured in `next.config.js`, middleware, or `redirect()` in server actions) are transparent to Playwright. After `page.goto()`, check `page.url()` to verify the final destination.
+
+### Turbopack Compatibility
+
+If using Turbopack (`next dev --turbopack`), update your `webServer.command`:
+
+```typescript
+webServer: {
+  command: process.env.CI
+    ? 'npm run build && npm run start'
+    : 'npx next dev --turbopack',
+  url: 'http://localhost:3000',
+  reuseExistingServer: !process.env.CI,
+},
+```
+
+### Multiple webServer Entries (Next.js + API Backend)
+
+If your Next.js app consumes a separate backend API:
+
+```typescript
+webServer: [
+  {
+    command: 'npm run dev:api',
+    url: 'http://localhost:4000/health',
+    reuseExistingServer: !process.env.CI,
+  },
+  {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+],
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `await page.waitForTimeout(3000)` after navigation | Next.js client-side transitions are fast; arbitrary waits are wasteful and fragile | `await page.waitForURL('/expected-path')` or `await expect(locator).toBeVisible()` |
+| Test `getServerSideProps` by importing and calling it directly | It depends on `context` (req/res) that Playwright cannot provide; it is a unit test concern | Navigate to the page and verify the rendered output |
+| Mock your own API routes with `page.route()` | You are testing a fiction; your API handler may have bugs the mock hides | Let the real API route handle requests; mock only external services |
+| Use `page.goto('http://localhost:3000/path')` with full URL | Breaks when port or host changes; ignores `baseURL` | Use `page.goto('/path')` and configure `baseURL` in config |
+| Run `npm run build && npm run start` locally for every test run | Extremely slow feedback loop during development | Use `npm run dev` locally with `reuseExistingServer: true`; reserve production builds for CI |
+| Test `next/image` by checking exact URL paths | `next/image` rewrites image URLs through `/_next/image`; paths change between dev and prod | Assert on `alt` text, visibility, `naturalWidth > 0`, and `srcset` existence |
+| Skip `.env.test` and hardcode test values in config | Values scatter across config and test files; hard to maintain | Use `.env.test` for shared test values; `.env.test.local` for secrets |
+| Test server actions by calling them as functions | Server actions are bound to the Next.js runtime; calling them outside a request context fails | Trigger server actions through their UI (form submissions, button clicks) |
+| Ignore console errors during SSR tests | Hydration mismatches and server errors appear in the console and indicate real bugs | Listen for `page.on('console')` errors and fail the test if hydration warnings appear |
+
+## Related
+
+- [core/configuration.md](configuration.md) -- base Playwright configuration patterns including `webServer`
+- [core/authentication.md](authentication.md) -- authentication setup projects and `storageState` reuse
+- [core/api-testing.md](api-testing.md) -- testing API routes directly with `request` context
+- [core/network-mocking.md](network-mocking.md) -- mocking external APIs that Next.js API routes call
+- [core/when-to-mock.md](when-to-mock.md) -- when to mock vs hit real services
+- [core/react.md](react.md) -- React-specific patterns that apply to Next.js client components
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI setup with `npm run build` caching for Next.js

--- a/engineering-team/playwright skill/core/performance-testing.md
+++ b/engineering-team/playwright skill/core/performance-testing.md
@@ -1,0 +1,608 @@
+# Performance Testing
+
+> **When to use**: Measuring and enforcing Web Vitals, resource loading timing, bundle sizes, and runtime performance. Use Playwright to catch performance regressions in CI before users notice them.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Reference
+
+```typescript
+// Measure Largest Contentful Paint (LCP)
+const lcp = await page.evaluate(() => {
+  return new Promise<number>((resolve) => {
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      resolve(entries[entries.length - 1].startTime);
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  });
+});
+expect(lcp).toBeLessThan(2500); // Good LCP threshold
+
+// Throttle network to 3G
+const client = await page.context().newCDPSession(page);
+await client.send('Network.emulateNetworkConditions', {
+  offline: false, downloadThroughput: 1.6 * 1024 * 1024 / 8,
+  uploadThroughput: 750 * 1024 / 8, latency: 150,
+});
+```
+
+## Patterns
+
+### Web Vitals Measurement (LCP, CLS, FID/INP)
+
+**Use when**: Enforcing Core Web Vitals thresholds as part of your test suite.
+**Avoid when**: You only need aggregate field data -- use Chrome UX Report or RUM tools instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('Core Web Vitals meet thresholds on homepage', async ({ page }) => {
+  // Inject Web Vitals observer before navigation
+  await page.addInitScript(() => {
+    (window as any).__webVitals = { lcp: 0, cls: 0, fid: 0 };
+
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      (window as any).__webVitals.lcp = entries[entries.length - 1].startTime;
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+
+    new PerformanceObserver((list) => {
+      let clsValue = 0;
+      for (const entry of list.getEntries()) {
+        if (!(entry as any).hadRecentInput) {
+          clsValue += (entry as any).value;
+        }
+      }
+      (window as any).__webVitals.cls = clsValue;
+    }).observe({ type: 'layout-shift', buffered: true });
+
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      (window as any).__webVitals.fid = entries[0]?.processingStart - entries[0]?.startTime;
+    }).observe({ type: 'first-input', buffered: true });
+  });
+
+  await page.goto('/');
+
+  // Trigger a user interaction to measure FID
+  await page.getByRole('button', { name: 'Get started' }).click();
+
+  // Wait for LCP to settle
+  await page.waitForTimeout(1000); // Acceptable here: waiting for metric to finalize
+
+  const vitals = await page.evaluate(() => (window as any).__webVitals);
+
+  expect(vitals.lcp).toBeLessThan(2500);   // Good: <2.5s
+  expect(vitals.cls).toBeLessThan(0.1);    // Good: <0.1
+  // FID may be 0 in automated tests due to no real user delay
+  if (vitals.fid > 0) {
+    expect(vitals.fid).toBeLessThan(100);  // Good: <100ms
+  }
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('LCP meets threshold on homepage', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__lcp = 0;
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      window.__lcp = entries[entries.length - 1].startTime;
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  });
+
+  await page.goto('/');
+  await page.waitForTimeout(1000);
+
+  const lcp = await page.evaluate(() => window.__lcp);
+  expect(lcp).toBeLessThan(2500);
+});
+```
+
+### Performance API Access
+
+**Use when**: Measuring navigation timing, resource loading, or custom performance marks.
+**Avoid when**: Web Vitals alone cover your needs.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('page load timing is within budget', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const timing = await page.evaluate(() => {
+    const nav = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
+    return {
+      dns: nav.domainLookupEnd - nav.domainLookupStart,
+      tcp: nav.connectEnd - nav.connectStart,
+      ttfb: nav.responseStart - nav.requestStart,
+      domContentLoaded: nav.domContentLoadedEventEnd - nav.startTime,
+      loadComplete: nav.loadEventEnd - nav.startTime,
+      domInteractive: nav.domInteractive - nav.startTime,
+    };
+  });
+
+  expect(timing.ttfb).toBeLessThan(600);           // TTFB under 600ms
+  expect(timing.domContentLoaded).toBeLessThan(2000); // DOM ready under 2s
+  expect(timing.loadComplete).toBeLessThan(5000);     // Full load under 5s
+});
+
+test('critical API calls complete within budget', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const apiTimings = await page.evaluate(() => {
+    return performance
+      .getEntriesByType('resource')
+      .filter((r) => r.name.includes('/api/'))
+      .map((r) => ({
+        name: r.name.split('/api/')[1],
+        duration: r.duration,
+        size: (r as PerformanceResourceTiming).transferSize,
+      }));
+  });
+
+  for (const api of apiTimings) {
+    expect(api.duration, `API ${api.name} too slow`).toBeLessThan(1000);
+  }
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('page load timing is within budget', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const timing = await page.evaluate(() => {
+    const nav = performance.getEntriesByType('navigation')[0];
+    return {
+      ttfb: nav.responseStart - nav.requestStart,
+      domContentLoaded: nav.domContentLoadedEventEnd - nav.startTime,
+      loadComplete: nav.loadEventEnd - nav.startTime,
+    };
+  });
+
+  expect(timing.ttfb).toBeLessThan(600);
+  expect(timing.domContentLoaded).toBeLessThan(2000);
+  expect(timing.loadComplete).toBeLessThan(5000);
+});
+```
+
+### Resource Loading and Bundle Size Monitoring
+
+**Use when**: Enforcing bundle size budgets and catching unexpected large resources.
+**Avoid when**: Bundle analysis is handled by webpack-bundle-analyzer or similar build tools.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('JavaScript bundle sizes are within budget', async ({ page }) => {
+  const resourceSizes: { name: string; size: number }[] = [];
+
+  page.on('response', async (response) => {
+    const url = response.url();
+    if (url.endsWith('.js') || url.includes('.js?')) {
+      const headers = response.headers();
+      const size = parseInt(headers['content-length'] || '0');
+      resourceSizes.push({
+        name: url.split('/').pop()!.split('?')[0],
+        size,
+      });
+    }
+  });
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  // No single JS bundle should exceed 250KB compressed
+  for (const resource of resourceSizes) {
+    expect(
+      resource.size,
+      `Bundle ${resource.name} is ${(resource.size / 1024).toFixed(1)}KB`
+    ).toBeLessThan(250 * 1024);
+  }
+
+  // Total JS payload should not exceed 500KB
+  const totalSize = resourceSizes.reduce((sum, r) => sum + r.size, 0);
+  expect(totalSize, `Total JS: ${(totalSize / 1024).toFixed(1)}KB`).toBeLessThan(500 * 1024);
+});
+
+test('no unexpected large images', async ({ page }) => {
+  const largeImages: { url: string; size: number }[] = [];
+
+  page.on('response', async (response) => {
+    const contentType = response.headers()['content-type'] || '';
+    if (contentType.startsWith('image/')) {
+      const size = parseInt(response.headers()['content-length'] || '0');
+      if (size > 200 * 1024) {
+        largeImages.push({ url: response.url(), size });
+      }
+    }
+  });
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  expect(
+    largeImages,
+    `Found ${largeImages.length} images over 200KB: ${largeImages.map(i => i.url).join(', ')}`
+  ).toHaveLength(0);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('JavaScript bundle sizes are within budget', async ({ page }) => {
+  const resourceSizes = [];
+
+  page.on('response', async (response) => {
+    const url = response.url();
+    if (url.endsWith('.js') || url.includes('.js?')) {
+      const size = parseInt(response.headers()['content-length'] || '0');
+      resourceSizes.push({ name: url.split('/').pop().split('?')[0], size });
+    }
+  });
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  const totalSize = resourceSizes.reduce((sum, r) => sum + r.size, 0);
+  expect(totalSize).toBeLessThan(500 * 1024);
+});
+```
+
+### Slow Network Simulation via CDP
+
+**Use when**: Testing your app's behavior and performance under constrained network conditions.
+**Avoid when**: Playwright's built-in `offline` option is sufficient for your test.
+
+**TypeScript**
+```typescript
+import { test, expect, type Page } from '@playwright/test';
+
+// Network presets
+const NETWORK_PRESETS = {
+  slow3G: {
+    offline: false,
+    downloadThroughput: (500 * 1024) / 8,  // 500 Kbps
+    uploadThroughput: (500 * 1024) / 8,
+    latency: 400,
+  },
+  fast3G: {
+    offline: false,
+    downloadThroughput: (1.6 * 1024 * 1024) / 8,  // 1.6 Mbps
+    uploadThroughput: (750 * 1024) / 8,
+    latency: 150,
+  },
+  regularLTE: {
+    offline: false,
+    downloadThroughput: (4 * 1024 * 1024) / 8,  // 4 Mbps
+    uploadThroughput: (3 * 1024 * 1024) / 8,
+    latency: 20,
+  },
+} as const;
+
+async function throttleNetwork(page: Page, preset: keyof typeof NETWORK_PRESETS) {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.enable');
+  await client.send('Network.emulateNetworkConditions', NETWORK_PRESETS[preset]);
+  return client;
+}
+
+test('app shows loading states on slow network', async ({ page }) => {
+  await throttleNetwork(page, 'slow3G');
+
+  await page.goto('/dashboard');
+
+  // Loading skeleton should appear while content loads slowly
+  await expect(page.getByTestId('loading-skeleton')).toBeVisible();
+
+  // Content should eventually load
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({ timeout: 30000 });
+});
+
+test('images lazy-load on slow connection', async ({ page }) => {
+  await throttleNetwork(page, 'fast3G');
+  await page.goto('/gallery');
+
+  // Only above-the-fold images should be loaded initially
+  const loadedImages = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('img'))
+      .filter((img) => img.complete && img.naturalWidth > 0).length
+  );
+
+  // Scroll to trigger lazy loading
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(2000);
+
+  const allLoadedImages = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('img'))
+      .filter((img) => img.complete && img.naturalWidth > 0).length
+  );
+
+  expect(allLoadedImages).toBeGreaterThan(loadedImages);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+async function throttleNetwork(page, preset) {
+  const presets = {
+    slow3G: { offline: false, downloadThroughput: (500 * 1024) / 8, uploadThroughput: (500 * 1024) / 8, latency: 400 },
+    fast3G: { offline: false, downloadThroughput: (1.6 * 1024 * 1024) / 8, uploadThroughput: (750 * 1024) / 8, latency: 150 },
+  };
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.enable');
+  await client.send('Network.emulateNetworkConditions', presets[preset]);
+  return client;
+}
+
+test('app shows loading states on slow network', async ({ page }) => {
+  await throttleNetwork(page, 'slow3G');
+  await page.goto('/dashboard');
+
+  await expect(page.getByTestId('loading-skeleton')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({ timeout: 30000 });
+});
+```
+
+### CPU Throttling via CDP
+
+**Use when**: Simulating low-powered devices to test animation smoothness, interaction responsiveness, or heavy computation.
+**Avoid when**: Network performance is the bottleneck, not CPU.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('animations remain smooth under CPU throttling', async ({ page }) => {
+  const client = await page.context().newCDPSession(page);
+
+  // 4x slowdown simulates a mid-tier mobile device
+  await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+  await page.goto('/animations-demo');
+  await page.getByRole('button', { name: 'Start animation' }).click();
+
+  // Measure frame rate during animation
+  const fps = await page.evaluate(() => {
+    return new Promise<number>((resolve) => {
+      let frames = 0;
+      const start = performance.now();
+      function count() {
+        frames++;
+        if (performance.now() - start < 1000) {
+          requestAnimationFrame(count);
+        } else {
+          resolve(frames);
+        }
+      }
+      requestAnimationFrame(count);
+    });
+  });
+
+  // Should maintain at least 30fps even on throttled CPU
+  expect(fps).toBeGreaterThan(30);
+
+  // Reset throttling
+  await client.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+});
+
+test('search input responds quickly under CPU constraint', async ({ page }) => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+  await page.goto('/search');
+
+  const start = Date.now();
+  await page.getByRole('textbox', { name: 'Search' }).fill('test query');
+  await expect(page.getByRole('listbox')).toBeVisible();
+  const elapsed = Date.now() - start;
+
+  // Autocomplete should appear within 500ms even under 4x CPU throttle
+  expect(elapsed).toBeLessThan(500);
+
+  await client.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('animations remain smooth under CPU throttling', async ({ page }) => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+  await page.goto('/animations-demo');
+  await page.getByRole('button', { name: 'Start animation' }).click();
+
+  const fps = await page.evaluate(() => {
+    return new Promise((resolve) => {
+      let frames = 0;
+      const start = performance.now();
+      function count() {
+        frames++;
+        if (performance.now() - start < 1000) {
+          requestAnimationFrame(count);
+        } else {
+          resolve(frames);
+        }
+      }
+      requestAnimationFrame(count);
+    });
+  });
+
+  expect(fps).toBeGreaterThan(30);
+  await client.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+});
+```
+
+### Performance Budgets in CI
+
+**Use when**: Enforcing hard performance limits that block merges when thresholds are exceeded.
+**Avoid when**: Performance varies too much in CI environment -- use trend-based monitoring instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Define budgets in a shared config
+const PERFORMANCE_BUDGETS = {
+  homepage: {
+    lcp: 2500,
+    cls: 0.1,
+    ttfb: 600,
+    totalJsSize: 500 * 1024,
+    totalImageSize: 1000 * 1024,
+    domContentLoaded: 2000,
+  },
+  dashboard: {
+    lcp: 3000,
+    cls: 0.1,
+    ttfb: 800,
+    totalJsSize: 750 * 1024,
+    totalImageSize: 500 * 1024,
+    domContentLoaded: 3000,
+  },
+} as const;
+
+test.describe('performance budgets', () => {
+  test('homepage meets performance budget', async ({ page }) => {
+    const budget = PERFORMANCE_BUDGETS.homepage;
+    let totalJsSize = 0;
+
+    page.on('response', (response) => {
+      if (response.url().endsWith('.js') || response.url().includes('.js?')) {
+        totalJsSize += parseInt(response.headers()['content-length'] || '0');
+      }
+    });
+
+    // Inject LCP observer
+    await page.addInitScript(() => {
+      (window as any).__lcp = 0;
+      new PerformanceObserver((list) => {
+        const entries = list.getEntries();
+        (window as any).__lcp = entries[entries.length - 1].startTime;
+      }).observe({ type: 'largest-contentful-paint', buffered: true });
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const metrics = await page.evaluate(() => {
+      const nav = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
+      return {
+        lcp: (window as any).__lcp,
+        ttfb: nav.responseStart - nav.requestStart,
+        domContentLoaded: nav.domContentLoadedEventEnd - nav.startTime,
+      };
+    });
+
+    expect(metrics.lcp, 'LCP budget exceeded').toBeLessThan(budget.lcp);
+    expect(metrics.ttfb, 'TTFB budget exceeded').toBeLessThan(budget.ttfb);
+    expect(metrics.domContentLoaded, 'DOMContentLoaded budget exceeded').toBeLessThan(budget.domContentLoaded);
+    expect(totalJsSize, 'JS bundle budget exceeded').toBeLessThan(budget.totalJsSize);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const PERFORMANCE_BUDGETS = {
+  homepage: { lcp: 2500, ttfb: 600, totalJsSize: 500 * 1024, domContentLoaded: 2000 },
+};
+
+test('homepage meets performance budget', async ({ page }) => {
+  const budget = PERFORMANCE_BUDGETS.homepage;
+  let totalJsSize = 0;
+
+  page.on('response', (response) => {
+    if (response.url().endsWith('.js')) {
+      totalJsSize += parseInt(response.headers()['content-length'] || '0');
+    }
+  });
+
+  await page.addInitScript(() => {
+    window.__lcp = 0;
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      window.__lcp = entries[entries.length - 1].startTime;
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  });
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  const metrics = await page.evaluate(() => {
+    const nav = performance.getEntriesByType('navigation')[0];
+    return {
+      lcp: window.__lcp,
+      ttfb: nav.responseStart - nav.requestStart,
+      domContentLoaded: nav.domContentLoadedEventEnd - nav.startTime,
+    };
+  });
+
+  expect(metrics.lcp).toBeLessThan(budget.lcp);
+  expect(metrics.ttfb).toBeLessThan(budget.ttfb);
+  expect(totalJsSize).toBeLessThan(budget.totalJsSize);
+});
+```
+
+## Decision Guide
+
+| What to Measure | Technique | When to Use |
+|---|---|---|
+| LCP, CLS, FID/INP | `PerformanceObserver` via `addInitScript` | Core Web Vitals regression testing |
+| TTFB, DOM load times | `performance.getEntriesByType('navigation')` | Server response and page load budgets |
+| API call durations | `performance.getEntriesByType('resource')` | Backend performance regression |
+| JS/CSS bundle sizes | `page.on('response')` + `content-length` header | Bundle size budgets in CI |
+| Slow network behavior | CDP `Network.emulateNetworkConditions` | Testing loading states, lazy loading, offline |
+| Low-end device behavior | CDP `Emulation.setCPUThrottlingRate` | Animation smoothness, interaction latency |
+| Full Lighthouse audit | `@playwright/test` + Lighthouse CLI via CDP port | Comprehensive performance scoring |
+| Runtime performance | `page.evaluate` + `requestAnimationFrame` FPS count | Animation and rendering performance |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Setting absolute thresholds based on local dev machine | CI machines are slower; thresholds flap | Calibrate budgets on CI hardware or use relative comparisons |
+| Using `networkidle` as a performance measurement point | `networkidle` includes analytics, ads, non-critical resources | Measure specific metrics (LCP, TTFB) directly via Performance API |
+| Running performance tests with `--headed` in CI | Headed mode adds GPU overhead and inconsistency | Use headless mode for consistent measurement |
+| Measuring FID in automated tests | No real user input delay exists in automation | Measure INP or use Lighthouse for FID estimates |
+| Running perf tests in parallel with other CI jobs | CPU contention skews results | Run performance tests in isolation or on dedicated CI runners |
+| Ignoring `content-length` being `0` | Compressed responses may not report size | Use `response.body().length` for actual transfer size |
+| Only testing happy-path performance | Slow error paths degrade user experience | Test performance of error states, empty states, and large datasets |
+| Hard-failing CI on minor regressions | Causes merge friction for non-performance changes | Use warning thresholds with mandatory review, fail only on large regressions |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| LCP is 0 or unrealistically low | Observer did not fire; page has no qualifying LCP element | Verify the page has images or large text blocks; add `buffered: true` to observer |
+| CLS is always 0 | Layout shifts occur before observer is registered | Use `addInitScript` to inject observer before page load |
+| CDP session errors with Firefox/WebKit | CDP is Chromium-only | Guard CDP code: `test.skip(browserName !== 'chromium')` |
+| Performance numbers vary wildly between runs | CI machine load fluctuates | Run performance tests multiple times and take the median; use dedicated runners |
+| `content-length` header is missing | Server uses chunked transfer encoding | Use `response.body()` then check `Buffer.byteLength()` |
+| Network throttling has no effect | CDP session created on wrong page | Create the CDP session from the page's context, not a separate browser |
+| Bundle size test passes but app feels slow | Measuring compressed size, not parsed size | Also check `performance.getEntriesByType('resource')` for `decodedBodySize` |
+
+## Related
+
+- [core/configuration.md](configuration.md) -- timeout and retry settings for performance-sensitive tests
+- [core/network-mocking.md](network-mocking.md) -- mocking slow APIs for performance boundary testing
+- [core/browser-apis.md](browser-apis.md) -- using browser APIs for measurement
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI configuration for performance budgets
+- [core/clock-and-time-mocking.md](clock-and-time-mocking.md) -- time-related performance testing

--- a/engineering-team/playwright skill/core/react.md
+++ b/engineering-team/playwright skill/core/react.md
@@ -1,0 +1,1082 @@
+# Testing React Apps with Playwright
+
+> **When to use**: Testing React applications built with Create React App (CRA), Vite, or custom bundlers. Covers E2E testing, experimental component testing, React Router navigation, form libraries, portals, error boundaries, and context/state verification through the UI.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```bash
+# Install Playwright in a React project
+npm init playwright@latest
+
+# Install component testing (experimental)
+npm install -D @playwright/experimental-ct-react
+
+# Run E2E tests
+npx playwright test
+
+# Run component tests
+npx playwright test -c playwright-ct.config.ts
+
+# Debug a specific test
+npx playwright test tests/login.spec.ts --headed --debug
+```
+
+## Setup
+
+### Playwright Config for React (Vite)
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:5173', // Vite default port
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npx serve -s build -l 5173' // CRA
+      // ? 'npm run build && npx vite preview --port 5173' // Vite
+      : 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npx serve -s build -l 5173'
+      : 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+### Component Testing Config
+
+Component testing mounts individual React components in a real browser without a full dev server. This is experimental but useful for testing complex components in isolation.
+
+**TypeScript**
+```typescript
+// playwright-ct.config.ts
+import { defineConfig, devices } from '@playwright/experimental-ct-react';
+
+export default defineConfig({
+  testDir: './tests/components',
+  testMatch: '**/*.ct.ts',
+
+  use: {
+    trace: 'on-first-retry',
+    ctPort: 3100,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+**JavaScript**
+```javascript
+// playwright-ct.config.js
+const { defineConfig, devices } = require('@playwright/experimental-ct-react');
+
+module.exports = defineConfig({
+  testDir: './tests/components',
+  testMatch: '**/*.ct.js',
+
+  use: {
+    trace: 'on-first-retry',
+    ctPort: 3100,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+## Patterns
+
+### Component Testing with `@playwright/experimental-ct-react`
+
+**Use when**: Testing complex interactive components in isolation -- data tables, form wizards, rich text editors, dropdowns with keyboard navigation. The component needs a real browser (not jsdom) but not a full application.
+**Avoid when**: The component behavior depends heavily on backend data or routing context. Use E2E tests instead.
+
+**TypeScript**
+```typescript
+// tests/components/Counter.ct.ts
+import { test, expect } from '@playwright/experimental-ct-react';
+import Counter from '../../src/components/Counter';
+
+test('increments count on button click', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={0} />);
+
+  await expect(component.getByText('Count: 0')).toBeVisible();
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 1')).toBeVisible();
+});
+
+test('decrements count on button click', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={5} />);
+
+  await component.getByRole('button', { name: 'Decrement' }).click();
+  await expect(component.getByText('Count: 4')).toBeVisible();
+});
+
+test('calls onChange callback when count changes', async ({ mount }) => {
+  const values: number[] = [];
+  const component = await mount(
+    <Counter initialCount={0} onChange={(val) => values.push(val)} />
+  );
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await component.getByRole('button', { name: 'Increment' }).click();
+
+  expect(values).toEqual([1, 2]);
+});
+
+test('disables decrement at zero when min is set', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={0} min={0} />);
+
+  await expect(component.getByRole('button', { name: 'Decrement' })).toBeDisabled();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/components/Counter.ct.js
+const { test, expect } = require('@playwright/experimental-ct-react');
+const Counter = require('../../src/components/Counter');
+
+test('increments count on button click', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={0} />);
+
+  await expect(component.getByText('Count: 0')).toBeVisible();
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 1')).toBeVisible();
+});
+
+test('decrements count on button click', async ({ mount }) => {
+  const component = await mount(<Counter initialCount={5} />);
+
+  await component.getByRole('button', { name: 'Decrement' }).click();
+  await expect(component.getByText('Count: 4')).toBeVisible();
+});
+
+test('calls onChange callback when count changes', async ({ mount }) => {
+  const values = [];
+  const component = await mount(
+    <Counter initialCount={0} onChange={(val) => values.push(val)} />
+  );
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await component.getByRole('button', { name: 'Increment' }).click();
+
+  expect(values).toEqual([1, 2]);
+});
+```
+
+### Testing Hooks Indirectly Through the UI
+
+**Use when**: Verifying that custom hooks produce the correct UI behavior. Playwright cannot call hooks directly -- test them through the components that consume them.
+**Avoid when**: The hook logic is pure computation with no UI side effects -- use a unit testing framework for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('useDebounce hook (tested through SearchInput)', () => {
+  test('debounced search triggers after user stops typing', async ({ page }) => {
+    await page.goto('/search');
+
+    // Set up a response interceptor to track API calls
+    const apiCalls: string[] = [];
+    await page.route('**/api/search*', async (route) => {
+      apiCalls.push(route.request().url());
+      await route.continue();
+    });
+
+    // Type quickly -- the debounce hook should batch these
+    await page.getByRole('textbox', { name: 'Search' }).pressSequentially('playwright', {
+      delay: 50,
+    });
+
+    // Wait for results to appear (debounce has fired)
+    await expect(page.getByRole('listitem')).toHaveCount(5);
+
+    // The debounced hook should have made 1-2 API calls, not 10 (one per keystroke)
+    expect(apiCalls.length).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('usePagination hook (tested through ProductList)', () => {
+  test('pagination controls navigate between pages', async ({ page }) => {
+    await page.goto('/products');
+
+    await expect(page.getByText('Page 1 of 5')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Next page' }).click();
+    await expect(page.getByText('Page 2 of 5')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Previous page' }).click();
+    await expect(page.getByText('Page 1 of 5')).toBeVisible();
+
+    // First page: previous should be disabled
+    await expect(page.getByRole('button', { name: 'Previous page' })).toBeDisabled();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('useDebounce hook (tested through SearchInput)', () => {
+  test('debounced search triggers after user stops typing', async ({ page }) => {
+    await page.goto('/search');
+
+    const apiCalls = [];
+    await page.route('**/api/search*', async (route) => {
+      apiCalls.push(route.request().url());
+      await route.continue();
+    });
+
+    await page.getByRole('textbox', { name: 'Search' }).pressSequentially('playwright', {
+      delay: 50,
+    });
+
+    await expect(page.getByRole('listitem')).toHaveCount(5);
+    expect(apiCalls.length).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('usePagination hook (tested through ProductList)', () => {
+  test('pagination controls navigate between pages', async ({ page }) => {
+    await page.goto('/products');
+
+    await expect(page.getByText('Page 1 of 5')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Next page' }).click();
+    await expect(page.getByText('Page 2 of 5')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Previous page' }).click();
+    await expect(page.getByText('Page 1 of 5')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Previous page' })).toBeDisabled();
+  });
+});
+```
+
+### Testing Context and State Changes Through User Interactions
+
+**Use when**: Verifying that React context (theme, auth, locale) and state management (Redux, Zustand, Jotai) produce correct UI changes.
+**Avoid when**: You want to assert on the raw state object -- Playwright tests the UI, not internal state. If the UI is correct, the state is correct.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('theme context', () => {
+  test('dark mode toggle changes the visual theme', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Verify initial light mode
+    const body = page.locator('body');
+    await expect(body).not.toHaveClass(/dark/);
+
+    // Toggle dark mode
+    await page.getByRole('switch', { name: 'Dark mode' }).click();
+
+    // Verify dark mode is applied
+    await expect(body).toHaveClass(/dark/);
+
+    // Verify the toggle state persists after navigation
+    await page.getByRole('link', { name: 'Home' }).click();
+    await expect(page.locator('body')).toHaveClass(/dark/);
+  });
+});
+
+test.describe('shopping cart state', () => {
+  test('adding items updates cart badge across pages', async ({ page }) => {
+    await page.goto('/products');
+
+    // Cart badge should show 0 or be hidden
+    const cartBadge = page.getByTestId('cart-count');
+
+    // Add first item
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Running Shoes' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('1');
+
+    // Add second item
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Trail Jacket' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('2');
+
+    // Navigate to a different page -- cart count persists (global state)
+    await page.getByRole('link', { name: 'About' }).click();
+    await expect(cartBadge).toHaveText('2');
+  });
+});
+
+test.describe('auth context', () => {
+  test('login updates the UI across all components consuming auth context', async ({ page }) => {
+    await page.goto('/');
+
+    // Unauthenticated state
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign out' })).toBeHidden();
+
+    // Log in
+    await page.getByRole('link', { name: 'Sign in' }).click();
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    // Authenticated state -- multiple components update
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeHidden();
+    await expect(page.getByText('user@example.com')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('theme context', () => {
+  test('dark mode toggle changes the visual theme', async ({ page }) => {
+    await page.goto('/settings');
+
+    const body = page.locator('body');
+    await expect(body).not.toHaveClass(/dark/);
+
+    await page.getByRole('switch', { name: 'Dark mode' }).click();
+
+    await expect(body).toHaveClass(/dark/);
+
+    await page.getByRole('link', { name: 'Home' }).click();
+    await expect(page.locator('body')).toHaveClass(/dark/);
+  });
+});
+
+test.describe('shopping cart state', () => {
+  test('adding items updates cart badge across pages', async ({ page }) => {
+    await page.goto('/products');
+
+    const cartBadge = page.getByTestId('cart-count');
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Running Shoes' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('1');
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Trail Jacket' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('2');
+
+    await page.getByRole('link', { name: 'About' }).click();
+    await expect(cartBadge).toHaveText('2');
+  });
+});
+```
+
+### Testing React Router Navigation
+
+**Use when**: Testing client-side routing with React Router v6+. Verify route transitions, URL parameters, protected routes, and browser history behavior.
+**Avoid when**: Your app uses server-side routing only (Next.js App Router handles this differently -- see [core/nextjs.md](nextjs.md)).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('React Router navigation', () => {
+  test('client-side navigation does not cause full page reload', async ({ page }) => {
+    await page.goto('/');
+
+    // Store a marker in window to detect full reload
+    await page.evaluate(() => {
+      (window as any).__testMarker = 'no-reload';
+    });
+
+    // Navigate via a React Router Link
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+
+    // If the page fully reloaded, the marker would be gone
+    const marker = await page.evaluate(() => (window as any).__testMarker);
+    expect(marker).toBe('no-reload');
+  });
+
+  test('URL params update the page content', async ({ page }) => {
+    await page.goto('/products?category=electronics');
+
+    await expect(page.getByRole('heading', { name: 'Electronics' })).toBeVisible();
+
+    // Change category via UI interaction (which updates the URL param)
+    await page.getByRole('link', { name: 'Clothing' }).click();
+    await page.waitForURL('/products?category=clothing');
+
+    await expect(page.getByRole('heading', { name: 'Clothing' })).toBeVisible();
+  });
+
+  test('nested routes render parent and child layouts', async ({ page }) => {
+    await page.goto('/settings/profile');
+
+    // Parent layout (Settings)
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Settings' })).toBeVisible();
+
+    // Child route (Profile)
+    await expect(page.getByRole('heading', { name: 'Profile', level: 2 })).toBeVisible();
+
+    // Navigate to sibling route
+    await page.getByRole('link', { name: 'Notifications' }).click();
+    await page.waitForURL('/settings/notifications');
+
+    // Parent layout persists
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Notifications', level: 2 })).toBeVisible();
+  });
+
+  test('browser back button works with client-side routing', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    // Go back
+    await page.goBack();
+    await expect(page).toHaveURL(/\/products/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('protected route redirects unauthenticated users', async ({ page }) => {
+    await page.goto('/admin');
+
+    // React Router's protected route should redirect to login
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('404 route shows not found page', async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+
+    await expect(page.getByRole('heading', { name: 'Page Not Found' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Go home' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('React Router navigation', () => {
+  test('client-side navigation does not cause full page reload', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      window.__testMarker = 'no-reload';
+    });
+
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+
+    const marker = await page.evaluate(() => window.__testMarker);
+    expect(marker).toBe('no-reload');
+  });
+
+  test('URL params update the page content', async ({ page }) => {
+    await page.goto('/products?category=electronics');
+
+    await expect(page.getByRole('heading', { name: 'Electronics' })).toBeVisible();
+
+    await page.getByRole('link', { name: 'Clothing' }).click();
+    await page.waitForURL('/products?category=clothing');
+
+    await expect(page.getByRole('heading', { name: 'Clothing' })).toBeVisible();
+  });
+
+  test('browser back button works with client-side routing', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/products/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('protected route redirects unauthenticated users', async ({ page }) => {
+    await page.goto('/admin');
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+});
+```
+
+### Testing Form Libraries (React Hook Form, Formik)
+
+**Use when**: Testing forms built with react-hook-form, Formik, or similar libraries. Playwright interacts with the DOM, so the form library is transparent -- test the user experience, not the library internals.
+**Avoid when**: Testing the form library itself. You are testing YOUR form behavior.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('registration form (react-hook-form)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/register');
+  });
+
+  test('shows validation errors on submit with empty fields', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    // react-hook-form shows errors after submit attempt
+    await expect(page.getByText('Email is required')).toBeVisible();
+    await expect(page.getByText('Password is required')).toBeVisible();
+  });
+
+  test('shows inline validation on blur', async ({ page }) => {
+    const emailInput = page.getByLabel('Email');
+    await emailInput.fill('not-an-email');
+    await emailInput.blur();
+
+    // react-hook-form with mode: 'onBlur' validates immediately
+    await expect(page.getByText('Invalid email address')).toBeVisible();
+  });
+
+  test('password requirements update in real time', async ({ page }) => {
+    const passwordInput = page.getByLabel('Password', { exact: true });
+
+    await passwordInput.fill('short');
+    await expect(page.getByText('At least 8 characters')).toHaveClass(/text-red/);
+
+    await passwordInput.fill('longenough');
+    await expect(page.getByText('At least 8 characters')).toHaveClass(/text-green/);
+
+    await passwordInput.fill('LongEnough1!');
+    await expect(page.getByText('Contains uppercase')).toHaveClass(/text-green/);
+    await expect(page.getByText('Contains number')).toHaveClass(/text-green/);
+    await expect(page.getByText('Contains special character')).toHaveClass(/text-green/);
+  });
+
+  test('successful registration submits form and redirects', async ({ page }) => {
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('I agree to the terms').check();
+
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await page.waitForURL('/dashboard');
+    await expect(page.getByText('Welcome, Jane')).toBeVisible();
+  });
+
+  test('disables submit button while form is submitting', async ({ page }) => {
+    // Slow down the API to observe the submitting state
+    await page.route('**/api/register', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1, email: 'jane@example.com' }),
+      });
+    });
+
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('I agree to the terms').check();
+
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    // Button should show loading state
+    await expect(page.getByRole('button', { name: /Creating|Loading|Submitting/ })).toBeDisabled();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('registration form (react-hook-form)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/register');
+  });
+
+  test('shows validation errors on submit with empty fields', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await expect(page.getByText('Email is required')).toBeVisible();
+    await expect(page.getByText('Password is required')).toBeVisible();
+  });
+
+  test('shows inline validation on blur', async ({ page }) => {
+    const emailInput = page.getByLabel('Email');
+    await emailInput.fill('not-an-email');
+    await emailInput.blur();
+
+    await expect(page.getByText('Invalid email address')).toBeVisible();
+  });
+
+  test('successful registration submits form and redirects', async ({ page }) => {
+    await page.getByLabel('Full name').fill('Jane Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Str0ng!Pass');
+    await page.getByLabel('Confirm password').fill('Str0ng!Pass');
+    await page.getByLabel('I agree to the terms').check();
+
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await page.waitForURL('/dashboard');
+    await expect(page.getByText('Welcome, Jane')).toBeVisible();
+  });
+});
+```
+
+### Testing React Portals (Modals, Tooltips, Dropdowns)
+
+**Use when**: Testing components rendered via `ReactDOM.createPortal()` -- modals, dialogs, tooltips, dropdown menus, toast notifications. These render outside the parent DOM hierarchy, but Playwright sees the full document.
+**Avoid when**: The component is not a portal -- it renders inline.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('portals', () => {
+  test('modal opens and is accessible', async ({ page }) => {
+    await page.goto('/products');
+
+    await page.getByRole('button', { name: 'Delete product' }).first().click();
+
+    // Modal is rendered via a portal to document.body, but Playwright
+    // sees it like any other element
+    const modal = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(modal).toBeVisible();
+
+    // Verify focus is trapped inside the modal
+    await expect(modal.getByRole('button', { name: 'Cancel' })).toBeFocused();
+
+    // Verify backdrop/overlay blocks interaction with elements behind
+    // (Playwright will auto-wait for the element to be actionable)
+    await modal.getByRole('button', { name: 'Delete' }).click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('modal closes on Escape key', async ({ page }) => {
+    await page.goto('/products');
+    await page.getByRole('button', { name: 'Delete product' }).first().click();
+
+    const modal = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(modal).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden();
+  });
+
+  test('tooltip shows on hover and hides on leave', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const triggerButton = page.getByRole('button', { name: 'Info' });
+    await triggerButton.hover();
+
+    // Tooltip rendered via portal
+    await expect(page.getByRole('tooltip')).toBeVisible();
+    await expect(page.getByRole('tooltip')).toContainText('Click for more details');
+
+    // Move mouse away
+    await page.mouse.move(0, 0);
+    await expect(page.getByRole('tooltip')).toBeHidden();
+  });
+
+  test('toast notifications stack and auto-dismiss', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Trigger multiple toasts
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Settings saved')).toBeVisible();
+
+    // Toast should auto-dismiss after a delay
+    await expect(page.getByText('Settings saved')).toBeHidden({ timeout: 10_000 });
+  });
+
+  test('dropdown menu rendered via portal positions correctly', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await page.getByRole('button', { name: 'More actions' }).click();
+
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: 'Edit' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: 'Delete' })).toBeVisible();
+
+    // Click a menu item
+    await menu.getByRole('menuitem', { name: 'Edit' }).click();
+    await expect(menu).toBeHidden();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('portals', () => {
+  test('modal opens and is accessible', async ({ page }) => {
+    await page.goto('/products');
+
+    await page.getByRole('button', { name: 'Delete product' }).first().click();
+
+    const modal = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(modal).toBeVisible();
+    await expect(modal.getByRole('button', { name: 'Cancel' })).toBeFocused();
+
+    await modal.getByRole('button', { name: 'Delete' }).click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('modal closes on Escape key', async ({ page }) => {
+    await page.goto('/products');
+    await page.getByRole('button', { name: 'Delete product' }).first().click();
+
+    const modal = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(modal).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden();
+  });
+
+  test('tooltip shows on hover and hides on leave', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await page.getByRole('button', { name: 'Info' }).hover();
+    await expect(page.getByRole('tooltip')).toBeVisible();
+
+    await page.mouse.move(0, 0);
+    await expect(page.getByRole('tooltip')).toBeHidden();
+  });
+});
+```
+
+### Testing Error Boundaries
+
+**Use when**: Verifying that React error boundaries catch rendering errors gracefully and show fallback UI instead of a white screen.
+**Avoid when**: You are testing error handling in event handlers or async code -- error boundaries only catch rendering errors.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('error boundaries', () => {
+  test('error boundary shows fallback UI when child crashes', async ({ page }) => {
+    // Capture console errors to verify the error was thrown
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/dashboard');
+
+    // Trigger an action that causes a component to throw during render
+    // (e.g., a component that crashes on specific data)
+    await page.route('**/api/dashboard/widgets', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ widgets: null }), // null causes .map() to throw
+      });
+    });
+
+    await page.reload();
+
+    // Error boundary should catch the error and show fallback
+    await expect(page.getByText('Something went wrong')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+
+    // The rest of the page should still be functional
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+  });
+
+  test('retry button in error boundary recovers the component', async ({ page }) => {
+    let requestCount = 0;
+    await page.route('**/api/dashboard/widgets', (route) => {
+      requestCount++;
+      if (requestCount === 1) {
+        // First request: return bad data that crashes the component
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ widgets: null }),
+        });
+      } else {
+        // Subsequent requests: return good data
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ widgets: [{ id: 1, name: 'Sales' }] }),
+        });
+      }
+    });
+
+    await page.goto('/dashboard');
+
+    // Error boundary shows fallback
+    await expect(page.getByText('Something went wrong')).toBeVisible();
+
+    // Click retry -- component re-mounts with good data
+    await page.getByRole('button', { name: 'Try again' }).click();
+
+    // Component recovers
+    await expect(page.getByText('Something went wrong')).toBeHidden();
+    await expect(page.getByText('Sales')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('error boundaries', () => {
+  test('error boundary shows fallback UI when child crashes', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.route('**/api/dashboard/widgets', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ widgets: null }),
+      });
+    });
+
+    await page.goto('/dashboard');
+
+    await expect(page.getByText('Something went wrong')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Main' })).toBeVisible();
+  });
+
+  test('retry button in error boundary recovers the component', async ({ page }) => {
+    let requestCount = 0;
+    await page.route('**/api/dashboard/widgets', (route) => {
+      requestCount++;
+      if (requestCount === 1) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ widgets: null }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ widgets: [{ id: 1, name: 'Sales' }] }),
+        });
+      }
+    });
+
+    await page.goto('/dashboard');
+
+    await expect(page.getByText('Something went wrong')).toBeVisible();
+    await page.getByRole('button', { name: 'Try again' }).click();
+
+    await expect(page.getByText('Something went wrong')).toBeHidden();
+    await expect(page.getByText('Sales')).toBeVisible();
+  });
+});
+```
+
+## Framework-Specific Tips
+
+### CRA vs Vite: Key Differences
+
+| Aspect | Create React App (CRA) | Vite |
+|---|---|---|
+| Default port | `3000` | `5173` |
+| Build output | `build/` | `dist/` |
+| Serve production build | `npx serve -s build -l 3000` | `npx vite preview --port 5173` |
+| Environment variables | `REACT_APP_*` prefix | `VITE_*` prefix |
+| Dev server start time | Slow (Webpack) | Fast (esbuild) |
+
+Adjust your `webServer.command` and `baseURL` accordingly.
+
+### React Strict Mode and Double Effects
+
+React Strict Mode in development runs effects twice. This can cause unexpected behavior in tests (e.g., double API calls). Your tests should be resilient to this:
+
+- Do not assert on exact API call counts in development mode
+- If you test API call counts, run against a production build or account for double invocations
+
+### Testing Suspense and Lazy Components
+
+```typescript
+// React.lazy() components show a fallback while loading
+test('lazy-loaded route shows spinner then content', async ({ page }) => {
+  await page.goto('/');
+
+  // Navigate to a lazy route
+  await page.getByRole('link', { name: 'Reports' }).click();
+
+  // The reports module loads lazily -- you may briefly see a spinner
+  // Playwright auto-waits for the final content
+  await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible();
+});
+```
+
+### Component Testing: When to Use It vs E2E
+
+| Scenario | Use Component Testing | Use E2E |
+|---|---|---|
+| Complex dropdown with keyboard navigation | Yes -- test in isolation with mount() | Also yes -- verify it works within the page |
+| Data table with sorting, filtering, pagination | Yes -- control props directly | Also yes -- verify API integration |
+| Button that submits a form | No -- trivial in isolation | Yes -- test the full form flow |
+| Theme toggle component | Yes -- verify visual changes | Also yes -- verify persistence |
+| Login form connected to auth context | No -- too many dependencies | Yes -- test the real flow |
+
+### Detecting Memory Leaks in Long-Running Tests
+
+If your React app has unmounted component state updates (the "Can't perform a React state update on an unmounted component" warning), catch them:
+
+```typescript
+test('no state-update-on-unmounted warnings during navigation', async ({ page }) => {
+  const warnings: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'warning' && msg.text().includes('unmounted')) {
+      warnings.push(msg.text());
+    }
+  });
+
+  // Rapid navigation to trigger unmount edge cases
+  await page.goto('/dashboard');
+  await page.getByRole('link', { name: 'Settings' }).click();
+  await page.goBack();
+  await page.getByRole('link', { name: 'Profile' }).click();
+  await page.goBack();
+
+  expect(warnings).toEqual([]);
+});
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.evaluate(() => store.getState())` to assert Redux state | Couples tests to implementation; state shape changes break tests | Assert on the UI that the state produces: `expect(cartBadge).toHaveText('3')` |
+| Import React components in E2E test files | E2E tests run in Node.js, not the browser; component imports fail | Use `@playwright/experimental-ct-react` for component testing, E2E for full-app tests |
+| `page.waitForTimeout(500)` after React state changes | React batches updates; timing varies across machines | Use `expect(locator).toHaveText('new value')` which auto-retries |
+| Test internal component state with `page.evaluate` | Fragile; breaks on refactors; tests implementation, not behavior | Interact through the UI and assert on visible output |
+| Mock `useState` or `useEffect` in Playwright tests | Playwright runs in the browser context, not the React component tree | Let hooks run naturally; control inputs (API responses, props via component testing) |
+| Use `page.locator('.MuiButton-root')` for Material UI | Class names change between MUI versions and are generated dynamically | `page.getByRole('button', { name: 'Submit' })` works regardless of the component library |
+| Test every component with `@playwright/experimental-ct-react` | Overhead of browser mounting for simple components; duplicates unit tests | Use component testing for complex interactive widgets; unit tests for pure logic; E2E for flows |
+| Skip testing keyboard navigation on custom components | Accessibility regressions are common in custom dropdowns, modals, tabs | Test `Tab`, `Enter`, `Escape`, `ArrowDown` interactions in component tests |
+| Assert on React DevTools or `__REACT_FIBER__` internals | Internal React properties are not stable across versions | Only interact with and assert on the rendered DOM |
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategies that work with any React component library
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-waiting assertions for React state changes
+- [core/forms-and-validation.md](forms-and-validation.md) -- form testing patterns applicable to react-hook-form and Formik
+- [core/component-testing.md](component-testing.md) -- in-depth component testing guide
+- [core/accessibility.md](accessibility.md) -- testing ARIA patterns in React component libraries
+- [core/test-architecture.md](test-architecture.md) -- when to use E2E vs component vs unit tests
+- [core/nextjs.md](nextjs.md) -- Next.js-specific patterns for React apps with SSR

--- a/engineering-team/playwright skill/core/search-and-filter.md
+++ b/engineering-team/playwright skill/core/search-and-filter.md
@@ -1,0 +1,1366 @@
+# Search and Filter Recipes
+
+> **When to use**: You need to test search inputs, filters (category, multi-select, date range), autocomplete suggestions, pagination with filters, or "no results" states.
+
+---
+
+## Recipe 1: Search Input with Results
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('searches for a product and displays matching results', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+
+  // Type a search query
+  await searchInput.fill('wireless keyboard');
+
+  // Submit the search (press Enter or click the search button)
+  await searchInput.press('Enter');
+
+  // Wait for results to load
+  await expect(page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') }).first())
+    .toBeVisible();
+
+  // Verify results match the query
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Each result should contain the search term
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toContainText(/wireless|keyboard/i);
+  }
+
+  // Verify the search query is preserved in the input
+  await expect(searchInput).toHaveValue('wireless keyboard');
+
+  // Verify result count is displayed
+  await expect(page.getByText(/\d+ results? found/i)).toBeVisible();
+
+  // Verify the URL reflects the search
+  await expect(page).toHaveURL(/[?&]q=wireless\+keyboard/);
+});
+
+test('search is case-insensitive', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+
+  // Search with different cases
+  await searchInput.fill('WIRELESS KEYBOARD');
+  await searchInput.press('Enter');
+
+  const uppercaseResults = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  await searchInput.clear();
+  await searchInput.fill('wireless keyboard');
+  await searchInput.press('Enter');
+
+  const lowercaseResults = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  expect(uppercaseResults).toBe(lowercaseResults);
+});
+
+test('search preserves query on page reload', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+  await searchInput.fill('keyboard');
+  await searchInput.press('Enter');
+
+  await expect(page).toHaveURL(/[?&]q=keyboard/);
+
+  // Reload the page
+  await page.reload();
+
+  // Search input should still have the query
+  await expect(searchInput).toHaveValue('keyboard');
+
+  // Results should still be filtered
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('searches for a product and displays matching results', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+
+  await searchInput.fill('wireless keyboard');
+  await searchInput.press('Enter');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toContainText(/wireless|keyboard/i);
+  }
+
+  await expect(searchInput).toHaveValue('wireless keyboard');
+  await expect(page).toHaveURL(/[?&]q=wireless\+keyboard/);
+});
+```
+
+---
+
+## Recipe 2: Search with Debounce (Waiting for Results)
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('debounced search triggers after user stops typing', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+  const resultsList = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+
+  // Track API calls to verify debounce behavior
+  let apiCallCount = 0;
+  await page.route('**/api/products?*', async (route) => {
+    apiCallCount++;
+    await route.continue();
+  });
+
+  // Type quickly (simulating real user typing)
+  await searchInput.pressSequentially('keyboard', { delay: 50 });
+
+  // Wait for debounce to settle and results to appear
+  // The debounce delay is typically 300-500ms after the last keystroke
+  await page.waitForResponse('**/api/products?*');
+
+  // Only one API call should have been made (debounced), not one per keystroke
+  expect(apiCallCount).toBeLessThanOrEqual(2); // Allow for at most 2 calls
+
+  // Verify results loaded
+  await expect(resultsList.first()).toBeVisible();
+});
+
+test('shows loading indicator during debounced search', async ({ page }) => {
+  // Slow down the search API to observe loading state
+  await page.route('**/api/products?*', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await route.continue();
+  });
+
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+
+  await searchInput.fill('keyboard');
+
+  // Loading indicator should appear while waiting for results
+  await expect(page.getByRole('progressbar').or(page.getByText(/loading|searching/i))).toBeVisible();
+
+  // After results load, loading indicator disappears
+  await expect(page.getByRole('progressbar').or(page.getByText(/loading|searching/i))).not.toBeVisible({
+    timeout: 5000,
+  });
+
+  // Results should be visible
+  await expect(
+    page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') }).first()
+  ).toBeVisible();
+});
+
+test('clears search results when input is emptied', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+
+  // Search for something specific
+  await searchInput.fill('keyboard');
+  await searchInput.press('Enter');
+
+  const filteredCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  // Clear the search
+  await searchInput.clear();
+
+  // Wait for results to reset (debounce + API call)
+  await page.waitForResponse('**/api/products?*');
+
+  const unfilteredCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  // Unfiltered should have more or equal results
+  expect(unfilteredCount).toBeGreaterThanOrEqual(filteredCount);
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('debounced search triggers after user stops typing', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+
+  let apiCallCount = 0;
+  await page.route('**/api/products?*', async (route) => {
+    apiCallCount++;
+    await route.continue();
+  });
+
+  await searchInput.pressSequentially('keyboard', { delay: 50 });
+
+  await page.waitForResponse('**/api/products?*');
+
+  expect(apiCallCount).toBeLessThanOrEqual(2);
+});
+
+test('shows loading indicator during debounced search', async ({ page }) => {
+  await page.route('**/api/products?*', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await route.continue();
+  });
+
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+  await searchInput.fill('keyboard');
+
+  await expect(page.getByRole('progressbar').or(page.getByText(/loading|searching/i))).toBeVisible();
+
+  await expect(page.getByRole('progressbar').or(page.getByText(/loading|searching/i))).not.toBeVisible({
+    timeout: 5000,
+  });
+});
+```
+
+---
+
+## Recipe 3: Filter by Category
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('filters products by a single category', async ({ page }) => {
+  await page.goto('/products');
+
+  // Get total count before filtering
+  const totalRows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const totalCount = await totalRows.count();
+
+  // Select a category filter
+  await page.getByLabel('Category').selectOption('Electronics');
+
+  // Wait for filtered results
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify fewer results (or at minimum, a different set)
+  const filteredRows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const filteredCount = await filteredRows.count();
+
+  expect(filteredCount).toBeLessThanOrEqual(totalCount);
+  expect(filteredCount).toBeGreaterThan(0);
+
+  // Verify all results belong to the selected category
+  for (let i = 0; i < filteredCount; i++) {
+    await expect(filteredRows.nth(i)).toContainText('Electronics');
+  }
+
+  // Verify URL updated
+  await expect(page).toHaveURL(/[?&]category=electronics/i);
+
+  // Verify active filter is displayed
+  await expect(page.getByText(/filtered by.*electronics/i).or(
+    page.locator('[data-testid="active-filter"]').filter({ hasText: 'Electronics' })
+  )).toBeVisible();
+});
+
+test('filters by category using sidebar checkboxes', async ({ page }) => {
+  await page.goto('/products');
+
+  // Click a category checkbox in the sidebar
+  const sidebar = page.getByRole('complementary');
+  await sidebar.getByLabel('Electronics').check();
+
+  await page.waitForResponse('**/api/products?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toContainText('Electronics');
+  }
+});
+
+test('changing category replaces previous filter', async ({ page }) => {
+  await page.goto('/products');
+
+  // Select first category
+  await page.getByLabel('Category').selectOption('Electronics');
+  await page.waitForResponse('**/api/products?*');
+
+  const electronicsCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  // Change to a different category
+  await page.getByLabel('Category').selectOption('Clothing');
+  await page.waitForResponse('**/api/products?*');
+
+  const clothingCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  // Results should be different
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  for (let i = 0; i < clothingCount; i++) {
+    await expect(rows.nth(i)).toContainText('Clothing');
+    await expect(rows.nth(i)).not.toContainText('Electronics');
+  }
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('filters products by a single category', async ({ page }) => {
+  await page.goto('/products');
+
+  const totalRows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const totalCount = await totalRows.count();
+
+  await page.getByLabel('Category').selectOption('Electronics');
+
+  await page.waitForResponse('**/api/products?*');
+
+  const filteredRows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const filteredCount = await filteredRows.count();
+
+  expect(filteredCount).toBeLessThanOrEqual(totalCount);
+
+  for (let i = 0; i < filteredCount; i++) {
+    await expect(filteredRows.nth(i)).toContainText('Electronics');
+  }
+
+  await expect(page).toHaveURL(/[?&]category=electronics/i);
+});
+```
+
+---
+
+## Recipe 4: Multi-Select Filter
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('filters by multiple categories simultaneously', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  // Select multiple category checkboxes
+  await sidebar.getByLabel('Electronics').check();
+  await sidebar.getByLabel('Clothing').check();
+
+  // Wait for results to update
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify results include items from both categories
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Collect all categories from results
+  const categories = new Set<string>();
+  for (let i = 0; i < count; i++) {
+    const text = await rows.nth(i).textContent();
+    if (text?.includes('Electronics')) categories.add('Electronics');
+    if (text?.includes('Clothing')) categories.add('Clothing');
+  }
+
+  // Should have results from both categories
+  expect(categories.has('Electronics')).toBe(true);
+  expect(categories.has('Clothing')).toBe(true);
+
+  // URL should reflect both filters
+  await expect(page).toHaveURL(/category=electronics/i);
+  await expect(page).toHaveURL(/category=clothing/i);
+
+  // Active filter chips should be visible
+  await expect(page.getByRole('button', { name: /Electronics.*×|Remove Electronics/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Clothing.*×|Remove Clothing/i })).toBeVisible();
+});
+
+test('removes one filter from a multi-select filter', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  // Apply two filters
+  await sidebar.getByLabel('Electronics').check();
+  await sidebar.getByLabel('Clothing').check();
+  await page.waitForResponse('**/api/products?*');
+
+  const bothCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  // Remove one filter by clicking the filter chip's remove button
+  await page.getByRole('button', { name: /Clothing.*×|Remove Clothing/i }).click();
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify only Electronics results remain
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const electronicsOnlyCount = await rows.count();
+
+  expect(electronicsOnlyCount).toBeLessThanOrEqual(bothCount);
+
+  for (let i = 0; i < electronicsOnlyCount; i++) {
+    await expect(rows.nth(i)).toContainText('Electronics');
+  }
+
+  // Clothing checkbox should be unchecked
+  await expect(sidebar.getByLabel('Clothing')).not.toBeChecked();
+  await expect(sidebar.getByLabel('Electronics')).toBeChecked();
+});
+
+test('multi-select dropdown filter', async ({ page }) => {
+  await page.goto('/products');
+
+  // Open the multi-select dropdown
+  await page.getByRole('combobox', { name: 'Tags' }).click();
+
+  // Select multiple options from the dropdown
+  await page.getByRole('option', { name: 'Featured' }).click();
+  await page.getByRole('option', { name: 'On Sale' }).click();
+
+  // Close the dropdown
+  await page.keyboard.press('Escape');
+
+  // Verify selected values displayed
+  await expect(page.getByText('Featured')).toBeVisible();
+  await expect(page.getByText('On Sale')).toBeVisible();
+
+  // Wait for results
+  await page.waitForResponse('**/api/products?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('filters by multiple categories simultaneously', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  await sidebar.getByLabel('Electronics').check();
+  await sidebar.getByLabel('Clothing').check();
+
+  await page.waitForResponse('**/api/products?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+
+  await expect(page).toHaveURL(/category=electronics/i);
+  await expect(page).toHaveURL(/category=clothing/i);
+});
+
+test('removes one filter from a multi-select filter', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  await sidebar.getByLabel('Electronics').check();
+  await sidebar.getByLabel('Clothing').check();
+  await page.waitForResponse('**/api/products?*');
+
+  await page.getByRole('button', { name: /Clothing.*×|Remove Clothing/i }).click();
+  await page.waitForResponse('**/api/products?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toContainText('Electronics');
+  }
+});
+```
+
+---
+
+## Recipe 5: Date Range Filter
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('filters records by date range', async ({ page }) => {
+  await page.goto('/orders');
+
+  // Fill in the date range inputs
+  await page.getByLabel('From date').fill('2024-01-01');
+  await page.getByLabel('To date').fill('2024-03-31');
+
+  // Apply the filter
+  await page.getByRole('button', { name: 'Apply filter' }).click();
+
+  // Wait for filtered results
+  await page.waitForResponse('**/api/orders?*');
+
+  // Verify all results fall within the date range
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Check that each row's date is within the range
+  for (let i = 0; i < count; i++) {
+    const dateCell = rows.nth(i).getByRole('cell').nth(3); // Assuming date is the 4th column
+    const dateText = await dateCell.textContent();
+    const date = new Date(dateText!.trim());
+    expect(date.getTime()).toBeGreaterThanOrEqual(new Date('2024-01-01').getTime());
+    expect(date.getTime()).toBeLessThanOrEqual(new Date('2024-03-31T23:59:59').getTime());
+  }
+
+  // Verify URL updated with date params
+  await expect(page).toHaveURL(/from=2024-01-01/);
+  await expect(page).toHaveURL(/to=2024-03-31/);
+});
+
+test('filters using a date picker component', async ({ page }) => {
+  await page.goto('/orders');
+
+  // Open the date picker
+  await page.getByRole('button', { name: /date range|calendar/i }).click();
+
+  // Navigate to January 2024
+  const calendar = page.getByRole('dialog');
+  await expect(calendar).toBeVisible();
+
+  // Select the month/year via navigation
+  while (!(await calendar.getByText('January 2024').isVisible())) {
+    await calendar.getByRole('button', { name: /previous month/i }).click();
+  }
+
+  // Click start date
+  await calendar.getByRole('gridcell', { name: '15' }).click();
+
+  // Click end date
+  await calendar.getByRole('gridcell', { name: '28' }).click();
+
+  // Apply
+  await calendar.getByRole('button', { name: 'Apply' }).click();
+  await expect(calendar).not.toBeVisible();
+
+  // Verify the date range is displayed
+  await expect(page.getByText(/Jan 15.*Jan 28/i)).toBeVisible();
+
+  await page.waitForResponse('**/api/orders?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+
+test('shows error for invalid date range', async ({ page }) => {
+  await page.goto('/orders');
+
+  // Set end date before start date
+  await page.getByLabel('From date').fill('2024-06-01');
+  await page.getByLabel('To date').fill('2024-01-01');
+
+  await page.getByRole('button', { name: 'Apply filter' }).click();
+
+  await expect(page.getByText(/end date.*before.*start date|invalid.*range/i)).toBeVisible();
+});
+
+test('uses preset date ranges', async ({ page }) => {
+  await page.goto('/orders');
+
+  // Click a preset date range shortcut
+  await page.getByRole('button', { name: 'Last 30 days' }).click();
+
+  await page.waitForResponse('**/api/orders?*');
+
+  // Verify the from date input reflects approximately 30 days ago
+  const fromValue = await page.getByLabel('From date').inputValue();
+  const fromDate = new Date(fromValue);
+  const now = new Date();
+  const diffDays = Math.round((now.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  expect(diffDays).toBeGreaterThanOrEqual(29);
+  expect(diffDays).toBeLessThanOrEqual(31);
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('filters records by date range', async ({ page }) => {
+  await page.goto('/orders');
+
+  await page.getByLabel('From date').fill('2024-01-01');
+  await page.getByLabel('To date').fill('2024-03-31');
+  await page.getByRole('button', { name: 'Apply filter' }).click();
+
+  await page.waitForResponse('**/api/orders?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+
+  await expect(page).toHaveURL(/from=2024-01-01/);
+  await expect(page).toHaveURL(/to=2024-03-31/);
+});
+
+test('uses preset date ranges', async ({ page }) => {
+  await page.goto('/orders');
+
+  await page.getByRole('button', { name: 'Last 30 days' }).click();
+
+  await page.waitForResponse('**/api/orders?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+```
+
+---
+
+## Recipe 6: Clear All Filters
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('clears all active filters at once', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  // Apply multiple filters
+  await sidebar.getByLabel('Electronics').check();
+  await page.getByLabel('Min price').fill('50');
+  await page.getByLabel('Max price').fill('200');
+  await page.getByRole('searchbox', { name: /search/i }).fill('keyboard');
+  await page.getByRole('searchbox', { name: /search/i }).press('Enter');
+
+  // Wait for filtered results
+  await page.waitForResponse('**/api/products?*');
+
+  const filteredCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  // Verify filters are active
+  await expect(page.getByText(/\d+ active filter/i)).toBeVisible();
+
+  // Click "Clear all filters"
+  await page.getByRole('button', { name: /clear all|reset filters/i }).click();
+
+  // Wait for unfiltered results
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify all filters are reset
+  await expect(sidebar.getByLabel('Electronics')).not.toBeChecked();
+  await expect(page.getByLabel('Min price')).toHaveValue('');
+  await expect(page.getByLabel('Max price')).toHaveValue('');
+  await expect(page.getByRole('searchbox', { name: /search/i })).toHaveValue('');
+
+  // Verify more results are shown
+  const unfilteredCount = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .count();
+
+  expect(unfilteredCount).toBeGreaterThanOrEqual(filteredCount);
+
+  // Verify URL is clean
+  await expect(page).toHaveURL('/products');
+
+  // Verify "active filters" indicator is gone
+  await expect(page.getByText(/active filter/i)).not.toBeVisible();
+});
+
+test('clear all button only appears when filters are active', async ({ page }) => {
+  await page.goto('/products');
+
+  // No filters active -- clear button should not be visible
+  await expect(page.getByRole('button', { name: /clear all|reset filters/i })).not.toBeVisible();
+
+  // Apply a filter
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  // Clear button should now be visible
+  await expect(page.getByRole('button', { name: /clear all|reset filters/i })).toBeVisible();
+
+  // Remove the filter manually
+  await page.getByRole('complementary').getByLabel('Electronics').uncheck();
+  await page.waitForResponse('**/api/products?*');
+
+  // Clear button should disappear again
+  await expect(page.getByRole('button', { name: /clear all|reset filters/i })).not.toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('clears all active filters at once', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  await sidebar.getByLabel('Electronics').check();
+  await page.getByLabel('Min price').fill('50');
+  await page.getByLabel('Max price').fill('200');
+  await page.getByRole('searchbox', { name: /search/i }).fill('keyboard');
+  await page.getByRole('searchbox', { name: /search/i }).press('Enter');
+
+  await page.waitForResponse('**/api/products?*');
+
+  await page.getByRole('button', { name: /clear all|reset filters/i }).click();
+
+  await page.waitForResponse('**/api/products?*');
+
+  await expect(sidebar.getByLabel('Electronics')).not.toBeChecked();
+  await expect(page.getByLabel('Min price')).toHaveValue('');
+  await expect(page.getByLabel('Max price')).toHaveValue('');
+  await expect(page.getByRole('searchbox', { name: /search/i })).toHaveValue('');
+
+  await expect(page).toHaveURL('/products');
+});
+```
+
+---
+
+## Recipe 7: Search with Autocomplete / Suggestions
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('shows autocomplete suggestions while typing', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+
+  // Type a partial query
+  await searchInput.fill('key');
+
+  // Suggestions dropdown should appear
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  // Verify suggestions contain the typed text
+  const options = suggestions.getByRole('option');
+  const count = await options.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    await expect(options.nth(i)).toContainText(/key/i);
+  }
+});
+
+test('selects a suggestion with click', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+  await searchInput.fill('key');
+
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  // Click a specific suggestion
+  await suggestions.getByRole('option', { name: /Wireless Keyboard/i }).click();
+
+  // Suggestions should close
+  await expect(suggestions).not.toBeVisible();
+
+  // Search input should contain the selected suggestion
+  await expect(searchInput).toHaveValue('Wireless Keyboard');
+
+  // Results should be filtered to the selected item
+  await expect(page.getByRole('row', { name: /Wireless Keyboard/i })).toBeVisible();
+});
+
+test('navigates suggestions with keyboard', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+  await searchInput.fill('key');
+
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  // Navigate down with arrow keys
+  await searchInput.press('ArrowDown');
+  const firstOption = suggestions.getByRole('option').first();
+  await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+
+  await searchInput.press('ArrowDown');
+  const secondOption = suggestions.getByRole('option').nth(1);
+  await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+  await expect(firstOption).toHaveAttribute('aria-selected', 'false');
+
+  // Select with Enter
+  await searchInput.press('Enter');
+
+  // Suggestions should close and value should be selected
+  await expect(suggestions).not.toBeVisible();
+
+  const selectedText = await searchInput.inputValue();
+  expect(selectedText.length).toBeGreaterThan(3); // More than just "key"
+});
+
+test('closes suggestions with Escape key', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+  await searchInput.fill('key');
+
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  await searchInput.press('Escape');
+
+  await expect(suggestions).not.toBeVisible();
+
+  // Input should retain the typed text
+  await expect(searchInput).toHaveValue('key');
+});
+
+test('shows recent searches when input is focused', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+
+  // Focus the input without typing
+  await searchInput.click();
+
+  // Should show recent searches or popular suggestions
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+  await expect(suggestions.getByText(/recent|popular/i)).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('shows autocomplete suggestions while typing', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+  await searchInput.fill('key');
+
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  const options = suggestions.getByRole('option');
+  const count = await options.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    await expect(options.nth(i)).toContainText(/key/i);
+  }
+});
+
+test('selects a suggestion with click', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+  await searchInput.fill('key');
+
+  const suggestions = page.getByRole('listbox');
+  await suggestions.getByRole('option', { name: /Wireless Keyboard/i }).click();
+
+  await expect(suggestions).not.toBeVisible();
+  await expect(searchInput).toHaveValue('Wireless Keyboard');
+});
+
+test('navigates suggestions with keyboard', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('combobox', { name: /search/i });
+  await searchInput.fill('key');
+
+  const suggestions = page.getByRole('listbox');
+  await expect(suggestions).toBeVisible();
+
+  await searchInput.press('ArrowDown');
+  await searchInput.press('ArrowDown');
+  await searchInput.press('Enter');
+
+  await expect(suggestions).not.toBeVisible();
+});
+```
+
+---
+
+## Recipe 8: No Results State
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('shows "no results" state for unmatched search', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+  await searchInput.fill('xyznonexistentproduct123');
+  await searchInput.press('Enter');
+
+  // Wait for the API response
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify no results message is displayed
+  await expect(page.getByText(/no results|no products found|nothing found/i)).toBeVisible();
+
+  // Table/list should be empty (no data rows)
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows).toHaveCount(0);
+
+  // Verify helpful suggestions are shown
+  await expect(
+    page.getByText(/try different|broaden your search|check spelling/i)
+  ).toBeVisible();
+
+  // Verify a "clear search" link or button is available
+  await expect(
+    page.getByRole('button', { name: /clear search|show all/i }).or(
+      page.getByRole('link', { name: /clear search|show all/i })
+    )
+  ).toBeVisible();
+});
+
+test('no results state with active filters offers to clear them', async ({ page }) => {
+  await page.goto('/products');
+
+  // Apply a very restrictive filter combination
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.getByLabel('Min price').fill('99999');
+  await page.getByRole('button', { name: 'Apply filter' }).click();
+
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify the no results state mentions the active filters
+  await expect(page.getByText(/no results|no products found/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: /clear filters|reset/i })).toBeVisible();
+
+  // Click clear filters and verify results appear
+  await page.getByRole('button', { name: /clear filters|reset/i }).click();
+
+  await page.waitForResponse('**/api/products?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  expect(await rows.count()).toBeGreaterThan(0);
+});
+
+test('no results state illustration is displayed', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByRole('searchbox', { name: /search/i }).fill('zzzznotfound');
+  await page.getByRole('searchbox', { name: /search/i }).press('Enter');
+
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify an illustration or icon is shown
+  await expect(
+    page.getByRole('img', { name: /no results|empty/i }).or(
+      page.locator('[data-testid="empty-state-illustration"]')
+    )
+  ).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('shows "no results" state for unmatched search', async ({ page }) => {
+  await page.goto('/products');
+
+  const searchInput = page.getByRole('searchbox', { name: /search/i });
+  await searchInput.fill('xyznonexistentproduct123');
+  await searchInput.press('Enter');
+
+  await page.waitForResponse('**/api/products?*');
+
+  await expect(page.getByText(/no results|no products found|nothing found/i)).toBeVisible();
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows).toHaveCount(0);
+
+  await expect(page.getByText(/try different|broaden your search/i)).toBeVisible();
+});
+
+test('no results state with filters offers to clear them', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.getByLabel('Min price').fill('99999');
+  await page.getByRole('button', { name: 'Apply filter' }).click();
+
+  await page.waitForResponse('**/api/products?*');
+
+  await expect(page.getByText(/no results|no products found/i)).toBeVisible();
+
+  await page.getByRole('button', { name: /clear filters|reset/i }).click();
+  await page.waitForResponse('**/api/products?*');
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  expect(await rows.count()).toBeGreaterThan(0);
+});
+```
+
+---
+
+## Recipe 9: Pagination with Filters
+
+### Complete Example
+
+**TypeScript**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('pagination resets to page 1 when a filter is applied', async ({ page }) => {
+  await page.goto('/products');
+
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+
+  // Navigate to page 3
+  await pagination.getByRole('button', { name: '3' }).click();
+  await expect(page).toHaveURL(/page=3/);
+
+  // Apply a filter
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  // Should reset to page 1
+  await expect(page).toHaveURL(/page=1|(?!.*page=)/);
+  await expect(pagination.getByRole('button', { name: '1' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  );
+});
+
+test('filters persist across pagination', async ({ page }) => {
+  await page.goto('/products');
+
+  // Apply a filter
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  // Get page 1 results
+  const page1FirstItem = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .first()
+    .textContent();
+
+  // Navigate to page 2
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+  await pagination.getByRole('button', { name: '2' }).click();
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify the filter is still applied (URL has both params)
+  await expect(page).toHaveURL(/category=electronics/i);
+  await expect(page).toHaveURL(/page=2/);
+
+  // Verify checkbox is still checked
+  await expect(page.getByRole('complementary').getByLabel('Electronics')).toBeChecked();
+
+  // Verify page 2 data is different from page 1
+  const page2FirstItem = await page
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') })
+    .first()
+    .textContent();
+
+  expect(page2FirstItem).not.toBe(page1FirstItem);
+
+  // All results on page 2 should still match the filter
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toContainText('Electronics');
+  }
+});
+
+test('total result count updates with filters', async ({ page }) => {
+  await page.goto('/products');
+
+  // Get unfiltered total
+  const totalText = await page.getByText(/showing.*of \d+/i).textContent();
+  const totalMatch = totalText?.match(/of (\d+)/);
+  const totalCount = parseInt(totalMatch?.[1] || '0');
+
+  // Apply a filter
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  // Total count should be less or equal
+  const filteredText = await page.getByText(/showing.*of \d+/i).textContent();
+  const filteredMatch = filteredText?.match(/of (\d+)/);
+  const filteredCount = parseInt(filteredMatch?.[1] || '0');
+
+  expect(filteredCount).toBeLessThanOrEqual(totalCount);
+
+  // Number of pagination buttons may also decrease
+  const paginationButtons = page
+    .getByRole('navigation', { name: /pagination/i })
+    .getByRole('button')
+    .filter({ hasNotText: /previous|next|prev|›|‹/i });
+
+  const pageCount = await paginationButtons.count();
+  expect(pageCount).toBeGreaterThan(0);
+});
+
+test('deep link with filters and page works correctly', async ({ page }) => {
+  // Navigate directly to a filtered, paginated URL
+  await page.goto('/products?category=electronics&q=wireless&page=2');
+
+  // Verify all filter controls reflect the URL state
+  await expect(page.getByRole('complementary').getByLabel('Electronics')).toBeChecked();
+  await expect(page.getByRole('searchbox', { name: /search/i })).toHaveValue('wireless');
+
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+  await expect(pagination.getByRole('button', { name: '2' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  );
+
+  // Verify results match the filters
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('pagination resets to page 1 when a filter is applied', async ({ page }) => {
+  await page.goto('/products');
+
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+
+  await pagination.getByRole('button', { name: '3' }).click();
+  await expect(page).toHaveURL(/page=3/);
+
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  await expect(page).toHaveURL(/page=1|(?!.*page=)/);
+});
+
+test('filters persist across pagination', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+  await pagination.getByRole('button', { name: '2' }).click();
+  await page.waitForResponse('**/api/products?*');
+
+  await expect(page).toHaveURL(/category=electronics/i);
+  await expect(page).toHaveURL(/page=2/);
+
+  await expect(page.getByRole('complementary').getByLabel('Electronics')).toBeChecked();
+
+  const rows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') });
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toContainText('Electronics');
+  }
+});
+
+test('deep link with filters and page works correctly', async ({ page }) => {
+  await page.goto('/products?category=electronics&q=wireless&page=2');
+
+  await expect(page.getByRole('complementary').getByLabel('Electronics')).toBeChecked();
+  await expect(page.getByRole('searchbox', { name: /search/i })).toHaveValue('wireless');
+
+  const pagination = page.getByRole('navigation', { name: /pagination/i });
+  await expect(pagination.getByRole('button', { name: '2' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  );
+});
+```
+
+---
+
+## Variations
+
+### Search with Highlight of Matching Terms
+
+```typescript
+test('highlights matching terms in search results', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByRole('searchbox', { name: /search/i }).fill('wireless');
+  await page.getByRole('searchbox', { name: /search/i }).press('Enter');
+
+  await page.waitForResponse('**/api/products?*');
+
+  // Verify matching text is wrapped in a highlight element
+  const highlights = page.locator('mark, .highlight, [data-highlight]');
+  const count = await highlights.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Each highlight should contain the search term
+  for (let i = 0; i < count; i++) {
+    await expect(highlights.nth(i)).toContainText(/wireless/i);
+  }
+});
+```
+
+### Search with URL Query Params for Sharing
+
+```typescript
+test('search results are shareable via URL', async ({ page, context }) => {
+  await page.goto('/products');
+
+  await page.getByRole('searchbox', { name: /search/i }).fill('keyboard');
+  await page.getByRole('complementary').getByLabel('Electronics').check();
+  await page.getByRole('searchbox', { name: /search/i }).press('Enter');
+
+  await page.waitForResponse('**/api/products?*');
+
+  // Get the current URL
+  const searchUrl = page.url();
+
+  // Open the same URL in a new page (simulating sharing the link)
+  const newPage = await context.newPage();
+  await newPage.goto(searchUrl);
+
+  // Verify the same filters and results are shown
+  await expect(newPage.getByRole('searchbox', { name: /search/i })).toHaveValue('keyboard');
+  await expect(newPage.getByRole('complementary').getByLabel('Electronics')).toBeChecked();
+
+  const rows = newPage.getByRole('row').filter({ hasNot: newPage.getByRole('columnheader') });
+  await expect(rows.first()).toBeVisible();
+
+  await newPage.close();
+});
+```
+
+### Faceted Search with Result Counts
+
+```typescript
+test('filter options show result counts', async ({ page }) => {
+  await page.goto('/products');
+
+  const sidebar = page.getByRole('complementary');
+
+  // Verify each filter option shows a count
+  await expect(sidebar.getByText(/Electronics \(\d+\)/)).toBeVisible();
+  await expect(sidebar.getByText(/Clothing \(\d+\)/)).toBeVisible();
+  await expect(sidebar.getByText(/Books \(\d+\)/)).toBeVisible();
+
+  // Apply a filter and verify counts update
+  await sidebar.getByLabel('Electronics').check();
+  await page.waitForResponse('**/api/products?*');
+
+  // Other category counts should update to reflect cross-filtering
+  const clothingText = await sidebar.getByText(/Clothing \(\d+\)/).textContent();
+  const clothingCount = parseInt(clothingText?.match(/\((\d+)\)/)?.[1] || '0');
+
+  // The counts should reflect what would happen if that filter were added
+  expect(clothingCount).toBeGreaterThanOrEqual(0);
+});
+```
+
+---
+
+## Tips
+
+1. **Always verify the URL reflects the filter state**. Search queries, category selections, date ranges, and pagination should all be encoded in query parameters. This ensures deep linking, bookmarking, and browser back/forward work correctly. If your app does not do this, file a bug.
+
+2. **Use `waitForResponse` instead of arbitrary waits**. After applying a filter or search, wait for the specific API call to complete: `await page.waitForResponse('**/api/products?*')`. This is deterministic and faster than `waitForTimeout`.
+
+3. **Test filter combinations, not just individual filters**. Users apply multiple filters simultaneously -- category + price range + search term. Test that filters compose correctly and that the resulting URL contains all parameters.
+
+4. **Verify the controls reflect the state, not just the results**. After filtering, check that the checkbox is checked, the dropdown shows the right value, and the search input still contains the query. After clearing, verify they all reset. This catches one-way binding bugs.
+
+5. **Test deep links for every filter combination**. Paste a URL with filter parameters directly (`/products?category=electronics&q=keyboard&page=2`) and verify the page renders correctly. This catches bugs where filters only work when set via the UI but not from URL params.
+
+---
+
+## Related
+
+- `recipes/crud-testing.md` -- Filter and search within CRUD resource lists
+- `foundations/assertions.md` -- Assertion patterns for dynamic content
+- `patterns/page-objects.md` -- Encapsulate search and filter controls
+- `foundations/waiting.md` -- Waiting strategies for async search results

--- a/engineering-team/playwright skill/core/security-testing.md
+++ b/engineering-team/playwright skill/core/security-testing.md
@@ -1,0 +1,624 @@
+# Security Testing
+
+> **When to use**: Validating your application's defenses against common web vulnerabilities — XSS, CSRF, insecure cookies, missing headers, authentication bypass, and sensitive data exposure. Playwright is not a replacement for dedicated security scanners, but it catches the most common issues as part of your E2E suite.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/authentication.md](authentication.md)
+
+## Quick Reference
+
+```typescript
+// Check security headers on every navigation
+const response = await page.goto('/dashboard');
+expect(response.headers()['content-security-policy']).toBeDefined();
+expect(response.headers()['x-frame-options']).toBe('DENY');
+
+// Verify cookie security flags
+const cookies = await context.cookies();
+const sessionCookie = cookies.find(c => c.name === 'session');
+expect(sessionCookie.httpOnly).toBe(true);
+expect(sessionCookie.secure).toBe(true);
+expect(sessionCookie.sameSite).toBe('Strict');
+```
+
+## Patterns
+
+### XSS Injection Testing
+
+**Use when**: Verifying that user inputs are properly sanitized and rendered as text, not HTML.
+**Avoid when**: You need comprehensive XSS scanning — use a dedicated tool like OWASP ZAP alongside Playwright.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const XSS_PAYLOADS = [
+  '<script>alert("xss")</script>',
+  '<img src=x onerror=alert("xss")>',
+  '"><script>alert("xss")</script>',
+  "javascript:alert('xss')",
+  '<svg onload=alert("xss")>',
+  '{{constructor.constructor("alert(1)")()}}', // Template injection
+];
+
+test.describe('XSS protection', () => {
+  for (const payload of XSS_PAYLOADS) {
+    test(`input sanitizes: ${payload.slice(0, 40)}...`, async ({ page }) => {
+      await page.goto('/profile/edit');
+
+      // Inject the payload into a text field
+      await page.getByLabel('Display name').fill(payload);
+      await page.getByRole('button', { name: 'Save' }).click();
+
+      // Verify the payload is rendered as text, not executed
+      await page.goto('/profile');
+      const displayName = page.getByTestId('display-name');
+      await expect(displayName).toBeVisible();
+
+      // The payload text should appear literally, not as HTML
+      const innerHTML = await displayName.innerHTML();
+      expect(innerHTML).not.toContain('<script');
+      expect(innerHTML).not.toContain('onerror');
+      expect(innerHTML).not.toContain('onload');
+
+      // No dialog should have appeared (script execution)
+      // If a dialog fires, the test will fail because it's unhandled
+    });
+  }
+});
+
+test('XSS via URL parameters is prevented', async ({ page }) => {
+  const xssUrl = '/search?q=<script>alert("xss")</script>';
+  await page.goto(xssUrl);
+
+  // The search term should be displayed as text
+  const searchInput = page.getByRole('textbox', { name: 'Search' });
+  const value = await searchInput.inputValue();
+  expect(value).not.toContain('<script');
+
+  // Page should not have injected script tags
+  const scriptCount = await page.locator('script:not([src])').count();
+  const pageContent = await page.content();
+  expect(pageContent).not.toContain('alert("xss")');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const XSS_PAYLOADS = [
+  '<script>alert("xss")</script>',
+  '<img src=x onerror=alert("xss")>',
+  '"><script>alert("xss")</script>',
+  '<svg onload=alert("xss")>',
+];
+
+test.describe('XSS protection', () => {
+  for (const payload of XSS_PAYLOADS) {
+    test(`input sanitizes: ${payload.slice(0, 40)}...`, async ({ page }) => {
+      await page.goto('/profile/edit');
+      await page.getByLabel('Display name').fill(payload);
+      await page.getByRole('button', { name: 'Save' }).click();
+
+      await page.goto('/profile');
+      const innerHTML = await page.getByTestId('display-name').innerHTML();
+      expect(innerHTML).not.toContain('<script');
+      expect(innerHTML).not.toContain('onerror');
+    });
+  }
+});
+```
+
+### CSRF Token Verification
+
+**Use when**: Ensuring state-changing requests include valid CSRF tokens and the server rejects requests without them.
+**Avoid when**: Your API uses token-based auth (JWT) with no cookie-based sessions — CSRF is not applicable.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('form submissions include CSRF token', async ({ page }) => {
+  await page.goto('/settings');
+
+  // Verify the CSRF token is present in the form
+  const csrfInput = page.locator('input[name="_csrf"], input[name="csrf_token"]');
+  await expect(csrfInput).toBeAttached();
+  const tokenValue = await csrfInput.inputValue();
+  expect(tokenValue).toBeTruthy();
+  expect(tokenValue.length).toBeGreaterThan(16);
+});
+
+test('server rejects requests without CSRF token', async ({ page, request }) => {
+  // First, get a valid session by logging in through the UI
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Attempt a state-changing request without the CSRF token
+  const cookies = await page.context().cookies();
+  const response = await request.post('/api/settings', {
+    headers: {
+      Cookie: cookies.map(c => `${c.name}=${c.value}`).join('; '),
+    },
+    data: { theme: 'dark' }, // No CSRF token
+  });
+
+  // Server should reject it
+  expect(response.status()).toBe(403);
+});
+
+test('CSRF token rotates per session', async ({ browser }) => {
+  const context1 = await browser.newContext();
+  const context2 = await browser.newContext();
+
+  const page1 = await context1.newPage();
+  const page2 = await context2.newPage();
+
+  await page1.goto('/login');
+  await page2.goto('/login');
+
+  const token1 = await page1.locator('input[name="_csrf"]').inputValue();
+  const token2 = await page2.locator('input[name="_csrf"]').inputValue();
+
+  // Tokens should differ between sessions
+  expect(token1).not.toBe(token2);
+
+  await context1.close();
+  await context2.close();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('form submissions include CSRF token', async ({ page }) => {
+  await page.goto('/settings');
+
+  const csrfInput = page.locator('input[name="_csrf"], input[name="csrf_token"]');
+  await expect(csrfInput).toBeAttached();
+  const tokenValue = await csrfInput.inputValue();
+  expect(tokenValue).toBeTruthy();
+  expect(tokenValue.length).toBeGreaterThan(16);
+});
+
+test('server rejects requests without CSRF token', async ({ page, request }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  const cookies = await page.context().cookies();
+  const response = await request.post('/api/settings', {
+    headers: {
+      Cookie: cookies.map(c => `${c.name}=${c.value}`).join('; '),
+    },
+    data: { theme: 'dark' },
+  });
+
+  expect(response.status()).toBe(403);
+});
+```
+
+### CSP Header Validation
+
+**Use when**: Verifying Content Security Policy headers are present and correctly configured.
+**Avoid when**: CSP is managed by infrastructure (CDN/WAF) tested separately.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('CSP headers are properly configured', async ({ page }) => {
+  const response = await page.goto('/');
+  const csp = response!.headers()['content-security-policy'];
+
+  expect(csp).toBeDefined();
+  expect(csp).toContain("default-src 'self'");
+  expect(csp).not.toContain("'unsafe-inline'"); // Disallow inline scripts
+  expect(csp).not.toContain("'unsafe-eval'");   // Disallow eval()
+  expect(csp).toContain('script-src');
+});
+
+test('security headers are present on all pages', async ({ page }) => {
+  const pagesToCheck = ['/', '/login', '/dashboard', '/api/health'];
+
+  for (const url of pagesToCheck) {
+    const response = await page.goto(url);
+    const headers = response!.headers();
+
+    expect(headers['x-content-type-options']).toBe('nosniff');
+    expect(headers['x-frame-options']).toMatch(/DENY|SAMEORIGIN/);
+    expect(headers['strict-transport-security']).toBeDefined();
+    expect(headers['referrer-policy']).toBeDefined();
+    expect(headers['x-xss-protection']).toBeUndefined(); // Deprecated, should not be set
+  }
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('CSP headers are properly configured', async ({ page }) => {
+  const response = await page.goto('/');
+  const csp = response.headers()['content-security-policy'];
+
+  expect(csp).toBeDefined();
+  expect(csp).toContain("default-src 'self'");
+  expect(csp).not.toContain("'unsafe-inline'");
+  expect(csp).not.toContain("'unsafe-eval'");
+});
+
+test('security headers are present on all pages', async ({ page }) => {
+  const pagesToCheck = ['/', '/login', '/dashboard'];
+
+  for (const url of pagesToCheck) {
+    const response = await page.goto(url);
+    const headers = response.headers();
+
+    expect(headers['x-content-type-options']).toBe('nosniff');
+    expect(headers['x-frame-options']).toMatch(/DENY|SAMEORIGIN/);
+    expect(headers['strict-transport-security']).toBeDefined();
+  }
+});
+```
+
+### Cookie Security Flags
+
+**Use when**: Verifying session cookies and auth cookies have proper security attributes.
+**Avoid when**: Your app is fully stateless with no cookies.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('session cookie has correct security flags', async ({ page, context }) => {
+  // Log in to create a session cookie
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  const cookies = await context.cookies();
+
+  // Check session cookie
+  const session = cookies.find(c => c.name === 'session' || c.name === 'sid');
+  expect(session).toBeDefined();
+  expect(session!.httpOnly).toBe(true);   // Not accessible via JavaScript
+  expect(session!.secure).toBe(true);     // Only sent over HTTPS
+  expect(session!.sameSite).toBe('Strict'); // Or 'Lax' at minimum
+
+  // Session cookie should not have an excessive expiry
+  if (session!.expires !== -1) {
+    const maxAge = session!.expires - Date.now() / 1000;
+    expect(maxAge).toBeLessThan(86400 * 30); // No more than 30 days
+  }
+});
+
+test('sensitive cookies are not exposed to JavaScript', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // document.cookie should NOT contain HttpOnly cookies
+  const jsCookies = await page.evaluate(() => document.cookie);
+  expect(jsCookies).not.toContain('session');
+  expect(jsCookies).not.toContain('sid');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('session cookie has correct security flags', async ({ page, context }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  const cookies = await context.cookies();
+  const session = cookies.find(c => c.name === 'session' || c.name === 'sid');
+
+  expect(session).toBeDefined();
+  expect(session.httpOnly).toBe(true);
+  expect(session.secure).toBe(true);
+  expect(session.sameSite).toBe('Strict');
+});
+```
+
+### Authentication Bypass Testing
+
+**Use when**: Ensuring protected routes redirect unauthenticated users and that session invalidation works.
+**Avoid when**: Auth is tested through dedicated API tests that cover these cases already.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('unauthenticated user cannot access protected routes', async ({ page }) => {
+  const protectedRoutes = ['/dashboard', '/settings', '/admin', '/api/users'];
+
+  for (const route of protectedRoutes) {
+    const response = await page.goto(route);
+
+    // Should redirect to login or return 401/403
+    const isRedirected = page.url().includes('/login');
+    const isBlocked = response!.status() === 401 || response!.status() === 403;
+    expect(isRedirected || isBlocked).toBe(true);
+  }
+});
+
+test('session is invalidated after logout', async ({ page, context }) => {
+  // Log in
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Capture session cookie
+  const cookiesBefore = await context.cookies();
+  const sessionBefore = cookiesBefore.find(c => c.name === 'session');
+
+  // Log out
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await page.waitForURL('/login');
+
+  // Verify session cookie is cleared
+  const cookiesAfter = await context.cookies();
+  const sessionAfter = cookiesAfter.find(c => c.name === 'session');
+  expect(sessionAfter).toBeUndefined();
+
+  // Attempting to access protected route should fail
+  await page.goto('/dashboard');
+  expect(page.url()).toContain('/login');
+});
+
+test('expired session redirects to login', async ({ page, context }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Manually expire the session cookie
+  await context.clearCookies();
+
+  // Next navigation should redirect to login
+  await page.goto('/dashboard');
+  expect(page.url()).toContain('/login');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('unauthenticated user cannot access protected routes', async ({ page }) => {
+  const protectedRoutes = ['/dashboard', '/settings', '/admin'];
+
+  for (const route of protectedRoutes) {
+    await page.goto(route);
+    expect(page.url()).toContain('/login');
+  }
+});
+
+test('session is invalidated after logout', async ({ page, context }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await page.waitForURL('/login');
+
+  const cookies = await context.cookies();
+  const session = cookies.find(c => c.name === 'session');
+  expect(session).toBeUndefined();
+});
+```
+
+### HTTPS Redirect and Sensitive Data Exposure
+
+**Use when**: Verifying that HTTP requests are redirected to HTTPS and that sensitive data is not leaked in URLs, headers, or client-side storage.
+**Avoid when**: Running against `localhost` where HTTPS is not configured.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('HTTP redirects to HTTPS', async ({ request }) => {
+  // Use the API request context to follow redirects
+  const response = await request.get('http://your-app.com/', {
+    maxRedirects: 0, // Don't follow — inspect the redirect
+  });
+  expect(response.status()).toBe(301);
+  expect(response.headers()['location']).toMatch(/^https:\/\//);
+});
+
+test('HSTS header is set', async ({ page }) => {
+  const response = await page.goto('/');
+  const hsts = response!.headers()['strict-transport-security'];
+  expect(hsts).toBeDefined();
+  expect(hsts).toContain('max-age=');
+
+  // Extract max-age value and verify it's at least 1 year
+  const maxAge = parseInt(hsts!.match(/max-age=(\d+)/)?.[1] || '0');
+  expect(maxAge).toBeGreaterThanOrEqual(31536000);
+});
+
+test('sensitive data is not in URL parameters', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Password should never appear in URL
+  expect(page.url()).not.toContain('password');
+  expect(page.url()).not.toContain('token');
+  expect(page.url()).not.toContain('secret');
+});
+
+test('sensitive data is not in localStorage', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  const storageData = await page.evaluate(() => {
+    const data: Record<string, string> = {};
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)!;
+      data[key] = localStorage.getItem(key)!;
+    }
+    return JSON.stringify(data);
+  });
+
+  expect(storageData).not.toContain('password');
+  expect(storageData.toLowerCase()).not.toContain('secret');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('sensitive data is not in localStorage', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  const storageData = await page.evaluate(() => {
+    const data = {};
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      data[key] = localStorage.getItem(key);
+    }
+    return JSON.stringify(data);
+  });
+
+  expect(storageData).not.toContain('password');
+  expect(storageData.toLowerCase()).not.toContain('secret');
+});
+```
+
+### Session Fixation Prevention
+
+**Use when**: Ensuring the session ID changes after authentication to prevent session fixation attacks.
+**Avoid when**: Using stateless token auth (JWT) with no server-side sessions.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('session ID changes after login', async ({ page, context }) => {
+  await page.goto('/login');
+
+  // Capture pre-login session identifier
+  const cookiesBefore = await context.cookies();
+  const preLoginSession = cookiesBefore.find(c => c.name === 'session');
+  const preLoginValue = preLoginSession?.value;
+
+  // Log in
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Session ID must change after authentication
+  const cookiesAfter = await context.cookies();
+  const postLoginSession = cookiesAfter.find(c => c.name === 'session');
+  expect(postLoginSession).toBeDefined();
+
+  if (preLoginValue) {
+    expect(postLoginSession!.value).not.toBe(preLoginValue);
+  }
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('session ID changes after login', async ({ page, context }) => {
+  await page.goto('/login');
+
+  const cookiesBefore = await context.cookies();
+  const preLoginSession = cookiesBefore.find(c => c.name === 'session');
+  const preLoginValue = preLoginSession?.value;
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  const cookiesAfter = await context.cookies();
+  const postLoginSession = cookiesAfter.find(c => c.name === 'session');
+  expect(postLoginSession).toBeDefined();
+
+  if (preLoginValue) {
+    expect(postLoginSession.value).not.toBe(preLoginValue);
+  }
+});
+```
+
+## Decision Guide
+
+| Vulnerability | Playwright Test Approach | Confidence Level |
+|---|---|---|
+| Reflected XSS | Inject payloads in inputs and URL params, assert no script execution | Medium -- covers common cases, not exhaustive |
+| Stored XSS | Inject payload, reload page, assert sanitized output | Medium -- catches rendering-level issues |
+| CSRF | Verify token presence, test rejection without token | High -- directly tests the mechanism |
+| Insecure cookies | Assert `httpOnly`, `secure`, `sameSite` flags | High -- deterministic check |
+| Missing security headers | Assert header presence and values | High -- deterministic check |
+| Auth bypass | Navigate to protected routes without auth | High -- tests the redirect/block mechanism |
+| Session fixation | Compare session IDs before and after login | High -- directly verifiable |
+| Sensitive data exposure | Check URLs, localStorage, response bodies for secrets | Medium -- catches obvious leaks |
+| HTTPS enforcement | Verify redirect and HSTS header | High -- deterministic check |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Only testing the "happy path" login | Misses bypass vectors | Test unauthenticated access, expired sessions, tampered tokens |
+| Checking `SameSite` only on one cookie | Other cookies may leak session info | Check all cookies that contain session data |
+| Ignoring CSP on API endpoints | APIs can serve HTML on error pages | Check headers on API routes too |
+| Testing security only in development | Dev servers often have relaxed security | Run security tests against staging with production-like config |
+| Using `page.waitForTimeout` after login | Hides timing-based auth issues | Use `page.waitForURL` or assertion-based waiting |
+| Hardcoding test credentials in test files | Credentials leak into version control | Use environment variables or a secrets manager |
+| Skipping HTTPS tests because "it works locally" | HTTP-only local dev hides HTTPS issues | Test HTTPS redirect against staging or use `--ignore-https-errors` carefully |
+| Treating Playwright as a full security scanner | Playwright tests are not penetration tests | Use Playwright for regression checks; pair with OWASP ZAP, Burp Suite, or Snyk for deep scanning |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| CSP header missing in test but present in production | Dev server does not set CSP | Run security tests against staging with production config |
+| Cookie `secure` flag is `false` | Testing over HTTP (localhost) | Test against HTTPS staging, or verify the flag is set conditionally for production |
+| CSRF test passes without token | CSRF protection disabled in test environment | Enable CSRF in test environment or run against staging |
+| XSS payload does not execute but test passes | Framework auto-escapes by default | Still test -- the test confirms the protection works; add edge cases for raw HTML rendering |
+| `context.cookies()` returns empty | Cookies set on a different domain or path | Pass the specific URL to `context.cookies('https://your-app.com')` |
+| HSTS header check fails on localhost | HSTS requires HTTPS with valid certs | Skip HSTS tests for localhost, run against staging |
+| Session cookie not found by name | Cookie name differs across environments | Search by pattern: `cookies.find(c => c.name.includes('sess'))` |
+
+## Related
+
+- [core/authentication.md](authentication.md) -- login flows and auth state management
+- [core/network-mocking.md](network-mocking.md) -- intercepting requests for security testing
+- [core/configuration.md](configuration.md) -- `ignoreHTTPSErrors` and base URL configuration
+- [core/third-party-integrations.md](third-party-integrations.md) -- testing OAuth and third-party auth providers
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- running security tests in CI pipelines

--- a/engineering-team/playwright skill/core/service-workers-and-pwa.md
+++ b/engineering-team/playwright skill/core/service-workers-and-pwa.md
@@ -1,0 +1,524 @@
+# Service Workers and PWA Testing
+
+> **When to use**: When your application is a Progressive Web App (PWA) or uses service workers for offline support, caching, push notifications, or background sync.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Reference
+
+```typescript
+// Service workers require a persistent context — use launchPersistentContext
+const context = await chromium.launchPersistentContext(userDataDir, {
+  baseURL: 'https://localhost:3000',
+});
+
+// Enable/disable offline mode
+await context.setOffline(true);   // Go offline
+await context.setOffline(false);  // Come back online
+
+// Wait for service worker to register
+const sw = await context.waitForEvent('serviceworker');
+console.log('SW URL:', sw.url());
+```
+
+## Patterns
+
+### Service Worker Registration
+
+**Use when**: You need to verify that your service worker registers successfully, activates, and controls the page.
+**Avoid when**: Your app does not use service workers.
+
+Service workers require a persistent browser context because they are tied to a profile. The default `page` fixture uses a temporary context that does not persist service worker registrations across navigations reliably.
+
+**TypeScript**
+```typescript
+import { test as base, expect, chromium, BrowserContext } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+// Create a fixture with a persistent context for SW testing
+const test = base.extend<{ swContext: BrowserContext }>({
+  swContext: async ({}, use) => {
+    const userDataDir = path.join(__dirname, '.tmp-profile');
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      baseURL: 'https://localhost:3000',
+    });
+    await use(context);
+    await context.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  },
+});
+
+test('service worker registers and activates', async ({ swContext }) => {
+  const page = await swContext.newPage();
+
+  // Listen for the service worker event
+  const swPromise = swContext.waitForEvent('serviceworker');
+
+  await page.goto('/');
+
+  const sw = await swPromise;
+  expect(sw.url()).toContain('service-worker.js');
+
+  // Verify the SW is controlling the page
+  const isControlled = await page.evaluate(() => {
+    return navigator.serviceWorker.controller !== null;
+  });
+  expect(isControlled).toBe(true);
+});
+```
+
+**JavaScript**
+```javascript
+const { test: base, expect, chromium } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+const test = base.extend({
+  swContext: async ({}, use) => {
+    const userDataDir = path.join(__dirname, '.tmp-profile');
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      baseURL: 'https://localhost:3000',
+    });
+    await use(context);
+    await context.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  },
+});
+
+test('service worker registers and activates', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  const swPromise = swContext.waitForEvent('serviceworker');
+
+  await page.goto('/');
+
+  const sw = await swPromise;
+  expect(sw.url()).toContain('service-worker.js');
+
+  const isControlled = await page.evaluate(() => {
+    return navigator.serviceWorker.controller !== null;
+  });
+  expect(isControlled).toBe(true);
+});
+```
+
+### Offline Mode Testing
+
+**Use when**: Your PWA should work offline -- serving cached pages, showing offline indicators, queuing data for sync.
+**Avoid when**: Your app has no offline support.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('app serves cached page when offline', async ({ swContext }) => {
+  const page = await swContext.newPage();
+
+  // First visit — caches the page and assets
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  // Wait for the service worker to finish caching
+  await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    // Wait for the SW to be in the 'activated' state
+    return registration.active?.state === 'activated';
+  });
+
+  // Go offline
+  await swContext.setOffline(true);
+
+  // Reload — should serve from cache
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  // Verify offline indicator appears
+  await expect(page.getByText('You are offline')).toBeVisible();
+
+  // Come back online
+  await swContext.setOffline(false);
+  await expect(page.getByText('You are offline')).toBeHidden();
+});
+
+test('form submission queues when offline', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/feedback');
+
+  // Ensure SW is active
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  // Go offline
+  await swContext.setOffline(true);
+
+  // Submit a form while offline
+  await page.getByLabel('Feedback').fill('Great product!');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  // App should show a "queued" message, not an error
+  await expect(page.getByText('Saved offline. Will sync when connected.')).toBeVisible();
+
+  // Come back online — the queued data should sync
+  await swContext.setOffline(false);
+  await expect(page.getByText('Feedback submitted successfully')).toBeVisible({ timeout: 10000 });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('app serves cached page when offline', async ({ swContext }) => {
+  const page = await swContext.newPage();
+
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.ready;
+    return registration.active?.state === 'activated';
+  });
+
+  await swContext.setOffline(true);
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(page.getByText('You are offline')).toBeVisible();
+
+  await swContext.setOffline(false);
+  await expect(page.getByText('You are offline')).toBeHidden();
+});
+```
+
+### Cache Verification
+
+**Use when**: You need to confirm that specific resources are cached by the service worker.
+**Avoid when**: You trust the framework's caching strategy and only need to verify the offline UX (test offline mode instead).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('critical assets are cached by the service worker', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/');
+
+  // Wait for SW to be ready
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  // Check the cache contents
+  const cachedUrls = await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const allUrls: string[] = [];
+    for (const name of cacheNames) {
+      const cache = await caches.open(name);
+      const keys = await cache.keys();
+      allUrls.push(...keys.map((req) => new URL(req.url).pathname));
+    }
+    return allUrls;
+  });
+
+  // Verify critical resources are cached
+  expect(cachedUrls).toContain('/');
+  expect(cachedUrls).toContain('/offline.html');
+  expect(cachedUrls.some((url) => url.endsWith('.js'))).toBe(true);
+  expect(cachedUrls.some((url) => url.endsWith('.css'))).toBe(true);
+});
+
+test('cache is invalidated after service worker update', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/');
+
+  // Get initial cache version
+  const initialCaches = await page.evaluate(() => caches.keys());
+
+  // Simulate a new SW version by clearing and reloading
+  await page.evaluate(async () => {
+    const registration = await navigator.serviceWorker.getRegistration();
+    await registration?.update();
+  });
+
+  // After update, old caches should be cleaned up
+  await page.reload();
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  const updatedCaches = await page.evaluate(() => caches.keys());
+
+  // The app should manage cache names with versioning
+  expect(updatedCaches.length).toBeGreaterThanOrEqual(1);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('critical assets are cached by the service worker', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/');
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  const cachedUrls = await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const allUrls = [];
+    for (const name of cacheNames) {
+      const cache = await caches.open(name);
+      const keys = await cache.keys();
+      allUrls.push(...keys.map((req) => new URL(req.url).pathname));
+    }
+    return allUrls;
+  });
+
+  expect(cachedUrls).toContain('/');
+  expect(cachedUrls).toContain('/offline.html');
+});
+```
+
+### PWA Install Prompt
+
+**Use when**: You need to test the "Add to Home Screen" / PWA install flow.
+**Avoid when**: Your app is not a PWA or does not handle the `beforeinstallprompt` event.
+
+The `beforeinstallprompt` event cannot be synthetically triggered by Playwright. Instead, verify that your app captures and handles the event correctly.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('app captures install prompt and shows install button', async ({ swContext }) => {
+  const page = await swContext.newPage();
+
+  // Mock the beforeinstallprompt event
+  await page.addInitScript(() => {
+    let deferredPrompt: Event | null = null;
+
+    // Simulate the browser firing beforeinstallprompt
+    window.addEventListener('load', () => {
+      const event = new Event('beforeinstallprompt');
+      (event as any).preventDefault = () => {};
+      (event as any).prompt = () => Promise.resolve();
+      (event as any).userChoice = Promise.resolve({ outcome: 'accepted' });
+
+      window.dispatchEvent(event);
+    });
+  });
+
+  await page.goto('/');
+
+  // Your app should show an install button when it captures the prompt
+  await expect(page.getByRole('button', { name: 'Install app' })).toBeVisible();
+});
+
+test('web app manifest is valid', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/');
+
+  // Verify manifest link exists
+  const manifestUrl = await page.evaluate(() => {
+    const link = document.querySelector('link[rel="manifest"]') as HTMLLinkElement;
+    return link?.href;
+  });
+  expect(manifestUrl).toBeTruthy();
+
+  // Fetch and validate the manifest
+  const response = await page.request.get(manifestUrl!);
+  expect(response.ok()).toBe(true);
+
+  const manifest = await response.json();
+  expect(manifest.name).toBeTruthy();
+  expect(manifest.icons).toHaveLength(expect.any(Number));
+  expect(manifest.start_url).toBeTruthy();
+  expect(manifest.display).toBe('standalone');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('app captures install prompt and shows install button', async ({ swContext }) => {
+  const page = await swContext.newPage();
+
+  await page.addInitScript(() => {
+    window.addEventListener('load', () => {
+      const event = new Event('beforeinstallprompt');
+      event.preventDefault = () => {};
+      event.prompt = () => Promise.resolve();
+      event.userChoice = Promise.resolve({ outcome: 'accepted' });
+      window.dispatchEvent(event);
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'Install app' })).toBeVisible();
+});
+```
+
+### Push Notification Testing
+
+**Use when**: Your PWA uses the Push API to receive push notifications from a server.
+**Avoid when**: Notifications are handled entirely client-side without the Push API.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('push notification triggers UI update', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/');
+
+  // Wait for SW to be ready
+  const swURL = await page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.ready;
+    return reg.active?.scriptURL;
+  });
+  expect(swURL).toBeTruthy();
+
+  // Get the service worker and evaluate inside it
+  const sw = swContext.serviceWorkers()[0];
+
+  // Simulate a push event inside the service worker
+  await sw.evaluate(async () => {
+    const event = new PushEvent('push', {
+      data: new TextEncoder().encode(JSON.stringify({
+        title: 'New Message',
+        body: 'You have a new message from Alice',
+        url: '/messages',
+      })),
+    });
+    // @ts-ignore — dispatchEvent works in SW context
+    self.dispatchEvent(event);
+  });
+
+  // Verify the app reacts (e.g., shows a badge or notification banner)
+  await expect(page.getByTestId('notification-badge')).toHaveText('1');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('push notification triggers UI update', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/');
+
+  const swURL = await page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.ready;
+    return reg.active?.scriptURL;
+  });
+  expect(swURL).toBeTruthy();
+
+  const sw = swContext.serviceWorkers()[0];
+
+  await sw.evaluate(async () => {
+    const event = new PushEvent('push', {
+      data: new TextEncoder().encode(JSON.stringify({
+        title: 'New Message',
+        body: 'You have a new message from Alice',
+        url: '/messages',
+      })),
+    });
+    self.dispatchEvent(event);
+  });
+
+  await expect(page.getByTestId('notification-badge')).toHaveText('1');
+});
+```
+
+### Background Sync Testing
+
+**Use when**: Your app uses the Background Sync API to defer network requests until the user has connectivity.
+**Avoid when**: Your app does not use background sync.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('background sync retries failed requests when online', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/tasks');
+
+  // Ensure SW is active
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  // Go offline
+  await swContext.setOffline(true);
+
+  // Create a task (will fail to sync)
+  await page.getByLabel('New task').fill('Buy groceries');
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  // Task shows as "pending sync"
+  await expect(page.getByText('Buy groceries')).toBeVisible();
+  await expect(page.getByTestId('sync-status')).toHaveText('Pending');
+
+  // Come back online — background sync should fire
+  await swContext.setOffline(false);
+
+  // Wait for sync to complete
+  await expect(page.getByTestId('sync-status')).toHaveText('Synced', { timeout: 15000 });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('background sync retries failed requests when online', async ({ swContext }) => {
+  const page = await swContext.newPage();
+  await page.goto('/tasks');
+  await page.evaluate(() => navigator.serviceWorker.ready);
+
+  await swContext.setOffline(true);
+
+  await page.getByLabel('New task').fill('Buy groceries');
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  await expect(page.getByText('Buy groceries')).toBeVisible();
+  await expect(page.getByTestId('sync-status')).toHaveText('Pending');
+
+  await swContext.setOffline(false);
+  await expect(page.getByTestId('sync-status')).toHaveText('Synced', { timeout: 15000 });
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Verify SW registers | `context.waitForEvent('serviceworker')` | Confirms the SW file was fetched and registered |
+| Test offline page serving | `context.setOffline(true)` + reload | Simulates network loss at the browser level |
+| Verify specific assets are cached | `page.evaluate(() => caches.keys())` | Directly queries the Cache API |
+| Test install prompt | `addInitScript` to mock `beforeinstallprompt` | Browser does not fire this event in automation |
+| Validate web manifest | `page.request.get(manifestUrl)` | Fetch and parse the JSON manifest |
+| Test push notifications | `sw.evaluate()` to dispatch PushEvent | Simulates a push message inside the SW |
+| Test background sync | Go offline, perform action, come back online | Verifies the sync queue processes correctly |
+| Test SW update flow | `registration.update()` via `page.evaluate` | Triggers a manual SW update check |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Test service workers with the default `page` fixture | Default context is temporary; SWs may not persist | Use `launchPersistentContext` for reliable SW testing |
+| Skip `navigator.serviceWorker.ready` before going offline | SW may not have finished caching | Always `await page.evaluate(() => navigator.serviceWorker.ready)` first |
+| Use `page.route()` to simulate offline | Only intercepts Playwright-visible requests; SW fetch events are not intercepted | Use `context.setOffline(true)` for true network-level offline |
+| Test the SW JavaScript file directly with unit tests only | Misses integration with the page and caching behavior | Combine unit tests with Playwright end-to-end SW tests |
+| Assume caches are clean at test start | Previous test runs may leave stale caches | Clear caches in fixture setup or use a fresh `userDataDir` |
+| `waitForTimeout` after `setOffline(false)` | Background sync timing is unpredictable | Use `expect(...).toHaveText('Synced', { timeout: 15000 })` |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `context.waitForEvent('serviceworker')` never resolves | SW already registered before listener attached | Register listener before `page.goto()`, or check `context.serviceWorkers()` |
+| SW does not activate | Old SW is still controlling the page | Use `skipWaiting()` in the SW or clear the `userDataDir` |
+| Offline test still loads fresh content | SW cache was not populated before going offline | Wait for `navigator.serviceWorker.ready` and verify cache contents first |
+| `context.setOffline(true)` has no effect | Using a non-persistent context or the wrong context | Ensure offline is set on the same context that owns the page |
+| Push event does nothing | SW is not the active controller | Ensure `sw.evaluate()` targets the correct service worker from `context.serviceWorkers()` |
+| Tests interfere with each other | Shared `userDataDir` between tests | Use a unique temp directory per test, cleaned in fixture teardown |
+| Service worker tests only work in Chromium | Firefox and WebKit have limited SW support in Playwright | Run SW tests in Chromium only via `test.skip` or project config |
+
+## Related
+
+- [core/browser-apis.md](browser-apis.md) -- IndexedDB and localStorage used alongside service workers
+- [core/configuration.md](configuration.md) -- project-level config for PWA testing
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- wrapping persistent context in fixtures
+- [core/websockets-and-realtime.md](websockets-and-realtime.md) -- real-time features that interact with offline/online state

--- a/engineering-team/playwright skill/core/test-architecture.md
+++ b/engineering-team/playwright skill/core/test-architecture.md
@@ -1,0 +1,569 @@
+# Test Architecture: E2E vs Component vs API
+
+> **When to use**: When deciding what kind of test to write for a feature. Before you write any test, ask: "What is the cheapest test that gives me confidence this works?"
+
+## Quick Answer
+
+Most teams write too many E2E tests. Default to the **testing trophy** approach:
+
+1. **API tests** for business logic, data validation, and permissions (fastest, most stable)
+2. **Component tests** for isolated UI behavior, form validation, and interactive widgets (fast, focused)
+3. **E2E tests only for critical user paths** -- login, checkout, onboarding (slow, highest confidence)
+
+If you only have time for one layer, start with API tests. They cover the most ground with the least maintenance cost.
+
+## The Testing Trophy
+
+The testing trophy (coined by Kent C. Dodds) replaces the traditional testing pyramid for modern web apps:
+
+```
+        ╱ ╲
+       ╱ E2E ╲           Thin layer -- critical paths only
+      ╱─────────╲
+     ╱           ╲
+    ╱ Integration  ╲      Thickest layer -- component + API tests
+   ╱                 ╲
+  ╱───────────────────╲
+ ╱        Unit         ╲   Utility functions, pure logic
+╱───────────────────────╲
+     Static Analysis       TypeScript, ESLint, Prettier
+```
+
+**Where Playwright fits**:
+- **E2E layer**: `@playwright/test` with a browser -- full user flow testing
+- **Integration / Component layer**: `@playwright/experimental-ct-*` -- render components in a real browser without a full app
+- **Integration / API layer**: `@playwright/test` with `request` context -- HTTP testing without a browser
+- **Static layer**: Not Playwright's job. Use TypeScript and ESLint.
+
+The trophy shape means integration tests (component + API) should be your **largest** investment. They give the best ratio of confidence to cost.
+
+## Decision Matrix
+
+| What You're Testing | Test Type | Why | Playwright Example |
+|---|---|---|---|
+| Login / auth flow | E2E | Cross-page, cookies, redirects, session state | Full browser flow with `storageState` |
+| Form submission | Component | Isolated validation logic, error states, UX | Mount form component, test states |
+| CRUD operations | API | Data integrity matters more than UI for create/update/delete | `request.post()`, `request.put()`, `request.delete()` |
+| Search with results UI | Component + API | API test for query logic; component test for rendering results | Split: API for data, component for display |
+| Cross-page navigation | E2E | Routing, history, deep linking are browser concerns | `page.goto()`, `page.waitForURL()` |
+| Error handling (API errors) | API | Validate status codes, error shapes, edge cases without UI | `expect(response.status()).toBe(422)` |
+| Error handling (UI feedback) | Component | Toast, banner, inline error rendering | Mount component, mock error response |
+| Accessibility | Component | Test ARIA roles, keyboard nav per-component; faster than full E2E | `expect(locator).toHaveAttribute('aria-expanded')` |
+| Responsive layout | Component | Viewport-specific rendering without full app overhead | `mount()` with viewport config |
+| API integration (contract) | API | Validate response shapes, headers, auth independently | `request.get()` with schema validation |
+| Real-time features (WebSocket) | E2E | Requires full browser environment for WebSocket connections | `page.evaluate()` with WebSocket listeners |
+| Payment / checkout flow | E2E | Multi-step, third-party iframes, real-world reliability | Full browser flow, `frameLocator()` |
+| Onboarding / wizard | E2E | Multi-step, state persists across pages | `test.step()` for each wizard stage |
+| Individual widget behavior | Component | Toggle, accordion, date picker, modal -- isolated interactions | Mount component, test open/close/select |
+| Permissions / authorization | API | Role-based access is backend logic; test without UI overhead | Request with different auth tokens |
+
+## When to Use E2E Tests
+
+**Best for**:
+- Critical user flows that generate revenue (checkout, signup, subscription)
+- Authentication and authorization flows (login, SSO, MFA, password reset)
+- Multi-page workflows where state carries across navigation (wizards, onboarding)
+- Flows involving third-party iframes (payment widgets, embedded forms)
+- Smoke tests validating the entire stack is wired together
+- Real-time collaboration features requiring multiple browser contexts
+
+**Avoid for**:
+- Testing every permutation of form validation (use component tests)
+- CRUD operations where the UI is a thin wrapper (use API tests)
+- Verifying individual component states (use component tests)
+- Testing API response shapes or error codes (use API tests)
+- Responsive layout at every breakpoint (use component tests)
+- Edge cases that only affect the backend (use API tests)
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// E2E: critical checkout flow -- this justifies the cost of a full browser
+test.describe('checkout flow', () => {
+  test.beforeEach(async ({ page }) => {
+    // Seed data via API to keep E2E tests focused on the flow, not setup
+    await page.request.post('/api/test/seed-cart', {
+      data: { items: [{ sku: 'SHOE-001', qty: 1 }] },
+    });
+    await page.goto('/cart');
+  });
+
+  test('completes purchase with valid payment', async ({ page }) => {
+    await test.step('review cart', async () => {
+      await expect(page.getByRole('heading', { name: 'Your Cart' })).toBeVisible();
+      await expect(page.getByText('Running Shoes')).toBeVisible();
+      await page.getByRole('button', { name: 'Proceed to checkout' }).click();
+    });
+
+    await test.step('fill shipping details', async () => {
+      await page.getByLabel('Full name').fill('Jane Doe');
+      await page.getByLabel('Address').fill('123 Main St');
+      await page.getByLabel('City').fill('Portland');
+      await page.getByRole('combobox', { name: 'State' }).selectOption('OR');
+      await page.getByLabel('ZIP code').fill('97201');
+      await page.getByRole('button', { name: 'Continue to payment' }).click();
+    });
+
+    await test.step('enter payment', async () => {
+      const paymentFrame = page.frameLocator('iframe[title="Payment"]');
+      await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+      await paymentFrame.getByLabel('Expiration').fill('12/28');
+      await paymentFrame.getByLabel('CVC').fill('123');
+      await page.getByRole('button', { name: 'Place order' }).click();
+    });
+
+    await test.step('verify confirmation', async () => {
+      await page.waitForURL('**/order/confirmation/**');
+      await expect(page.getByRole('heading', { name: 'Order Confirmed' })).toBeVisible();
+      await expect(page.getByText(/Order #\d+/)).toBeVisible();
+    });
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('checkout flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.request.post('/api/test/seed-cart', {
+      data: { items: [{ sku: 'SHOE-001', qty: 1 }] },
+    });
+    await page.goto('/cart');
+  });
+
+  test('completes purchase with valid payment', async ({ page }) => {
+    await test.step('review cart', async () => {
+      await expect(page.getByRole('heading', { name: 'Your Cart' })).toBeVisible();
+      await expect(page.getByText('Running Shoes')).toBeVisible();
+      await page.getByRole('button', { name: 'Proceed to checkout' }).click();
+    });
+
+    await test.step('fill shipping details', async () => {
+      await page.getByLabel('Full name').fill('Jane Doe');
+      await page.getByLabel('Address').fill('123 Main St');
+      await page.getByLabel('City').fill('Portland');
+      await page.getByRole('combobox', { name: 'State' }).selectOption('OR');
+      await page.getByLabel('ZIP code').fill('97201');
+      await page.getByRole('button', { name: 'Continue to payment' }).click();
+    });
+
+    await test.step('enter payment', async () => {
+      const paymentFrame = page.frameLocator('iframe[title="Payment"]');
+      await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+      await paymentFrame.getByLabel('Expiration').fill('12/28');
+      await paymentFrame.getByLabel('CVC').fill('123');
+      await page.getByRole('button', { name: 'Place order' }).click();
+    });
+
+    await test.step('verify confirmation', async () => {
+      await page.waitForURL('**/order/confirmation/**');
+      await expect(page.getByRole('heading', { name: 'Order Confirmed' })).toBeVisible();
+      await expect(page.getByText(/Order #\d+/)).toBeVisible();
+    });
+  });
+});
+```
+
+## When to Use Component Tests
+
+**Best for**:
+- Form validation (required fields, format rules, error messages, field interactions)
+- Interactive widgets (modals, dropdowns, accordions, date pickers, tabs)
+- Conditional rendering (show/hide logic, loading states, empty states, error states)
+- Accessibility per-component (ARIA attributes, keyboard navigation, focus management)
+- Responsive layout at different viewports without full app overhead
+- Visual states (hover, focus, disabled, selected) for design system components
+
+**Avoid for**:
+- Testing routing or navigation between pages (use E2E)
+- Flows requiring real cookies, sessions, or server-side state (use E2E)
+- Data persistence or API contract validation (use API tests)
+- Third-party iframe interactions (use E2E)
+- Anything requiring multiple pages or browser contexts (use E2E)
+
+**TypeScript** (React example using `@playwright/experimental-ct-react`)
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { LoginForm } from '../src/components/LoginForm';
+
+test.describe('LoginForm component', () => {
+  test('shows validation errors for empty submission', async ({ mount }) => {
+    const component = await mount(<LoginForm onSubmit={() => {}} />);
+
+    await component.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(component.getByText('Email is required')).toBeVisible();
+    await expect(component.getByText('Password is required')).toBeVisible();
+  });
+
+  test('shows error for invalid email format', async ({ mount }) => {
+    const component = await mount(<LoginForm onSubmit={() => {}} />);
+
+    await component.getByLabel('Email').fill('not-an-email');
+    await component.getByLabel('Password').fill('password123');
+    await component.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(component.getByText('Enter a valid email address')).toBeVisible();
+  });
+
+  test('calls onSubmit with credentials for valid input', async ({ mount }) => {
+    const submitted: Array<{ email: string; password: string }> = [];
+    const component = await mount(
+      <LoginForm onSubmit={(data) => submitted.push(data)} />
+    );
+
+    await component.getByLabel('Email').fill('jane@example.com');
+    await component.getByLabel('Password').fill('s3cure!Pass');
+    await component.getByRole('button', { name: 'Sign in' }).click();
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]).toEqual({
+      email: 'jane@example.com',
+      password: 's3cure!Pass',
+    });
+  });
+
+  test('disables submit button while loading', async ({ mount }) => {
+    const component = await mount(<LoginForm onSubmit={() => {}} loading={true} />);
+
+    await expect(component.getByRole('button', { name: 'Signing in...' })).toBeDisabled();
+  });
+
+  test('meets accessibility requirements', async ({ mount }) => {
+    const component = await mount(<LoginForm onSubmit={() => {}} />);
+
+    // Labels are associated with inputs
+    await expect(component.getByRole('textbox', { name: 'Email' })).toBeVisible();
+
+    // Error messages are announced via aria-live
+    await component.getByRole('button', { name: 'Sign in' }).click();
+    await expect(component.getByRole('alert')).toContainText('Email is required');
+  });
+});
+```
+
+**JavaScript** (React example using `@playwright/experimental-ct-react`)
+```javascript
+const { test, expect } = require('@playwright/experimental-ct-react');
+const { LoginForm } = require('../src/components/LoginForm');
+
+test.describe('LoginForm component', () => {
+  test('shows validation errors for empty submission', async ({ mount }) => {
+    const component = await mount(<LoginForm onSubmit={() => {}} />);
+
+    await component.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(component.getByText('Email is required')).toBeVisible();
+    await expect(component.getByText('Password is required')).toBeVisible();
+  });
+
+  test('calls onSubmit with credentials for valid input', async ({ mount }) => {
+    const submitted = [];
+    const component = await mount(
+      <LoginForm onSubmit={(data) => submitted.push(data)} />
+    );
+
+    await component.getByLabel('Email').fill('jane@example.com');
+    await component.getByLabel('Password').fill('s3cure!Pass');
+    await component.getByRole('button', { name: 'Sign in' }).click();
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]).toEqual({
+      email: 'jane@example.com',
+      password: 's3cure!Pass',
+    });
+  });
+
+  test('disables submit button while loading', async ({ mount }) => {
+    const component = await mount(<LoginForm onSubmit={() => {}} loading={true} />);
+
+    await expect(component.getByRole('button', { name: 'Signing in...' })).toBeDisabled();
+  });
+});
+```
+
+## When to Use API Tests
+
+**Best for**:
+- CRUD operations (create, read, update, delete resources)
+- Input validation and error responses (400, 422 with structured error bodies)
+- Permission and authorization checks (role-based access, token scoping)
+- Data integrity and business rules (uniqueness, referential integrity, calculations)
+- API contract verification (response shapes, headers, pagination)
+- Edge cases that are expensive to reproduce through the UI (rate limiting, concurrent updates)
+- Test data setup and teardown for E2E tests (seed via API, verify via API)
+
+**Avoid for**:
+- Testing how errors are displayed to the user (use component tests)
+- Testing browser-specific behavior (cookies, redirects, navigation)
+- Verifying visual layout or responsive design (use component tests)
+- Flows requiring JavaScript execution or DOM interaction (use E2E or component)
+- Third-party iframe interactions (use E2E)
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Users API', () => {
+  let authToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    const response = await request.post('/api/auth/login', {
+      data: { email: 'admin@example.com', password: 'admin-pass' },
+    });
+    const body = await response.json();
+    authToken = body.token;
+  });
+
+  test('creates a user with valid data', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${authToken}` },
+      data: {
+        email: 'newuser@example.com',
+        name: 'Jane Doe',
+        role: 'editor',
+      },
+    });
+
+    expect(response.status()).toBe(201);
+
+    const user = await response.json();
+    expect(user).toMatchObject({
+      email: 'newuser@example.com',
+      name: 'Jane Doe',
+      role: 'editor',
+    });
+    expect(user).toHaveProperty('id');
+    expect(user).toHaveProperty('createdAt');
+  });
+
+  test('rejects duplicate email with 409', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${authToken}` },
+      data: {
+        email: 'admin@example.com', // already exists
+        name: 'Duplicate',
+        role: 'viewer',
+      },
+    });
+
+    expect(response.status()).toBe(409);
+
+    const error = await response.json();
+    expect(error.message).toContain('already exists');
+  });
+
+  test('returns 422 for invalid email format', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${authToken}` },
+      data: {
+        email: 'not-valid',
+        name: 'Bad Email',
+        role: 'viewer',
+      },
+    });
+
+    expect(response.status()).toBe(422);
+
+    const error = await response.json();
+    expect(error.errors).toContainEqual(
+      expect.objectContaining({ field: 'email' })
+    );
+  });
+
+  test('non-admin cannot create users', async ({ request }) => {
+    // Login as a non-admin user
+    const loginResponse = await request.post('/api/auth/login', {
+      data: { email: 'viewer@example.com', password: 'viewer-pass' },
+    });
+    const { token: viewerToken } = await loginResponse.json();
+
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${viewerToken}` },
+      data: {
+        email: 'another@example.com',
+        name: 'Unauthorized',
+        role: 'editor',
+      },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+
+  test('lists users with pagination', async ({ request }) => {
+    const response = await request.get('/api/users', {
+      headers: { Authorization: `Bearer ${authToken}` },
+      params: { page: '1', limit: '10' },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.data).toBeInstanceOf(Array);
+    expect(body.data.length).toBeLessThanOrEqual(10);
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('page', 1);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Users API', () => {
+  let authToken;
+
+  test.beforeAll(async ({ request }) => {
+    const response = await request.post('/api/auth/login', {
+      data: { email: 'admin@example.com', password: 'admin-pass' },
+    });
+    const body = await response.json();
+    authToken = body.token;
+  });
+
+  test('creates a user with valid data', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${authToken}` },
+      data: {
+        email: 'newuser@example.com',
+        name: 'Jane Doe',
+        role: 'editor',
+      },
+    });
+
+    expect(response.status()).toBe(201);
+
+    const user = await response.json();
+    expect(user).toMatchObject({
+      email: 'newuser@example.com',
+      name: 'Jane Doe',
+      role: 'editor',
+    });
+    expect(user).toHaveProperty('id');
+    expect(user).toHaveProperty('createdAt');
+  });
+
+  test('rejects duplicate email with 409', async ({ request }) => {
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${authToken}` },
+      data: {
+        email: 'admin@example.com',
+        name: 'Duplicate',
+        role: 'viewer',
+      },
+    });
+
+    expect(response.status()).toBe(409);
+
+    const error = await response.json();
+    expect(error.message).toContain('already exists');
+  });
+
+  test('non-admin cannot create users', async ({ request }) => {
+    const loginResponse = await request.post('/api/auth/login', {
+      data: { email: 'viewer@example.com', password: 'viewer-pass' },
+    });
+    const { token: viewerToken } = await loginResponse.json();
+
+    const response = await request.post('/api/users', {
+      headers: { Authorization: `Bearer ${viewerToken}` },
+      data: {
+        email: 'another@example.com',
+        name: 'Unauthorized',
+        role: 'editor',
+      },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+});
+```
+
+## Combining Test Types
+
+The most effective test suites layer all three types. Here is how they work together for a "user management" feature:
+
+### Layer 1: API Tests (60% of test count)
+
+Cover every permutation of the backend logic. These are cheap to run and maintain.
+
+```
+tests/api/users.spec.ts
+  - creates user with valid data (201)
+  - rejects duplicate email (409)
+  - rejects invalid email format (422)
+  - rejects missing required fields (422)
+  - non-admin cannot create users (403)
+  - unauthenticated request returns 401
+  - lists users with pagination
+  - filters users by role
+  - updates user profile
+  - soft-deletes a user
+  - prevents deleting last admin
+```
+
+### Layer 2: Component Tests (30% of test count)
+
+Cover every visual state and interaction of the UI components.
+
+```
+tests/components/UserForm.spec.tsx
+  - shows validation errors on empty submit
+  - shows inline error for invalid email
+  - disables submit while loading
+  - calls onSubmit with form data
+  - resets form after successful submit
+
+tests/components/UserTable.spec.tsx
+  - renders user rows from props
+  - shows empty state when no users
+  - handles delete confirmation modal
+  - sorts by column header click
+  - shows role badges with correct colors
+```
+
+### Layer 3: E2E Tests (10% of test count)
+
+Cover only the critical path that proves the full stack works together.
+
+```
+tests/e2e/user-management.spec.ts
+  - admin creates a user and sees them in the list
+  - admin edits a user's role
+  - viewer cannot access user management page
+```
+
+### The math
+
+For this single feature, you might have:
+- **11 API tests** -- run in ~2 seconds total, no browser needed
+- **10 component tests** -- run in ~5 seconds total, real browser but no server
+- **3 E2E tests** -- run in ~15 seconds total, full stack
+
+Total: 24 tests, ~22 seconds. The 11 API tests catch most regressions. The 10 component tests catch UI bugs. The 3 E2E tests prove the wiring works. If the E2E tests fail but API and component tests pass, you know the problem is in the integration layer (routing, state management, API client) -- not in the business logic or UI components.
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Better Approach |
+|---|---|---|
+| E2E test for every form validation rule | 30-second browser test for something an API test covers in 200ms | API test for validation logic, one component test for error display |
+| No API tests -- all E2E | Slow suite, flaky from UI timing, hard to diagnose failures | API tests for data/logic, E2E for critical paths only |
+| Component tests that mock everything | Tests pass but app is broken because mocks drift from reality | Mock only external boundaries; use API tests to verify real contracts |
+| Duplicating assertions across layers | Same check in API, component, AND E2E test -- triple maintenance cost | Each layer tests what it is uniquely positioned to verify |
+| E2E test that creates its own test data via the UI | 2-minute test where 90 seconds is setup; breaks when unrelated UI changes | Seed data via API calls in `beforeEach`, then test the actual flow |
+| Testing third-party behavior | Testing that Stripe validates card numbers (that is Stripe's job) | Mock Stripe in component/E2E tests; trust their API contract |
+| Skipping the API layer entirely | UI tests catch the bug but you can't tell if it is frontend or backend | API tests isolate backend bugs; component tests isolate frontend bugs |
+| One giant E2E test for the whole feature | 5-minute test that fails somewhere in the middle with no clear cause | Break into focused E2E tests per critical path; use `test.step()` for clarity |
+
+## Related
+
+- [core/test-organization.md](test-organization.md) -- file structure and naming conventions for each test type
+- [core/api-testing.md](api-testing.md) -- deep-dive on Playwright's `request` API for HTTP testing
+- [core/component-testing.md](component-testing.md) -- setting up and writing component tests with Playwright CT
+- [core/authentication.md](authentication.md) -- auth flow testing patterns (E2E + `storageState` reuse)
+- [core/when-to-mock.md](when-to-mock.md) -- when to mock network requests vs hit real services
+- [pom/pom-vs-fixtures-vs-helpers.md](../pom/pom-vs-fixtures-vs-helpers.md) -- organizing shared test logic across layers

--- a/engineering-team/playwright skill/core/test-data-management.md
+++ b/engineering-team/playwright skill/core/test-data-management.md
@@ -1,0 +1,1209 @@
+# Test Data Management
+
+> **When to use**: Every test that interacts with data — user accounts, form inputs, entities, or any state that must exist before assertions run.
+
+## Quick Reference
+
+| Strategy | Speed | Isolation | Complexity | Best For |
+|---|---|---|---|---|
+| Inline data | Instant | Perfect | None | Simple value checks, form inputs |
+| Factory functions | Instant | Perfect | Low | Unique identifiers, consistent shapes |
+| Faker/random data | Instant | Perfect | Low | Realistic fields, edge-case discovery |
+| Builder pattern | Instant | Perfect | Medium | Complex objects with many optional fields |
+| API seeding | Fast | Perfect | Medium | Creating entities the app depends on |
+| Database seeding | Fast | Good | High | Complex relational data, bulk setup |
+| Storage state | Fast | Good | Low | Reusing authenticated sessions |
+| Fixture-based setup | Fast | Perfect | Medium | Encapsulating setup + guaranteed teardown |
+
+**Core principle**: Every test creates its own data and cleans up after itself. No test should depend on data left behind by another test or pre-existing in the environment.
+
+## Patterns
+
+### Inline Test Data
+
+**Use when**: The data is simple, unique to one test, and essential for understanding the assertion.
+
+**Avoid when**: The same data shape repeats across many tests — extract a factory instead.
+
+Inline data makes tests self-documenting. The reader sees exactly what matters without chasing imports.
+
+**TypeScript**
+```typescript
+// tests/contact-form.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('submits contact form with valid data', async ({ page }) => {
+  const name = 'Ada Lovelace';
+  const email = `ada-${Date.now()}@example.com`;
+  const message = 'Inquiry about analytics engine';
+
+  await page.goto('/contact');
+  await page.getByLabel('Name').fill(name);
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Message').fill(message);
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Thank you, Ada Lovelace')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/contact-form.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('submits contact form with valid data', async ({ page }) => {
+  const name = 'Ada Lovelace';
+  const email = `ada-${Date.now()}@example.com`;
+  const message = 'Inquiry about analytics engine';
+
+  await page.goto('/contact');
+  await page.getByLabel('Name').fill(name);
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Message').fill(message);
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Thank you, Ada Lovelace')).toBeVisible();
+});
+```
+
+Use `Date.now()` or `crypto.randomUUID()` for fields that must be unique (emails, usernames). This prevents collisions during parallel execution.
+
+---
+
+### Factory Functions
+
+**Use when**: Multiple tests need the same data shape with different values, or you need guaranteed uniqueness.
+
+**Avoid when**: The data is trivial and only used once — inline it instead.
+
+Factories centralize data creation logic. When the data shape changes, you update one function, not dozens of tests.
+
+**TypeScript**
+```typescript
+// tests/factories/user.factory.ts
+export interface UserData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+}
+
+let counter = 0;
+
+export function createUserData(overrides: Partial<UserData> = {}): UserData {
+  counter++;
+  const id = `${Date.now()}-${counter}`;
+  return {
+    firstName: `Test`,
+    lastName: `User${id}`,
+    email: `testuser-${id}@example.com`,
+    password: 'SecureP@ss123!',
+    ...overrides,
+  };
+}
+```
+
+```typescript
+// tests/registration.spec.ts
+import { test, expect } from '@playwright/test';
+import { createUserData } from './factories/user.factory';
+
+test('registers a new user', async ({ page }) => {
+  const user = createUserData();
+
+  await page.goto('/register');
+  await page.getByLabel('First name').fill(user.firstName);
+  await page.getByLabel('Last name').fill(user.lastName);
+  await page.getByLabel('Email').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  await expect(page.getByText(`Welcome, ${user.firstName}`)).toBeVisible();
+});
+
+test('rejects duplicate email', async ({ page }) => {
+  const user = createUserData({ email: 'duplicate@example.com' });
+
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  await expect(page.getByText('Email already registered')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/factories/user.factory.js
+let counter = 0;
+
+function createUserData(overrides = {}) {
+  counter++;
+  const id = `${Date.now()}-${counter}`;
+  return {
+    firstName: 'Test',
+    lastName: `User${id}`,
+    email: `testuser-${id}@example.com`,
+    password: 'SecureP@ss123!',
+    ...overrides,
+  };
+}
+
+module.exports = { createUserData };
+```
+
+```javascript
+// tests/registration.spec.js
+const { test, expect } = require('@playwright/test');
+const { createUserData } = require('./factories/user.factory');
+
+test('registers a new user', async ({ page }) => {
+  const user = createUserData();
+
+  await page.goto('/register');
+  await page.getByLabel('First name').fill(user.firstName);
+  await page.getByLabel('Last name').fill(user.lastName);
+  await page.getByLabel('Email').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  await expect(page.getByText(`Welcome, ${user.firstName}`)).toBeVisible();
+});
+```
+
+---
+
+### Faker / Random Data
+
+**Use when**: You need realistic-looking data (names, addresses, phone numbers) or want to discover edge cases through randomness.
+
+**Avoid when**: Debugging a failure — use a fixed seed to make it reproducible.
+
+Always seed faker so failures are reproducible. Use `testInfo.testId` or a fixed seed per test file.
+
+**TypeScript**
+```typescript
+// tests/factories/faker-user.factory.ts
+import { faker } from '@faker-js/faker';
+
+export function createFakerUser(seed?: number) {
+  if (seed !== undefined) {
+    faker.seed(seed);
+  }
+  return {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: faker.internet.email({ provider: 'testmail.example.com' }),
+    phone: faker.phone.number(),
+    address: {
+      street: faker.location.streetAddress(),
+      city: faker.location.city(),
+      state: faker.location.state({ abbreviated: true }),
+      zip: faker.location.zipCode(),
+    },
+  };
+}
+```
+
+```typescript
+// tests/checkout.spec.ts
+import { test, expect } from '@playwright/test';
+import { createFakerUser } from './factories/faker-user.factory';
+
+test('completes checkout with shipping address', async ({ page }, testInfo) => {
+  // Seed with a stable value so re-runs produce the same data
+  const user = createFakerUser(testInfo.workerIndex);
+
+  await page.goto('/checkout');
+  await page.getByLabel('Street address').fill(user.address.street);
+  await page.getByLabel('City').fill(user.address.city);
+  await page.getByLabel('State').fill(user.address.state);
+  await page.getByLabel('ZIP code').fill(user.address.zip);
+  await page.getByRole('button', { name: 'Place order' }).click();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/factories/faker-user.factory.js
+const { faker } = require('@faker-js/faker');
+
+function createFakerUser(seed) {
+  if (seed !== undefined) {
+    faker.seed(seed);
+  }
+  return {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: faker.internet.email({ provider: 'testmail.example.com' }),
+    phone: faker.phone.number(),
+    address: {
+      street: faker.location.streetAddress(),
+      city: faker.location.city(),
+      state: faker.location.state({ abbreviated: true }),
+      zip: faker.location.zipCode(),
+    },
+  };
+}
+
+module.exports = { createFakerUser };
+```
+
+```javascript
+// tests/checkout.spec.js
+const { test, expect } = require('@playwright/test');
+const { createFakerUser } = require('./factories/faker-user.factory');
+
+test('completes checkout with shipping address', async ({ page }, testInfo) => {
+  const user = createFakerUser(testInfo.workerIndex);
+
+  await page.goto('/checkout');
+  await page.getByLabel('Street address').fill(user.address.street);
+  await page.getByLabel('City').fill(user.address.city);
+  await page.getByLabel('State').fill(user.address.state);
+  await page.getByLabel('ZIP code').fill(user.address.zip);
+  await page.getByRole('button', { name: 'Place order' }).click();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+Always use a test-specific email domain (e.g., `testmail.example.com`) so faker-generated emails never hit real inboxes. The `example.com` domain is reserved by RFC 2606 and is safe for testing.
+
+---
+
+### Builder Pattern
+
+**Use when**: Objects have many optional fields, conditional logic, or multiple valid configurations. Common for product listings, user profiles, or form payloads with nested data.
+
+**Avoid when**: The object has fewer than 5 fields — a factory with overrides is simpler.
+
+**TypeScript**
+```typescript
+// tests/builders/product.builder.ts
+export interface Product {
+  name: string;
+  price: number;
+  currency: string;
+  category: string;
+  description: string;
+  inStock: boolean;
+  tags: string[];
+  variants: { size: string; color: string }[];
+}
+
+export class ProductBuilder {
+  private product: Product = {
+    name: `Product-${Date.now()}`,
+    price: 29.99,
+    currency: 'USD',
+    category: 'Electronics',
+    description: 'A test product',
+    inStock: true,
+    tags: [],
+    variants: [],
+  };
+
+  withName(name: string): this {
+    this.product.name = name;
+    return this;
+  }
+
+  withPrice(price: number, currency = 'USD'): this {
+    this.product.price = price;
+    this.product.currency = currency;
+    return this;
+  }
+
+  withCategory(category: string): this {
+    this.product.category = category;
+    return this;
+  }
+
+  outOfStock(): this {
+    this.product.inStock = false;
+    return this;
+  }
+
+  withTags(...tags: string[]): this {
+    this.product.tags = tags;
+    return this;
+  }
+
+  withVariant(size: string, color: string): this {
+    this.product.variants.push({ size, color });
+    return this;
+  }
+
+  build(): Product {
+    return { ...this.product };
+  }
+}
+```
+
+```typescript
+// tests/product-catalog.spec.ts
+import { test, expect } from '@playwright/test';
+import { ProductBuilder } from './builders/product.builder';
+
+test('displays out-of-stock badge for unavailable products', async ({ page, request }) => {
+  const product = new ProductBuilder()
+    .withName('Wireless Keyboard')
+    .withCategory('Accessories')
+    .outOfStock()
+    .build();
+
+  // Seed via API (see API Seeding pattern below)
+  await request.post('/api/products', { data: product });
+
+  await page.goto('/products');
+  const card = page.getByRole('listitem').filter({ hasText: product.name });
+  await expect(card.getByText('Out of Stock')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/builders/product.builder.js
+class ProductBuilder {
+  constructor() {
+    this.product = {
+      name: `Product-${Date.now()}`,
+      price: 29.99,
+      currency: 'USD',
+      category: 'Electronics',
+      description: 'A test product',
+      inStock: true,
+      tags: [],
+      variants: [],
+    };
+  }
+
+  withName(name) {
+    this.product.name = name;
+    return this;
+  }
+
+  withPrice(price, currency = 'USD') {
+    this.product.price = price;
+    this.product.currency = currency;
+    return this;
+  }
+
+  withCategory(category) {
+    this.product.category = category;
+    return this;
+  }
+
+  outOfStock() {
+    this.product.inStock = false;
+    return this;
+  }
+
+  withTags(...tags) {
+    this.product.tags = tags;
+    return this;
+  }
+
+  withVariant(size, color) {
+    this.product.variants.push({ size, color });
+    return this;
+  }
+
+  build() {
+    return { ...this.product };
+  }
+}
+
+module.exports = { ProductBuilder };
+```
+
+```javascript
+// tests/product-catalog.spec.js
+const { test, expect } = require('@playwright/test');
+const { ProductBuilder } = require('./builders/product.builder');
+
+test('displays out-of-stock badge for unavailable products', async ({ page, request }) => {
+  const product = new ProductBuilder()
+    .withName('Wireless Keyboard')
+    .withCategory('Accessories')
+    .outOfStock()
+    .build();
+
+  await request.post('/api/products', { data: product });
+
+  await page.goto('/products');
+  const card = page.getByRole('listitem').filter({ hasText: product.name });
+  await expect(card.getByText('Out of Stock')).toBeVisible();
+});
+```
+
+---
+
+### API Seeding
+
+**Use when**: Tests need entities to already exist (users, products, orders) and the app exposes APIs to create them. This is the default strategy for test data setup.
+
+**Avoid when**: No API exists for the entity, or the API itself is what you are testing (use the UI or database instead).
+
+API seeding is faster than UI-based setup, more maintainable than database seeding, and exercises real application logic. Prefer it over all other approaches when an API is available.
+
+**TypeScript**
+```typescript
+// tests/fixtures/api-data.fixture.ts
+import { test as base, APIRequestContext } from '@playwright/test';
+import { createUserData, UserData } from '../factories/user.factory';
+
+type ApiDataFixtures = {
+  apiUser: UserData & { id: string };
+};
+
+export const test = base.extend<ApiDataFixtures>({
+  apiUser: async ({ request }, use) => {
+    const userData = createUserData();
+
+    // Create
+    const response = await request.post('/api/users', { data: userData });
+    const created = await response.json();
+    const user = { ...userData, id: created.id };
+
+    // Provide to test
+    await use(user);
+
+    // Cleanup — runs even if test fails
+    await request.delete(`/api/users/${user.id}`);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/user-profile.spec.ts
+import { test, expect } from './fixtures/api-data.fixture';
+
+test('edits user profile name', async ({ page, apiUser }) => {
+  await page.goto(`/users/${apiUser.id}/profile`);
+  await page.getByLabel('First name').fill('Updated');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/fixtures/api-data.fixture.js
+const { test: base } = require('@playwright/test');
+const { createUserData } = require('../factories/user.factory');
+
+const test = base.extend({
+  apiUser: async ({ request }, use) => {
+    const userData = createUserData();
+
+    const response = await request.post('/api/users', { data: userData });
+    const created = await response.json();
+    const user = { ...userData, id: created.id };
+
+    await use(user);
+
+    await request.delete(`/api/users/${user.id}`);
+  },
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+```javascript
+// tests/user-profile.spec.js
+const { test, expect } = require('./fixtures/api-data.fixture');
+
+test('edits user profile name', async ({ page, apiUser }) => {
+  await page.goto(`/users/${apiUser.id}/profile`);
+  await page.getByLabel('First name').fill('Updated');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Profile updated')).toBeVisible();
+});
+```
+
+For multi-entity seeding, compose fixtures:
+
+**TypeScript**
+```typescript
+// tests/fixtures/order-data.fixture.ts
+import { test as base } from './api-data.fixture';
+
+export const test = base.extend({
+  apiOrder: async ({ request, apiUser }, use) => {
+    const orderResponse = await request.post('/api/orders', {
+      data: { userId: apiUser.id, items: [{ sku: 'WIDGET-001', qty: 2 }] },
+    });
+    const order = await orderResponse.json();
+
+    await use(order);
+
+    await request.delete(`/api/orders/${order.id}`);
+  },
+});
+```
+
+---
+
+### Database Seeding
+
+**Use when**: No API exists for the data you need, you need bulk data, or you need to set up complex relational state that is cumbersome via API calls.
+
+**Avoid when**: An API exists — API seeding is more maintainable and exercises real application logic. Database seeding couples tests to schema details.
+
+**TypeScript**
+```typescript
+// tests/fixtures/db.fixture.ts
+import { test as base } from '@playwright/test';
+import { Pool } from 'pg';
+
+type DbFixtures = {
+  db: Pool;
+  seededOrg: { id: string; name: string };
+};
+
+export const test = base.extend<DbFixtures>({
+  db: async ({}, use) => {
+    const pool = new Pool({
+      connectionString: process.env.TEST_DATABASE_URL,
+    });
+    await use(pool);
+    await pool.end();
+  },
+
+  seededOrg: async ({ db }, use) => {
+    const orgName = `TestOrg-${Date.now()}`;
+    const result = await db.query(
+      'INSERT INTO organizations (name, plan) VALUES ($1, $2) RETURNING id',
+      [orgName, 'enterprise']
+    );
+    const orgId = result.rows[0].id;
+
+    await use({ id: orgId, name: orgName });
+
+    // Cascade delete cleans up related data
+    await db.query('DELETE FROM organizations WHERE id = $1', [orgId]);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+**JavaScript**
+```javascript
+// tests/fixtures/db.fixture.js
+const { test: base } = require('@playwright/test');
+const { Pool } = require('pg');
+
+const test = base.extend({
+  db: async ({}, use) => {
+    const pool = new Pool({
+      connectionString: process.env.TEST_DATABASE_URL,
+    });
+    await use(pool);
+    await pool.end();
+  },
+
+  seededOrg: async ({ db }, use) => {
+    const orgName = `TestOrg-${Date.now()}`;
+    const result = await db.query(
+      'INSERT INTO organizations (name, plan) VALUES ($1, $2) RETURNING id',
+      [orgName, 'enterprise']
+    );
+    const orgId = result.rows[0].id;
+
+    await use({ id: orgId, name: orgName });
+
+    await db.query('DELETE FROM organizations WHERE id = $1', [orgId]);
+  },
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+Always use parameterized queries (`$1`, `$2`) to prevent SQL injection — even in tests. It is a good habit and prevents breakage from special characters in generated data.
+
+---
+
+### Storage State
+
+**Use when**: Multiple tests need an authenticated session and you want to avoid logging in via the UI in every test.
+
+**Avoid when**: The test is specifically testing the login flow itself.
+
+Generate storage state once in a setup project, then reuse it across all tests that need authentication.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'auth-setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'authenticated-tests',
+      dependencies: ['auth-setup'],
+      use: {
+        storageState: '.auth/user.json',
+      },
+    },
+  ],
+});
+```
+
+```typescript
+// tests/auth.setup.ts
+import { test as setup, expect } from '@playwright/test';
+import path from 'node:path';
+
+const authFile = path.join(__dirname, '..', '.auth', 'user.json');
+
+setup('authenticate as standard user', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.context().storageState({ path: authFile });
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    {
+      name: 'auth-setup',
+      testMatch: /auth\.setup\.js/,
+    },
+    {
+      name: 'authenticated-tests',
+      dependencies: ['auth-setup'],
+      use: {
+        storageState: '.auth/user.json',
+      },
+    },
+  ],
+});
+```
+
+```javascript
+// tests/auth.setup.js
+const { test: setup, expect } = require('@playwright/test');
+const path = require('node:path');
+
+const authFile = path.join(__dirname, '..', '.auth', 'user.json');
+
+setup('authenticate as standard user', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  await page.context().storageState({ path: authFile });
+});
+```
+
+For multiple roles, create separate setup files and storage state files:
+
+```typescript
+// tests/admin-auth.setup.ts
+import { test as setup } from '@playwright/test';
+import path from 'node:path';
+
+const adminAuthFile = path.join(__dirname, '..', '.auth', 'admin.json');
+
+setup('authenticate as admin', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(process.env.ADMIN_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.ADMIN_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.context().storageState({ path: adminAuthFile });
+});
+```
+
+Add `.auth/` to `.gitignore` — storage state files contain session tokens.
+
+---
+
+### Test Data Cleanup
+
+**Use when**: Always. Every test that creates data must clean it up.
+
+**Avoid when**: Never. Skipping cleanup causes cascading failures in subsequent runs.
+
+**Strategy 1: Fixture teardown (preferred)**
+
+Put cleanup in the fixture's teardown block. Runs even if the test throws.
+
+```typescript
+// Already shown in API Seeding — the cleanup runs after `use()`
+apiUser: async ({ request }, use) => {
+  const user = await createViaApi(request);
+  await use(user);
+  // This ALWAYS runs — even on test failure
+  await request.delete(`/api/users/${user.id}`);
+},
+```
+
+**Strategy 2: Batch cleanup by timestamp prefix**
+
+Tag all test-created data with a recognizable prefix, then sweep it in global teardown.
+
+**TypeScript**
+```typescript
+// global-teardown.ts
+import { request } from '@playwright/test';
+
+export default async function globalTeardown() {
+  const context = await request.newContext({
+    baseURL: process.env.BASE_URL,
+  });
+
+  // Delete all test entities created in this run
+  // Assumes entities created with the "test-" prefix
+  const response = await context.delete('/api/test-data/cleanup', {
+    data: { prefix: 'test-', olderThanMinutes: 60 },
+  });
+
+  if (!response.ok()) {
+    console.warn(`Cleanup returned ${response.status()}`);
+  }
+
+  await context.dispose();
+}
+```
+
+**JavaScript**
+```javascript
+// global-teardown.js
+const { request } = require('@playwright/test');
+
+module.exports = async function globalTeardown() {
+  const context = await request.newContext({
+    baseURL: process.env.BASE_URL,
+  });
+
+  const response = await context.delete('/api/test-data/cleanup', {
+    data: { prefix: 'test-', olderThanMinutes: 60 },
+  });
+
+  if (!response.ok()) {
+    console.warn(`Cleanup returned ${response.status()}`);
+  }
+
+  await context.dispose();
+};
+```
+
+**Strategy 3: Isolated tenant per worker**
+
+Each Playwright worker gets its own tenant/organization. All data is scoped to that tenant. Teardown deletes the entire tenant.
+
+```typescript
+// tests/fixtures/tenant.fixture.ts
+import { test as base } from '@playwright/test';
+
+export const test = base.extend<{}, { workerTenant: { id: string; apiKey: string } }>({
+  workerTenant: [async ({ request }, use) => {
+    const res = await request.post('/api/tenants', {
+      data: { name: `test-worker-${Date.now()}` },
+    });
+    const tenant = await res.json();
+
+    await use(tenant);
+
+    await request.delete(`/api/tenants/${tenant.id}`);
+  }, { scope: 'worker' }],
+});
+```
+
+---
+
+### Environment-Specific Data
+
+**Use when**: Tests run against multiple environments (dev, staging, production-mirror) with different base URLs, credentials, or data constraints.
+
+**Avoid when**: You only have one test environment.
+
+Never hardcode environment-specific values in test files. Use `.env` files and `playwright.config` to inject them.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'node:path';
+
+// Load environment-specific .env file
+const envFile = process.env.TEST_ENV || 'local';
+dotenv.config({ path: path.resolve(__dirname, `.env.${envFile}`) });
+
+export default defineConfig({
+  use: {
+    baseURL: process.env.BASE_URL,
+  },
+});
+```
+
+```
+# .env.local
+BASE_URL=http://localhost:3000
+TEST_USER_EMAIL=testuser@localhost.test
+TEST_USER_PASSWORD=localpassword123
+
+# .env.staging
+BASE_URL=https://staging.example.com
+TEST_USER_EMAIL=e2e-bot@staging.example.com
+TEST_USER_PASSWORD=staging-secret-from-vault
+```
+
+```typescript
+// tests/fixtures/env-data.fixture.ts
+import { test as base } from '@playwright/test';
+
+type EnvConfig = {
+  testCredentials: { email: string; password: string };
+};
+
+export const test = base.extend<EnvConfig>({
+  testCredentials: async ({}, use) => {
+    const email = process.env.TEST_USER_EMAIL;
+    const password = process.env.TEST_USER_PASSWORD;
+    if (!email || !password) {
+      throw new Error('TEST_USER_EMAIL and TEST_USER_PASSWORD must be set');
+    }
+    await use({ email, password });
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+const dotenv = require('dotenv');
+const path = require('node:path');
+
+const envFile = process.env.TEST_ENV || 'local';
+dotenv.config({ path: path.resolve(__dirname, `.env.${envFile}`) });
+
+module.exports = defineConfig({
+  use: {
+    baseURL: process.env.BASE_URL,
+  },
+});
+```
+
+Run against a specific environment:
+
+```bash
+TEST_ENV=staging npx playwright test
+```
+
+---
+
+### Fixtures for Test Data
+
+**Use when**: Test data setup and teardown should be encapsulated, reusable, and guaranteed to clean up. This is the recommended pattern for all non-trivial test data.
+
+**Avoid when**: The data is a simple inline value that does not require cleanup.
+
+Fixtures are the backbone of reliable test data management in Playwright. They compose, they guarantee teardown, and they make tests declarative.
+
+**TypeScript**
+```typescript
+// tests/fixtures/index.ts
+import { test as base, expect } from '@playwright/test';
+import { createUserData, UserData } from '../factories/user.factory';
+
+type TestFixtures = {
+  seedUser: UserData & { id: string };
+  seedProduct: { id: string; name: string; price: number };
+};
+
+export const test = base.extend<TestFixtures>({
+  seedUser: async ({ request }, use) => {
+    const data = createUserData();
+    const res = await request.post('/api/users', { data });
+    expect(res.ok()).toBeTruthy();
+    const user = { ...data, id: (await res.json()).id };
+
+    await use(user);
+
+    await request.delete(`/api/users/${user.id}`);
+  },
+
+  seedProduct: async ({ request }, use) => {
+    const data = {
+      name: `Product-${Date.now()}`,
+      price: 49.99,
+      category: 'Testing',
+    };
+    const res = await request.post('/api/products', { data });
+    expect(res.ok()).toBeTruthy();
+    const product = { ...data, id: (await res.json()).id };
+
+    await use(product);
+
+    await request.delete(`/api/products/${product.id}`);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// tests/shopping-cart.spec.ts
+import { test, expect } from './fixtures';
+
+test('adds product to cart', async ({ page, seedUser, seedProduct }) => {
+  // seedUser and seedProduct are already created and will be cleaned up automatically
+  await page.goto(`/products/${seedProduct.id}`);
+  await page.getByRole('button', { name: 'Add to cart' }).click();
+
+  await page.goto('/cart');
+  await expect(page.getByText(seedProduct.name)).toBeVisible();
+  await expect(page.getByText('$49.99')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/fixtures/index.js
+const { test: base, expect } = require('@playwright/test');
+const { createUserData } = require('../factories/user.factory');
+
+const test = base.extend({
+  seedUser: async ({ request }, use) => {
+    const data = createUserData();
+    const res = await request.post('/api/users', { data });
+    expect(res.ok()).toBeTruthy();
+    const user = { ...data, id: (await res.json()).id };
+
+    await use(user);
+
+    await request.delete(`/api/users/${user.id}`);
+  },
+
+  seedProduct: async ({ request }, use) => {
+    const data = {
+      name: `Product-${Date.now()}`,
+      price: 49.99,
+      category: 'Testing',
+    };
+    const res = await request.post('/api/products', { data });
+    expect(res.ok()).toBeTruthy();
+    const product = { ...data, id: (await res.json()).id };
+
+    await use(product);
+
+    await request.delete(`/api/products/${product.id}`);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+```javascript
+// tests/shopping-cart.spec.js
+const { test, expect } = require('./fixtures');
+
+test('adds product to cart', async ({ page, seedUser, seedProduct }) => {
+  await page.goto(`/products/${seedProduct.id}`);
+  await page.getByRole('button', { name: 'Add to cart' }).click();
+
+  await page.goto('/cart');
+  await expect(page.getByText(seedProduct.name)).toBeVisible();
+  await expect(page.getByText('$49.99')).toBeVisible();
+});
+```
+
+Fixtures only run when a test requests them by name. If a test does not use `seedProduct`, the product is never created — no wasted setup, no unnecessary cleanup.
+
+## Decision Guide
+
+```
+What data does your test need?
+│
+├── Simple values (strings, numbers for form fields)?
+│   └── Use INLINE DATA — keep it in the test
+│
+├── Same shape used across many tests?
+│   ├── < 5 fields? → Use a FACTORY FUNCTION
+│   └── >= 5 fields with optional/conditional fields? → Use a BUILDER
+│
+├── Need realistic-looking data (names, addresses)?
+│   └── Use FAKER with a fixed seed
+│
+├── Entities that must exist before the test starts?
+│   ├── App has an API for this entity?
+│   │   └── Use API SEEDING in a fixture (preferred)
+│   ├── No API, but have database access?
+│   │   └── Use DATABASE SEEDING in a fixture
+│   └── No API, no DB access?
+│       └── Use UI setup in a beforeEach (slowest — avoid if possible)
+│
+├── Need an authenticated session?
+│   └── Use STORAGE STATE via setup project
+│
+└── Need data isolated per worker?
+    └── Use WORKER-SCOPED FIXTURES with tenant isolation
+```
+
+### Speed ranking (fastest to slowest)
+
+1. Inline data / factories / faker — no I/O, instant
+2. API seeding — one HTTP call per entity
+3. Database seeding — direct DB call, skips app logic
+4. Storage state — one-time login, reused across tests
+5. UI-based setup — full browser interaction per test (avoid)
+
+### Isolation ranking (most to least isolated)
+
+1. Test-scoped fixtures with API teardown — each test gets fresh data, cleaned up after
+2. Worker-scoped tenant isolation — tests in a worker share a tenant, cleaned up when worker exits
+3. Timestamp-prefixed batch cleanup — catches orphaned data, runs in global teardown
+4. Shared database state — fragile, prone to ordering bugs (avoid)
+
+## Anti-Patterns
+
+### Shared mutable data across tests
+
+```typescript
+// BAD — tests share the same user object and depend on execution order
+let sharedUser: UserData;
+
+test.beforeAll(async ({ request }) => {
+  sharedUser = await createUser(request);
+});
+
+test('updates user name', async ({ page }) => {
+  // Mutates sharedUser — other tests see the changed state
+});
+
+test('checks original name', async ({ page }) => {
+  // Fails because the previous test changed the name
+});
+```
+
+Fix: Use test-scoped fixtures. Each test gets its own instance.
+
+### Hardcoded IDs
+
+```typescript
+// BAD — this ID only exists in your local database
+test('edits product', async ({ page }) => {
+  await page.goto('/products/507f1f77bcf86cd799439011/edit');
+});
+```
+
+Fix: Create the product in a fixture and use the returned ID.
+
+### No cleanup
+
+```typescript
+// BAD — creates data but never deletes it
+test.beforeEach(async ({ request }) => {
+  await request.post('/api/products', { data: { name: 'Leaked Product' } });
+});
+// Over time, the database fills with test debris causing slowdowns and false positives
+```
+
+Fix: Always pair creation with deletion in a fixture teardown.
+
+### Relying on pre-existing database state
+
+```typescript
+// BAD — assumes "Premium Plan" already exists in the database
+test('subscribes to premium', async ({ page }) => {
+  await page.goto('/pricing');
+  await page.getByRole('button', { name: 'Premium Plan' }).click();
+  // Breaks on a fresh database or different environment
+});
+```
+
+Fix: Seed the plan via API or database fixture before the test.
+
+### Using production data in tests
+
+```typescript
+// BAD — tests against real customer data
+test('views customer orders', async ({ page }) => {
+  await page.goto('/admin/customers/real-customer-id/orders');
+});
+```
+
+Fix: Create synthetic test data. Never point test suites at production databases or use real customer identifiers.
+
+### Over-engineering data setup
+
+```typescript
+// BAD — abstraction for its own sake
+const data = new TestDataOrchestrator()
+  .withStrategy('api')
+  .withRetry(3)
+  .withCleanupPolicy('deferred')
+  .withEnvironment('staging')
+  .build();
+```
+
+Fix: A factory function and a fixture cover 95% of cases. Add complexity only when you have a proven need.
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| Tests fail with "duplicate key" errors | Data from previous runs was not cleaned up | Add fixture teardown; run batch cleanup in `globalTeardown` |
+| Tests pass alone but fail in parallel | Tests share mutable state or collide on unique fields | Use `Date.now()` or `crypto.randomUUID()` in factory output; use test-scoped fixtures |
+| Faker produces different data on retry | Faker was not seeded, or seed changes between runs | Seed with `testInfo.workerIndex` or a fixed value |
+| Storage state expired / session invalid | Auth tokens have a short TTL | Re-run auth setup before each suite; set `fullyParallel: false` on auth-dependent project if needed |
+| Cleanup fails and blocks other tests | Teardown makes network calls that can timeout | Wrap cleanup in `try/catch`; log failures but do not throw; rely on batch cleanup as a safety net |
+| Database seeding is slow | Too many individual INSERT statements | Batch inserts; use transactions; consider API seeding instead |
+| Tests break when run against staging | Hardcoded values that only exist locally | Use environment variables for all environment-specific data; validate in fixture with clear error messages |
+
+### Making cleanup resilient
+
+```typescript
+// Wrap fixture teardown in try/catch so a cleanup failure does not mask the real test failure
+seedUser: async ({ request }, use) => {
+  const user = await createViaApi(request);
+  await use(user);
+
+  try {
+    await request.delete(`/api/users/${user.id}`);
+  } catch (error) {
+    console.warn(`Failed to clean up user ${user.id}:`, error);
+  }
+},
+```
+
+## Related
+
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) — fixture mechanics, scoping, composition
+- [core/authentication.md](authentication.md) — storage state setup, multi-role auth patterns
+- [core/api-testing.md](api-testing.md) — API request context, response validation
+- [ci/global-setup-teardown.md](../ci/global-setup-teardown.md) — global setup/teardown for batch operations
+- [pom/pom-vs-fixtures-vs-helpers.md](../pom/pom-vs-fixtures-vs-helpers.md) — when to use fixtures vs page objects vs helpers

--- a/engineering-team/playwright skill/core/test-organization.md
+++ b/engineering-team/playwright skill/core/test-organization.md
@@ -1,0 +1,946 @@
+# Test Organization
+
+> **When to use**: Structuring test files, naming tests, grouping with `describe`, tagging, filtering, and deciding parallel vs serial execution.
+> **Prerequisites**: [core/configuration.md](foundations/configuration.md)
+
+## Quick Reference
+
+| Concept | Rule |
+|---|---|
+| File suffix | `.spec.ts` / `.spec.js` — always |
+| Grouping | By feature/domain, not by page or URL |
+| Test names | `test('should ...')` or `test('user can ...')` — describe behavior |
+| Nesting | Max 2 levels of `test.describe()` |
+| Default execution | `fullyParallel: true` — tests run in parallel by default |
+| Serial tests | Almost never use `test.describe.serial()` |
+| Test dependencies | Avoid — each test sets up its own state |
+| Tags | `@smoke`, `@regression`, `@slow` — filter with `--grep` |
+
+## Patterns
+
+### Pattern 1: Feature-Based File Structure
+
+**Use when**: Any project — this is the default layout.
+**Avoid when**: Never. This is always correct.
+
+Group tests by feature or domain, not by page class or test type.
+
+**Small project (< 20 tests):**
+
+```
+tests/
+├── auth.spec.ts
+├── dashboard.spec.ts
+├── settings.spec.ts
+└── checkout.spec.ts
+playwright.config.ts
+```
+
+**Medium project (20–200 tests):**
+
+```
+tests/
+├── auth/
+│   ├── login.spec.ts
+│   ├── signup.spec.ts
+│   ├── password-reset.spec.ts
+│   └── mfa.spec.ts
+├── dashboard/
+│   ├── widgets.spec.ts
+│   ├── filters.spec.ts
+│   └── export.spec.ts
+├── checkout/
+│   ├── cart.spec.ts
+│   ├── payment.spec.ts
+│   └── confirmation.spec.ts
+├── settings/
+│   ├── profile.spec.ts
+│   └── notifications.spec.ts
+└── fixtures/
+    ├── auth.fixture.ts
+    └── test-data.ts
+playwright.config.ts
+```
+
+**Large project (200+ tests):**
+
+```
+tests/
+├── e2e/
+│   ├── auth/
+│   │   ├── login.spec.ts
+│   │   ├── signup.spec.ts
+│   │   ├── password-reset.spec.ts
+│   │   └── mfa.spec.ts
+│   ├── checkout/
+│   │   ├── cart.spec.ts
+│   │   ├── payment.spec.ts
+│   │   ├── promo-codes.spec.ts
+│   │   └── confirmation.spec.ts
+│   ├── admin/
+│   │   ├── user-management.spec.ts
+│   │   ├── reports.spec.ts
+│   │   └── audit-log.spec.ts
+│   └── inventory/
+│       ├── product-list.spec.ts
+│       ├── product-detail.spec.ts
+│       └── stock-management.spec.ts
+├── api/
+│   ├── users.spec.ts
+│   ├── orders.spec.ts
+│   └── products.spec.ts
+├── visual/
+│   ├── homepage.spec.ts
+│   └── product-page.spec.ts
+├── fixtures/
+│   ├── auth.fixture.ts
+│   ├── db.fixture.ts
+│   └── base.fixture.ts
+├── page-objects/
+│   ├── login.page.ts
+│   ├── dashboard.page.ts
+│   └── checkout.page.ts
+└── helpers/
+    ├── test-data.ts
+    └── api-client.ts
+playwright.config.ts
+```
+
+---
+
+### Pattern 2: Naming Conventions
+
+**Use when**: Writing any test or file.
+**Avoid when**: Never.
+
+**TypeScript:**
+
+```typescript
+// tests/checkout/cart.spec.ts
+import { test, expect } from '@playwright/test';
+
+// Good: group by feature, describe behavior
+test.describe('Shopping Cart', () => {
+  test('should add item to empty cart', async ({ page }) => {
+    await page.goto('/products/widget-a');
+    await page.getByRole('button', { name: 'Add to cart' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+
+  test('should update quantity when same item added twice', async ({ page }) => {
+    await page.goto('/products/widget-a');
+    await page.getByRole('button', { name: 'Add to cart' }).click();
+    await page.getByRole('button', { name: 'Add to cart' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('2');
+  });
+
+  test('user can remove item from cart', async ({ page }) => {
+    await page.goto('/cart');
+    // ... setup item in cart via API or fixture
+    await page.getByRole('button', { name: 'Remove' }).first().click();
+    await expect(page.getByText('Your cart is empty')).toBeVisible();
+  });
+});
+```
+
+**JavaScript:**
+
+```javascript
+// tests/checkout/cart.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe('Shopping Cart', () => {
+  test('should add item to empty cart', async ({ page }) => {
+    await page.goto('/products/widget-a');
+    await page.getByRole('button', { name: 'Add to cart' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+
+  test('should update quantity when same item added twice', async ({ page }) => {
+    await page.goto('/products/widget-a');
+    await page.getByRole('button', { name: 'Add to cart' }).click();
+    await page.getByRole('button', { name: 'Add to cart' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('2');
+  });
+
+  test('user can remove item from cart', async ({ page }) => {
+    await page.goto('/cart');
+    await page.getByRole('button', { name: 'Remove' }).first().click();
+    await expect(page.getByText('Your cart is empty')).toBeVisible();
+  });
+});
+```
+
+**Naming rules:**
+
+| Element | Convention | Example |
+|---|---|---|
+| File name | `kebab-case.spec.ts` | `password-reset.spec.ts` |
+| `test.describe()` | Title Case, feature name | `'Password Reset'` |
+| `test()` | Sentence starting with `should` or `user can` | `'should send reset email'` |
+| Page objects | `PascalCase.page.ts` | `login.page.ts` / `LoginPage` |
+| Fixtures | `kebab-case.fixture.ts` | `auth.fixture.ts` |
+
+---
+
+### Pattern 3: `test.describe()` Grouping
+
+**Use when**: A file has multiple related tests that share context or setup.
+**Avoid when**: A file has only 1–3 tests with no shared setup — skip the `describe` wrapper.
+
+**TypeScript:**
+
+```typescript
+// tests/auth/login.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Login', () => {
+  // Shared setup for all tests in this describe block
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+  });
+
+  test('should login with valid credentials', async ({ page }) => {
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('securepass123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page).toHaveURL('/dashboard');
+  });
+
+  test('should show error for invalid password', async ({ page }) => {
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('wrongpassword');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page.getByRole('alert')).toHaveText('Invalid credentials');
+  });
+
+  // One level of nesting — acceptable
+  test.describe('Rate Limiting', () => {
+    test('should lock account after 5 failed attempts', async ({ page }) => {
+      for (let i = 0; i < 5; i++) {
+        await page.getByLabel('Email').fill('user@example.com');
+        await page.getByLabel('Password').fill('wrong');
+        await page.getByRole('button', { name: 'Sign in' }).click();
+      }
+      await expect(page.getByRole('alert')).toContainText('Account locked');
+    });
+  });
+});
+```
+
+**JavaScript:**
+
+```javascript
+// tests/auth/login.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe('Login', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+  });
+
+  test('should login with valid credentials', async ({ page }) => {
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('securepass123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page).toHaveURL('/dashboard');
+  });
+
+  test('should show error for invalid password', async ({ page }) => {
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('wrongpassword');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page.getByRole('alert')).toHaveText('Invalid credentials');
+  });
+
+  test.describe('Rate Limiting', () => {
+    test('should lock account after 5 failed attempts', async ({ page }) => {
+      for (let i = 0; i < 5; i++) {
+        await page.getByLabel('Email').fill('user@example.com');
+        await page.getByLabel('Password').fill('wrong');
+        await page.getByRole('button', { name: 'Sign in' }).click();
+      }
+      await expect(page.getByRole('alert')).toContainText('Account locked');
+    });
+  });
+});
+```
+
+**Nesting limit: 2 levels max.** If you need a third level, split into a separate file.
+
+---
+
+### Pattern 4: Tags and Annotations
+
+**Use when**: You need to categorize tests for selective runs (smoke suites, CI pipelines, skip known issues).
+**Avoid when**: All tests always run together and you have < 20 tests.
+
+**TypeScript:**
+
+```typescript
+// tests/checkout/payment.spec.ts
+import { test, expect } from '@playwright/test';
+
+// Tag in the test title — simplest approach
+test('should process credit card payment @smoke', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Card number').fill('4242424242424242');
+  await page.getByLabel('Expiry').fill('12/28');
+  await page.getByLabel('CVC').fill('123');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('should handle declined card @regression', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Card number').fill('4000000000000002');
+  await page.getByLabel('Expiry').fill('12/28');
+  await page.getByLabel('CVC').fill('123');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+  await expect(page.getByRole('alert')).toContainText('Card declined');
+});
+
+// Tag via test.describe for group-level tagging
+test.describe('Payment Edge Cases @regression', () => {
+  test('should handle network timeout during payment', async ({ page }) => {
+    await page.goto('/checkout');
+    // ... test implementation
+    await expect(page.getByText('Please try again')).toBeVisible();
+  });
+});
+
+// Annotations for test lifecycle control
+test('should render 3D Secure iframe @slow', async ({ page }) => {
+  test.slow(); // Triples the default timeout
+  await page.goto('/checkout/3ds');
+  // ... long-running 3D Secure flow
+  await expect(page.getByText('Verified')).toBeVisible();
+});
+
+test('should apply loyalty points discount', async ({ page }) => {
+  test.skip(process.env.CI !== 'true', 'Only run in CI — needs loyalty service');
+  await page.goto('/checkout');
+  // ...
+});
+
+test('should handle Apple Pay on Safari', async ({ page, browserName }) => {
+  test.skip(browserName !== 'webkit', 'Apple Pay only works in Safari');
+  await page.goto('/checkout');
+  // ...
+});
+
+test('should display PayPal button', async ({ page }) => {
+  test.fixme(); // Known broken — tracked in JIRA-1234
+  await page.goto('/checkout');
+  await expect(page.getByRole('button', { name: 'PayPal' })).toBeVisible();
+});
+
+test('should fail when submitting empty card form', async ({ page }) => {
+  test.fail(); // This test is expected to fail — documents known bug
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+  // Bug: currently no validation shown — this assertion will fail
+  await expect(page.getByRole('alert')).toBeVisible();
+});
+```
+
+**JavaScript:**
+
+```javascript
+// tests/checkout/payment.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('should process credit card payment @smoke', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Card number').fill('4242424242424242');
+  await page.getByLabel('Expiry').fill('12/28');
+  await page.getByLabel('CVC').fill('123');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('should handle declined card @regression', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Card number').fill('4000000000000002');
+  await page.getByLabel('Expiry').fill('12/28');
+  await page.getByLabel('CVC').fill('123');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+  await expect(page.getByRole('alert')).toContainText('Card declined');
+});
+
+test.describe('Payment Edge Cases @regression', () => {
+  test('should handle network timeout during payment', async ({ page }) => {
+    await page.goto('/checkout');
+    await expect(page.getByText('Please try again')).toBeVisible();
+  });
+});
+
+test('should render 3D Secure iframe @slow', async ({ page }) => {
+  test.slow();
+  await page.goto('/checkout/3ds');
+  await expect(page.getByText('Verified')).toBeVisible();
+});
+
+test('should apply loyalty points discount', async ({ page }) => {
+  test.skip(process.env.CI !== 'true', 'Only run in CI — needs loyalty service');
+  await page.goto('/checkout');
+});
+
+test('should handle Apple Pay on Safari', async ({ page, browserName }) => {
+  test.skip(browserName !== 'webkit', 'Apple Pay only works in Safari');
+  await page.goto('/checkout');
+});
+
+test('should display PayPal button', async ({ page }) => {
+  test.fixme(); // Known broken — tracked in JIRA-1234
+  await page.goto('/checkout');
+  await expect(page.getByRole('button', { name: 'PayPal' })).toBeVisible();
+});
+
+test('should fail when submitting empty card form', async ({ page }) => {
+  test.fail();
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay now' }).click();
+  await expect(page.getByRole('alert')).toBeVisible();
+});
+```
+
+**Annotation cheat sheet:**
+
+| Annotation | Effect | When to use |
+|---|---|---|
+| `test.skip()` | Skips the test entirely | Feature not available in this env/browser |
+| `test.skip(condition, reason)` | Conditional skip | Browser-specific or env-specific tests |
+| `test.fixme()` | Skips and marks as "needs fix" | Known bug, not yet fixed |
+| `test.slow()` | Triples the timeout | Tests with inherently slow workflows |
+| `test.fail()` | Expects the test to fail; fails if it passes | Documenting a known bug with a regression guard |
+| `test.info().annotations` | Add custom annotations | Custom metadata for reports |
+
+---
+
+### Pattern 5: Test Filtering
+
+**Use when**: Running a subset of tests from the CLI or CI.
+**Avoid when**: Never — know these commands.
+
+```bash
+# By tag (in test title)
+npx playwright test --grep @smoke
+npx playwright test --grep @regression
+npx playwright test --grep-invert @slow     # everything except @slow
+
+# By file
+npx playwright test tests/auth/
+npx playwright test tests/checkout/payment.spec.ts
+
+# By test name
+npx playwright test --grep "should login"
+
+# By project (from playwright.config)
+npx playwright test --project=chromium
+npx playwright test --project=mobile-safari
+
+# Combine filters
+npx playwright test --grep @smoke --project=chromium
+npx playwright test tests/checkout/ --grep @smoke
+
+# By line number — run a single test
+npx playwright test tests/auth/login.spec.ts:15
+```
+
+**Using tags with `test.describe.configure()`:**
+
+**TypeScript:**
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'smoke',
+      testMatch: '**/*.spec.ts',
+      grep: /@smoke/,
+    },
+    {
+      name: 'regression',
+      testMatch: '**/*.spec.ts',
+      grep: /@regression/,
+    },
+    {
+      name: 'all',
+      testMatch: '**/*.spec.ts',
+      grepInvert: /@slow/,
+    },
+  ],
+});
+```
+
+**JavaScript:**
+
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    {
+      name: 'smoke',
+      testMatch: '**/*.spec.js',
+      grep: /@smoke/,
+    },
+    {
+      name: 'regression',
+      testMatch: '**/*.spec.js',
+      grep: /@regression/,
+    },
+    {
+      name: 'all',
+      testMatch: '**/*.spec.js',
+      grepInvert: /@slow/,
+    },
+  ],
+});
+```
+
+---
+
+### Pattern 6: Parallel vs Serial Execution
+
+**Use when**: Deciding how tests run relative to each other.
+**Avoid when**: You have < 5 tests (parallelism doesn't matter).
+
+**Default: always parallel.** Set `fullyParallel: true` in config.
+
+**TypeScript:**
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  fullyParallel: true, // All tests run in parallel by default
+  workers: process.env.CI ? 1 : undefined, // Use all cores locally, 1 in CI (or adjust)
+});
+```
+
+**JavaScript:**
+
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  fullyParallel: true,
+  workers: process.env.CI ? 1 : undefined,
+});
+```
+
+**Serial execution — use only when tests share external state you cannot isolate:**
+
+**TypeScript:**
+
+```typescript
+// tests/onboarding/wizard.spec.ts
+import { test, expect } from '@playwright/test';
+
+// ONLY use serial when steps truly depend on prior state that cannot be set up independently
+test.describe.serial('Onboarding Wizard', () => {
+  test('step 1: user enters company name', async ({ page }) => {
+    await page.goto('/onboarding');
+    await page.getByLabel('Company name').fill('Acme Corp');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-2');
+  });
+
+  test('step 2: user selects plan', async ({ page }) => {
+    await page.goto('/onboarding/step-2');
+    await page.getByRole('radio', { name: 'Pro plan' }).check();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-3');
+  });
+
+  test('step 3: user confirms and completes', async ({ page }) => {
+    await page.goto('/onboarding/step-3');
+    await page.getByRole('button', { name: 'Complete setup' }).click();
+    await expect(page.getByText('Welcome to Acme Corp')).toBeVisible();
+  });
+});
+```
+
+**JavaScript:**
+
+```javascript
+// tests/onboarding/wizard.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe.serial('Onboarding Wizard', () => {
+  test('step 1: user enters company name', async ({ page }) => {
+    await page.goto('/onboarding');
+    await page.getByLabel('Company name').fill('Acme Corp');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-2');
+  });
+
+  test('step 2: user selects plan', async ({ page }) => {
+    await page.goto('/onboarding/step-2');
+    await page.getByRole('radio', { name: 'Pro plan' }).check();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-3');
+  });
+
+  test('step 3: user confirms and completes', async ({ page }) => {
+    await page.goto('/onboarding/step-3');
+    await page.getByRole('button', { name: 'Complete setup' }).click();
+    await expect(page.getByText('Welcome to Acme Corp')).toBeVisible();
+  });
+});
+```
+
+**Better alternative: test the full flow in one test with `test.step()`:**
+
+**TypeScript:**
+
+```typescript
+// tests/onboarding/wizard.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('user completes full onboarding wizard', async ({ page }) => {
+  await test.step('enter company name', async () => {
+    await page.goto('/onboarding');
+    await page.getByLabel('Company name').fill('Acme Corp');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-2');
+  });
+
+  await test.step('select plan', async () => {
+    await page.getByRole('radio', { name: 'Pro plan' }).check();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-3');
+  });
+
+  await test.step('confirm and complete', async () => {
+    await page.getByRole('button', { name: 'Complete setup' }).click();
+    await expect(page.getByText('Welcome to Acme Corp')).toBeVisible();
+  });
+});
+```
+
+**JavaScript:**
+
+```javascript
+// tests/onboarding/wizard.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('user completes full onboarding wizard', async ({ page }) => {
+  await test.step('enter company name', async () => {
+    await page.goto('/onboarding');
+    await page.getByLabel('Company name').fill('Acme Corp');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-2');
+  });
+
+  await test.step('select plan', async () => {
+    await page.getByRole('radio', { name: 'Pro plan' }).check();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/onboarding/step-3');
+  });
+
+  await test.step('confirm and complete', async () => {
+    await page.getByRole('button', { name: 'Complete setup' }).click();
+    await expect(page.getByText('Welcome to Acme Corp')).toBeVisible();
+  });
+});
+```
+
+---
+
+### Pattern 7: Monorepo Testing
+
+**Use when**: A single repository contains multiple apps or packages that each need E2E tests.
+**Avoid when**: Single app repo.
+
+**TypeScript:**
+
+```typescript
+// playwright.config.ts (root of monorepo)
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'web-app',
+      testDir: './apps/web/tests',
+      use: {
+        baseURL: 'http://localhost:3000',
+      },
+    },
+    {
+      name: 'admin-panel',
+      testDir: './apps/admin/tests',
+      use: {
+        baseURL: 'http://localhost:3001',
+      },
+    },
+    {
+      name: 'marketing-site',
+      testDir: './apps/marketing/tests',
+      use: {
+        baseURL: 'http://localhost:4000',
+      },
+    },
+  ],
+});
+```
+
+**JavaScript:**
+
+```javascript
+// playwright.config.js (root of monorepo)
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    {
+      name: 'web-app',
+      testDir: './apps/web/tests',
+      use: {
+        baseURL: 'http://localhost:3000',
+      },
+    },
+    {
+      name: 'admin-panel',
+      testDir: './apps/admin/tests',
+      use: {
+        baseURL: 'http://localhost:3001',
+      },
+    },
+    {
+      name: 'marketing-site',
+      testDir: './apps/marketing/tests',
+      use: {
+        baseURL: 'http://localhost:4000',
+      },
+    },
+  ],
+});
+```
+
+**Monorepo directory layout:**
+
+```
+monorepo/
+├── apps/
+│   ├── web/
+│   │   ├── src/
+│   │   └── tests/
+│   │       ├── auth/
+│   │       │   └── login.spec.ts
+│   │       └── dashboard/
+│   │           └── widgets.spec.ts
+│   ├── admin/
+│   │   ├── src/
+│   │   └── tests/
+│   │       └── user-management.spec.ts
+│   └── marketing/
+│       ├── src/
+│       └── tests/
+│           └── landing-page.spec.ts
+├── packages/
+│   └── shared-fixtures/
+│       ├── auth.fixture.ts
+│       └── index.ts
+└── playwright.config.ts
+```
+
+Run only one app's tests:
+
+```bash
+npx playwright test --project=web-app
+npx playwright test --project=admin-panel
+```
+
+## Decision Guide
+
+```
+How many tests do you have?
+│
+├── < 20 tests (small)
+│   ├── Flat structure: all .spec.ts files in tests/
+│   ├── No subdirectories needed
+│   ├── Tags optional — just run everything
+│   └── fullyParallel: true, single config project
+│
+├── 20–200 tests (medium)
+│   ├── Feature subdirectories: tests/auth/, tests/checkout/
+│   ├── Use @smoke tag for critical-path subset (< 15 min)
+│   ├── Shared fixtures in tests/fixtures/
+│   ├── Page objects in tests/page-objects/ (if you use them)
+│   └── Consider separate projects for different browsers
+│
+└── 200+ tests (large)
+    ├── Top-level split: tests/e2e/, tests/api/, tests/visual/
+    ├── Feature subdirectories under each
+    ├── @smoke, @regression, @slow tags — multiple CI pipelines
+    ├── Sharding in CI for faster runs
+    ├── Project-based filtering: smoke project, full project
+    └── Shared fixtures as a package in monorepo
+```
+
+```
+Should I use test.describe.serial()?
+│
+├── Can each test set up its own state via API/fixture?
+│   └── YES → Do NOT use serial. Use independent parallel tests.
+│
+├── Is this a multi-step wizard where each step changes server state
+│   that cannot be reset between tests?
+│   └── Write it as ONE test with test.step() instead.
+│
+└── Is this genuinely stateful (e.g., database migration sequence)?
+    └── Use serial as last resort. Add a comment explaining why.
+```
+
+## Anti-Patterns
+
+### One giant test file
+
+```typescript
+// BAD: tests/all-tests.spec.ts with 80 tests and 2000+ lines
+test.describe('Everything', () => {
+  test('login works', async ({ page }) => { /* ... */ });
+  test('signup works', async ({ page }) => { /* ... */ });
+  test('cart works', async ({ page }) => { /* ... */ });
+  // ... 77 more tests
+});
+```
+
+**Fix:** Split by feature — one file per feature area, 5–15 tests per file.
+
+---
+
+### Meaningless test names
+
+```typescript
+// BAD
+test('test1', async ({ page }) => { /* ... */ });
+test('test2', async ({ page }) => { /* ... */ });
+test('payment test', async ({ page }) => { /* ... */ });
+test('it works', async ({ page }) => { /* ... */ });
+```
+
+**Fix:** Describe behavior. When a test fails, the name should tell you what broke.
+
+```typescript
+// GOOD
+test('should reject expired credit card', async ({ page }) => { /* ... */ });
+test('user can update shipping address during checkout', async ({ page }) => { /* ... */ });
+```
+
+---
+
+### Deep describe nesting
+
+```typescript
+// BAD: 3+ levels deep — hard to read, hard to find tests in reports
+test.describe('Auth', () => {
+  test.describe('Login', () => {
+    test.describe('With MFA', () => {
+      test.describe('SMS', () => {
+        test('should send code', async ({ page }) => { /* ... */ });
+      });
+    });
+  });
+});
+```
+
+**Fix:** Max 2 levels. Split deeper nesting into separate files.
+
+```typescript
+// GOOD: tests/auth/login-mfa-sms.spec.ts
+test.describe('Login with SMS MFA', () => {
+  test('should send verification code', async ({ page }) => { /* ... */ });
+  test('should reject invalid code', async ({ page }) => { /* ... */ });
+});
+```
+
+---
+
+### Using `test.describe.serial()` as the default
+
+```typescript
+// BAD: serial for no reason — kills parallelism, creates hidden dependencies
+test.describe.serial('User Profile', () => {
+  test('should display profile page', async ({ page }) => { /* ... */ });
+  test('should update display name', async ({ page }) => { /* ... */ });
+  test('should upload avatar', async ({ page }) => { /* ... */ });
+});
+```
+
+**Fix:** Each test should be independent. Use `beforeEach` or fixtures to set up state.
+
+```typescript
+// GOOD
+test.describe('User Profile', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/profile');
+  });
+
+  test('should display profile page', async ({ page }) => { /* ... */ });
+  test('should update display name', async ({ page }) => { /* ... */ });
+  test('should upload avatar', async ({ page }) => { /* ... */ });
+});
+```
+
+---
+
+### Relying on test execution order
+
+```typescript
+// BAD: test 2 depends on test 1 creating data
+test('should create a product', async ({ page }) => {
+  // creates "Widget X" in the database
+});
+
+test('should edit the product', async ({ page }) => {
+  // assumes "Widget X" exists — breaks if run alone or in parallel
+});
+```
+
+**Fix:** Each test creates its own data via API calls or fixtures.
+
+```typescript
+// GOOD
+test('should edit a product', async ({ page, request }) => {
+  // Set up test data independently
+  const response = await request.post('/api/products', {
+    data: { name: 'Widget X', price: 9.99 },
+  });
+  const product = await response.json();
+
+  await page.goto(`/products/${product.id}/edit`);
+  await page.getByLabel('Name').fill('Widget X Updated');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Widget X Updated')).toBeVisible();
+});
+```
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| Tests pass alone but fail together | Shared state between tests (cookies, DB rows, global variables) | Isolate each test — use fixtures for setup/teardown |
+| `--grep @smoke` matches nothing | Tag not in test title string | Verify the tag appears literally in `test('... @smoke', ...)` |
+| Serial tests cascade-fail | One test fails, all subsequent tests skip | Rewrite as independent tests or use `test.step()` in a single test |
+| Tests run slower than expected | `fullyParallel` not set | Add `fullyParallel: true` in `playwright.config` |
+| Wrong tests run in CI | `testMatch` or `testDir` misconfigured | Check `playwright.config` — print resolved config with `npx playwright test --list` |
+| Monorepo tests pick up wrong files | Default `testDir` is `.` | Set explicit `testDir` per project |
+
+## Related
+
+- [core/configuration.md](foundations/configuration.md) — `testMatch`, `testDir`, `fullyParallel`, `workers`
+- [core/fixtures-and-hooks.md](foundations/fixtures-and-hooks.md) — shared setup via fixtures instead of `beforeAll`
+- [core/test-architecture.md](decisions/test-architecture.md) — when to write E2E vs API vs component tests
+- [ci/parallel-and-sharding.md](infrastructure/parallel-and-sharding.md) — CI sharding for large suites
+- [ci/projects-and-dependencies.md](infrastructure/projects-and-dependencies.md) — multi-project config

--- a/engineering-team/playwright skill/core/third-party-integrations.md
+++ b/engineering-team/playwright skill/core/third-party-integrations.md
@@ -1,0 +1,754 @@
+# Third-Party Integrations
+
+> **When to use**: Testing your application's interaction with external services -- OAuth providers, payment gateways, analytics, chat widgets, maps, social login, and CAPTCHAs. The core principle: mock the third-party boundary, not your own application code.
+> **Prerequisites**: [core/network-mocking.md](network-mocking.md), [core/when-to-mock.md](when-to-mock.md), [core/authentication.md](authentication.md)
+
+## Quick Reference
+
+```typescript
+// Mock an OAuth callback to bypass the real provider
+await page.route('**/auth/callback*', (route) => {
+  route.fulfill({
+    status: 302,
+    headers: { Location: '/dashboard?token=mock-jwt-token' },
+  });
+});
+
+// Block analytics scripts from loading
+await page.route('**/*.google-analytics.com/**', (route) => route.abort());
+await page.route('**/segment.io/**', (route) => route.abort());
+
+// Mock a third-party widget endpoint
+await page.route('**/api.stripe.com/**', (route) => {
+  route.fulfill({ status: 200, contentType: 'application/json', body: '{"id":"pi_mock"}' });
+});
+```
+
+**Core principle**: In E2E tests, mock the external service, not your own application. Your code should run as-is; only the third-party responses are faked.
+
+## Patterns
+
+### Mocking OAuth Providers (Google, GitHub, etc.)
+
+**Use when**: Testing the full login flow without depending on real OAuth provider availability, rate limits, or test accounts.
+**Avoid when**: You need to verify the actual OAuth integration works end-to-end (use a dedicated integration test for that).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('Google OAuth login via route mocking', async ({ page }) => {
+  // Intercept the redirect to Google and simulate the callback
+  await page.route('**/accounts.google.com/**', async (route) => {
+    // Extract the redirect_uri from the request URL
+    const url = new URL(route.request().url());
+    const redirectUri = url.searchParams.get('redirect_uri') || '/auth/callback';
+
+    // Simulate Google redirecting back with an auth code
+    await route.fulfill({
+      status: 302,
+      headers: {
+        Location: `${redirectUri}?code=mock-auth-code&state=${url.searchParams.get('state') || ''}`,
+      },
+    });
+  });
+
+  // Mock your own backend's token exchange endpoint
+  await page.route('**/api/auth/google/callback*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        token: 'mock-jwt-token',
+        user: {
+          id: '1',
+          name: 'Test User',
+          email: 'testuser@gmail.com',
+          avatar: 'https://placehold.co/100x100',
+        },
+      }),
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+
+  // Should land on dashboard with user info
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText('Test User')).toBeVisible();
+});
+
+test('GitHub OAuth login with mocked provider', async ({ page }) => {
+  await page.route('**/github.com/login/oauth/**', async (route) => {
+    const url = new URL(route.request().url());
+    const redirectUri = url.searchParams.get('redirect_uri') || '/auth/callback';
+    await route.fulfill({
+      status: 302,
+      headers: {
+        Location: `${redirectUri}?code=mock-github-code`,
+      },
+    });
+  });
+
+  await page.route('**/api/auth/github/callback*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        token: 'mock-jwt-token',
+        user: { id: '2', name: 'GitHub User', email: 'user@github.com' },
+      }),
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with GitHub' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText('GitHub User')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('Google OAuth login via route mocking', async ({ page }) => {
+  await page.route('**/accounts.google.com/**', async (route) => {
+    const url = new URL(route.request().url());
+    const redirectUri = url.searchParams.get('redirect_uri') || '/auth/callback';
+    await route.fulfill({
+      status: 302,
+      headers: {
+        Location: `${redirectUri}?code=mock-auth-code&state=${url.searchParams.get('state') || ''}`,
+      },
+    });
+  });
+
+  await page.route('**/api/auth/google/callback*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        token: 'mock-jwt-token',
+        user: { id: '1', name: 'Test User', email: 'testuser@gmail.com' },
+      }),
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText('Test User')).toBeVisible();
+});
+```
+
+### Payment Gateway Testing (Stripe Elements)
+
+**Use when**: Testing checkout flows that use Stripe Elements, PayPal buttons, or similar embedded payment UIs.
+**Avoid when**: Stripe provides test mode with test card numbers and you want full integration coverage.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('complete Stripe checkout with test card', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Stripe Elements load in an iframe
+  const stripeFrame = page.frameLocator('iframe[name*="__privateStripeFrame"]').first();
+
+  // Fill card details inside the Stripe iframe
+  await stripeFrame.getByPlaceholder('Card number').fill('4242424242424242');
+  await stripeFrame.getByPlaceholder('MM / YY').fill('12/28');
+  await stripeFrame.getByPlaceholder('CVC').fill('123');
+  await stripeFrame.getByPlaceholder('ZIP').fill('10001');
+
+  await page.getByRole('button', { name: 'Pay' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible({ timeout: 15000 });
+});
+
+test('Stripe checkout with mocked API for speed', async ({ page }) => {
+  // Mock Stripe API calls for faster, more reliable tests
+  await page.route('**/api.stripe.com/v1/payment_intents*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'pi_mock_123',
+        status: 'succeeded',
+        client_secret: 'pi_mock_123_secret_456',
+      }),
+    });
+  });
+
+  await page.route('**/api.stripe.com/v1/payment_methods*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'pm_mock_789',
+        type: 'card',
+        card: { brand: 'visa', last4: '4242' },
+      }),
+    });
+  });
+
+  await page.goto('/checkout');
+  // With mocked Stripe, your app-level payment form may work without the iframe
+  await page.getByRole('button', { name: 'Pay' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('handles declined card gracefully', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const stripeFrame = page.frameLocator('iframe[name*="__privateStripeFrame"]').first();
+  // Stripe test card that always declines
+  await stripeFrame.getByPlaceholder('Card number').fill('4000000000000002');
+  await stripeFrame.getByPlaceholder('MM / YY').fill('12/28');
+  await stripeFrame.getByPlaceholder('CVC').fill('123');
+  await stripeFrame.getByPlaceholder('ZIP').fill('10001');
+
+  await page.getByRole('button', { name: 'Pay' }).click();
+  await expect(page.getByText(/declined|failed/i)).toBeVisible({ timeout: 15000 });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('complete Stripe checkout with test card', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const stripeFrame = page.frameLocator('iframe[name*="__privateStripeFrame"]').first();
+  await stripeFrame.getByPlaceholder('Card number').fill('4242424242424242');
+  await stripeFrame.getByPlaceholder('MM / YY').fill('12/28');
+  await stripeFrame.getByPlaceholder('CVC').fill('123');
+  await stripeFrame.getByPlaceholder('ZIP').fill('10001');
+
+  await page.getByRole('button', { name: 'Pay' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible({ timeout: 15000 });
+});
+```
+
+### Analytics Blocking
+
+**Use when**: Preventing analytics scripts from executing during tests to improve speed, avoid polluting analytics data, and eliminate flakiness from third-party script failures.
+**Avoid when**: You specifically need to test that analytics events are fired correctly.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Block analytics in a fixture for all tests
+import { test as base } from '@playwright/test';
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // Block common analytics and tracking scripts
+    await page.route(/(google-analytics|googletagmanager|segment\.io|hotjar|mixpanel|amplitude)/, (route) =>
+      route.abort()
+    );
+    await page.route('**/collect?**', (route) => route.abort()); // GA beacon
+    await page.route('**/analytics/**', (route) => route.abort());
+    await use(page);
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// For tests that verify analytics events ARE sent
+import { test, expect } from '@playwright/test';
+
+test('purchase event fires on checkout completion', async ({ page }) => {
+  const analyticsRequests: { url: string; body: string }[] = [];
+
+  // Intercept analytics calls instead of blocking them
+  await page.route('**/collect**', async (route) => {
+    analyticsRequests.push({
+      url: route.request().url(),
+      body: route.request().postData() || '',
+    });
+    await route.fulfill({ status: 200 }); // Respond but don't send to real analytics
+  });
+
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Complete order' }).click();
+  await page.waitForURL('/order/confirmation');
+
+  // Verify the purchase event was sent
+  const purchaseEvent = analyticsRequests.find(
+    (r) => r.body.includes('purchase') || r.url.includes('purchase')
+  );
+  expect(purchaseEvent).toBeDefined();
+});
+```
+
+**JavaScript**
+```javascript
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route(/(google-analytics|googletagmanager|segment\.io|hotjar|mixpanel)/, (route) =>
+      route.abort()
+    );
+    await use(page);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+### Chat Widget Testing (Intercom, Drift, etc.)
+
+**Use when**: Your app embeds a third-party chat widget and you need to test the interaction or verify it does not break your UI.
+**Avoid when**: The chat widget is cosmetic and not part of critical user flows.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('Intercom chat widget opens and accepts messages', async ({ page }) => {
+  await page.goto('/');
+
+  // Wait for the chat widget to load (often delayed)
+  const chatLauncher = page.frameLocator('iframe[name*="intercom"]')
+    .getByRole('button', { name: /chat|message/i });
+  await expect(chatLauncher).toBeVisible({ timeout: 15000 });
+
+  // Open the chat
+  await chatLauncher.click();
+
+  // The chat conversation iframe loads
+  const chatFrame = page.frameLocator('iframe[name*="intercom-messenger"]');
+  await expect(chatFrame.getByText(/How can we help/i)).toBeVisible();
+
+  // Type a message
+  await chatFrame.getByRole('textbox').fill('I need help with my order');
+  await chatFrame.getByRole('button', { name: /send/i }).click();
+
+  await expect(chatFrame.getByText('I need help with my order')).toBeVisible();
+});
+
+test('chat widget does not overlap critical UI', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // Get chat widget position
+  const chatWidget = page.locator('iframe[name*="intercom"]').first();
+  if (await chatWidget.isVisible()) {
+    const chatBox = await chatWidget.boundingBox();
+    const payButton = await page.getByRole('button', { name: 'Pay' }).boundingBox();
+
+    // Ensure the pay button is not hidden behind the chat widget
+    if (chatBox && payButton) {
+      const overlaps =
+        payButton.x < chatBox.x + chatBox.width &&
+        payButton.x + payButton.width > chatBox.x &&
+        payButton.y < chatBox.y + chatBox.height &&
+        payButton.y + payButton.height > chatBox.y;
+      expect(overlaps).toBe(false);
+    }
+  }
+});
+
+// Block chat widget in most tests for speed
+test('block chat widget for non-chat tests', async ({ page }) => {
+  await page.route('**/widget.intercom.io/**', (route) => route.abort());
+  await page.route('**/js.intercomcdn.com/**', (route) => route.abort());
+
+  await page.goto('/dashboard');
+  // Chat widget will not load — test runs faster
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('block chat widget for speed', async ({ page }) => {
+  await page.route('**/widget.intercom.io/**', (route) => route.abort());
+  await page.route('**/js.intercomcdn.com/**', (route) => route.abort());
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+### Map Integration Testing (Google Maps)
+
+**Use when**: Your app embeds Google Maps or a similar map provider and you need to verify map-related interactions.
+**Avoid when**: The map is decorative and not part of a user workflow.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('store locator shows markers on the map', async ({ page }) => {
+  await page.goto('/store-locator');
+
+  // Google Maps loads in an iframe or directly on the page
+  await page.getByLabel('Search location').fill('New York');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  // Wait for map markers to appear
+  await expect(page.locator('[data-testid="map-marker"]')).toHaveCount(5, {
+    timeout: 10000,
+  });
+
+  // Click a marker to see store details
+  await page.locator('[data-testid="map-marker"]').first().click();
+  await expect(page.getByTestId('store-info')).toBeVisible();
+  await expect(page.getByTestId('store-info')).toContainText('New York');
+});
+
+test('mock Google Maps API for offline testing', async ({ page }) => {
+  // Block real Google Maps and provide mock responses
+  await page.route('**/maps.googleapis.com/**', async (route) => {
+    const url = route.request().url();
+
+    if (url.includes('/geocode/')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [{
+            geometry: { location: { lat: 40.7128, lng: -74.0060 } },
+            formatted_address: 'New York, NY, USA',
+          }],
+          status: 'OK',
+        }),
+      });
+    } else if (url.includes('/places/')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [
+            { name: 'Store A', geometry: { location: { lat: 40.71, lng: -74.00 } } },
+            { name: 'Store B', geometry: { location: { lat: 40.72, lng: -74.01 } } },
+          ],
+          status: 'OK',
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto('/store-locator');
+  await page.getByLabel('Search location').fill('New York');
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  await expect(page.getByText('Store A')).toBeVisible();
+  await expect(page.getByText('Store B')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('mock Google Maps geocode API', async ({ page }) => {
+  await page.route('**/maps.googleapis.com/maps/api/geocode/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{
+          geometry: { location: { lat: 40.7128, lng: -74.0060 } },
+          formatted_address: 'New York, NY, USA',
+        }],
+        status: 'OK',
+      }),
+    });
+  });
+
+  await page.goto('/store-locator');
+  await page.getByLabel('Search location').fill('New York');
+  await page.getByRole('button', { name: 'Search' }).click();
+  await expect(page.getByText('New York')).toBeVisible();
+});
+```
+
+### reCAPTCHA Bypass for Testing
+
+**Use when**: Your app uses reCAPTCHA or hCaptcha and you need tests to proceed without solving challenges.
+**Avoid when**: You can disable CAPTCHA in your test environment through a server-side flag (preferred approach).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('reCAPTCHA handling', () => {
+  // Best approach: Use test keys provided by Google
+  // Site key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI (always passes)
+  // Secret key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+  test('form submission with reCAPTCHA bypassed via test keys', async ({ page }) => {
+    // Your test environment should be configured with Google's test keys
+    await page.goto('/contact');
+
+    await page.getByLabel('Name').fill('Test User');
+    await page.getByLabel('Email').fill('test@example.com');
+    await page.getByLabel('Message').fill('Test message');
+
+    // With test keys, reCAPTCHA auto-passes — just click submit
+    await page.getByRole('button', { name: 'Send' }).click();
+    await expect(page.getByText('Message sent')).toBeVisible();
+  });
+
+  test('mock reCAPTCHA verification endpoint', async ({ page }) => {
+    // Mock Google's reCAPTCHA verification API
+    await page.route('**/recaptcha/api/siteverify**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, score: 0.9 }),
+      });
+    });
+
+    // Mock the reCAPTCHA script to provide a fake token
+    await page.addInitScript(() => {
+      (window as any).grecaptcha = {
+        ready: (cb: () => void) => cb(),
+        execute: () => Promise.resolve('mock-recaptcha-token'),
+        render: () => 'mock-widget-id',
+        getResponse: () => 'mock-recaptcha-token',
+        reset: () => {},
+      };
+    });
+
+    await page.goto('/contact');
+    await page.getByLabel('Name').fill('Test User');
+    await page.getByLabel('Email').fill('test@example.com');
+    await page.getByLabel('Message').fill('Test message');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    await expect(page.getByText('Message sent')).toBeVisible();
+  });
+
+  test('invisible reCAPTCHA v3 bypass', async ({ page }) => {
+    // For reCAPTCHA v3, mock the enterprise API
+    await page.route('**/recaptcha/**', async (route) => {
+      if (route.request().url().includes('api.js')) {
+        // Serve a mock script that provides the grecaptcha object
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/javascript',
+          body: `
+            window.grecaptcha = {
+              ready: function(cb) { cb(); },
+              execute: function() { return Promise.resolve('mock-token'); },
+              enterprise: {
+                ready: function(cb) { cb(); },
+                execute: function() { return Promise.resolve('mock-token'); },
+              }
+            };
+          `,
+        });
+      } else {
+        await route.abort();
+      }
+    });
+
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('mock reCAPTCHA for form submission', async ({ page }) => {
+  await page.route('**/recaptcha/api/siteverify**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, score: 0.9 }),
+    });
+  });
+
+  await page.addInitScript(() => {
+    window.grecaptcha = {
+      ready: (cb) => cb(),
+      execute: () => Promise.resolve('mock-recaptcha-token'),
+      render: () => 'mock-widget-id',
+      getResponse: () => 'mock-recaptcha-token',
+      reset: () => {},
+    };
+  });
+
+  await page.goto('/contact');
+  await page.getByLabel('Name').fill('Test User');
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByLabel('Message').fill('Test message');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByText('Message sent')).toBeVisible();
+});
+```
+
+### Social Login Mocking
+
+**Use when**: Your app offers multiple social login options and you need to test the login flow without real provider accounts.
+**Avoid when**: You have a backend bypass that sets auth state directly.
+
+**TypeScript**
+```typescript
+import { test as base, expect } from '@playwright/test';
+
+// Reusable fixture that mocks any OAuth provider
+type OAuthFixtures = {
+  mockOAuth: (provider: string, userData: Record<string, string>) => Promise<void>;
+};
+
+export const test = base.extend<OAuthFixtures>({
+  mockOAuth: async ({ page }, use) => {
+    const mock = async (provider: string, userData: Record<string, string>) => {
+      const providerPatterns: Record<string, string> = {
+        google: '**/accounts.google.com/**',
+        github: '**/github.com/login/oauth/**',
+        facebook: '**/facebook.com/v*/dialog/oauth**',
+        apple: '**/appleid.apple.com/**',
+        microsoft: '**/login.microsoftonline.com/**',
+      };
+
+      const pattern = providerPatterns[provider];
+      if (!pattern) throw new Error(`Unknown provider: ${provider}`);
+
+      // Intercept the OAuth redirect
+      await page.route(pattern, async (route) => {
+        const url = new URL(route.request().url());
+        const redirectUri = url.searchParams.get('redirect_uri') || '/auth/callback';
+        await route.fulfill({
+          status: 302,
+          headers: { Location: `${redirectUri}?code=mock-${provider}-code` },
+        });
+      });
+
+      // Mock the token exchange
+      await page.route(`**/api/auth/${provider}/callback*`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ token: `mock-${provider}-jwt`, user: userData }),
+        });
+      });
+    };
+
+    await use(mock);
+  },
+});
+
+// Usage in tests
+test('login with multiple social providers', async ({ page, mockOAuth }) => {
+  // Test Google login
+  await mockOAuth('google', { name: 'Google User', email: 'user@gmail.com' });
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText('Google User')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  mockOAuth: async ({ page }, use) => {
+    const mock = async (provider, userData) => {
+      const patterns = {
+        google: '**/accounts.google.com/**',
+        github: '**/github.com/login/oauth/**',
+        facebook: '**/facebook.com/v*/dialog/oauth**',
+      };
+
+      await page.route(patterns[provider], async (route) => {
+        const url = new URL(route.request().url());
+        const redirectUri = url.searchParams.get('redirect_uri') || '/auth/callback';
+        await route.fulfill({
+          status: 302,
+          headers: { Location: `${redirectUri}?code=mock-${provider}-code` },
+        });
+      });
+
+      await page.route(`**/api/auth/${provider}/callback*`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ token: `mock-${provider}-jwt`, user: userData }),
+        });
+      });
+    };
+    await use(mock);
+  },
+});
+
+test('login with Google', async ({ page, mockOAuth }) => {
+  await mockOAuth('google', { name: 'Google User', email: 'user@gmail.com' });
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByText('Google User')).toBeVisible();
+});
+
+module.exports = { test, expect };
+```
+
+## Decision Guide
+
+| Integration | Mock Strategy | When to Use Real | When to Mock |
+|---|---|---|---|
+| OAuth (Google, GitHub, etc.) | Route intercept on provider URL + mock callback | Dedicated integration test with test accounts | All E2E feature tests that require login |
+| Stripe/payment gateway | Use Stripe test mode with test cards OR mock API | Checkout flow integration tests | All non-payment E2E tests |
+| Google Analytics / Segment | `route.abort()` to block entirely | Dedicated analytics verification tests | Every other test (block for speed) |
+| Chat widgets (Intercom, Drift) | `route.abort()` to block, or interact via iframe | Tests specifically about chat functionality | Every other test (block for speed/stability) |
+| Google Maps | Mock geocoding/places API responses | Tests verifying real map rendering | Tests that only need location data |
+| reCAPTCHA | Google test keys (preferred) or mock `grecaptcha` | Never in automated tests | Always -- CAPTCHA cannot be solved by automation |
+| Social login | Reusable OAuth mock fixture per provider | Periodic integration check | All E2E tests requiring auth |
+| Email services (SendGrid, SES) | Mock API endpoints, verify calls were made | End-to-end email delivery tests (separate suite) | All tests that trigger emails |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Using real OAuth provider accounts in tests | Rate limits, 2FA requirements, account lockouts, test flakiness | Mock the OAuth flow or use provider test modes |
+| Letting analytics scripts run in all tests | Slower tests, pollutes real analytics data, adds network flakiness | Block analytics with `route.abort()` in a shared fixture |
+| Solving reCAPTCHA with image recognition | Fragile, slow, violates CAPTCHA terms of service | Use Google's test keys or mock the `grecaptcha` object |
+| Mocking your own application code instead of the third-party | Does not test your integration logic | Mock only the external boundary (API endpoints, scripts) |
+| Hardcoding mock responses for every test | Duplicated mock setup, hard to maintain | Build reusable mock fixtures (see Social Login pattern) |
+| Not testing error paths from third parties | Misses how your app handles OAuth failures, payment declines | Mock error responses: `{ error: 'access_denied' }`, declined cards |
+| Loading real Stripe.js in every test | Slow initial load, occasional CDN failures | Mock Stripe for non-payment tests; use real Stripe only for checkout tests |
+| Trusting `networkidle` for third-party scripts | Third-party scripts may poll indefinitely | Wait for specific app-level indicators, not `networkidle` |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| OAuth mock route never fires | The app uses a redirect chain that bypasses your route pattern | Use a broader pattern like `**accounts.google.com**` or log all requests to see the actual URL |
+| Stripe iframe not found | Stripe.js loads async; iframe name varies by version | Use a flexible selector: `iframe[name*="__privateStripeFrame"]` with a long timeout |
+| reCAPTCHA mock does not work | Script loads before `addInitScript` runs | Use `route` to intercept the reCAPTCHA script and serve a mock version |
+| Analytics blocking breaks the app | App code depends on analytics library being present (e.g., `window.gtag`) | Instead of blocking, fulfill with a stub: `route.fulfill({ body: 'window.gtag=function(){}' })` |
+| Chat widget iframe is not accessible | Cross-origin iframe restrictions | Use `frameLocator` with the correct iframe name/selector |
+| Mock OAuth returns wrong redirect URI | The `redirect_uri` parameter is URL-encoded or different in test | Log the actual request URL with `page.on('request')` and match accordingly |
+| Payment test passes locally but fails in CI | Stripe test mode has rate limits; CI IP may be blocked | Mock Stripe API in CI, use real Stripe only in a separate integration pipeline |
+| Social login mock does not redirect | Your app opens OAuth in a popup, not a redirect | Handle the popup: `page.waitForEvent('popup')` and mock routes on the popup page |
+
+## Related
+
+- [core/network-mocking.md](network-mocking.md) -- foundational route interception patterns
+- [core/authentication.md](authentication.md) -- auth state management and login bypasses
+- [core/when-to-mock.md](when-to-mock.md) -- decision framework for mocking vs real services
+- [core/multi-context-and-popups.md](multi-context-and-popups.md) -- handling OAuth popup windows
+- [core/security-testing.md](security-testing.md) -- testing auth security aspects
+- [core/iframes-and-shadow-dom.md](iframes-and-shadow-dom.md) -- interacting with payment widget iframes

--- a/engineering-team/playwright skill/core/visual-regression.md
+++ b/engineering-team/playwright skill/core/visual-regression.md
@@ -1,0 +1,1006 @@
+# Visual Regression Testing
+
+> **When to use**: Catching unintended visual changes -- layout shifts, style regressions, broken responsive designs, theme corruption -- that functional assertions miss. Visual tests answer "does it still look right?" after code changes.
+> **Prerequisites**: [core/configuration.md](configuration.md) for project setup, [core/assertions-and-waiting.md](assertions-and-waiting.md) for assertion basics.
+
+## Quick Reference
+
+```typescript
+// Page screenshot -- compare entire viewport
+await expect(page).toHaveScreenshot();
+
+// Element screenshot -- compare a specific component
+await expect(page.getByTestId('pricing-card')).toHaveScreenshot();
+
+// Named snapshot -- explicit file name
+await expect(page).toHaveScreenshot('homepage-hero.png');
+
+// With threshold -- allow minor pixel differences
+await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.01 });
+
+// Mask dynamic content -- hide timestamps, avatars, ads
+await expect(page).toHaveScreenshot({
+  mask: [page.getByTestId('timestamp'), page.getByRole('img', { name: 'Avatar' })],
+});
+
+// Disable animations -- prevent flaky diffs from CSS transitions
+await expect(page).toHaveScreenshot({ animations: 'disabled' });
+
+// Update baselines (CLI)
+npx playwright test --update-snapshots
+```
+
+## Patterns
+
+### 1. Screenshot Comparison Basics
+
+**Use when**: Verifying that a page or component renders correctly after code changes. Best for pages with stable layouts -- landing pages, dashboards, settings panels.
+**Avoid when**: The page is highly dynamic with real-time data, live feeds, or content that changes on every load. Use functional assertions instead.
+
+Playwright compares a screenshot taken during the test against a stored baseline (golden) image. On first run, the baseline is created. On subsequent runs, differences cause the test to fail with a visual diff report.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('homepage renders correctly', async ({ page }) => {
+  await page.goto('/');
+
+  // Full page screenshot comparison
+  await expect(page).toHaveScreenshot('homepage.png');
+});
+
+test('pricing card matches design', async ({ page }) => {
+  await page.goto('/pricing');
+
+  // Element-level screenshot -- scoped to a single component
+  const card = page.getByTestId('pro-plan-card');
+  await expect(card).toHaveScreenshot('pro-plan-card.png');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('homepage renders correctly', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveScreenshot('homepage.png');
+});
+
+test('pricing card matches design', async ({ page }) => {
+  await page.goto('/pricing');
+
+  const card = page.getByTestId('pro-plan-card');
+  await expect(card).toHaveScreenshot('pro-plan-card.png');
+});
+```
+
+Snapshots are stored alongside tests by default in a folder named `<test-file-name>-snapshots/`. The folder structure includes the project name and platform:
+
+```
+tests/
+  homepage.spec.ts
+  homepage.spec.ts-snapshots/
+    homepage-chromium-linux.png
+    homepage-chromium-darwin.png
+```
+
+### 2. Configuring Thresholds
+
+**Use when**: Your UI has minor rendering differences between runs -- anti-aliasing, font hinting, sub-pixel rendering. Thresholds prevent false failures from pixel-level noise.
+**Avoid when**: You want pixel-perfect comparisons (design-system component libraries, icon rendering). Keep thresholds at zero.
+
+Three knobs control comparison sensitivity:
+
+| Option | What it controls | Good default |
+|---|---|---|
+| `maxDiffPixels` | Absolute number of pixels that can differ | `100` for full pages, `10` for components |
+| `maxDiffPixelRatio` | Fraction of total pixels that can differ (0-1) | `0.01` (1%) for full pages |
+| `threshold` | Per-pixel color difference tolerance (0-1) | `0.2` for most UIs, `0.1` for design systems |
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('dashboard allows minor rendering variance', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Allow up to 1% of pixels to differ
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('icon renders pixel-perfect', async ({ page }) => {
+  await page.goto('/icons');
+
+  // Strict: zero tolerance
+  await expect(page.getByTestId('logo')).toHaveScreenshot('logo.png', {
+    maxDiffPixels: 0,
+    threshold: 0,
+  });
+});
+
+test('chart allows anti-aliasing differences', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // Per-pixel color threshold + absolute pixel count cap
+  await expect(page.getByTestId('revenue-chart')).toHaveScreenshot('revenue-chart.png', {
+    threshold: 0.3,
+    maxDiffPixels: 200,
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('dashboard allows minor rendering variance', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('icon renders pixel-perfect', async ({ page }) => {
+  await page.goto('/icons');
+
+  await expect(page.getByTestId('logo')).toHaveScreenshot('logo.png', {
+    maxDiffPixels: 0,
+    threshold: 0,
+  });
+});
+
+test('chart allows anti-aliasing differences', async ({ page }) => {
+  await page.goto('/analytics');
+
+  await expect(page.getByTestId('revenue-chart')).toHaveScreenshot('revenue-chart.png', {
+    threshold: 0.3,
+    maxDiffPixels: 200,
+  });
+});
+```
+
+**Global thresholds** in `playwright.config.ts`:
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.2,
+      animations: 'disabled',
+    },
+  },
+});
+```
+
+### 3. Full Page vs Element Screenshots
+
+**Use when**: Deciding scope. Full page catches layout shifts and spacing regressions. Element screenshots isolate components and are more stable.
+**Avoid when**: Neither -- use both strategically.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('full page screenshot catches layout shifts', async ({ page }) => {
+  await page.goto('/');
+
+  // Captures the visible viewport
+  await expect(page).toHaveScreenshot('homepage-viewport.png');
+
+  // Captures the entire scrollable page
+  await expect(page).toHaveScreenshot('homepage-full.png', {
+    fullPage: true,
+  });
+});
+
+test('element screenshot isolates component changes', async ({ page }) => {
+  await page.goto('/pricing');
+
+  // Only the pricing table -- immune to header/footer changes
+  await expect(page.getByRole('table')).toHaveScreenshot('pricing-table.png');
+
+  // A specific card within the page
+  await expect(page.getByTestId('enterprise-card')).toHaveScreenshot('enterprise-card.png');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('full page screenshot catches layout shifts', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveScreenshot('homepage-viewport.png');
+
+  await expect(page).toHaveScreenshot('homepage-full.png', {
+    fullPage: true,
+  });
+});
+
+test('element screenshot isolates component changes', async ({ page }) => {
+  await page.goto('/pricing');
+
+  await expect(page.getByRole('table')).toHaveScreenshot('pricing-table.png');
+  await expect(page.getByTestId('enterprise-card')).toHaveScreenshot('enterprise-card.png');
+});
+```
+
+**Rule of thumb**: Use element screenshots for components that change independently. Use full page screenshots for key landing pages and layouts where spacing between sections matters.
+
+### 4. Masking Dynamic Content
+
+**Use when**: The page contains content that changes between test runs -- timestamps, user avatars, ad slots, relative dates ("3 minutes ago"), random hero images, A/B test variants.
+**Avoid when**: All content is deterministic. Masking adds maintenance overhead.
+
+The `mask` option overlays a solid-colored box over specified locators before taking the screenshot. The masked region is excluded from comparison.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('dashboard with masked dynamic content', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    mask: [
+      page.getByTestId('current-time'),
+      page.getByTestId('user-avatar'),
+      page.getByTestId('live-visitor-count'),
+      page.locator('.ad-banner'),
+    ],
+    maskColor: '#FF00FF', // visible magenta -- makes it obvious what's masked in reviews
+  });
+});
+
+test('feed page with relative timestamps', async ({ page }) => {
+  await page.goto('/feed');
+
+  // Mask all relative time elements at once
+  await expect(page).toHaveScreenshot('feed.png', {
+    mask: [page.locator('time[datetime]')],
+  });
+});
+
+test('profile page with user-generated content', async ({ page }) => {
+  await page.goto('/profile/test-user');
+
+  await expect(page).toHaveScreenshot('profile.png', {
+    mask: [
+      page.getByRole('img', { name: 'Profile photo' }),
+      page.getByTestId('last-login'),
+      page.getByTestId('member-since'),
+    ],
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('dashboard with masked dynamic content', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    mask: [
+      page.getByTestId('current-time'),
+      page.getByTestId('user-avatar'),
+      page.getByTestId('live-visitor-count'),
+      page.locator('.ad-banner'),
+    ],
+    maskColor: '#FF00FF',
+  });
+});
+
+test('feed page with relative timestamps', async ({ page }) => {
+  await page.goto('/feed');
+
+  await expect(page).toHaveScreenshot('feed.png', {
+    mask: [page.locator('time[datetime]')],
+  });
+});
+
+test('profile page with user-generated content', async ({ page }) => {
+  await page.goto('/profile/test-user');
+
+  await expect(page).toHaveScreenshot('profile.png', {
+    mask: [
+      page.getByRole('img', { name: 'Profile photo' }),
+      page.getByTestId('last-login'),
+      page.getByTestId('member-since'),
+    ],
+  });
+});
+```
+
+**Alternative: freeze dynamic content with JavaScript**
+
+When masking is not sufficient (e.g., content affects layout), inject JavaScript to freeze the content:
+
+```typescript
+test('freeze clock before screenshot', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  // Replace all dynamic timestamps with a fixed value
+  await page.evaluate(() => {
+    document.querySelectorAll('[data-testid="timestamp"]').forEach((el) => {
+      el.textContent = 'Jan 1, 2025 12:00 PM';
+    });
+  });
+
+  await expect(page).toHaveScreenshot('dashboard-frozen.png');
+});
+```
+
+### 5. Animations Handling
+
+**Use when**: Always. CSS animations and transitions are the number one cause of flaky visual diffs. A screenshot captured mid-animation will never match the baseline.
+**Avoid when**: You are explicitly testing the animation itself (rare).
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('page renders without animation interference', async ({ page }) => {
+  await page.goto('/');
+
+  // Disables CSS animations and transitions before screenshotting
+  await expect(page).toHaveScreenshot('homepage.png', {
+    animations: 'disabled',
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('page renders without animation interference', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveScreenshot('homepage.png', {
+    animations: 'disabled',
+  });
+});
+```
+
+**Set globally** -- this should be the default for every project:
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  expect: {
+    toHaveScreenshot: {
+      animations: 'disabled',
+    },
+  },
+});
+```
+
+When `animations: 'disabled'` is set, Playwright:
+1. Injects a stylesheet that sets `* { animation-duration: 0s !important; transition-duration: 0s !important; }`.
+2. Waits for any currently running animations to finish (forces them to their end state).
+3. Takes the screenshot.
+
+For JavaScript-driven animations (requestAnimationFrame, GSAP, Framer Motion), you may also need to wait for stability:
+
+```typescript
+test('page with JS animations', async ({ page }) => {
+  await page.goto('/animated-landing');
+
+  // Wait for the hero animation to settle
+  await page.getByTestId('hero-section').waitFor({ state: 'visible' });
+  await page.waitForTimeout(500); // last resort for JS animations -- use sparingly
+
+  await expect(page).toHaveScreenshot('landing.png', {
+    animations: 'disabled',
+  });
+});
+```
+
+### 6. Updating Snapshots
+
+**Use when**: You have intentionally changed the UI and need to update the baselines. A design refresh, rebrand, new feature, or layout change.
+**Avoid when**: The diff is unexpected -- investigate the cause before blindly updating.
+
+```bash
+# Update all snapshots
+npx playwright test --update-snapshots
+
+# Update snapshots for a specific test file
+npx playwright test tests/homepage.spec.ts --update-snapshots
+
+# Update snapshots for a specific project (browser)
+npx playwright test --project=chromium --update-snapshots
+```
+
+**Workflow for reviewing snapshot changes:**
+
+1. Run tests and observe failures in the HTML report:
+   ```bash
+   npx playwright test
+   npx playwright show-report
+   ```
+   The report shows the expected image, actual image, and a diff image side-by-side.
+
+2. If the changes are intentional, update the snapshots:
+   ```bash
+   npx playwright test --update-snapshots
+   ```
+
+3. Review the updated snapshots in your diff tool before committing:
+   ```bash
+   git diff --name-only  # see which snapshot files changed
+   ```
+
+4. Commit the updated snapshots with a clear message explaining why they changed.
+
+**Tip**: Never run `--update-snapshots` in CI. Always update locally, review the diffs, and commit the new baselines.
+
+**TypeScript -- helper for controlled updates**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Tag visual tests so you can update them selectively
+test('homepage visual @visual', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveScreenshot('homepage.png', {
+    animations: 'disabled',
+  });
+});
+
+test('pricing visual @visual', async ({ page }) => {
+  await page.goto('/pricing');
+  await expect(page).toHaveScreenshot('pricing.png', {
+    animations: 'disabled',
+  });
+});
+```
+
+```bash
+# Update only visual tests
+npx playwright test --grep @visual --update-snapshots
+```
+
+### 7. Cross-Browser Visual Testing
+
+**Use when**: Your users span Chrome, Firefox, and Safari and you need to verify rendering consistency per browser.
+**Avoid when**: Early stage projects targeting a single browser -- visual tests across three browsers triple the maintenance burden.
+
+Playwright automatically separates snapshots by project name. Each browser gets its own baseline file. This is correct behavior -- browsers render fonts, shadows, and anti-aliasing differently.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  expect: {
+    toHaveScreenshot: {
+      animations: 'disabled',
+      maxDiffPixelRatio: 0.01,
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});
+```
+
+```typescript
+// tests/homepage.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('homepage renders correctly per browser', async ({ page }) => {
+  await page.goto('/');
+
+  // Playwright creates separate baselines per project:
+  //   homepage.spec.ts-snapshots/homepage-chromium-linux.png
+  //   homepage.spec.ts-snapshots/homepage-firefox-linux.png
+  //   homepage.spec.ts-snapshots/homepage-webkit-linux.png
+  await expect(page).toHaveScreenshot('homepage.png', {
+    animations: 'disabled',
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('homepage renders correctly per browser', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveScreenshot('homepage.png', {
+    animations: 'disabled',
+  });
+});
+```
+
+**Strategy for managing cross-browser snapshots**: Run visual tests in a single browser (Chromium on Linux in CI) to minimize snapshot count and only add other browsers when you have actual cross-browser rendering bugs. You can scope visual tests to one project:
+
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'visual',
+      testMatch: '**/*.visual.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium',
+      testIgnore: '**/*.visual.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      testIgnore: '**/*.visual.spec.ts',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+});
+```
+
+### 8. Responsive Visual Testing
+
+**Use when**: Your application has responsive breakpoints and you need to verify layouts at different viewport sizes.
+**Avoid when**: The page has a single fixed-width layout.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+const viewports = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1440, height: 900 },
+];
+
+for (const viewport of viewports) {
+  test(`homepage at ${viewport.name} (${viewport.width}x${viewport.height})`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/');
+
+    await expect(page).toHaveScreenshot(`homepage-${viewport.name}.png`, {
+      animations: 'disabled',
+      fullPage: true,
+    });
+  });
+}
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+const viewports = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1440, height: 900 },
+];
+
+for (const viewport of viewports) {
+  test(`homepage at ${viewport.name} (${viewport.width}x${viewport.height})`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/');
+
+    await expect(page).toHaveScreenshot(`homepage-${viewport.name}.png`, {
+      animations: 'disabled',
+      fullPage: true,
+    });
+  });
+}
+```
+
+**Alternative: use Playwright projects for responsive testing.**
+
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'desktop',
+      testMatch: '**/*.visual.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+    {
+      name: 'tablet',
+      testMatch: '**/*.visual.spec.ts',
+      use: {
+        ...devices['iPad (gen 7)'],
+      },
+    },
+    {
+      name: 'mobile',
+      testMatch: '**/*.visual.spec.ts',
+      use: {
+        ...devices['iPhone 14'],
+      },
+    },
+  ],
+});
+```
+
+This approach gives you separate snapshot folders per device and runs them in parallel.
+
+### 9. CI Setup for Visual Tests
+
+**Use when**: Running visual regression tests in CI. The critical requirement is consistent rendering -- the same test must produce the same screenshot every time.
+**Avoid when**: Never skip this. Visual tests without CI consistency are worthless.
+
+**The problem**: Font rendering, anti-aliasing, and sub-pixel rendering differ across operating systems. A snapshot taken on macOS will not match one taken on Linux. This is the most common source of visual test pain.
+
+**The solution**: Run visual tests inside Docker using the official Playwright container. Generate and update snapshots from the same container.
+
+**GitHub Actions with Docker**
+
+```yaml
+# .github/workflows/visual-tests.yml
+name: Visual Regression Tests
+on: [push, pull_request]
+
+jobs:
+  visual-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.50.0-noble
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run visual tests
+        run: npx playwright test --project=visual
+        env:
+          HOME: /root  # required for Playwright in Docker
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: visual-test-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+**Updating snapshots locally using Docker** -- so your local baselines match CI:
+
+```bash
+# Generate/update snapshots using the same container as CI
+docker run --rm -v $(pwd):/work -w /work \
+  mcr.microsoft.com/playwright:v1.50.0-noble \
+  npx playwright test --update-snapshots --project=visual
+```
+
+**Add a script to `package.json`** for convenience:
+
+```json
+{
+  "scripts": {
+    "test:visual": "npx playwright test --project=visual",
+    "test:visual:update": "docker run --rm -v $(pwd):/work -w /work mcr.microsoft.com/playwright:v1.50.0-noble npx playwright test --update-snapshots --project=visual"
+  }
+}
+```
+
+**Configure snapshots for Linux only** in your config:
+
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}{-projectName}{ext}',
+  // Omits {-snapshotSuffix} which includes the platform name (linux, darwin, win32).
+  // This means snapshots are platform-agnostic -- you MUST generate them in Docker.
+  projects: [
+    {
+      name: 'visual',
+      testMatch: '**/*.visual.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+### 10. Component Visual Testing
+
+**Use when**: Testing individual UI components in isolation -- buttons, cards, forms, modals. Faster than full-page screenshots, more stable, and easier to maintain.
+**Avoid when**: You need to verify interactions between multiple components or page-level layout.
+
+**TypeScript -- using Playwright component testing**
+```typescript
+// tests/components/button.visual.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Button component visual states', () => {
+  test('primary button', async ({ page }) => {
+    await page.goto('/storybook/iframe.html?id=button--primary');
+    const button = page.getByRole('button');
+    await expect(button).toHaveScreenshot('button-primary.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('primary button hover', async ({ page }) => {
+    await page.goto('/storybook/iframe.html?id=button--primary');
+    const button = page.getByRole('button');
+    await button.hover();
+    await expect(button).toHaveScreenshot('button-primary-hover.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('primary button disabled', async ({ page }) => {
+    await page.goto('/storybook/iframe.html?id=button--primary-disabled');
+    const button = page.getByRole('button');
+    await expect(button).toHaveScreenshot('button-primary-disabled.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('button sizes', async ({ page }) => {
+    for (const size of ['small', 'medium', 'large']) {
+      await page.goto(`/storybook/iframe.html?id=button--${size}`);
+      const button = page.getByRole('button');
+      await expect(button).toHaveScreenshot(`button-${size}.png`, {
+        animations: 'disabled',
+      });
+    }
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Button component visual states', () => {
+  test('primary button', async ({ page }) => {
+    await page.goto('/storybook/iframe.html?id=button--primary');
+    const button = page.getByRole('button');
+    await expect(button).toHaveScreenshot('button-primary.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('primary button hover', async ({ page }) => {
+    await page.goto('/storybook/iframe.html?id=button--primary');
+    const button = page.getByRole('button');
+    await button.hover();
+    await expect(button).toHaveScreenshot('button-primary-hover.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('primary button disabled', async ({ page }) => {
+    await page.goto('/storybook/iframe.html?id=button--primary-disabled');
+    const button = page.getByRole('button');
+    await expect(button).toHaveScreenshot('button-primary-disabled.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('button sizes', async ({ page }) => {
+    for (const size of ['small', 'medium', 'large']) {
+      await page.goto(`/storybook/iframe.html?id=button--${size}`);
+      const button = page.getByRole('button');
+      await expect(button).toHaveScreenshot(`button-${size}.png`, {
+        animations: 'disabled',
+      });
+    }
+  });
+});
+```
+
+**Using a dedicated visual test page** instead of Storybook:
+
+```typescript
+// tests/components/card.visual.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Card component', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to a page that renders the component in isolation
+    await page.goto('/test-harness/card');
+  });
+
+  test('default state', async ({ page }) => {
+    await expect(page.getByTestId('card')).toHaveScreenshot('card-default.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('with long content truncates correctly', async ({ page }) => {
+    await page.goto('/test-harness/card?content=long');
+    await expect(page.getByTestId('card')).toHaveScreenshot('card-long-content.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('error state', async ({ page }) => {
+    await page.goto('/test-harness/card?state=error');
+    await expect(page.getByTestId('card')).toHaveScreenshot('card-error.png', {
+      animations: 'disabled',
+    });
+  });
+});
+```
+
+## Decision Guide
+
+| Scenario | Recommended Approach | Why |
+|---|---|---|
+| Key landing pages, marketing site | Full page screenshot, `fullPage: true` | Catches layout shifts, spacing, and overall visual harmony |
+| Individual UI components (buttons, cards, modals) | Element screenshot on the component | Isolated, fast, stable -- immune to unrelated page changes |
+| Page with dynamic content (timestamps, live data) | Full page + `mask` on dynamic elements | Covers layout while ignoring volatile content |
+| Design system component library | Element screenshot per variant, zero threshold | Pixel-perfect enforcement for shared components |
+| Responsive layout verification | Screenshot per viewport (loop or projects) | Catches breakpoint bugs at mobile/tablet/desktop |
+| Cross-browser rendering consistency | Separate snapshots per browser project | Browsers render fonts and shadows differently |
+| CI pipeline | Docker container (Playwright image), Linux-only snapshots | Consistent rendering, no OS-dependent diffs |
+| Pixel threshold: design system | `threshold: 0`, `maxDiffPixels: 0` | Zero tolerance for component library |
+| Pixel threshold: content pages | `maxDiffPixelRatio: 0.01`, `threshold: 0.2` | Allows minor anti-aliasing variance |
+| Pixel threshold: charts and graphs | `maxDiffPixels: 200`, `threshold: 0.3` | Anti-aliasing on curves varies across runs |
+| Visual tests add value | Stable pages, design systems, post-refactor verification | Clear baseline, predictable content |
+| Visual tests are noise | Highly dynamic pages, real-time dashboards, A/B test pages | Content changes on every load, diffs are meaningless |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Visual testing every page in the app | Massive snapshot maintenance, constant false failures, team ignores results | Pick 5-10 key pages and critical components. Quality over quantity. |
+| Not masking dynamic content (timestamps, avatars, counters) | Screenshots differ on every run. Tests are permanently flaky. | Use `mask` option for all dynamic elements. Audit pages for volatility before adding visual tests. |
+| Running visual tests across macOS, Linux, and Windows | Font rendering differs per OS. Snapshots never match cross-platform. | Standardize on Linux via Docker. Generate and run snapshots in the same Playwright Docker container. |
+| Not using Docker in CI for visual tests | CI runner OS updates, font changes, or library upgrades silently shift rendering. | Pin a specific Playwright Docker image version. Update intentionally. |
+| Updating snapshots blindly with `--update-snapshots` | Accepts unintentional regressions. The baseline becomes wrong. | Always review the diff in the HTML report first. Understand why the snapshot changed. |
+| Skipping `animations: 'disabled'` | CSS transitions and keyframe animations create random diffs. One of the top causes of flaky visual tests. | Set `animations: 'disabled'` globally in config. |
+| Using visual tests instead of functional assertions | Screenshot diffs do not tell you *what* broke -- just that *something* looks different. Slow to debug. | Use functional assertions (`toHaveText`, `toBeVisible`) for behavior. Visual tests complement, never replace. |
+| Committing snapshots generated on different platforms | The repo has macOS snapshots from dev A, Linux snapshots from dev B. Tests fail for everyone. | All team members generate snapshots using the same Docker container. Add a `test:visual:update` script. |
+| Setting threshold too high (e.g., `maxDiffPixelRatio: 0.1`) | 10% of pixels can change and the test still passes. Defeats the purpose. | Start with `0.01` (1%) and adjust per-test if needed. |
+| Full page screenshots on pages with infinite scroll or lazy loading | Page height is nondeterministic. Screenshots vary by load timing. | Use element screenshots on the above-the-fold content, or scroll to a deterministic state first. |
+
+## Troubleshooting
+
+### "Screenshot comparison failed" on first CI run after local development
+
+**Cause**: Snapshots were generated on macOS (or Windows) locally. CI runs on Linux. Font rendering differs between operating systems, so every pixel comparison fails.
+
+**Fix**: Generate snapshots using Docker locally so they match CI:
+
+```bash
+docker run --rm -v $(pwd):/work -w /work \
+  mcr.microsoft.com/playwright:v1.50.0-noble \
+  npx playwright test --update-snapshots --project=visual
+```
+
+Commit the Linux-generated snapshots. Never commit macOS-generated snapshots if CI runs on Linux.
+
+### "Expected screenshot to match but X pixels differ"
+
+**Cause**: Minor rendering differences from anti-aliasing, font hinting, or sub-pixel rendering. Common with text-heavy pages and curved shapes (charts, rounded corners).
+
+**Fix**: Add a small tolerance:
+
+```typescript
+await expect(page).toHaveScreenshot('page.png', {
+  maxDiffPixelRatio: 0.01,  // allow 1% variance
+  threshold: 0.2,           // per-pixel color tolerance
+});
+```
+
+If the diff is larger, check the HTML report. Look at the diff image to determine if the change is a real regression or rendering noise.
+
+### Visual tests pass locally but fail in CI (even with Docker)
+
+**Cause**: Different Playwright versions locally vs CI. The Docker image pins a specific Playwright version. If your local `@playwright/test` is newer, the rendering engine may differ.
+
+**Fix**: Ensure the Playwright version in `package.json` matches the Docker image tag:
+
+```json
+{
+  "devDependencies": {
+    "@playwright/test": "1.50.0"
+  }
+}
+```
+
+```yaml
+# CI config
+container:
+  image: mcr.microsoft.com/playwright:v1.50.0-noble  # must match
+```
+
+### Animations cause random diff failures
+
+**Cause**: CSS animations or transitions captured mid-frame. The screenshot is taken at a non-deterministic point in the animation timeline.
+
+**Fix**: Set `animations: 'disabled'` globally:
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  expect: {
+    toHaveScreenshot: {
+      animations: 'disabled',
+    },
+  },
+});
+```
+
+For JavaScript-driven animations, wait for a stable state before screenshotting. As a last resort, use `page.waitForTimeout(300)` after the animation trigger.
+
+### Snapshot file names conflict between tests
+
+**Cause**: Two tests in different files use the same screenshot name (`'homepage.png'`) without unique file paths.
+
+**Fix**: Playwright includes the test file name in the snapshot path by default. If you still have conflicts, use explicit unique names:
+
+```typescript
+await expect(page).toHaveScreenshot('auth-homepage.png');   // in auth.spec.ts
+await expect(page).toHaveScreenshot('public-homepage.png'); // in public.spec.ts
+```
+
+Or customize the snapshot path template in config:
+
+```typescript
+export default defineConfig({
+  snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}{-projectName}{ext}',
+});
+```
+
+### Too many snapshot files to maintain
+
+**Cause**: Visual tests for every page, every browser, every viewport. The snapshot count explodes.
+
+**Fix**: Be selective. Visual test only pages where visual regressions are high-risk:
+- Landing pages and marketing pages
+- Design system components
+- Complex layouts (dashboards, data tables)
+- Pages after a major refactor
+
+Skip pages where functional assertions already cover the key elements. A `toHaveText` and `toBeVisible` check is often enough.
+
+## Related
+
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- `toHaveScreenshot()` is a web-first assertion and follows the same retry semantics
+- [core/configuration.md](configuration.md) -- global screenshot config, project setup, `snapshotPathTemplate`
+- [core/mobile-and-responsive.md](mobile-and-responsive.md) -- responsive viewport testing patterns
+- [ci/docker-and-containers.md](../ci/docker-and-containers.md) -- Docker setup for consistent rendering
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI pipeline configuration for visual tests

--- a/engineering-team/playwright skill/core/vue.md
+++ b/engineering-team/playwright skill/core/vue.md
@@ -1,0 +1,1162 @@
+# Testing Vue Apps with Playwright
+
+> **When to use**: Testing Vue 3 applications, including composition API components, Pinia stores, Vue Router navigation, Nuxt.js apps, Teleport portals, and transitions. Covers E2E testing and experimental component testing with `@playwright/experimental-ct-vue`.
+> **Prerequisites**: [core/configuration.md](configuration.md), [core/locators.md](locators.md)
+
+## Quick Reference
+
+```bash
+# Install Playwright in a Vue project
+npm init playwright@latest
+
+# Install component testing (experimental)
+npm install -D @playwright/experimental-ct-vue
+
+# Run E2E tests
+npx playwright test
+
+# Run component tests
+npx playwright test -c playwright-ct.config.ts
+
+# Debug a test with headed browser and inspector
+npx playwright test tests/home.spec.ts --headed --debug
+```
+
+## Setup
+
+### Playwright Config for Vue (Vite)
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npx vite preview --port 5173'
+      : 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? '50%' : undefined,
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && npx vite preview --port 5173'
+      : 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+### Component Testing Config
+
+**TypeScript**
+```typescript
+// playwright-ct.config.ts
+import { defineConfig, devices } from '@playwright/experimental-ct-vue';
+
+export default defineConfig({
+  testDir: './tests/components',
+  testMatch: '**/*.ct.ts',
+
+  use: {
+    trace: 'on-first-retry',
+    ctPort: 3100,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+**JavaScript**
+```javascript
+// playwright-ct.config.js
+const { defineConfig, devices } = require('@playwright/experimental-ct-vue');
+
+module.exports = defineConfig({
+  testDir: './tests/components',
+  testMatch: '**/*.ct.js',
+
+  use: {
+    trace: 'on-first-retry',
+    ctPort: 3100,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+### Nuxt.js Setup
+
+Nuxt requires a build step before testing and uses port 3000 by default.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npx nuxi build && npx nuxi preview'
+      : 'npx nuxi dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NUXT_PUBLIC_API_BASE: 'http://localhost:3000/api',
+    },
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: process.env.CI
+      ? 'npx nuxi build && npx nuxi preview'
+      : 'npx nuxi dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NUXT_PUBLIC_API_BASE: 'http://localhost:3000/api',
+    },
+  },
+});
+```
+
+## Patterns
+
+### Component Testing with `@playwright/experimental-ct-vue`
+
+**Use when**: Testing complex interactive Vue components in isolation -- data tables, form components, custom select dropdowns, rich editors. The component needs a real browser but not a full application.
+**Avoid when**: The component depends heavily on Pinia stores, Vue Router, or backend data. Use E2E tests instead, or provide the dependencies in your component test setup.
+
+**TypeScript**
+```typescript
+// tests/components/Counter.ct.ts
+import { test, expect } from '@playwright/experimental-ct-vue';
+import Counter from '../../src/components/Counter.vue';
+
+test('renders with initial count and increments', async ({ mount }) => {
+  const component = await mount(Counter, {
+    props: {
+      initialCount: 0,
+    },
+  });
+
+  await expect(component.getByText('Count: 0')).toBeVisible();
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 1')).toBeVisible();
+});
+
+test('emits update event when count changes', async ({ mount }) => {
+  const emittedValues: number[] = [];
+  const component = await mount(Counter, {
+    props: {
+      initialCount: 5,
+    },
+    on: {
+      update: (value: number) => emittedValues.push(value),
+    },
+  });
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await component.getByRole('button', { name: 'Increment' }).click();
+
+  expect(emittedValues).toEqual([6, 7]);
+});
+
+test('respects max prop', async ({ mount }) => {
+  const component = await mount(Counter, {
+    props: {
+      initialCount: 9,
+      max: 10,
+    },
+  });
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 10')).toBeVisible();
+
+  // At max -- button should be disabled
+  await expect(component.getByRole('button', { name: 'Increment' })).toBeDisabled();
+});
+
+test('renders with slot content', async ({ mount }) => {
+  const component = await mount(Counter, {
+    props: { initialCount: 0 },
+    slots: {
+      default: '<span class="custom-label">Items in cart</span>',
+    },
+  });
+
+  await expect(component.getByText('Items in cart')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+// tests/components/Counter.ct.js
+const { test, expect } = require('@playwright/experimental-ct-vue');
+const Counter = require('../../src/components/Counter.vue');
+
+test('renders with initial count and increments', async ({ mount }) => {
+  const component = await mount(Counter, {
+    props: {
+      initialCount: 0,
+    },
+  });
+
+  await expect(component.getByText('Count: 0')).toBeVisible();
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await expect(component.getByText('Count: 1')).toBeVisible();
+});
+
+test('emits update event when count changes', async ({ mount }) => {
+  const emittedValues = [];
+  const component = await mount(Counter, {
+    props: {
+      initialCount: 5,
+    },
+    on: {
+      update: (value) => emittedValues.push(value),
+    },
+  });
+
+  await component.getByRole('button', { name: 'Increment' }).click();
+  await component.getByRole('button', { name: 'Increment' }).click();
+
+  expect(emittedValues).toEqual([6, 7]);
+});
+
+test('renders with slot content', async ({ mount }) => {
+  const component = await mount(Counter, {
+    props: { initialCount: 0 },
+    slots: {
+      default: '<span class="custom-label">Items in cart</span>',
+    },
+  });
+
+  await expect(component.getByText('Items in cart')).toBeVisible();
+});
+```
+
+### Testing Pinia Stores Through the UI
+
+**Use when**: Verifying that Pinia stores produce the correct UI behavior. Playwright tests the rendered output, not the store directly. If the UI is correct, the store is correct.
+**Avoid when**: Testing pure store logic (getters, actions with no UI side effect) -- use unit tests with Vitest for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Pinia cart store (tested through UI)', () => {
+  test('adding items updates the cart across the app', async ({ page }) => {
+    await page.goto('/products');
+
+    const cartBadge = page.getByTestId('cart-count');
+
+    // Initially empty
+    await expect(cartBadge).toHaveText('0');
+
+    // Add first item -- Pinia store action is triggered
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Vue T-Shirt' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('1');
+
+    // Add second item
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Pinia Sticker Pack' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('2');
+
+    // Navigate to cart page -- store state persists
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.waitForURL('/cart');
+
+    await expect(page.getByText('Vue T-Shirt')).toBeVisible();
+    await expect(page.getByText('Pinia Sticker Pack')).toBeVisible();
+    await expect(page.getByText('Total: $29.98')).toBeVisible();
+  });
+
+  test('removing items from cart updates total', async ({ page }) => {
+    // Navigate to a pre-populated cart (seed via API or navigate through adding items)
+    await page.goto('/products');
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Vue T-Shirt' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.waitForURL('/cart');
+
+    await page.getByRole('button', { name: 'Remove Vue T-Shirt' }).click();
+
+    await expect(page.getByText('Your cart is empty')).toBeVisible();
+    await expect(page.getByTestId('cart-count')).toHaveText('0');
+  });
+
+  test('store persists after page reload when using pinia-plugin-persistedstate', async ({ page }) => {
+    await page.goto('/products');
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Vue T-Shirt' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+
+    // Reload the page -- persisted store should restore state
+    await page.reload();
+
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+});
+
+test.describe('Pinia auth store (tested through UI)', () => {
+  test('login updates auth state across all components', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+
+    await page.getByRole('link', { name: 'Sign in' }).click();
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    await page.waitForURL('/dashboard');
+
+    // Header updates (uses auth store)
+    await expect(page.getByText('user@example.com')).toBeVisible();
+    // Navigation updates (uses auth store for conditional routes)
+    await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Pinia cart store (tested through UI)', () => {
+  test('adding items updates the cart across the app', async ({ page }) => {
+    await page.goto('/products');
+
+    const cartBadge = page.getByTestId('cart-count');
+    await expect(cartBadge).toHaveText('0');
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Vue T-Shirt' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('1');
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Pinia Sticker Pack' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+    await expect(cartBadge).toHaveText('2');
+
+    await page.getByRole('link', { name: 'Cart' }).click();
+    await page.waitForURL('/cart');
+
+    await expect(page.getByText('Vue T-Shirt')).toBeVisible();
+    await expect(page.getByText('Pinia Sticker Pack')).toBeVisible();
+  });
+
+  test('store persists after page reload when using pinia-plugin-persistedstate', async ({ page }) => {
+    await page.goto('/products');
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Vue T-Shirt' })
+      .getByRole('button', { name: 'Add to cart' })
+      .click();
+
+    await page.reload();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+  });
+});
+```
+
+### Testing Vue Router Navigation
+
+**Use when**: Testing client-side routing with Vue Router. Verify route transitions, navigation guards, URL parameters, and browser history behavior.
+**Avoid when**: Testing Nuxt.js file-based routing -- the patterns are similar but Nuxt has additional server-side concerns.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Vue Router navigation', () => {
+  test('client-side navigation does not cause full page reload', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      (window as any).__testMarker = 'no-reload';
+    });
+
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+
+    const marker = await page.evaluate(() => (window as any).__testMarker);
+    expect(marker).toBe('no-reload');
+  });
+
+  test('dynamic route params render correct content', async ({ page }) => {
+    await page.goto('/products/42');
+
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByText('Product #42')).toBeVisible();
+  });
+
+  test('navigation guard redirects unauthenticated users', async ({ page }) => {
+    // Visit a route guarded by router.beforeEach
+    await page.goto('/admin/users');
+
+    // Guard should redirect to login
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('named routes and nested views render correctly', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Parent layout
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Settings' })).toBeVisible();
+
+    // Default child route
+    await expect(page.getByRole('heading', { name: 'General', level: 2 })).toBeVisible();
+
+    // Navigate to sibling child route
+    await page.getByRole('link', { name: 'Notifications' }).click();
+    await page.waitForURL('/settings/notifications');
+
+    // Parent layout persists, child content changes
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Notifications', level: 2 })).toBeVisible();
+  });
+
+  test('browser back/forward works with Vue Router', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/products/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/products/);
+  });
+
+  test('query parameters update reactive computed properties', async ({ page }) => {
+    await page.goto('/products?sort=price-asc&category=electronics');
+
+    await expect(page.getByRole('heading', { name: 'Electronics' })).toBeVisible();
+
+    // Change sort via UI (updates route query params)
+    await page.getByRole('combobox', { name: 'Sort by' }).selectOption('name-asc');
+    await expect(page).toHaveURL(/sort=name-asc/);
+  });
+
+  test('404 catch-all route displays not found page', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist');
+
+    await expect(page.getByRole('heading', { name: 'Page Not Found' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Go home' })).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Vue Router navigation', () => {
+  test('client-side navigation does not cause full page reload', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      window.__testMarker = 'no-reload';
+    });
+
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+
+    const marker = await page.evaluate(() => window.__testMarker);
+    expect(marker).toBe('no-reload');
+  });
+
+  test('dynamic route params render correct content', async ({ page }) => {
+    await page.goto('/products/42');
+
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByText('Product #42')).toBeVisible();
+  });
+
+  test('navigation guard redirects unauthenticated users', async ({ page }) => {
+    await page.goto('/admin/users');
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  });
+
+  test('browser back/forward works with Vue Router', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Products' }).click();
+    await page.waitForURL('/products');
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/products/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+  });
+});
+```
+
+### Testing Teleport (Portals)
+
+**Use when**: Testing components rendered via Vue's `<Teleport>` -- modals, notifications, overlay menus. Teleport moves DOM elements to a different location (often `body`), but Playwright sees the entire document.
+**Avoid when**: The component is not teleported -- it renders inline in its parent.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Teleport components', () => {
+  test('modal teleported to body is visible and interactive', async ({ page }) => {
+    await page.goto('/products');
+
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+
+    // Modal is teleported to <body> with <Teleport to="body">
+    // Playwright sees it like any other element
+    const modal = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(modal).toBeVisible();
+
+    await modal.getByRole('button', { name: 'Cancel' }).click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('teleported notification appears above all content', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Notification teleported to #notifications container
+    const notification = page.getByRole('alert');
+    await expect(notification).toBeVisible();
+    await expect(notification).toContainText('Settings saved');
+
+    // Auto-dismiss
+    await expect(notification).toBeHidden({ timeout: 10_000 });
+  });
+
+  test('teleported dropdown closes on outside click', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await page.getByRole('button', { name: 'User menu' }).click();
+
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    // Click outside the menu
+    await page.locator('body').click({ position: { x: 10, y: 10 } });
+    await expect(menu).toBeHidden();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Teleport components', () => {
+  test('modal teleported to body is visible and interactive', async ({ page }) => {
+    await page.goto('/products');
+
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+
+    const modal = page.getByRole('dialog', { name: 'Confirm deletion' });
+    await expect(modal).toBeVisible();
+
+    await modal.getByRole('button', { name: 'Cancel' }).click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('teleported notification appears above all content', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    const notification = page.getByRole('alert');
+    await expect(notification).toBeVisible();
+    await expect(notification).toContainText('Settings saved');
+
+    await expect(notification).toBeHidden({ timeout: 10_000 });
+  });
+
+  test('teleported dropdown closes on outside click', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await page.getByRole('button', { name: 'User menu' }).click();
+
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    await page.locator('body').click({ position: { x: 10, y: 10 } });
+    await expect(menu).toBeHidden();
+  });
+});
+```
+
+### Testing Transitions and Animations
+
+**Use when**: Verifying that Vue `<Transition>` and `<TransitionGroup>` components work correctly -- elements appear, disappear, and reorder with expected behavior. Focus on the end state, not the animation itself.
+**Avoid when**: Testing the exact CSS animation keyframes -- visual regression testing is better for pixel-level validation.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('transitions', () => {
+  test('list items animate in when added', async ({ page }) => {
+    await page.goto('/todo');
+
+    await page.getByRole('textbox', { name: 'New task' }).fill('Buy groceries');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    // The item should be visible after the enter transition completes
+    // Playwright auto-waits for visibility, handling the transition automatically
+    await expect(page.getByText('Buy groceries')).toBeVisible();
+  });
+
+  test('deleted items animate out and are removed from DOM', async ({ page }) => {
+    await page.goto('/todo');
+
+    // Add an item first
+    await page.getByRole('textbox', { name: 'New task' }).fill('Temporary task');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.getByText('Temporary task')).toBeVisible();
+
+    // Delete it
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Temporary task' })
+      .getByRole('button', { name: 'Delete' })
+      .click();
+
+    // After the leave transition, the element should be gone
+    await expect(page.getByText('Temporary task')).toBeHidden();
+  });
+
+  test('page transition completes between routes', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'About' }).click();
+    await page.waitForURL('/about');
+
+    // After the route transition animation, content should be visible
+    await expect(page.getByRole('heading', { name: 'About' })).toBeVisible();
+  });
+
+  test('disable animations for faster, more reliable tests', async ({ page }) => {
+    // Disable all CSS animations and transitions for deterministic testing
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0s !important;
+          animation-delay: 0s !important;
+          transition-duration: 0s !important;
+          transition-delay: 0s !important;
+        }
+      `,
+    });
+
+    await page.goto('/todo');
+
+    await page.getByRole('textbox', { name: 'New task' }).fill('Instant task');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    // With animations disabled, elements appear/disappear instantly
+    await expect(page.getByText('Instant task')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('transitions', () => {
+  test('list items animate in when added', async ({ page }) => {
+    await page.goto('/todo');
+
+    await page.getByRole('textbox', { name: 'New task' }).fill('Buy groceries');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    await expect(page.getByText('Buy groceries')).toBeVisible();
+  });
+
+  test('deleted items animate out and are removed from DOM', async ({ page }) => {
+    await page.goto('/todo');
+
+    await page.getByRole('textbox', { name: 'New task' }).fill('Temporary task');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.getByText('Temporary task')).toBeVisible();
+
+    await page.getByRole('listitem')
+      .filter({ hasText: 'Temporary task' })
+      .getByRole('button', { name: 'Delete' })
+      .click();
+
+    await expect(page.getByText('Temporary task')).toBeHidden();
+  });
+
+  test('disable animations for faster, more reliable tests', async ({ page }) => {
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0s !important;
+          animation-delay: 0s !important;
+          transition-duration: 0s !important;
+          transition-delay: 0s !important;
+        }
+      `,
+    });
+
+    await page.goto('/todo');
+
+    await page.getByRole('textbox', { name: 'New task' }).fill('Instant task');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    await expect(page.getByText('Instant task')).toBeVisible();
+  });
+});
+```
+
+### Testing Composition API Components
+
+**Use when**: Testing components built with the Vue 3 Composition API (`<script setup>`, `setup()` function). From Playwright's perspective, Composition API and Options API components are identical -- you test the rendered output.
+**Avoid when**: You want to test composable functions in isolation -- use Vitest for that.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('composition API patterns', () => {
+  test('computed properties update the UI reactively', async ({ page }) => {
+    await page.goto('/calculator');
+
+    await page.getByLabel('Price').fill('100');
+    await page.getByLabel('Quantity').fill('3');
+
+    // Computed total should update reactively
+    await expect(page.getByTestId('total')).toHaveText('$300.00');
+
+    // Apply discount
+    await page.getByLabel('Discount (%)').fill('10');
+    await expect(page.getByTestId('total')).toHaveText('$270.00');
+  });
+
+  test('watcher triggers side effect on value change', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Changing the language triggers a watcher that reloads translations
+    await page.getByRole('combobox', { name: 'Language' }).selectOption('fr');
+
+    // Watcher fetches French translations -- UI updates
+    await expect(page.getByRole('heading', { name: 'Parametres' })).toBeVisible();
+  });
+
+  test('composable hook (useSearch) provides debounced search', async ({ page }) => {
+    await page.goto('/products');
+
+    const searchInput = page.getByRole('textbox', { name: 'Search products' });
+    await searchInput.pressSequentially('vue stickers', { delay: 50 });
+
+    // useSearch composable debounces and fetches results
+    await expect(page.getByRole('listitem')).toHaveCount(3);
+    await expect(page.getByText('Vue Sticker Pack')).toBeVisible();
+  });
+
+  test('provide/inject context works across component tree', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // Theme is provided at the app root and injected in child components
+    await page.getByRole('switch', { name: 'Dark mode' }).click();
+
+    // All components using inject('theme') should update
+    await expect(page.locator('body')).toHaveClass(/dark/);
+    await expect(page.getByRole('navigation')).toHaveCSS('background-color', /rgb\(30/);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('composition API patterns', () => {
+  test('computed properties update the UI reactively', async ({ page }) => {
+    await page.goto('/calculator');
+
+    await page.getByLabel('Price').fill('100');
+    await page.getByLabel('Quantity').fill('3');
+
+    await expect(page.getByTestId('total')).toHaveText('$300.00');
+
+    await page.getByLabel('Discount (%)').fill('10');
+    await expect(page.getByTestId('total')).toHaveText('$270.00');
+  });
+
+  test('watcher triggers side effect on value change', async ({ page }) => {
+    await page.goto('/settings');
+
+    await page.getByRole('combobox', { name: 'Language' }).selectOption('fr');
+    await expect(page.getByRole('heading', { name: 'Parametres' })).toBeVisible();
+  });
+
+  test('composable hook (useSearch) provides debounced search', async ({ page }) => {
+    await page.goto('/products');
+
+    const searchInput = page.getByRole('textbox', { name: 'Search products' });
+    await searchInput.pressSequentially('vue stickers', { delay: 50 });
+
+    await expect(page.getByRole('listitem')).toHaveCount(3);
+    await expect(page.getByText('Vue Sticker Pack')).toBeVisible();
+  });
+});
+```
+
+### Testing Nuxt.js Specific Patterns
+
+**Use when**: Testing Nuxt 3 applications with server-side rendering, auto-imports, server routes (`/server/api/`), and middleware.
+**Avoid when**: Testing a plain Vue SPA without Nuxt.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Nuxt-specific patterns', () => {
+  test('SSR page renders server-fetched data', async ({ page }) => {
+    await page.goto('/blog');
+
+    // useFetch/useAsyncData runs on the server -- content is in the initial HTML
+    await expect(page.getByRole('article')).toHaveCount(10);
+    await expect(page.getByRole('article').first()).toContainText(/\w+/);
+  });
+
+  test('Nuxt server route returns correct data', async ({ request }) => {
+    const response = await request.get('/api/products');
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body).toBeInstanceOf(Array);
+    expect(body[0]).toHaveProperty('id');
+  });
+
+  test('Nuxt middleware redirects unauthenticated users', async ({ page }) => {
+    await page.goto('/admin');
+
+    // definePageMeta({ middleware: 'auth' }) in the page triggers redirect
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('NuxtLink enables client-side navigation', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      (window as any).__testMarker = 'no-reload';
+    });
+
+    await page.getByRole('link', { name: 'Blog' }).click();
+    await page.waitForURL('/blog');
+
+    const marker = await page.evaluate(() => (window as any).__testMarker);
+    expect(marker).toBe('no-reload');
+  });
+
+  test('useHead sets meta tags for SEO', async ({ page }) => {
+    await page.goto('/blog/my-post');
+
+    const title = await page.title();
+    expect(title).toContain('My Post');
+
+    const description = await page.locator('meta[name="description"]').getAttribute('content');
+    expect(description).toBeTruthy();
+    expect(description!.length).toBeGreaterThan(50);
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Nuxt-specific patterns', () => {
+  test('SSR page renders server-fetched data', async ({ page }) => {
+    await page.goto('/blog');
+
+    await expect(page.getByRole('article')).toHaveCount(10);
+    await expect(page.getByRole('article').first()).toContainText(/\w+/);
+  });
+
+  test('Nuxt server route returns correct data', async ({ request }) => {
+    const response = await request.get('/api/products');
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body).toBeInstanceOf(Array);
+    expect(body[0]).toHaveProperty('id');
+  });
+
+  test('Nuxt middleware redirects unauthenticated users', async ({ page }) => {
+    await page.goto('/admin');
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('NuxtLink enables client-side navigation', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      window.__testMarker = 'no-reload';
+    });
+
+    await page.getByRole('link', { name: 'Blog' }).click();
+    await page.waitForURL('/blog');
+
+    const marker = await page.evaluate(() => window.__testMarker);
+    expect(marker).toBe('no-reload');
+  });
+});
+```
+
+## Framework-Specific Tips
+
+### Vue DevTools and Playwright
+
+Vue DevTools is a browser extension. It does not interfere with Playwright tests since Playwright launches its own browser profile without extensions. Do not rely on Vue DevTools for debugging in CI -- use Playwright traces instead.
+
+### Testing `v-model` Two-Way Binding
+
+`v-model` on form inputs works through standard HTML events. Playwright's `fill()`, `check()`, `selectOption()` methods trigger the correct events automatically. No special handling is needed.
+
+```typescript
+// This works for any v-model input -- no special Vue handling needed
+await page.getByLabel('Username').fill('janedoe');
+await page.getByRole('checkbox', { name: 'Remember me' }).check();
+await page.getByRole('combobox', { name: 'Role' }).selectOption('admin');
+```
+
+### Vue vs Nuxt: Configuration Differences
+
+| Aspect | Vue 3 (Vite) | Nuxt 3 |
+|---|---|---|
+| Default port | `5173` | `3000` |
+| Dev command | `npm run dev` (vite) | `npx nuxi dev` |
+| Build + preview | `npm run build && npx vite preview` | `npx nuxi build && npx nuxi preview` |
+| SSR | Optional (vue-server-renderer) | Built-in |
+| API routes | External backend | `/server/api/` built-in |
+| Environment variables | `VITE_*` prefix | `NUXT_PUBLIC_*` prefix for client, `NUXT_*` for server |
+| File-based routing | No (uses vue-router config) | Yes (automatic from `/pages/`) |
+
+### Component Testing: Providing Pinia and Router
+
+When using `@playwright/experimental-ct-vue`, components that depend on Pinia or Vue Router need these dependencies provided. Configure the test wrapper:
+
+```typescript
+// playwright/index.ts (component testing setup)
+import { beforeMount } from '@playwright/experimental-ct-vue/hooks';
+import { createPinia } from 'pinia';
+import { createMemoryHistory, createRouter } from 'vue-router';
+
+beforeMount(async ({ app, hooksConfig }) => {
+  // Install Pinia for all component tests
+  const pinia = createPinia();
+  app.use(pinia);
+
+  // Install a minimal router if the component uses <RouterLink> or useRoute()
+  if (hooksConfig?.routes) {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: hooksConfig.routes,
+    });
+    app.use(router);
+  }
+});
+```
+
+### Handling Vue Warnings in Tests
+
+Vue emits runtime warnings (prop validation, missing components, etc.) that can indicate real issues:
+
+```typescript
+test('no Vue warnings during render', async ({ page }) => {
+  const warnings: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'warning' && msg.text().includes('[Vue warn]')) {
+      warnings.push(msg.text());
+    }
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+
+  expect(warnings).toEqual([]);
+});
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.evaluate(() => app.__vue_app__.config.globalProperties.$store)` | Accesses Vue internals; breaks on upgrades; tests implementation | Assert on the UI that state produces |
+| `page.locator('[data-v-abc123]')` (scoped style hash) | Vue generates random scoped attribute hashes; changes on every build | Use `getByRole`, `getByText`, `getByTestId` |
+| Import `.vue` files in E2E tests | E2E tests run in Node.js; `.vue` files need Vite/Webpack compilation | Use `@playwright/experimental-ct-vue` for component tests |
+| `page.waitForTimeout(300)` to wait for transition to finish | Transition durations vary; arbitrary waits are fragile | `await expect(locator).toBeVisible()` auto-waits through transitions |
+| Mock Pinia stores by patching `window.__pinia` | Fragile; depends on Pinia internals; may not trigger reactivity | Control state through UI interactions or mock the API responses the store consumes |
+| Test composables by calling them via `page.evaluate` | Composables rely on Vue's setup context; calling them outside a component fails | Test composables through the components that use them, or unit test with Vitest |
+| Use `page.locator('.v-btn')` for Vuetify components | Vuetify class names are internal and change between versions | `page.getByRole('button', { name: 'Submit' })` works regardless of the component library |
+| Skip testing keyboard navigation for custom components | Vue component libraries often have incomplete keyboard support | Test `Tab`, `Enter`, `Escape`, `ArrowDown/Up` on dropdowns, modals, tabs |
+| Run Nuxt dev server in CI | Dev mode includes hot reload overhead, slower builds, development warnings | Use `npx nuxi build && npx nuxi preview` in CI |
+
+## Related
+
+- [core/locators.md](locators.md) -- locator strategies for any Vue component library (Vuetify, PrimeVue, Quasar)
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-waiting assertions for Vue reactivity
+- [core/component-testing.md](component-testing.md) -- in-depth component testing patterns
+- [core/forms-and-validation.md](forms-and-validation.md) -- form testing patterns for VeeValidate and FormKit
+- [core/accessibility.md](accessibility.md) -- accessibility testing for Vue component libraries
+- [core/test-architecture.md](test-architecture.md) -- when to use E2E vs component vs unit tests
+- [core/nextjs.md](nextjs.md) -- comparison: Nuxt vs Next.js testing patterns

--- a/engineering-team/playwright skill/core/websockets-and-realtime.md
+++ b/engineering-team/playwright skill/core/websockets-and-realtime.md
@@ -1,0 +1,572 @@
+# WebSockets and Real-Time Testing
+
+> **When to use**: When your application uses WebSockets, Server-Sent Events (SSE), or polling for real-time features -- chat, live dashboards, notifications, collaborative editing, stock tickers, live sports scores.
+> **Prerequisites**: [core/assertions-and-waiting.md](assertions-and-waiting.md), [core/fixtures-and-hooks.md](fixtures-and-hooks.md)
+
+## Quick Reference
+
+```typescript
+// Listen for WebSocket connections
+page.on('websocket', (ws) => {
+  console.log('WebSocket opened:', ws.url());
+
+  ws.on('framesent', (frame) => console.log('Sent:', frame.payload));
+  ws.on('framereceived', (frame) => console.log('Received:', frame.payload));
+  ws.on('close', () => console.log('WebSocket closed'));
+});
+
+// Mock a WebSocket via route (Playwright 1.48+)
+await page.routeWebSocket('**/ws', (ws) => {
+  ws.onMessage((message) => {
+    ws.send(JSON.stringify({ echo: message }));
+  });
+});
+```
+
+## Patterns
+
+### Observing WebSocket Traffic
+
+**Use when**: You need to verify that your app sends and receives the correct WebSocket messages without modifying them.
+**Avoid when**: You need to intercept or mock the messages. Use `routeWebSocket` instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('chat message is sent over WebSocket', async ({ page }) => {
+  const messages: { direction: string; payload: string }[] = [];
+
+  page.on('websocket', (ws) => {
+    ws.on('framesent', (frame) => {
+      messages.push({ direction: 'sent', payload: String(frame.payload) });
+    });
+    ws.on('framereceived', (frame) => {
+      messages.push({ direction: 'received', payload: String(frame.payload) });
+    });
+  });
+
+  await page.goto('/chat');
+  await page.getByRole('textbox', { name: 'Message' }).fill('Hello!');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  // Wait for the message to appear in UI (confirms round-trip)
+  await expect(page.getByText('Hello!')).toBeVisible();
+
+  // Verify WebSocket traffic
+  const sentMessage = messages.find(
+    (m) => m.direction === 'sent' && m.payload.includes('Hello!')
+  );
+  expect(sentMessage).toBeDefined();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('chat message is sent over WebSocket', async ({ page }) => {
+  const messages = [];
+
+  page.on('websocket', (ws) => {
+    ws.on('framesent', (frame) => {
+      messages.push({ direction: 'sent', payload: String(frame.payload) });
+    });
+    ws.on('framereceived', (frame) => {
+      messages.push({ direction: 'received', payload: String(frame.payload) });
+    });
+  });
+
+  await page.goto('/chat');
+  await page.getByRole('textbox', { name: 'Message' }).fill('Hello!');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Hello!')).toBeVisible();
+
+  const sentMessage = messages.find(
+    (m) => m.direction === 'sent' && m.payload.includes('Hello!')
+  );
+  expect(sentMessage).toBeDefined();
+});
+```
+
+### Waiting for a Specific WebSocket Message
+
+**Use when**: Your test depends on a particular server-pushed message before proceeding.
+**Avoid when**: The UI already reflects the message. Assert on the UI instead.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('wait for server acknowledgment over WebSocket', async ({ page }) => {
+  // Create a promise that resolves when we get the specific message
+  const ackPromise = new Promise<void>((resolve) => {
+    page.on('websocket', (ws) => {
+      ws.on('framereceived', (frame) => {
+        const data = JSON.parse(String(frame.payload));
+        if (data.type === 'message_ack') {
+          resolve();
+        }
+      });
+    });
+  });
+
+  await page.goto('/chat');
+  await page.getByRole('textbox', { name: 'Message' }).fill('Important update');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  // Wait for server to acknowledge
+  await ackPromise;
+
+  // Now verify the message shows a "delivered" checkmark
+  await expect(page.getByTestId('message-status').last()).toHaveText('Delivered');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('wait for server acknowledgment over WebSocket', async ({ page }) => {
+  const ackPromise = new Promise((resolve) => {
+    page.on('websocket', (ws) => {
+      ws.on('framereceived', (frame) => {
+        const data = JSON.parse(String(frame.payload));
+        if (data.type === 'message_ack') {
+          resolve();
+        }
+      });
+    });
+  });
+
+  await page.goto('/chat');
+  await page.getByRole('textbox', { name: 'Message' }).fill('Important update');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await ackPromise;
+  await expect(page.getByTestId('message-status').last()).toHaveText('Delivered');
+});
+```
+
+### Mocking WebSocket Messages with `routeWebSocket`
+
+**Use when**: You want to control what the server sends to test specific UI states -- error messages, edge cases, high-volume data -- without a real backend.
+**Avoid when**: You need to test actual server behavior. Use a real backend.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('display notification when server pushes an alert', async ({ page }) => {
+  const wsRoute = await page.routeWebSocket('**/ws/notifications', (ws) => {
+    // Let the app send its initial handshake
+    ws.onMessage((message) => {
+      const data = JSON.parse(message);
+      if (data.type === 'subscribe') {
+        ws.send(JSON.stringify({ type: 'subscribed', channel: data.channel }));
+      }
+    });
+
+    // Push a notification after a short delay
+    setTimeout(() => {
+      ws.send(JSON.stringify({
+        type: 'notification',
+        title: 'Server Alert',
+        body: 'Deployment completed successfully',
+        severity: 'info',
+      }));
+    }, 500);
+  });
+
+  await page.goto('/dashboard');
+
+  // Verify the notification appears in the UI
+  await expect(page.getByRole('alert')).toContainText('Deployment completed successfully');
+});
+
+test('handle WebSocket server error gracefully', async ({ page }) => {
+  await page.routeWebSocket('**/ws', (ws) => {
+    // Immediately close with an error code
+    ws.close({ code: 1011, reason: 'Internal server error' });
+  });
+
+  await page.goto('/chat');
+
+  // App should show a reconnection message, not crash
+  await expect(page.getByText('Connection lost. Reconnecting...')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('display notification when server pushes an alert', async ({ page }) => {
+  await page.routeWebSocket('**/ws/notifications', (ws) => {
+    ws.onMessage((message) => {
+      const data = JSON.parse(message);
+      if (data.type === 'subscribe') {
+        ws.send(JSON.stringify({ type: 'subscribed', channel: data.channel }));
+      }
+    });
+
+    setTimeout(() => {
+      ws.send(JSON.stringify({
+        type: 'notification',
+        title: 'Server Alert',
+        body: 'Deployment completed successfully',
+        severity: 'info',
+      }));
+    }, 500);
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('alert')).toContainText('Deployment completed successfully');
+});
+
+test('handle WebSocket server error gracefully', async ({ page }) => {
+  await page.routeWebSocket('**/ws', (ws) => {
+    ws.close({ code: 1011, reason: 'Internal server error' });
+  });
+
+  await page.goto('/chat');
+  await expect(page.getByText('Connection lost. Reconnecting...')).toBeVisible();
+});
+```
+
+### Forwarding with Modification (Man-in-the-Middle)
+
+**Use when**: You want to connect to the real server but intercept, modify, or inject messages.
+**Avoid when**: Full mocking (`routeWebSocket` without `connectToServer`) is sufficient.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('inject a fake high-priority message into real stream', async ({ page }) => {
+  await page.routeWebSocket('**/ws/feed', (ws) => {
+    const server = ws.connectToServer();
+
+    // Forward all messages from server to client, but inject extras
+    server.onMessage((message) => {
+      ws.send(message); // Forward the real message
+    });
+
+    // Forward all client messages to server
+    ws.onMessage((message) => {
+      server.send(message);
+    });
+
+    // Inject a synthetic message after 1 second
+    setTimeout(() => {
+      ws.send(JSON.stringify({
+        type: 'alert',
+        priority: 'high',
+        text: 'Injected test alert',
+      }));
+    }, 1000);
+  });
+
+  await page.goto('/live-feed');
+  await expect(page.getByText('Injected test alert')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('inject a fake high-priority message into real stream', async ({ page }) => {
+  await page.routeWebSocket('**/ws/feed', (ws) => {
+    const server = ws.connectToServer();
+
+    server.onMessage((message) => {
+      ws.send(message);
+    });
+
+    ws.onMessage((message) => {
+      server.send(message);
+    });
+
+    setTimeout(() => {
+      ws.send(JSON.stringify({
+        type: 'alert',
+        priority: 'high',
+        text: 'Injected test alert',
+      }));
+    }, 1000);
+  });
+
+  await page.goto('/live-feed');
+  await expect(page.getByText('Injected test alert')).toBeVisible();
+});
+```
+
+### Server-Sent Events (SSE) Testing
+
+**Use when**: Your app uses `EventSource` for server-to-client streaming (live logs, progress updates, news feeds).
+**Avoid when**: The app uses WebSockets. SSE is HTTP-based and intercepted differently.
+
+SSE responses are standard HTTP -- intercept them with `page.route()` and return a streaming response.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('SSE live log stream displays entries', async ({ page }) => {
+  // Intercept the SSE endpoint and return controlled events
+  await page.route('**/api/logs/stream', async (route) => {
+    const events = [
+      'data: {"level":"info","message":"Server started"}\n\n',
+      'data: {"level":"warn","message":"High memory usage"}\n\n',
+      'data: {"level":"error","message":"Connection timeout"}\n\n',
+    ];
+
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body: events.join(''),
+    });
+  });
+
+  await page.goto('/admin/logs');
+
+  await expect(page.getByText('Server started')).toBeVisible();
+  await expect(page.getByText('High memory usage')).toBeVisible();
+  await expect(page.getByText('Connection timeout')).toBeVisible();
+});
+
+test('SSE reconnection on connection drop', async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route('**/api/events', async (route) => {
+    requestCount++;
+    if (requestCount === 1) {
+      // First request: send one event then close abruptly
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+        body: 'data: {"msg":"first"}\n\n',
+      });
+    } else {
+      // Reconnection: send the next event
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+        body: 'data: {"msg":"reconnected"}\n\n',
+      });
+    }
+  });
+
+  await page.goto('/live');
+  await expect(page.getByText('first')).toBeVisible();
+  // EventSource auto-reconnects; verify the app handles it
+  await expect(page.getByText('reconnected')).toBeVisible({ timeout: 10000 });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('SSE live log stream displays entries', async ({ page }) => {
+  await page.route('**/api/logs/stream', async (route) => {
+    const events = [
+      'data: {"level":"info","message":"Server started"}\n\n',
+      'data: {"level":"warn","message":"High memory usage"}\n\n',
+      'data: {"level":"error","message":"Connection timeout"}\n\n',
+    ];
+
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body: events.join(''),
+    });
+  });
+
+  await page.goto('/admin/logs');
+
+  await expect(page.getByText('Server started')).toBeVisible();
+  await expect(page.getByText('High memory usage')).toBeVisible();
+  await expect(page.getByText('Connection timeout')).toBeVisible();
+});
+```
+
+### Polling-Based Real-Time Testing
+
+**Use when**: Your app uses HTTP polling (setInterval + fetch) instead of WebSockets or SSE.
+**Avoid when**: The app uses WebSockets or SSE -- use the patterns above.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('polling updates dashboard data every interval', async ({ page }) => {
+  let callCount = 0;
+
+  await page.route('**/api/dashboard/stats', async (route) => {
+    callCount++;
+    const data = callCount === 1
+      ? { activeUsers: 100, revenue: 5000 }
+      : { activeUsers: 142, revenue: 5250 };
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(data),
+    });
+  });
+
+  await page.goto('/dashboard');
+
+  // First poll result
+  await expect(page.getByTestId('active-users')).toHaveText('100');
+
+  // Wait for the second poll to update the UI
+  await expect(page.getByTestId('active-users')).toHaveText('142', { timeout: 15000 });
+
+  // Verify at least 2 requests were made
+  expect(callCount).toBeGreaterThanOrEqual(2);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('polling updates dashboard data every interval', async ({ page }) => {
+  let callCount = 0;
+
+  await page.route('**/api/dashboard/stats', async (route) => {
+    callCount++;
+    const data = callCount === 1
+      ? { activeUsers: 100, revenue: 5000 }
+      : { activeUsers: 142, revenue: 5250 };
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(data),
+    });
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('active-users')).toHaveText('100');
+  await expect(page.getByTestId('active-users')).toHaveText('142', { timeout: 15000 });
+  expect(callCount).toBeGreaterThanOrEqual(2);
+});
+```
+
+### WebSocket Connection Lifecycle
+
+**Use when**: You need to verify that your app handles connection, disconnection, and reconnection properly.
+**Avoid when**: Connection lifecycle is not user-visible.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('app reconnects after WebSocket drops', async ({ page }) => {
+  let connectionCount = 0;
+
+  await page.routeWebSocket('**/ws', (ws) => {
+    connectionCount++;
+
+    if (connectionCount === 1) {
+      // First connection: close after a brief moment
+      setTimeout(() => ws.close({ code: 1006, reason: 'Abnormal closure' }), 500);
+    } else {
+      // Second connection (reconnect): stay open and respond
+      ws.onMessage((message) => {
+        ws.send(JSON.stringify({ type: 'pong' }));
+      });
+    }
+  });
+
+  await page.goto('/app');
+
+  // App detects disconnect and shows status
+  await expect(page.getByText('Reconnecting...')).toBeVisible();
+
+  // App reconnects and status returns to normal
+  await expect(page.getByText('Connected')).toBeVisible({ timeout: 10000 });
+
+  expect(connectionCount).toBe(2);
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('app reconnects after WebSocket drops', async ({ page }) => {
+  let connectionCount = 0;
+
+  await page.routeWebSocket('**/ws', (ws) => {
+    connectionCount++;
+
+    if (connectionCount === 1) {
+      setTimeout(() => ws.close({ code: 1006, reason: 'Abnormal closure' }), 500);
+    } else {
+      ws.onMessage((message) => {
+        ws.send(JSON.stringify({ type: 'pong' }));
+      });
+    }
+  });
+
+  await page.goto('/app');
+  await expect(page.getByText('Reconnecting...')).toBeVisible();
+  await expect(page.getByText('Connected')).toBeVisible({ timeout: 10000 });
+  expect(connectionCount).toBe(2);
+});
+```
+
+## Decision Guide
+
+| Scenario | Approach | Why |
+|---|---|---|
+| Verify app sends correct WS message | `page.on('websocket')` + `ws.on('framesent')` | Observe without intercepting |
+| Verify app handles server push | `page.routeWebSocket()` with mock server | Full control over what the "server" sends |
+| Test with real server but inject messages | `routeWebSocket` + `connectToServer()` | Man-in-the-middle: forward real traffic plus inject extras |
+| Test SSE endpoint | `page.route()` with `text/event-stream` content type | SSE is HTTP -- standard route interception works |
+| Test HTTP polling | `page.route()` with changing responses per call | Increment a counter; return different data each call |
+| Verify reconnection logic | `routeWebSocket` that closes the first connection | Simulate server failure, verify the app retries |
+| Test binary WebSocket data | `ws.on('framereceived')`, check `frame.payload` as Buffer | Binary frames arrive as `Buffer` in Node.js |
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| `page.waitForTimeout(3000)` to wait for WS message | Arbitrary delay; flaky and slow | `await expect(page.getByText('msg')).toBeVisible()` or wait on a Promise |
+| Directly construct `WebSocket` in `page.evaluate` | You lose Playwright's observation and routing capabilities | Let the app create its own WebSocket; intercept via `routeWebSocket` |
+| Ignore WebSocket close codes in mocks | App may behave differently for 1000 (normal) vs 1006 (abnormal) | Use the correct close code: `ws.close({ code: 1000 })` |
+| Test real-time features against live third-party servers | Flaky, slow, and may incur costs | Mock the WebSocket or SSE endpoint |
+| Assert on raw WebSocket frame content in every test | Couples tests to wire protocol; breaks on payload format changes | Assert on the UI -- that is what users see |
+| Forget to handle binary vs text frames | `frame.payload` can be `string` or `Buffer` | Check frame type or use `String(frame.payload)` consistently |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `page.on('websocket')` never fires | WebSocket connects before the listener is attached | Register the listener before `page.goto()` |
+| `routeWebSocket` does not intercept | URL pattern does not match the actual WebSocket URL | Check the URL in DevTools Network tab; update the glob pattern |
+| SSE mock returns all events at once | `route.fulfill` sends the body synchronously | For true streaming, use the real server or chunk the response with pauses via `page.evaluate` |
+| WebSocket messages arrive but UI does not update | App processes messages asynchronously; assertion runs too early | Use `await expect(...).toBeVisible()` which auto-retries |
+| Binary frames show as garbled text | `String(frame.payload)` on binary data produces garbage | Treat `frame.payload` as `Buffer` and decode appropriately |
+| Reconnection test is flaky | App has exponential backoff; timeout too short | Increase assertion timeout: `toBeVisible({ timeout: 15000 })` |
+
+## Related
+
+- [core/multi-user-and-collaboration.md](multi-user-and-collaboration.md) -- multi-user tests that rely on WebSocket for real-time sync
+- [core/assertions-and-waiting.md](assertions-and-waiting.md) -- auto-retrying assertions for async UI updates
+- [core/when-to-mock.md](when-to-mock.md) -- deciding when to mock WebSocket vs use real server
+- [core/debugging.md](debugging.md) -- tracing WebSocket frames in Playwright traces

--- a/engineering-team/playwright skill/core/when-to-mock.md
+++ b/engineering-team/playwright skill/core/when-to-mock.md
@@ -1,0 +1,827 @@
+# When to Mock vs Use Real Services
+
+> **When to use**: When deciding whether to mock API calls, intercept network requests, or hit real services in your Playwright tests.
+> **Prerequisites**: [core/locators.md](locators.md), [core/assertions-and-waiting.md](assertions-and-waiting.md)
+
+## Quick Answer
+
+**Mock at the boundary, test your stack end-to-end.** Mock third-party services you do not own (Stripe, SendGrid, OAuth providers, analytics). Never mock your own frontend-to-backend communication. Your tests should prove that YOUR code works, not that third-party APIs are up.
+
+## Decision Flowchart
+
+```
+Is this service part of YOUR codebase (your API, your backend)?
+├── YES → Do NOT mock. Test the real integration.
+│   ├── Is it slow? → Optimize the service, not the test.
+│   └── Is it flaky? → Fix the service. Flaky infra is a bug.
+└── NO → It's a third-party service.
+    ├── Is it free, fast, and reliable? (rare)
+    │   └── Consider real in CI. Mock if rate-limited.
+    ├── Is it paid per call? (Stripe, Twilio, SendGrid)
+    │   └── ALWAYS mock.
+    ├── Is it rate-limited? (OAuth, social APIs)
+    │   └── ALWAYS mock.
+    ├── Is it slow or unreliable?
+    │   └── ALWAYS mock.
+    └── Is it a complex multi-step flow? (OAuth redirect dance)
+        └── Mock with HAR recording. Update periodically.
+```
+
+## Decision Matrix
+
+| Scenario | Mock? | Why | Strategy |
+|---|---|---|---|
+| Your own REST/GraphQL API | Never | This IS the integration you are testing | Hit real API against staging or local dev |
+| Your database (through your API) | Never | Data round-trips are the whole point of E2E | Seed via API or fixtures, never mock DB |
+| Authentication (your auth system) | Mostly no | Auth bugs are critical; test the real flow | Use `storageState` to skip login in most tests, but keep a few real login tests |
+| Stripe / payment gateway | Always | Costs money, rate-limited, flaky in CI | `route.fulfill()` with expected responses |
+| SendGrid / email service | Always | Side effects (real emails), no UI to assert | Mock the API call, verify request payload |
+| OAuth providers (Google, GitHub) | Always | Redirect-heavy, rate-limited, CAPTCHAs | Mock token exchange, test your callback handler |
+| Analytics (Segment, Mixpanel) | Always | Fire-and-forget, no UI impact, slows tests | `route.abort()` or `route.fulfill()` |
+| Maps / geocoding APIs | Always | Rate-limited, paid, slow | Mock with static responses |
+| Feature flags (LaunchDarkly, etc.) | Usually | Control test conditions deterministically | Mock to force specific flag states |
+| CDN / static assets | Never | Already fast, part of your infra | Let them load normally |
+| Flaky external dependency | CI: mock, local: real | Keeps CI green, catches real issues locally | Conditional mocking based on environment |
+| Slow external dependency | Dev: mock, nightly: real | Fast feedback in dev, full integration in nightly | Separate test projects in config |
+
+## Mocking Strategies
+
+### Full Mock (route.fulfill)
+
+**Use when**: You want to completely replace a third-party API response. The most common mocking strategy.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('checkout flow with mocked payment API', async ({ page }) => {
+  // Mock Stripe payment intent creation
+  await page.route('**/api/create-payment-intent', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        clientSecret: 'pi_mock_secret_123',
+        amount: 9900,
+        currency: 'usd',
+      }),
+    });
+  });
+
+  // Mock Stripe confirmation
+  await page.route('**/api/confirm-payment', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'succeeded',
+        receiptUrl: 'https://receipt.example.com/123',
+      }),
+    });
+  });
+
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay $99.00' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('handle payment failure gracefully', async ({ page }) => {
+  // Mock a declined card response
+  await page.route('**/api/confirm-payment', (route) => {
+    route.fulfill({
+      status: 402,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: { code: 'card_declined', message: 'Your card was declined.' },
+      }),
+    });
+  });
+
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay $99.00' }).click();
+  await expect(page.getByRole('alert')).toContainText('card was declined');
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('checkout flow with mocked payment API', async ({ page }) => {
+  await page.route('**/api/create-payment-intent', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        clientSecret: 'pi_mock_secret_123',
+        amount: 9900,
+        currency: 'usd',
+      }),
+    });
+  });
+
+  await page.route('**/api/confirm-payment', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'succeeded',
+        receiptUrl: 'https://receipt.example.com/123',
+      }),
+    });
+  });
+
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay $99.00' }).click();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('handle payment failure gracefully', async ({ page }) => {
+  await page.route('**/api/confirm-payment', (route) => {
+    route.fulfill({
+      status: 402,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: { code: 'card_declined', message: 'Your card was declined.' },
+      }),
+    });
+  });
+
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay $99.00' }).click();
+  await expect(page.getByRole('alert')).toContainText('card was declined');
+});
+```
+
+### Partial Mock (Modify Responses)
+
+**Use when**: You want the real API call to happen but need to tweak the response -- injecting error states, adding edge-case data, or overriding a single field.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('show warning when inventory is low', async ({ page }) => {
+  // Let the real API call go through, but override the stock count
+  await page.route('**/api/products/*', async (route) => {
+    const response = await route.fetch(); // forward to real server
+    const body = await response.json();
+
+    // Modify just the field we care about
+    body.stockCount = 2;
+    body.lowStockWarning = true;
+
+    await route.fulfill({
+      response, // preserve headers, status
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.goto('/products/running-shoes');
+  await expect(page.getByText('Only 2 left in stock')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+});
+
+test('inject additional items into a real API response', async ({ page }) => {
+  await page.route('**/api/notifications', async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+
+    // Append a test notification to whatever real data comes back
+    body.notifications.push({
+      id: 'test-notif',
+      message: 'Your export is ready',
+      type: 'success',
+      read: false,
+    });
+
+    await route.fulfill({
+      response,
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByText('Your export is ready')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('show warning when inventory is low', async ({ page }) => {
+  await page.route('**/api/products/*', async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+
+    body.stockCount = 2;
+    body.lowStockWarning = true;
+
+    await route.fulfill({
+      response,
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.goto('/products/running-shoes');
+  await expect(page.getByText('Only 2 left in stock')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+});
+
+test('inject additional items into a real API response', async ({ page }) => {
+  await page.route('**/api/notifications', async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+
+    body.notifications.push({
+      id: 'test-notif',
+      message: 'Your export is ready',
+      type: 'success',
+      read: false,
+    });
+
+    await route.fulfill({
+      response,
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByText('Your export is ready')).toBeVisible();
+});
+```
+
+### Record and Replay (HAR Files)
+
+**Use when**: Complex API sequences with many endpoints (OAuth flows, multi-step wizards, dashboard data loading). Record once from a real session, replay deterministically. Update the recording periodically so mocks do not drift from reality.
+
+**Recording a HAR file:**
+
+**TypeScript**
+```typescript
+import { test } from '@playwright/test';
+
+// Record HAR — run this once, then commit the .har file
+test('record API traffic for dashboard', async ({ page }) => {
+  await page.routeFromHAR('tests/fixtures/dashboard.har', {
+    url: '**/api/**',
+    update: true, // record mode: forwards requests and saves responses
+  });
+
+  await page.goto('/dashboard');
+  // Interact with the page to capture all relevant API calls
+  await page.getByRole('tab', { name: 'Analytics' }).click();
+  await page.getByRole('tab', { name: 'Users' }).click();
+  await page.getByRole('button', { name: 'Load more' }).click();
+
+  // HAR file is saved automatically when the page closes
+});
+```
+
+**Replaying a HAR file:**
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('dashboard loads with recorded data', async ({ page }) => {
+  // Replay mode: serves responses from the HAR file
+  await page.routeFromHAR('tests/fixtures/dashboard.har', {
+    url: '**/api/**',
+    update: false, // replay mode (default)
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Analytics' })).toBeVisible();
+  await expect(page.getByTestId('revenue-chart')).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+// Record
+test('record API traffic for dashboard', async ({ page }) => {
+  await page.routeFromHAR('tests/fixtures/dashboard.har', {
+    url: '**/api/**',
+    update: true,
+  });
+
+  await page.goto('/dashboard');
+  await page.getByRole('tab', { name: 'Analytics' }).click();
+  await page.getByRole('tab', { name: 'Users' }).click();
+  await page.getByRole('button', { name: 'Load more' }).click();
+});
+
+// Replay
+test('dashboard loads with recorded data', async ({ page }) => {
+  await page.routeFromHAR('tests/fixtures/dashboard.har', {
+    url: '**/api/**',
+    update: false,
+  });
+
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Analytics' })).toBeVisible();
+  await expect(page.getByTestId('revenue-chart')).toBeVisible();
+});
+```
+
+**HAR maintenance workflow:**
+1. Record HAR files against a known-good staging environment.
+2. Commit `.har` files to version control (they are JSON, diffable).
+3. Re-record monthly or when APIs change. Add a CI reminder or calendar event.
+4. Use `update: true` in a dedicated test file to refresh recordings.
+5. Scope HAR to specific URL patterns (`url: '**/api/v2/**'`) so unrelated requests still hit real servers.
+
+### Blocking Unwanted Requests
+
+**Use when**: Third-party scripts (analytics, ads, chat widgets) slow down tests and add no value. Block them outright.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  // Block analytics and tracking — they slow tests and add no coverage
+  await page.route('**/{google-analytics,segment,hotjar,intercom}.{com,io}/**', (route) => {
+    route.abort();
+  });
+
+  // Block all image requests in tests that don't need them
+  // await page.route('**/*.{png,jpg,jpeg,gif,svg,webp}', (route) => route.abort());
+});
+
+test('page loads fast without third-party scripts', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/{google-analytics,segment,hotjar,intercom}.{com,io}/**', (route) => {
+    route.abort();
+  });
+});
+
+test('page loads fast without third-party scripts', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+## Real Service Strategies
+
+### Against Staging Environment
+
+**Use when**: You have a shared staging environment that mirrors production. Best for integration confidence.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: process.env.CI
+      ? 'https://staging.yourapp.com'
+      : 'http://localhost:3000',
+  },
+  projects: [
+    {
+      name: 'integration',
+      testMatch: '**/*.integration.spec.ts',
+      use: { baseURL: 'https://staging.yourapp.com' },
+    },
+    {
+      name: 'e2e',
+      testMatch: '**/*.e2e.spec.ts',
+      use: { baseURL: 'http://localhost:3000' },
+    },
+  ],
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    baseURL: process.env.CI
+      ? 'https://staging.yourapp.com'
+      : 'http://localhost:3000',
+  },
+  projects: [
+    {
+      name: 'integration',
+      testMatch: '**/*.integration.spec.js',
+      use: { baseURL: 'https://staging.yourapp.com' },
+    },
+    {
+      name: 'e2e',
+      testMatch: '**/*.e2e.spec.js',
+      use: { baseURL: 'http://localhost:3000' },
+    },
+  ],
+});
+```
+
+### Against Local Dev Server
+
+**Use when**: Fastest feedback loop. Run your backend locally and test against it.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI, // start fresh in CI, reuse locally
+    timeout: 30_000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});
+```
+
+### Against Test Containers
+
+**Use when**: You need a fully isolated environment with databases, caches, and services. Best for reproducible CI runs.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'docker compose -f docker-compose.test.yml up --wait',
+    url: 'http://localhost:3000/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000, // containers take longer to start
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  // Global teardown to stop containers
+  globalTeardown: './tests/global-teardown.ts',
+});
+```
+
+```typescript
+// tests/global-teardown.ts
+import { execSync } from 'child_process';
+
+export default function globalTeardown() {
+  if (process.env.CI) {
+    execSync('docker compose -f docker-compose.test.yml down -v');
+  }
+}
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  webServer: {
+    command: 'docker compose -f docker-compose.test.yml up --wait',
+    url: 'http://localhost:3000/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  globalTeardown: './tests/global-teardown.js',
+});
+```
+
+```javascript
+// tests/global-teardown.js
+const { execSync } = require('child_process');
+
+module.exports = function globalTeardown() {
+  if (process.env.CI) {
+    execSync('docker compose -f docker-compose.test.yml down -v');
+  }
+};
+```
+
+## Hybrid Approach
+
+The strongest test suites combine real and mocked services. The principle: **mock what you do not own, run what you do.**
+
+### Fixture-Based Mock Control
+
+Create a fixture that lets individual tests opt into mocking specific services while keeping everything else real.
+
+**TypeScript**
+```typescript
+// tests/fixtures/mock-fixtures.ts
+import { test as base } from '@playwright/test';
+
+type MockOptions = {
+  mockPayments: boolean;
+  mockEmail: boolean;
+  mockAnalytics: boolean;
+};
+
+export const test = base.extend<MockOptions>({
+  mockPayments: [true, { option: true }],  // default: mock payments
+  mockEmail: [true, { option: true }],     // default: mock email
+  mockAnalytics: [true, { option: true }], // default: mock analytics
+
+  page: async ({ page, mockPayments, mockEmail, mockAnalytics }, use) => {
+    if (mockPayments) {
+      await page.route('**/api/payments/**', (route) => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'succeeded', id: 'pay_mock_123' }),
+        });
+      });
+    }
+
+    if (mockEmail) {
+      await page.route('**/api/send-email', (route) => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ messageId: 'msg_mock_456' }),
+        });
+      });
+    }
+
+    if (mockAnalytics) {
+      await page.route('**/{segment,google-analytics,mixpanel}.**/**', (route) => {
+        route.abort();
+      });
+    }
+
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/checkout.spec.ts
+import { test, expect } from './fixtures/mock-fixtures';
+
+// Uses defaults: payments mocked, email mocked, analytics blocked
+test('checkout sends confirmation email', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay $99.00' }).click();
+  await expect(page.getByText('Confirmation email sent')).toBeVisible();
+});
+
+// Override: test with real payment API (nightly integration test)
+test.describe('nightly integration', () => {
+  test.use({ mockPayments: false });
+
+  test('real payment flow against Stripe test mode', async ({ page }) => {
+    await page.goto('/checkout');
+    // This hits the real Stripe test API
+    await page.getByRole('button', { name: 'Pay $99.00' }).click();
+    await expect(page.getByText('Payment successful')).toBeVisible();
+  });
+});
+```
+
+**JavaScript**
+```javascript
+// tests/fixtures/mock-fixtures.js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  mockPayments: [true, { option: true }],
+  mockEmail: [true, { option: true }],
+  mockAnalytics: [true, { option: true }],
+
+  page: async ({ page, mockPayments, mockEmail, mockAnalytics }, use) => {
+    if (mockPayments) {
+      await page.route('**/api/payments/**', (route) => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'succeeded', id: 'pay_mock_123' }),
+        });
+      });
+    }
+
+    if (mockEmail) {
+      await page.route('**/api/send-email', (route) => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ messageId: 'msg_mock_456' }),
+        });
+      });
+    }
+
+    if (mockAnalytics) {
+      await page.route('**/{segment,google-analytics,mixpanel}.**/**', (route) => {
+        route.abort();
+      });
+    }
+
+    await use(page);
+  },
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+```javascript
+// tests/checkout.spec.js
+const { test, expect } = require('./fixtures/mock-fixtures');
+
+test('checkout sends confirmation email', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Pay $99.00' }).click();
+  await expect(page.getByText('Confirmation email sent')).toBeVisible();
+});
+
+test.describe('nightly integration', () => {
+  test.use({ mockPayments: false });
+
+  test('real payment flow against Stripe test mode', async ({ page }) => {
+    await page.goto('/checkout');
+    await page.getByRole('button', { name: 'Pay $99.00' }).click();
+    await expect(page.getByText('Payment successful')).toBeVisible();
+  });
+});
+```
+
+### Environment-Based Mocking
+
+Split test projects by environment to run mocked tests in every CI push and full-integration tests nightly.
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'fast-ci',
+      testMatch: '**/*.spec.ts',
+      use: {
+        baseURL: 'http://localhost:3000',
+        // All external services mocked via fixtures
+      },
+    },
+    {
+      name: 'nightly-integration',
+      testMatch: '**/*.integration.spec.ts',
+      use: {
+        baseURL: 'https://staging.yourapp.com',
+        // Real services, longer timeouts
+      },
+      timeout: 120_000,
+    },
+  ],
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    {
+      name: 'fast-ci',
+      testMatch: '**/*.spec.js',
+      use: {
+        baseURL: 'http://localhost:3000',
+      },
+    },
+    {
+      name: 'nightly-integration',
+      testMatch: '**/*.integration.spec.js',
+      use: {
+        baseURL: 'https://staging.yourapp.com',
+      },
+      timeout: 120_000,
+    },
+  ],
+});
+```
+
+### Verifying Mock Accuracy
+
+Mock responses drift from real APIs over time. Guard against this.
+
+**TypeScript**
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Run this weekly or when APIs change — validates that mocks match reality
+test.describe('mock contract validation', () => {
+  test('payment mock matches real Stripe test API shape', async ({ request }) => {
+    // Hit the real API
+    const realResponse = await request.post('/api/create-payment-intent', {
+      data: { amount: 9900, currency: 'usd' },
+    });
+    const realBody = await realResponse.json();
+
+    // Verify mock has the same shape
+    const mockBody = {
+      clientSecret: 'pi_mock_secret_123',
+      amount: 9900,
+      currency: 'usd',
+    };
+
+    // Same keys exist in both
+    expect(Object.keys(mockBody).sort()).toEqual(Object.keys(realBody).sort());
+
+    // Same types for each key
+    for (const key of Object.keys(mockBody)) {
+      expect(typeof mockBody[key]).toBe(typeof realBody[key]);
+    }
+  });
+});
+```
+
+**JavaScript**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('mock contract validation', () => {
+  test('payment mock matches real Stripe test API shape', async ({ request }) => {
+    const realResponse = await request.post('/api/create-payment-intent', {
+      data: { amount: 9900, currency: 'usd' },
+    });
+    const realBody = await realResponse.json();
+
+    const mockBody = {
+      clientSecret: 'pi_mock_secret_123',
+      amount: 9900,
+      currency: 'usd',
+    };
+
+    expect(Object.keys(mockBody).sort()).toEqual(Object.keys(realBody).sort());
+
+    for (const key of Object.keys(mockBody)) {
+      expect(typeof mockBody[key]).toBe(typeof realBody[key]);
+    }
+  });
+});
+```
+
+## Anti-Patterns
+
+| Don't Do This | Problem | Do This Instead |
+|---|---|---|
+| Mock your own API (`page.route('**/api/users', ...)` when you own the `/api/users` endpoint) | You are testing a fiction. Your frontend and backend may be completely incompatible. | Hit your real API. Mock only third-party services behind your API. |
+| Mock everything for speed | Tests pass, app breaks. You have zero integration coverage. | Mock only external boundaries. Optimize your own services for test speed. |
+| Never mock anything | Tests are slow, flaky, and fail when Stripe has an outage. You test third-party uptime, not your code. | Mock third-party services. Your CI should not depend on someone else's infrastructure. |
+| Use outdated mocks that do not match the real API | Mock returns `{ status: "ok" }` but real API returns `{ status: "success", data: {...} }`. Tests pass, production breaks. | Run contract validation tests periodically. Re-record HAR files monthly. |
+| Mock at the wrong layer (intercepting your own frontend HTTP client) | Bypasses request/response serialization, headers, error handling. | Mock at the network level with `page.route()`. This tests your full HTTP client code. |
+| Copy-paste mock responses across dozens of test files | One API change requires updating 40 files. Mocks diverge. | Centralize mocks in fixtures or helper files. Single source of truth. |
+| Mock with `page.evaluate()` to stub `fetch`/`XMLHttpRequest` | Fragile, does not survive navigation, misses service workers. | Use `page.route()` which intercepts at the network layer. |
+| Block all network requests and whitelist | Extremely brittle. Every new API endpoint requires a whitelist update. Tests break on any backend change. | Allow all traffic by default. Selectively mock only the third-party services you need to. |
+
+## Related
+
+- [core/network-mocking.md](network-mocking.md) -- detailed network interception patterns and API
+- [core/api-testing.md](api-testing.md) -- testing your API directly with `request` context
+- [core/authentication.md](authentication.md) -- when to mock auth vs test real login flows
+- [core/fixtures-and-hooks.md](fixtures-and-hooks.md) -- building reusable mock fixtures
+- [core/configuration.md](configuration.md) -- `webServer`, `baseURL`, and project configuration
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI setup for different test tiers

--- a/engineering-team/playwright skill/migration/SKILL.md
+++ b/engineering-team/playwright skill/migration/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: playwright-migration
+description: Step-by-step migration guides for moving to Playwright from Cypress or Selenium/WebDriver — command mappings, architecture changes, and incremental adoption strategies.
+---
+
+# Playwright Migration Guides
+
+> Move to Playwright with confidence — side-by-side command mappings, architecture translations, and incremental migration strategies.
+
+**2 guides** covering complete migration paths from the most popular testing frameworks.
+
+## Guide Index
+
+| Migrating from | Guide |
+|---|---|
+| Cypress | [from-cypress.md](from-cypress.md) |
+| Selenium / WebDriver | [from-selenium.md](from-selenium.md) |

--- a/engineering-team/playwright skill/migration/from-cypress.md
+++ b/engineering-team/playwright skill/migration/from-cypress.md
@@ -1,0 +1,1209 @@
+# Migrating from Cypress to Playwright
+
+> **When to use**: When converting a Cypress test suite to Playwright. Follow this guide command-by-command, pattern-by-pattern.
+
+## Key Mindset Shifts
+
+Before converting any code, internalize these five differences. They affect every line you write.
+
+### 1. Chains vs async/await
+
+Cypress commands are enqueued and run in a serial chain that _looks_ synchronous but is not. Playwright uses standard `async`/`await` -- real asynchronous JavaScript with no magic scheduling.
+
+```javascript
+// Cypress — chain-based, implicitly queued
+cy.get('.todo-list li').should('have.length', 3);
+cy.get('.todo-list li').first().should('have.text', 'Buy milk');
+
+// Playwright — async/await, explicit control flow
+const items = page.getByTestId('todo-item');
+await expect(items).toHaveCount(3);
+await expect(items.first()).toHaveText('Buy milk');
+```
+
+**Why it matters**: You can use `if`/`else`, `for` loops, `try`/`catch`, and any JavaScript construct naturally. No `cy.then()` workarounds.
+
+### 2. Automatic retry vs auto-wait
+
+Cypress retries the _entire command chain_ until assertions pass (or time out). Playwright locators are lazy -- they do nothing until you perform an _action_ or _assertion_, at which point Playwright auto-waits for the element to be actionable (visible, enabled, stable).
+
+```javascript
+// Cypress — retries cy.get + .should together
+cy.get('[data-testid="submit"]').should('be.visible').click();
+
+// Playwright — locator is created instantly; .click() auto-waits for visibility + stability
+await page.getByTestId('submit').click();
+```
+
+### 3. In-browser vs Node.js
+
+Cypress test code runs _inside_ the browser (same origin). Playwright runs in Node.js and controls browsers over the Chrome DevTools Protocol or equivalent. This means:
+
+- Playwright can open multiple tabs, windows, and even multiple browsers in a single test.
+- Playwright has native access to the file system, databases, and APIs from test code -- no `cy.task()` needed.
+- You cannot access `window` or `document` directly; use `page.evaluate()` when you need browser-side code.
+
+### 4. One tab vs multi-tab, multi-browser
+
+Cypress is limited to a single browser tab and a single browser. Playwright can control multiple pages, multiple browser contexts (each with isolated cookies/storage), and even multiple browser types (Chromium, Firefox, WebKit) in the same test run.
+
+### 5. Custom commands vs fixtures
+
+Cypress extends via `Cypress.Commands.add()` -- a global mutable registry. Playwright uses `test.extend()` fixtures with dependency injection, guaranteed teardown, and type safety. Fixtures are dramatically more powerful.
+
+## Command Mapping Table
+
+| Cypress | Playwright | Notes |
+|---|---|---|
+| `cy.visit('/path')` | `await page.goto('/path')` | Use `baseURL` in config to avoid full URLs |
+| `cy.get('selector')` | `page.locator('selector')` | Prefer `page.getByRole()` over CSS selectors |
+| `cy.get('[data-testid="x"]')` | `page.getByTestId('x')` | Configure `testIdAttribute` in playwright.config |
+| `cy.contains('text')` | `page.getByText('text')` | For buttons/links, prefer `page.getByRole('button', { name: 'text' })` |
+| `cy.find('child')` | `locator.locator('child')` | Chain locators to scope within a parent |
+| `cy.get('sel').click()` | `await locator.click()` | Auto-waits for element to be actionable |
+| `cy.get('sel').type('text')` | `await locator.fill('text')` | `fill()` sets value instantly. Use `locator.pressSequentially('text')` for character-by-character typing |
+| `cy.get('sel').clear()` | `await locator.clear()` | Or `await locator.fill('')` |
+| `cy.get('select').select('val')` | `await locator.selectOption('val')` | Accepts value, label, or `{ index }` |
+| `cy.get('input').check()` | `await locator.check()` | No-op if already checked |
+| `cy.get('input').uncheck()` | `await locator.uncheck()` | No-op if already unchecked |
+| `cy.get('sel').should('be.visible')` | `await expect(locator).toBeVisible()` | Web-first assertion; auto-retries |
+| `cy.get('sel').should('have.text', 'x')` | `await expect(locator).toHaveText('x')` | Also accepts regex: `.toHaveText(/pattern/)` |
+| `cy.get('sel').should('contain', 'x')` | `await expect(locator).toContainText('x')` | Substring match |
+| `cy.get('sel').should('have.length', 3)` | `await expect(locator).toHaveCount(3)` | Counts matching elements |
+| `cy.get('sel').should('have.value', 'x')` | `await expect(locator).toHaveValue('x')` | Input/textarea value |
+| `cy.get('sel').should('have.attr', 'href', '/x')` | `await expect(locator).toHaveAttribute('href', '/x')` | Any HTML attribute |
+| `cy.get('sel').should('have.class', 'active')` | `await expect(locator).toHaveClass(/active/)` | Regex for partial class match |
+| `cy.get('sel').should('be.disabled')` | `await expect(locator).toBeDisabled()` | |
+| `cy.get('sel').should('not.exist')` | `await expect(locator).toBeHidden()` | Or `.toHaveCount(0)` for truly absent elements |
+| `cy.intercept('GET', '/api/**', { body })` | `await page.route('/api/**', route => route.fulfill({ body }))` | Set up _before_ the action that triggers the request |
+| `cy.intercept('POST', '/api/save').as('save')` | `const resp = page.waitForResponse('**/api/save')` | Start _before_ the action, `await` after |
+| `cy.wait('@save')` | `await resp` | Returns `Response` object with `.json()`, `.status()` |
+| `cy.fixture('users.json')` | Fixtures via `test.extend()` or direct `import`/`require` | See Example 5 below |
+| `cy.request('GET', '/api/users')` | `const resp = await request.get('/api/users')` | Use the `request` fixture or `APIRequestContext` |
+| `cy.request('POST', '/api/users', body)` | `const resp = await request.post('/api/users', { data: body })` | |
+| `cy.wrap(value)` | No equivalent needed | Just use the value directly with `await` |
+| `cy.then((result) => { ... })` | `const result = await ...` | Standard async/await replaces `.then()` chains |
+| `Cypress.env('API_KEY')` | `process.env.API_KEY` | Or use `use: {}` in playwright.config for test-specific values |
+| `Cypress.Commands.add('login', fn)` | Custom fixture via `test.extend()` | See Example 5 below |
+| `cy.clock()` / `cy.tick(1000)` | `await page.clock.install()` / `await page.clock.fastForward(1000)` | `page.clock` API for full time control |
+| `cy.screenshot('name')` | `await page.screenshot({ path: 'name.png' })` | Auto-captured on failure when `screenshot: 'on'` in config |
+| `cy.viewport(1280, 720)` | `await page.setViewportSize({ width: 1280, height: 720 })` | Prefer setting in config or per-project |
+| `beforeEach(() => { cy.visit('/') })` | `test.beforeEach(async ({ page }) => { await page.goto('/') })` | Destructure `page` from fixtures |
+| `cy.scrollTo('bottom')` | `await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))` | Actions auto-scroll to elements; manual scroll is rarely needed |
+| `cy.focused()` | `page.locator(':focus')` | Or assert: `await expect(locator).toBeFocused()` |
+| `cy.go('back')` | `await page.goBack()` | Also `page.goForward()` |
+| `cy.reload()` | `await page.reload()` | |
+| `cy.title()` | `await expect(page).toHaveTitle('text')` | Web-first assertion on page title |
+| `cy.url()` | `await expect(page).toHaveURL('/path')` | Accepts string or regex |
+| `cy.getCookie('name')` | `const cookies = await context.cookies()` | Filter by name from the array |
+| `cy.setCookie('name', 'val')` | `await context.addCookies([{ name, value, url }])` | |
+| `cy.clearCookies()` | `await context.clearCookies()` | |
+
+## Before/After Examples
+
+### Example 1: Basic Navigation and Assertion
+
+**Cypress**
+```javascript
+describe('Homepage', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('displays the welcome heading', () => {
+    cy.get('h1').should('have.text', 'Welcome to Acme');
+    cy.get('[data-testid="hero-subtitle"]').should('be.visible');
+    cy.url().should('include', '/');
+  });
+
+  it('navigates to the about page', () => {
+    cy.contains('About').click();
+    cy.url().should('include', '/about');
+    cy.get('h1').should('have.text', 'About Us');
+  });
+});
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('displays the welcome heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Welcome to Acme');
+    await expect(page.getByTestId('hero-subtitle')).toBeVisible();
+    await expect(page).toHaveURL('/');
+  });
+
+  test('navigates to the about page', async ({ page }) => {
+    await page.getByRole('link', { name: 'About' }).click();
+    await expect(page).toHaveURL(/\/about/);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('About Us');
+  });
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Homepage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('displays the welcome heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Welcome to Acme');
+    await expect(page.getByTestId('hero-subtitle')).toBeVisible();
+    await expect(page).toHaveURL('/');
+  });
+
+  test('navigates to the about page', async ({ page }) => {
+    await page.getByRole('link', { name: 'About' }).click();
+    await expect(page).toHaveURL(/\/about/);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('About Us');
+  });
+});
+```
+
+**Key changes**: `cy.get('h1')` becomes `page.getByRole('heading', { level: 1 })` for resilience. `cy.contains('About').click()` becomes `page.getByRole('link', { name: 'About' }).click()` to assert the element is actually a link. `cy.url().should('include', ...)` becomes `await expect(page).toHaveURL(...)` which auto-retries.
+
+---
+
+### Example 2: Form Interaction
+
+**Cypress**
+```javascript
+describe('Registration Form', () => {
+  it('submits a valid form', () => {
+    cy.visit('/register');
+
+    cy.get('#first-name').type('Jane');
+    cy.get('#last-name').type('Doe');
+    cy.get('#email').type('jane@example.com');
+    cy.get('#password').type('s3cure!Pass');
+    cy.get('#country').select('United States');
+    cy.get('#terms').check();
+
+    cy.get('form').submit();
+
+    cy.get('.success-message').should('be.visible');
+    cy.get('.success-message').should('contain', 'Welcome, Jane');
+  });
+
+  it('shows validation errors for empty fields', () => {
+    cy.visit('/register');
+    cy.get('[type="submit"]').click();
+
+    cy.get('.error').should('have.length', 4);
+    cy.get('#first-name').should('have.attr', 'aria-invalid', 'true');
+  });
+});
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Registration Form', () => {
+  test('submits a valid form', async ({ page }) => {
+    await page.goto('/register');
+
+    await page.getByLabel('First name').fill('Jane');
+    await page.getByLabel('Last name').fill('Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password').fill('s3cure!Pass');
+    await page.getByLabel('Country').selectOption('United States');
+    await page.getByLabel('I agree to the terms').check();
+
+    await page.getByRole('button', { name: 'Register' }).click();
+
+    const successMessage = page.getByText('Welcome, Jane');
+    await expect(successMessage).toBeVisible();
+  });
+
+  test('shows validation errors for empty fields', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByRole('button', { name: 'Register' }).click();
+
+    await expect(page.getByRole('alert')).toHaveCount(4);
+    await expect(page.getByLabel('First name')).toHaveAttribute('aria-invalid', 'true');
+  });
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Registration Form', () => {
+  test('submits a valid form', async ({ page }) => {
+    await page.goto('/register');
+
+    await page.getByLabel('First name').fill('Jane');
+    await page.getByLabel('Last name').fill('Doe');
+    await page.getByLabel('Email').fill('jane@example.com');
+    await page.getByLabel('Password').fill('s3cure!Pass');
+    await page.getByLabel('Country').selectOption('United States');
+    await page.getByLabel('I agree to the terms').check();
+
+    await page.getByRole('button', { name: 'Register' }).click();
+
+    const successMessage = page.getByText('Welcome, Jane');
+    await expect(successMessage).toBeVisible();
+  });
+
+  test('shows validation errors for empty fields', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByRole('button', { name: 'Register' }).click();
+
+    await expect(page.getByRole('alert')).toHaveCount(4);
+    await expect(page.getByLabel('First name')).toHaveAttribute('aria-invalid', 'true');
+  });
+});
+```
+
+**Key changes**: `cy.get('#id').type()` becomes `page.getByLabel('Label').fill()`. No IDs needed -- labels are resilient and accessible. `fill()` replaces `type()` and sets the value instantly. `cy.get('form').submit()` becomes an explicit button click, matching real user behavior.
+
+---
+
+### Example 3: Network Mocking
+
+**Cypress**
+```javascript
+describe('Product List', () => {
+  it('displays products from the API', () => {
+    cy.intercept('GET', '/api/products', {
+      statusCode: 200,
+      body: [
+        { id: 1, name: 'Widget', price: 9.99 },
+        { id: 2, name: 'Gadget', price: 24.99 },
+      ],
+    }).as('getProducts');
+
+    cy.visit('/products');
+    cy.wait('@getProducts');
+
+    cy.get('[data-testid="product-card"]').should('have.length', 2);
+    cy.get('[data-testid="product-card"]').first().should('contain', 'Widget');
+  });
+
+  it('shows error state when API fails', () => {
+    cy.intercept('GET', '/api/products', {
+      statusCode: 500,
+      body: { error: 'Internal server error' },
+    }).as('getProducts');
+
+    cy.visit('/products');
+    cy.wait('@getProducts');
+
+    cy.get('[data-testid="error-message"]').should('contain', 'Something went wrong');
+  });
+
+  it('submits a new product', () => {
+    cy.intercept('POST', '/api/products', {
+      statusCode: 201,
+      body: { id: 3, name: 'Doohickey', price: 14.99 },
+    }).as('createProduct');
+
+    cy.visit('/products/new');
+    cy.get('#product-name').type('Doohickey');
+    cy.get('#product-price').type('14.99');
+    cy.get('button[type="submit"]').click();
+
+    cy.wait('@createProduct').its('request.body').should('deep.equal', {
+      name: 'Doohickey',
+      price: 14.99,
+    });
+  });
+});
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Product List', () => {
+  test('displays products from the API', async ({ page }) => {
+    await page.route('**/api/products', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, name: 'Widget', price: 9.99 },
+          { id: 2, name: 'Gadget', price: 24.99 },
+        ]),
+      })
+    );
+
+    await page.goto('/products');
+
+    await expect(page.getByTestId('product-card')).toHaveCount(2);
+    await expect(page.getByTestId('product-card').first()).toContainText('Widget');
+  });
+
+  test('shows error state when API fails', async ({ page }) => {
+    await page.route('**/api/products', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Internal server error' }),
+      })
+    );
+
+    await page.goto('/products');
+
+    await expect(page.getByTestId('error-message')).toContainText('Something went wrong');
+  });
+
+  test('submits a new product', async ({ page }) => {
+    // Set up route mock AND capture the request
+    let requestBody: unknown;
+    await page.route('**/api/products', (route) => {
+      requestBody = route.request().postDataJSON();
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 3, name: 'Doohickey', price: 14.99 }),
+      });
+    });
+
+    await page.goto('/products/new');
+    await page.getByLabel('Product name').fill('Doohickey');
+    await page.getByLabel('Price').fill('14.99');
+    await page.getByRole('button', { name: 'Create product' }).click();
+
+    // Assert on the captured request body
+    expect(requestBody).toEqual({ name: 'Doohickey', price: 14.99 });
+  });
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test.describe('Product List', () => {
+  test('displays products from the API', async ({ page }) => {
+    await page.route('**/api/products', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, name: 'Widget', price: 9.99 },
+          { id: 2, name: 'Gadget', price: 24.99 },
+        ]),
+      })
+    );
+
+    await page.goto('/products');
+
+    await expect(page.getByTestId('product-card')).toHaveCount(2);
+    await expect(page.getByTestId('product-card').first()).toContainText('Widget');
+  });
+
+  test('shows error state when API fails', async ({ page }) => {
+    await page.route('**/api/products', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Internal server error' }),
+      })
+    );
+
+    await page.goto('/products');
+
+    await expect(page.getByTestId('error-message')).toContainText('Something went wrong');
+  });
+
+  test('submits a new product', async ({ page }) => {
+    let requestBody;
+    await page.route('**/api/products', (route) => {
+      requestBody = route.request().postDataJSON();
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 3, name: 'Doohickey', price: 14.99 }),
+      });
+    });
+
+    await page.goto('/products/new');
+    await page.getByLabel('Product name').fill('Doohickey');
+    await page.getByLabel('Price').fill('14.99');
+    await page.getByRole('button', { name: 'Create product' }).click();
+
+    expect(requestBody).toEqual({ name: 'Doohickey', price: 14.99 });
+  });
+});
+```
+
+**Key changes**: `cy.intercept()` becomes `page.route()`. Set up routes _before_ the action that triggers the request. No `cy.wait('@alias')` needed -- Playwright auto-waits for the UI to update. To assert on request bodies, capture them in the route handler. For waiting on a specific response, use `page.waitForResponse()`.
+
+---
+
+### Example 4: Authentication
+
+**Cypress**
+```javascript
+// cypress/support/commands.js
+Cypress.Commands.add('login', (email, password) => {
+  cy.session([email, password], () => {
+    cy.visit('/login');
+    cy.get('#email').type(email);
+    cy.get('#password').type(password);
+    cy.get('button[type="submit"]').click();
+    cy.url().should('include', '/dashboard');
+  });
+});
+
+// cypress/e2e/dashboard.cy.js
+describe('Dashboard', () => {
+  beforeEach(() => {
+    cy.login('admin@example.com', 'password123');
+    cy.visit('/dashboard');
+  });
+
+  it('shows admin content', () => {
+    cy.get('[data-testid="admin-panel"]').should('be.visible');
+  });
+});
+```
+
+**Playwright (TypeScript)** -- using `storageState` for session reuse (recommended)
+```typescript
+// auth.setup.ts — runs once, saves auth state to a file
+import { test as setup, expect } from '@playwright/test';
+import path from 'path';
+
+const authFile = path.join(__dirname, '../.auth/user.json');
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('admin@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  // Save signed-in state to file
+  await page.context().storageState({ path: authFile });
+});
+```
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    // Setup project — runs auth first
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
+
+    // All tests reuse the saved auth state
+    {
+      name: 'chromium',
+      dependencies: ['setup'],
+      use: {
+        storageState: '.auth/user.json',
+      },
+    },
+  ],
+});
+```
+
+```typescript
+// dashboard.spec.ts — already authenticated, no login code needed
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard', () => {
+  test('shows admin content', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('admin-panel')).toBeVisible();
+  });
+});
+```
+
+**Playwright (JavaScript)** -- using `storageState` for session reuse (recommended)
+```javascript
+// auth.setup.js
+const { test: setup, expect } = require('@playwright/test');
+const path = require('path');
+
+const authFile = path.join(__dirname, '../.auth/user.json');
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('admin@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/dashboard');
+
+  await page.context().storageState({ path: authFile });
+});
+```
+
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  projects: [
+    { name: 'setup', testMatch: /.*\.setup\.js/ },
+    {
+      name: 'chromium',
+      dependencies: ['setup'],
+      use: {
+        storageState: '.auth/user.json',
+      },
+    },
+  ],
+});
+```
+
+```javascript
+// dashboard.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe('Dashboard', () => {
+  test('shows admin content', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('admin-panel')).toBeVisible();
+  });
+});
+```
+
+**Key changes**: Cypress `cy.session()` becomes Playwright's `storageState`. Auth runs once as a setup project, saves cookies/localStorage to a JSON file, and all test projects reuse it. Tests never touch login flows -- they start authenticated. Add `.auth/` to `.gitignore`.
+
+---
+
+### Example 5: Custom Commands to Fixtures
+
+**Cypress** -- custom commands are globally registered
+```javascript
+// cypress/support/commands.js
+Cypress.Commands.add('createTodo', (text) => {
+  cy.get('[data-testid="new-todo"]').type(`${text}{enter}`);
+});
+
+Cypress.Commands.add('getTodos', () => {
+  return cy.get('[data-testid="todo-item"]');
+});
+
+Cypress.Commands.add('apiCreateUser', (userData) => {
+  return cy.request('POST', '/api/users', userData);
+});
+
+// cypress/e2e/todos.cy.js
+describe('Todos', () => {
+  beforeEach(() => {
+    cy.visit('/todos');
+  });
+
+  it('adds and verifies todos', () => {
+    cy.createTodo('Buy milk');
+    cy.createTodo('Walk dog');
+    cy.getTodos().should('have.length', 2);
+  });
+});
+```
+
+**Playwright (TypeScript)** -- fixtures replace custom commands
+```typescript
+// fixtures.ts
+import { test as base, expect } from '@playwright/test';
+
+// Define the types for your custom fixtures
+type TodoFixtures = {
+  todosPage: TodosPage;
+  apiHelper: ApiHelper;
+};
+
+class TodosPage {
+  constructor(private page: import('@playwright/test').Page) {}
+
+  async createTodo(text: string) {
+    await this.page.getByTestId('new-todo').fill(text);
+    await this.page.getByTestId('new-todo').press('Enter');
+  }
+
+  get todos() {
+    return this.page.getByTestId('todo-item');
+  }
+}
+
+class ApiHelper {
+  constructor(private request: import('@playwright/test').APIRequestContext) {}
+
+  async createUser(userData: { name: string; email: string }) {
+    const response = await this.request.post('/api/users', { data: userData });
+    return response.json();
+  }
+}
+
+export const test = base.extend<TodoFixtures>({
+  todosPage: async ({ page }, use) => {
+    await page.goto('/todos');
+    await use(new TodosPage(page));
+  },
+
+  apiHelper: async ({ request }, use) => {
+    await use(new ApiHelper(request));
+  },
+});
+
+export { expect };
+```
+
+```typescript
+// todos.spec.ts
+import { test, expect } from './fixtures';
+
+test('adds and verifies todos', async ({ todosPage }) => {
+  await todosPage.createTodo('Buy milk');
+  await todosPage.createTodo('Walk dog');
+  await expect(todosPage.todos).toHaveCount(2);
+});
+
+test('creates a user via API then verifies in UI', async ({ todosPage, apiHelper, page }) => {
+  const user = await apiHelper.createUser({ name: 'Jane', email: 'jane@test.com' });
+  await page.goto(`/users/${user.id}`);
+  await expect(page.getByRole('heading')).toHaveText('Jane');
+});
+```
+
+**Playwright (JavaScript)** -- fixtures replace custom commands
+```javascript
+// fixtures.js
+const { test: base, expect } = require('@playwright/test');
+
+class TodosPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async createTodo(text) {
+    await this.page.getByTestId('new-todo').fill(text);
+    await this.page.getByTestId('new-todo').press('Enter');
+  }
+
+  get todos() {
+    return this.page.getByTestId('todo-item');
+  }
+}
+
+class ApiHelper {
+  constructor(request) {
+    this.request = request;
+  }
+
+  async createUser(userData) {
+    const response = await this.request.post('/api/users', { data: userData });
+    return response.json();
+  }
+}
+
+const test = base.extend({
+  todosPage: async ({ page }, use) => {
+    await page.goto('/todos');
+    await use(new TodosPage(page));
+  },
+
+  apiHelper: async ({ request }, use) => {
+    await use(new ApiHelper(request));
+  },
+});
+
+module.exports = { test, expect };
+```
+
+```javascript
+// todos.spec.js
+const { test, expect } = require('./fixtures');
+
+test('adds and verifies todos', async ({ todosPage }) => {
+  await todosPage.createTodo('Buy milk');
+  await todosPage.createTodo('Walk dog');
+  await expect(todosPage.todos).toHaveCount(2);
+});
+```
+
+**Key changes**: Every Cypress custom command maps to either a method on a page object (for UI interactions) or a helper class (for API calls), exposed via `test.extend()` fixtures. Fixtures provide dependency injection, type safety, and guaranteed teardown. Tests declare what they need by name in the function signature.
+
+## Migration Steps
+
+A battle-tested process for migrating an existing Cypress test suite to Playwright.
+
+### Step 1: Install Playwright alongside Cypress
+
+Do not remove Cypress yet. Run both frameworks in parallel during migration.
+
+```bash
+npm init playwright@latest
+# Accept defaults: TypeScript (or JavaScript), tests folder, GitHub Actions CI, install browsers
+```
+
+This creates `playwright.config.ts`, a `tests/` folder, and installs browsers.
+
+### Step 2: Configure playwright.config to match your Cypress setup
+
+Map your `cypress.config.js` settings to `playwright.config.ts`:
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',       // Your new Playwright test directory
+  timeout: 30_000,          // Cypress default is 4s per command; Playwright uses 30s per test
+  expect: { timeout: 5_000 }, // Assertion auto-retry timeout (like Cypress defaultCommandTimeout)
+  fullyParallel: true,      // Cypress runs serially by default; Playwright parallelizes
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'html' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000', // Matches Cypress baseUrl
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    // Add more browsers — something Cypress cannot do:
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+
+  // Equivalent to Cypress's devServer config
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'html' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+### Step 3: Convert custom commands to fixtures
+
+Before migrating individual tests, convert your `cypress/support/commands.js` into Playwright fixtures. This gives every migrated test immediate access to the same helpers.
+
+1. Identify each custom command in `cypress/support/commands.js` and `cypress/support/e2e.js`.
+2. Group UI commands into page object classes.
+3. Group API commands into API helper classes.
+4. Expose them via `test.extend()` in a shared `fixtures.ts` (or `fixtures.js`).
+5. See Example 5 above for the complete pattern.
+
+### Step 4: Set up authentication
+
+Convert `cy.session()` or login-in-`beforeEach` patterns to Playwright's `storageState`:
+
+1. Create an `auth.setup.ts` file (see Example 4 above).
+2. Add a `setup` project to `playwright.config.ts`.
+3. Add `.auth/` to `.gitignore`.
+4. Remove all login code from individual test files.
+
+### Step 5: Migrate tests file by file
+
+Start with the simplest spec files. For each file:
+
+1. Create the corresponding Playwright test file in `tests/`.
+2. Convert using the Command Mapping Table above.
+3. Replace CSS selectors with semantic locators (`getByRole`, `getByLabel`, `getByText`).
+4. Run the Playwright test in headed mode: `npx playwright test tests/my-test.spec.ts --headed`.
+5. Once passing, mark the Cypress spec as migrated (move to an `archived/` folder or delete).
+
+Prioritize by value: migrate your critical path tests first (auth, checkout, core CRUD).
+
+### Step 6: Convert cy.intercept patterns to page.route
+
+For each intercepted route:
+
+1. Move `page.route()` calls _before_ the action that triggers the request (Playwright routes must be set up in advance).
+2. Replace `cy.wait('@alias')` with either `page.waitForResponse()` (when you need the response) or just let auto-waiting assertions handle it (when you only care about UI updates).
+3. For request body assertions, capture the body inside the `page.route()` handler.
+
+### Step 7: Convert Cypress plugins to Node.js code
+
+Cypress plugins (in `cypress/plugins/` or `setupNodeEvents` in config) run in a separate Node.js process and communicate with test code via `cy.task()`. In Playwright, your test code already runs in Node.js, so:
+
+- Database seeding: call directly from fixtures or `globalSetup`.
+- File operations: use `fs` directly in test code or fixtures.
+- Environment setup: use `globalSetup` / `globalTeardown` in config.
+- Custom task logic: move into fixture setup/teardown.
+
+### Step 8: Update CI pipeline
+
+Replace the Cypress CI step with Playwright:
+
+```yaml
+# GitHub Actions example
+- name: Install Playwright Browsers
+  run: npx playwright install --with-deps
+
+- name: Run Playwright tests
+  run: npx playwright test
+
+- name: Upload Playwright Report
+  uses: actions/upload-artifact@v4
+  if: ${{ !cancelled() }}
+  with:
+    name: playwright-report
+    path: playwright-report/
+    retention-days: 30
+```
+
+### Step 9: Remove Cypress
+
+Once all tests are migrated and passing in CI:
+
+```bash
+npm uninstall cypress
+rm -rf cypress/
+rm cypress.config.js   # or .ts
+# Remove any Cypress-related CI config
+# Remove Cypress-related entries from .eslintrc if present
+```
+
+## Common Gotchas
+
+Things that look similar between Cypress and Playwright but behave differently.
+
+### 1. Locators are lazy, not retrying
+
+Cypress `cy.get()` immediately starts querying the DOM and retries until the chain passes. Playwright `page.locator()` creates a locator object instantly -- it does _nothing_ until you call an action (`.click()`, `.fill()`) or assertion (`expect(locator).toBeVisible()`).
+
+```typescript
+// This does NOT query the DOM — it just creates a locator reference
+const button = page.getByRole('button', { name: 'Submit' });
+
+// This is where the actual DOM query + waiting happens
+await button.click();
+```
+
+This means storing locators in variables is free and encouraged. Reuse them across multiple actions and assertions.
+
+### 2. Assertions are separate from locators
+
+Cypress chains assertions onto commands: `cy.get('x').should('be.visible').and('have.text', 'y')`. Playwright uses separate `expect()` calls for each assertion:
+
+```typescript
+// Cypress — chained assertions
+cy.get('.card').should('be.visible').and('have.text', 'Hello').and('have.class', 'active');
+
+// Playwright — separate expect() calls, each auto-retries independently
+const card = page.locator('.card');
+await expect(card).toBeVisible();
+await expect(card).toHaveText('Hello');
+await expect(card).toHaveClass(/active/);
+```
+
+### 3. fill() vs type() — the speed difference
+
+`cy.type('text')` sends keystrokes one at a time, triggering `keydown`, `keypress`, `input`, and `keyup` events for each character. Playwright's `locator.fill('text')` clears the field and sets the value in one shot, only triggering `input` and `change` events.
+
+Use `fill()` by default. Use `pressSequentially()` only when character-by-character input matters (autocomplete, search-as-you-type, input masks):
+
+```typescript
+// Default — fast, sets value directly
+await page.getByLabel('Name').fill('Jane Doe');
+
+// Character-by-character — only when keystroke events matter
+await page.getByLabel('Search').pressSequentially('play', { delay: 100 });
+```
+
+### 4. Auto-scroll behavior
+
+Cypress auto-scrolls to bring elements into view before _any_ interaction. Playwright auto-scrolls into view only when performing _actions_ (click, fill, check). Assertions like `toBeVisible()` do **not** scroll -- they check if the element is visible in its current position.
+
+If you need to scroll before asserting visibility:
+
+```typescript
+// Scroll into view first, then assert
+await page.getByText('Footer content').scrollIntoViewIfNeeded();
+await expect(page.getByText('Footer content')).toBeVisible();
+```
+
+### 5. No implicit cy.wrap() equivalent
+
+Cypress `cy.wrap()` brings a non-Cypress value into the command chain. Playwright does not need this because you are already in async/await land:
+
+```typescript
+// Cypress
+const value = 42;
+cy.wrap(value).should('equal', 42);
+
+// Playwright — just use the value
+const value = 42;
+expect(value).toBe(42);
+```
+
+### 6. Route setup timing
+
+Cypress `cy.intercept()` can be called at any point and will match the _next_ matching request. Playwright `page.route()` must be set up _before_ the action that triggers the request. A common mistake is setting up the route _after_ `page.goto()` -- by then the request may have already fired.
+
+```typescript
+// WRONG — route set up too late
+await page.goto('/products');
+await page.route('**/api/products', (route) => route.fulfill({ body: '[]' }));
+
+// CORRECT — route set up before navigation
+await page.route('**/api/products', (route) => route.fulfill({ body: '[]' }));
+await page.goto('/products');
+```
+
+### 7. Cypress subject vs Playwright return values
+
+Cypress commands yield a "subject" to the next command in the chain. Playwright actions return `void` (or a `Promise<void>`). If you need a value _from_ the browser, use `evaluate`, `textContent`, `inputValue`, etc.:
+
+```typescript
+// Cypress — subject chaining
+cy.get('#counter').invoke('text').then((text) => {
+  const count = parseInt(text, 10);
+  expect(count).to.be.greaterThan(0);
+});
+
+// Playwright — direct return values
+const text = await page.locator('#counter').textContent();
+const count = parseInt(text!, 10);
+expect(count).toBeGreaterThan(0);
+
+// Better: use a web-first assertion when possible
+await expect(page.locator('#counter')).not.toHaveText('0');
+```
+
+### 8. Cypress plugins vs Playwright global setup
+
+Cypress uses `setupNodeEvents` (or the legacy `plugins/index.js`) for Node.js-side operations, accessed via `cy.task()`. Since Playwright tests already run in Node.js, you do not need a separate plugin layer:
+
+```typescript
+// Cypress — plugin pattern
+// cypress.config.js
+setupNodeEvents(on) {
+  on('task', {
+    seedDatabase(data) { return db.seed(data); },
+  });
+}
+// Test: cy.task('seedDatabase', testData);
+
+// Playwright — direct call in fixture
+export const test = base.extend({
+  seededDatabase: async ({}, use) => {
+    await db.seed(testData);
+    await use();
+    await db.cleanup();
+  },
+});
+```
+
+### 9. cy.within() vs locator scoping
+
+Cypress `cy.within()` scopes all subsequent commands to a container element. Playwright scopes by chaining locators:
+
+```typescript
+// Cypress
+cy.get('[data-testid="signup-form"]').within(() => {
+  cy.get('input[name="email"]').type('user@test.com');
+  cy.get('button').click();
+});
+
+// Playwright — chain locators for scoping
+const form = page.getByTestId('signup-form');
+await form.getByLabel('Email').fill('user@test.com');
+await form.getByRole('button', { name: 'Sign up' }).click();
+```
+
+### 10. Test isolation differences
+
+Cypress clears cookies, localStorage, and sessionStorage between tests by default but shares the same browser instance. Playwright creates a _fresh browser context_ for each test -- complete isolation of cookies, storage, cache, and service workers. This means:
+
+- You never need to manually clear state between tests.
+- You cannot "leak" state from one test to another (which can mask or cause flakiness in Cypress).
+- Worker-scoped fixtures are the way to share expensive resources across tests.
+
+## What's Better in Playwright
+
+Features that have no Cypress equivalent and make Playwright the stronger choice for production test suites.
+
+### Multi-browser testing out of the box
+
+Test on Chromium, Firefox, and WebKit (Safari) in a single config. No plugins, no paid dashboard.
+
+```typescript
+// playwright.config.ts — three browsers, zero extra setup
+projects: [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+  { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+  { name: 'mobile-safari', use: { ...devices['iPhone 13'] } },
+],
+```
+
+### Multi-tab and multi-window testing
+
+Test popups, OAuth flows, new tabs, and multi-window interactions:
+
+```typescript
+// Handle a popup window (e.g., OAuth)
+const popupPromise = page.waitForEvent('popup');
+await page.getByRole('button', { name: 'Sign in with Google' }).click();
+const popup = await popupPromise;
+await popup.getByLabel('Email').fill('user@gmail.com');
+```
+
+### Multi-user testing in a single test
+
+Test collaboration features with multiple independent browser contexts:
+
+```typescript
+test('two users can collaborate', async ({ browser }) => {
+  const aliceContext = await browser.newContext({ storageState: 'auth/alice.json' });
+  const bobContext = await browser.newContext({ storageState: 'auth/bob.json' });
+  const alicePage = await aliceContext.newPage();
+  const bobPage = await bobContext.newPage();
+
+  await alicePage.goto('/doc/shared');
+  await bobPage.goto('/doc/shared');
+
+  await alicePage.getByRole('textbox').fill('Hello from Alice');
+  await expect(bobPage.getByText('Hello from Alice')).toBeVisible();
+
+  await aliceContext.close();
+  await bobContext.close();
+});
+```
+
+### Native API testing
+
+Test APIs without a browser, using the same runner and assertion library:
+
+```typescript
+test('API returns user list', async ({ request }) => {
+  const response = await request.get('/api/users');
+  expect(response.ok()).toBeTruthy();
+
+  const users = await response.json();
+  expect(users).toHaveLength(3);
+  expect(users[0]).toHaveProperty('email');
+});
+```
+
+### Parallel execution with sharding
+
+Run tests across multiple machines with zero configuration:
+
+```bash
+# Split across 4 CI machines
+npx playwright test --shard=1/4  # Machine 1
+npx playwright test --shard=2/4  # Machine 2
+npx playwright test --shard=3/4  # Machine 3
+npx playwright test --shard=4/4  # Machine 4
+```
+
+### Trace viewer
+
+Playwright traces capture a complete record of test execution: DOM snapshots, network requests, console logs, and action screenshots. Open with:
+
+```bash
+npx playwright show-trace trace.zip
+```
+
+This replaces Cypress's time-travel debugger with a more detailed, offline-capable tool.
+
+### Component testing with framework support
+
+Test React, Vue, Svelte, and Solid components in real browsers (not jsdom):
+
+```typescript
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Button } from './Button';
+
+test('button renders with label', async ({ mount }) => {
+  const component = await mount(<Button label="Click me" />);
+  await expect(component).toContainText('Click me');
+  await component.click();
+});
+```
+
+### Built-in code generation
+
+Generate test code by interacting with your app:
+
+```bash
+npx playwright codegen http://localhost:3000
+```
+
+Records your clicks, fills, and assertions, and outputs Playwright test code. Use it as a starting point, then refine locators to use `getByRole`.
+
+### Clock control
+
+Full control over `Date`, `setTimeout`, `setInterval`, and `requestAnimationFrame`:
+
+```typescript
+test('shows expired badge after timeout', async ({ page }) => {
+  await page.clock.install({ time: new Date('2024-01-01T00:00:00Z') });
+  await page.goto('/offers');
+
+  await page.clock.fastForward('24:00:00');
+
+  await expect(page.getByText('Offer expired')).toBeVisible();
+});
+```
+
+### Network request interception with HAR files
+
+Record and replay network traffic from HAR files for deterministic tests:
+
+```typescript
+// Record all network traffic
+await page.routeFromHAR('tests/fixtures/products.har', {
+  url: '**/api/**',
+  update: true, // Set to true once to record, then false to replay
+});
+```
+
+## Related
+
+- [core/locators.md](../core/locators.md) -- locator strategy for Playwright (replaces Cypress `cy.get()` patterns)
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- deep dive on fixtures (replaces Cypress custom commands)
+- [core/assertions-and-waiting.md](../core/assertions-and-waiting.md) -- web-first assertions (replaces Cypress `should` chains)
+- [core/configuration.md](../core/configuration.md) -- playwright.config setup
+- [core/authentication.md](../core/authentication.md) -- auth patterns (replaces Cypress `cy.session()`)
+- [core/network-mocking.md](../core/network-mocking.md) -- route mocking (replaces Cypress `cy.intercept()`)
+- [ci/ci-github-actions.md](../ci/ci-github-actions.md) -- CI setup for Playwright

--- a/engineering-team/playwright skill/migration/from-selenium.md
+++ b/engineering-team/playwright skill/migration/from-selenium.md
@@ -1,0 +1,955 @@
+# Migrating from Selenium to Playwright
+
+> **When to use**: When converting a Selenium/WebDriver test suite to Playwright. Covers Java/Python/C# Selenium idioms mapped to TypeScript and JavaScript Playwright equivalents.
+> **Prerequisites**: [core/locators.md](../core/locators.md), [core/assertions-and-waiting.md](../core/assertions-and-waiting.md)
+
+## Key Mindset Shifts
+
+Before translating any code, internalize these six changes. They are not syntax swaps -- they are fundamental differences in how Playwright works.
+
+### 1. No More Explicit Waits
+
+Selenium requires `WebDriverWait` and `ExpectedConditions` on nearly every interaction. Playwright auto-waits on every action (`click`, `fill`, `check`, `selectOption`) and every web-first assertion (`expect(locator).toBeVisible()`). Delete all your waits. They are not needed.
+
+```
+Selenium:  WebDriverWait + ExpectedConditions.visibilityOfElementLocated(...)
+Playwright: nothing — auto-waiting is built into every action and assertion
+```
+
+### 2. No WebDriver Protocol Overhead
+
+Selenium sends every command over the WebDriver (W3C) HTTP protocol -- each click, each find, each assertion is a round-trip HTTP request. Playwright communicates over CDP (Chromium), the DevTools protocol (Firefox), or native WebKit protocol. This is a persistent bidirectional connection, not request-response. Tests are faster by default.
+
+### 3. No Driver Management
+
+Selenium requires matching browser drivers (`chromedriver`, `geckodriver`) to browser versions. Version mismatches are a constant source of CI failures. Playwright bundles browser binaries. One command installs everything:
+
+```bash
+npx playwright install
+```
+
+No `WebDriverManager`. No `chromedriver` path. No version matrix.
+
+### 4. No Implicit vs Explicit Wait Confusion
+
+Selenium has implicit waits (global, apply to all `findElement` calls), explicit waits (`WebDriverWait`), and `Thread.sleep()` / `time.sleep()`. Teams mix these, creating unpredictable timing behavior. Playwright has one mechanism: auto-waiting. Every action waits for the element to be actionable. Every web-first assertion retries until timeout. There is nothing to configure.
+
+### 5. Locators Are Lazy and Auto-Retry
+
+In Selenium, `findElement()` immediately queries the DOM and returns a `WebElement` reference. If the DOM changes, that reference is stale and throws `StaleElementReferenceException`. In Playwright, `page.locator()` returns a lazy locator that re-queries the DOM on every action. There is no stale element. There is no `StaleElementReferenceException`. Ever.
+
+### 6. Built-In Test Runner
+
+Selenium is a browser automation library, not a test framework. You need JUnit, TestNG, pytest, or Mocha on top. Playwright Test is a full test runner with parallel execution, retries, fixtures, HTML reports, trace viewer, and UI mode. No assembly required.
+
+## API Mapping Table
+
+Every Selenium API and its direct Playwright equivalent. The "Notes" column calls out behavior differences.
+
+### Navigation
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `driver.get(url)` | `await page.goto(url)` | Playwright waits for `load` event by default; configurable via `waitUntil` |
+| `driver.navigate().to(url)` | `await page.goto(url)` | Same as above |
+| `driver.navigate().back()` | `await page.goBack()` | Waits for navigation to complete |
+| `driver.navigate().forward()` | `await page.goForward()` | Waits for navigation to complete |
+| `driver.navigate().refresh()` | `await page.reload()` | Waits for `load` event |
+| `driver.getCurrentUrl()` | `page.url()` | Synchronous in Playwright -- no await needed |
+| `driver.getTitle()` | `await page.title()` | Or use `await expect(page).toHaveTitle('...')` for assertion |
+
+### Element Location
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `driver.findElement(By.id("x"))` | `page.locator('#x')` or `page.getByTestId('x')` | Prefer `getByRole()` or `getByTestId()` over ID selectors |
+| `driver.findElement(By.css("x"))` | `page.locator('x')` | CSS selectors work, but prefer semantic locators |
+| `driver.findElement(By.xpath("x"))` | `page.locator('xpath=x')` | Works but avoid XPath; use `getByRole()`, `getByLabel()`, `getByText()` |
+| `driver.findElement(By.name("x"))` | `page.locator('[name="x"]')` | Or `page.getByLabel()` if the field has a label |
+| `driver.findElement(By.linkText("x"))` | `page.getByRole('link', { name: 'x' })` | Role-based is more resilient |
+| `driver.findElement(By.partialLinkText("x"))` | `page.getByRole('link', { name: /x/ })` | Regex for partial match |
+| `driver.findElement(By.className("x"))` | `page.locator('.x')` | Class selectors are fragile; prefer semantic locators |
+| `driver.findElement(By.tagName("x"))` | `page.locator('x')` | Rarely useful alone; combine with role or text |
+| `driver.findElements(By.css("x"))` | `await page.locator('x').all()` | Returns array of locators; or use `toHaveCount()` to assert count |
+
+### Element Interaction
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `element.click()` | `await locator.click()` | Auto-waits for element to be visible, stable, enabled, and unobscured |
+| `element.sendKeys("text")` | `await locator.fill("text")` | **Behavior change**: `fill()` clears existing text first, then sets the value. Use `pressSequentially()` to type character by character. |
+| `element.sendKeys(Keys.ENTER)` | `await locator.press('Enter')` | Or `await page.keyboard.press('Enter')` |
+| `element.clear()` | `await locator.clear()` | Or `await locator.fill('')` |
+| `element.submit()` | `await locator.press('Enter')` | No direct equivalent; click the submit button or press Enter |
+| `new Select(element).selectByVisibleText("x")` | `await locator.selectOption({ label: 'x' })` | Also supports `{ value: 'x' }` and `{ index: 0 }` |
+| `element.isDisplayed()` | `await expect(locator).toBeVisible()` | Use assertion form -- it auto-retries. `locator.isVisible()` does not retry. |
+| `element.isEnabled()` | `await expect(locator).toBeEnabled()` | Use assertion form for reliability |
+| `element.isSelected()` | `await expect(locator).toBeChecked()` | For checkboxes and radio buttons |
+| `element.getText()` | `await locator.textContent()` | Or prefer `await expect(locator).toHaveText('...')` which auto-retries |
+| `element.getAttribute("x")` | `await locator.getAttribute('x')` | Or `await expect(locator).toHaveAttribute('x', 'value')` |
+| `element.getCssValue("x")` | `await expect(locator).toHaveCSS('x', 'value')` | Use assertion form; computed values only |
+
+### Waits and Conditions
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `WebDriverWait(driver, 10).until(...)` | Not needed | Playwright auto-waits on all actions and assertions |
+| `ExpectedConditions.visibilityOfElementLocated(...)` | `await expect(locator).toBeVisible()` | Built into every action; use assertion only when you need to verify visibility explicitly |
+| `ExpectedConditions.elementToBeClickable(...)` | Not needed | `click()` auto-waits for clickability |
+| `ExpectedConditions.presenceOfElementLocated(...)` | `await expect(locator).toBeAttached()` | Rarely needed; most actions wait for attachment automatically |
+| `ExpectedConditions.invisibilityOfElementLocated(...)` | `await expect(locator).not.toBeVisible()` | Auto-retries until element disappears |
+| `ExpectedConditions.textToBePresentInElement(...)` | `await expect(locator).toHaveText('...')` | Auto-retries until text matches |
+| `ExpectedConditions.titleIs("x")` | `await expect(page).toHaveTitle('x')` | Auto-retries |
+| `ExpectedConditions.urlContains("x")` | `await expect(page).toHaveURL(/x/)` | Or `await page.waitForURL('**/x')` |
+| `ExpectedConditions.alertIsPresent()` | `page.on('dialog', ...)` or `page.waitForEvent('dialog')` | Register handler before the action that triggers the dialog |
+| `Thread.sleep(5000)` / `time.sleep(5)` | Never | Delete it. Use auto-waiting assertions instead. |
+| `driver.manage().timeouts().implicitlyWait(10)` | Not needed | No implicit waits in Playwright -- auto-waiting handles everything |
+
+### Frames and Windows
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `driver.switchTo().frame("name")` | `page.frameLocator('iframe[name="name"]')` | No context switching; chain locators directly into the frame |
+| `driver.switchTo().frame(element)` | `page.frameLocator('iframe#id')` | Target the iframe by any CSS selector |
+| `driver.switchTo().defaultContent()` | Not needed | No frame switching in Playwright; each `frameLocator` is scoped |
+| `driver.switchTo().parentFrame()` | Not needed | No frame switching to undo |
+| `driver.switchTo().window(handle)` | `context.pages()` | Access all pages in the context by index |
+| `driver.getWindowHandle()` | Not needed | Use `page` references directly |
+| `driver.getWindowHandles()` | `context.pages()` | Returns array of all open pages |
+| New window/tab opened by click | `page.waitForEvent('popup')` | Register before the click; returns the new `Page` object |
+
+### Browser and Context
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `driver.manage().window().setSize(w, h)` | `await page.setViewportSize({ width: w, height: h })` | Sets the viewport, not the OS window |
+| `driver.manage().window().maximize()` | Configure in `playwright.config` `use.viewport` | Or pass `--headed` with large viewport |
+| `driver.manage().addCookie(cookie)` | `await context.addCookies([cookie])` | Takes an array; operates on the browser context |
+| `driver.manage().getCookieNamed("x")` | `await context.cookies()` then filter | Returns all cookies; filter in JS |
+| `driver.manage().deleteAllCookies()` | `await context.clearCookies()` | Clears all cookies in the context |
+| `driver.executeScript("return ...")` | `await page.evaluate(() => { ... })` | Full access to browser JS context; supports return values |
+| `driver.executeAsyncScript(...)` | `await page.evaluate(async () => { ... })` | `evaluate` supports async functions natively |
+| `driver.getScreenshotAs(OutputType.FILE)` | `await page.screenshot({ path: 'shot.png' })` | Also supports `fullPage: true`, element screenshots via `locator.screenshot()` |
+| `driver.quit()` | Handled automatically | Playwright Test manages browser lifecycle. No manual cleanup. |
+
+### Actions Class
+
+| Selenium WebDriver | Playwright | Notes |
+|---|---|---|
+| `new Actions(driver).moveToElement(el).perform()` | `await locator.hover()` | Single method, auto-waits |
+| `new Actions(driver).doubleClick(el).perform()` | `await locator.dblclick()` | Single method, auto-waits |
+| `new Actions(driver).contextClick(el).perform()` | `await locator.click({ button: 'right' })` | Right-click option |
+| `new Actions(driver).dragAndDrop(src, tgt).perform()` | `await source.dragTo(target)` | Both are locators |
+| `new Actions(driver).keyDown(Keys.SHIFT).click(el).keyUp(Keys.SHIFT).perform()` | `await locator.click({ modifiers: ['Shift'] })` | Modifier keys as option |
+| `new Actions(driver).sendKeys(Keys.chord(Keys.CONTROL, "a")).perform()` | `await page.keyboard.press('Control+a')` | Keyboard API for global shortcuts |
+| `new Actions(driver).moveByOffset(x, y).perform()` | `await page.mouse.move(x, y)` | Raw mouse API for canvas/map interactions |
+
+## Before/After Examples
+
+### Example 1: Login Test
+
+The most common Selenium test. Notice the complete absence of explicit waits in the Playwright version.
+
+**Selenium (Java)**
+```java
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.junit.jupiter.api.*;
+
+public class LoginTest {
+    WebDriver driver;
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty("webdriver.chrome.driver", "/path/to/chromedriver");
+        driver = new ChromeDriver();
+        driver.manage().window().maximize();
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (driver != null) driver.quit();
+    }
+
+    @Test
+    void userCanLogIn() {
+        driver.get("https://myapp.com/login");
+
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+        WebElement emailField = wait.until(
+            ExpectedConditions.visibilityOfElementLocated(By.id("email"))
+        );
+        emailField.clear();
+        emailField.sendKeys("user@example.com");
+
+        WebElement passwordField = driver.findElement(By.id("password"));
+        passwordField.clear();
+        passwordField.sendKeys("s3cure!Pass");
+
+        WebElement loginButton = wait.until(
+            ExpectedConditions.elementToBeClickable(By.cssSelector("button[type='submit']"))
+        );
+        loginButton.click();
+
+        wait.until(ExpectedConditions.urlContains("/dashboard"));
+
+        WebElement heading = wait.until(
+            ExpectedConditions.visibilityOfElementLocated(By.tagName("h1"))
+        );
+        Assertions.assertEquals("Dashboard", heading.getText());
+    }
+}
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('user can log in', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('s3cure!Pass');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Dashboard');
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('user can log in', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill('user@example.com');
+  await page.getByLabel('Password').fill('s3cure!Pass');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Dashboard');
+});
+```
+
+**What changed**: 45 lines of Java with explicit waits, driver management, and element references became 9 lines of Playwright. No setup, no teardown, no waits, no driver path. The `fill()` call replaces `clear()` + `sendKeys()`. Semantic locators (`getByLabel`, `getByRole`) replace brittle `By.id` and `By.cssSelector`.
+
+---
+
+### Example 2: Search and Verify Results
+
+Demonstrates replacing `findElements()`, explicit waits for result count, and text assertions.
+
+**Selenium (Java)**
+```java
+@Test
+void searchReturnsResults() {
+    driver.get("https://myapp.com/products");
+
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+    WebElement searchBox = wait.until(
+        ExpectedConditions.visibilityOfElementLocated(By.cssSelector("input[placeholder='Search products']"))
+    );
+    searchBox.clear();
+    searchBox.sendKeys("wireless headphones");
+    searchBox.sendKeys(Keys.ENTER);
+
+    wait.until(ExpectedConditions.numberOfElementsToBeMoreThan(
+        By.cssSelector(".product-card"), 0
+    ));
+
+    List<WebElement> results = driver.findElements(By.cssSelector(".product-card"));
+    Assertions.assertTrue(results.size() >= 3);
+
+    String firstTitle = results.get(0).findElement(By.cssSelector(".product-title")).getText();
+    Assertions.assertTrue(firstTitle.toLowerCase().contains("wireless"));
+}
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('search returns results', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByPlaceholder('Search products').fill('wireless headphones');
+  await page.getByPlaceholder('Search products').press('Enter');
+
+  const results = page.getByTestId('product-card');
+  await expect(results).toHaveCount(3, { timeout: 10_000 });
+
+  await expect(results.first().getByTestId('product-title')).toContainText(/wireless/i);
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('search returns results', async ({ page }) => {
+  await page.goto('/products');
+
+  await page.getByPlaceholder('Search products').fill('wireless headphones');
+  await page.getByPlaceholder('Search products').press('Enter');
+
+  const results = page.getByTestId('product-card');
+  await expect(results).toHaveCount(3, { timeout: 10_000 });
+
+  await expect(results.first().getByTestId('product-title')).toContainText(/wireless/i);
+});
+```
+
+**What changed**: No `WebDriverWait` for element visibility. No `clear()` before `sendKeys()`. No `findElements()` returning a stale list. The Playwright `toHaveCount()` auto-retries until the results appear. The regex assertion on `toContainText` replaces manual `getText()` + `toLowerCase()` + `contains()`.
+
+---
+
+### Example 3: Working with Iframes
+
+Selenium's frame switching is stateful and error-prone. Playwright's `frameLocator` is scoped and stateless.
+
+**Selenium (Java)**
+```java
+@Test
+void fillPaymentFormInIframe() {
+    driver.get("https://myapp.com/checkout");
+
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+    // Switch into the payment iframe
+    wait.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt(
+        By.cssSelector("iframe#payment-frame")
+    ));
+
+    // Now inside the iframe context
+    WebElement cardNumber = wait.until(
+        ExpectedConditions.visibilityOfElementLocated(By.id("card-number"))
+    );
+    cardNumber.sendKeys("4242424242424242");
+
+    driver.findElement(By.id("expiry")).sendKeys("12/28");
+    driver.findElement(By.id("cvc")).sendKeys("123");
+
+    // Switch back to main content before interacting with the page
+    driver.switchTo().defaultContent();
+
+    driver.findElement(By.id("place-order")).click();
+
+    wait.until(ExpectedConditions.visibilityOfElementLocated(
+        By.cssSelector(".confirmation-message")
+    ));
+}
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('fill payment form in iframe', async ({ page }) => {
+  await page.goto('/checkout');
+
+  // No switching — just scope into the frame
+  const paymentFrame = page.frameLocator('#payment-frame');
+  await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+  await paymentFrame.getByLabel('Expiry').fill('12/28');
+  await paymentFrame.getByLabel('CVC').fill('123');
+
+  // No switching back — main page locators still work
+  await page.getByRole('button', { name: 'Place order' }).click();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('fill payment form in iframe', async ({ page }) => {
+  await page.goto('/checkout');
+
+  const paymentFrame = page.frameLocator('#payment-frame');
+  await paymentFrame.getByLabel('Card number').fill('4242424242424242');
+  await paymentFrame.getByLabel('Expiry').fill('12/28');
+  await paymentFrame.getByLabel('CVC').fill('123');
+
+  await page.getByRole('button', { name: 'Place order' }).click();
+
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+});
+```
+
+**What changed**: No `switchTo().frame()`. No `switchTo().defaultContent()`. No risk of forgetting to switch back. Playwright's `frameLocator` scopes into the iframe without changing the driver's global state. You can interact with the main page and the iframe in any order.
+
+---
+
+### Example 4: Handling Popups and New Windows
+
+Selenium window handle management is notoriously fragile. Playwright makes it declarative.
+
+**Selenium (Java)**
+```java
+@Test
+void handlePopupWindow() {
+    driver.get("https://myapp.com/settings");
+
+    String originalWindow = driver.getWindowHandle();
+
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+    driver.findElement(By.linkText("Connect OAuth Provider")).click();
+
+    // Wait for new window to appear
+    wait.until(ExpectedConditions.numberOfWindowsToBe(2));
+
+    // Find and switch to the new window
+    for (String handle : driver.getWindowHandles()) {
+        if (!handle.equals(originalWindow)) {
+            driver.switchTo().window(handle);
+            break;
+        }
+    }
+
+    // Interact with the popup
+    wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("authorize-btn")));
+    driver.findElement(By.id("authorize-btn")).click();
+
+    // Wait for popup to close and switch back
+    wait.until(ExpectedConditions.numberOfWindowsToBe(1));
+    driver.switchTo().window(originalWindow);
+
+    wait.until(ExpectedConditions.visibilityOfElementLocated(
+        By.cssSelector(".connection-status.success")
+    ));
+}
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('handle popup window', async ({ page }) => {
+  await page.goto('/settings');
+
+  // Register listener BEFORE the click that opens the popup
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Connect OAuth Provider' }).click();
+  const popup = await popupPromise;
+
+  // Interact with the popup — it's just another Page object
+  await popup.getByRole('button', { name: 'Authorize' }).click();
+
+  // Popup closes automatically; verify result on original page
+  await expect(page.getByText('Connected successfully')).toBeVisible();
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('handle popup window', async ({ page }) => {
+  await page.goto('/settings');
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('link', { name: 'Connect OAuth Provider' }).click();
+  const popup = await popupPromise;
+
+  await popup.getByRole('button', { name: 'Authorize' }).click();
+
+  await expect(page.getByText('Connected successfully')).toBeVisible();
+});
+```
+
+**What changed**: No window handle iteration. No `switchTo()`. No tracking original vs new window. The popup is a `Page` object you interact with directly. When it closes, you just continue using the original `page`. The `waitForEvent('popup')` pattern is declarative and race-condition-free.
+
+---
+
+### Example 5: Drag and Drop with Actions
+
+Selenium's `Actions` class requires chaining and `perform()`. Playwright has direct methods.
+
+**Selenium (Java)**
+```java
+@Test
+void dragAndDropTask() {
+    driver.get("https://myapp.com/kanban");
+
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+    WebElement sourceCard = wait.until(
+        ExpectedConditions.visibilityOfElementLocated(
+            By.xpath("//div[@class='card' and contains(text(),'Fix login bug')]")
+        )
+    );
+    WebElement targetColumn = driver.findElement(
+        By.xpath("//div[@class='column' and .//h2[text()='Done']]")
+    );
+
+    Actions actions = new Actions(driver);
+    actions.dragAndDrop(sourceCard, targetColumn).perform();
+
+    // Verify the card moved
+    WebElement doneColumn = driver.findElement(
+        By.xpath("//div[@class='column' and .//h2[text()='Done']]")
+    );
+    WebElement movedCard = doneColumn.findElement(
+        By.xpath(".//div[@class='card' and contains(text(),'Fix login bug')]")
+    );
+    Assertions.assertTrue(movedCard.isDisplayed());
+}
+```
+
+**Playwright (TypeScript)**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('drag and drop task to done column', async ({ page }) => {
+  await page.goto('/kanban');
+
+  const card = page.getByText('Fix login bug');
+  const doneColumn = page.getByRole('heading', { name: 'Done' }).locator('..');
+
+  await card.dragTo(doneColumn);
+
+  // Verify card is now inside the Done column
+  await expect(doneColumn.getByText('Fix login bug')).toBeVisible();
+});
+```
+
+**Playwright (JavaScript)**
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('drag and drop task to done column', async ({ page }) => {
+  await page.goto('/kanban');
+
+  const card = page.getByText('Fix login bug');
+  const doneColumn = page.getByRole('heading', { name: 'Done' }).locator('..');
+
+  await card.dragTo(doneColumn);
+
+  await expect(doneColumn.getByText('Fix login bug')).toBeVisible();
+});
+```
+
+**What changed**: No `Actions` class. No `perform()`. No XPath for finding elements. `dragTo()` is a single method call on a locator. The verification uses scoped locators instead of XPath ancestor traversal.
+
+## Migration Steps
+
+A practical, ordered checklist for converting a Selenium suite to Playwright.
+
+### Step 1: Set Up Playwright Alongside Selenium
+
+Do not rip out Selenium on day one. Run both in parallel.
+
+```bash
+# Install Playwright in your existing project
+npm init playwright@latest
+
+# This creates:
+# - playwright.config.ts (or .js)
+# - tests/ directory
+# - package.json dependencies
+```
+
+Configure `baseURL` in `playwright.config` to match your Selenium target:
+
+**TypeScript**
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests-playwright', // separate from Selenium tests
+  use: {
+    baseURL: 'https://staging.myapp.com',
+    trace: 'on-first-retry',
+  },
+  retries: process.env.CI ? 2 : 0,
+});
+```
+
+**JavaScript**
+```javascript
+// playwright.config.js
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests-playwright',
+  use: {
+    baseURL: 'https://staging.myapp.com',
+    trace: 'on-first-retry',
+  },
+  retries: process.env.CI ? 2 : 0,
+});
+```
+
+### Step 2: Convert Page Objects First
+
+If you have Selenium page objects, convert them to Playwright page objects. The pattern is similar but simpler.
+
+**Selenium Page Object (Java)**
+```java
+public class LoginPage {
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+    private By emailField = By.id("email");
+    private By passwordField = By.id("password");
+    private By loginButton = By.cssSelector("button[type='submit']");
+    private By errorMessage = By.cssSelector(".error-message");
+
+    public LoginPage(WebDriver driver) {
+        this.driver = driver;
+        this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    }
+
+    public void login(String email, String password) {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(emailField));
+        driver.findElement(emailField).clear();
+        driver.findElement(emailField).sendKeys(email);
+        driver.findElement(passwordField).clear();
+        driver.findElement(passwordField).sendKeys(password);
+        driver.findElement(loginButton).click();
+    }
+
+    public String getErrorMessage() {
+        return wait.until(
+            ExpectedConditions.visibilityOfElementLocated(errorMessage)
+        ).getText();
+    }
+}
+```
+
+**Playwright Page Object (TypeScript)**
+```typescript
+// page-objects/login-page.ts
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class LoginPage {
+  private readonly emailField: Locator;
+  private readonly passwordField: Locator;
+  private readonly loginButton: Locator;
+  private readonly errorMessage: Locator;
+
+  constructor(private readonly page: Page) {
+    this.emailField = page.getByLabel('Email');
+    this.passwordField = page.getByLabel('Password');
+    this.loginButton = page.getByRole('button', { name: 'Sign In' });
+    this.errorMessage = page.getByRole('alert');
+  }
+
+  async login(email: string, password: string) {
+    await this.emailField.fill(email);
+    await this.passwordField.fill(password);
+    await this.loginButton.click();
+  }
+
+  async expectError(message: string) {
+    await expect(this.errorMessage).toHaveText(message);
+  }
+}
+```
+
+**Playwright Page Object (JavaScript)**
+```javascript
+// page-objects/login-page.js
+const { expect } = require('@playwright/test');
+
+class LoginPage {
+  constructor(page) {
+    this.page = page;
+    this.emailField = page.getByLabel('Email');
+    this.passwordField = page.getByLabel('Password');
+    this.loginButton = page.getByRole('button', { name: 'Sign In' });
+    this.errorMessage = page.getByRole('alert');
+  }
+
+  async login(email, password) {
+    await this.emailField.fill(email);
+    await this.passwordField.fill(password);
+    await this.loginButton.click();
+  }
+
+  async expectError(message) {
+    await expect(this.errorMessage).toHaveText(message);
+  }
+}
+
+module.exports = { LoginPage };
+```
+
+Key differences in page objects:
+- Locators are defined in the constructor, not as `By` objects -- they are lazy and never go stale
+- No `WebDriverWait` anywhere
+- No `clear()` before `fill()`
+- Assertions can live inside the page object (`expectError`) because they auto-retry
+
+### Step 3: Convert Tests by Priority
+
+Start with your most valuable and most flaky tests. Convert them in order:
+
+1. **Smoke tests** -- highest value, run on every deploy
+2. **Flaky tests** -- Playwright's auto-waiting eliminates most flakiness
+3. **Slow tests** -- Playwright's parallelism and faster protocol make these faster
+4. **Everything else** -- bulk conversion of the remaining suite
+
+For each test, apply the API mapping table above. The mechanical translation is:
+1. Remove all `WebDriverWait` and `ExpectedConditions`
+2. Replace `findElement(By.xxx)` with semantic locators (`getByRole`, `getByLabel`, `getByText`)
+3. Replace `sendKeys` with `fill` (or `pressSequentially` for character-by-character input)
+4. Replace `Assert` / `assertEquals` with `expect(locator).toHaveText()` / `toBeVisible()` / etc.
+5. Remove `setUp` and `tearDown` -- Playwright Test handles browser lifecycle
+6. Remove `Thread.sleep()` / `time.sleep()` entirely
+
+### Step 4: Replace Test Infrastructure
+
+| Selenium Infrastructure | Playwright Equivalent |
+|---|---|
+| Selenium Grid / Hub | `npx playwright test --shard=1/4` (built-in sharding) |
+| BrowserStack / SauceLabs | Often unnecessary; Playwright runs 3 browsers locally. Use for Safari on CI if needed. |
+| WebDriverManager | `npx playwright install` (one command, all browsers) |
+| TestNG XML suites | `playwright.config` `projects` array |
+| JUnit @Tag / pytest marks | `test.describe()` grouping + `--grep` filtering |
+| Allure / ExtentReports | Built-in HTML reporter (`npx playwright show-report`) + trace viewer |
+| Screenshot on failure | Built-in: `use: { screenshot: 'only-on-failure' }` |
+| Video recording | Built-in: `use: { video: 'on-first-retry' }` |
+
+### Step 5: Remove Selenium
+
+Once all tests pass in Playwright and have run green in CI for at least two weeks:
+
+1. Delete Selenium test files
+2. Remove Selenium dependencies (`selenium-webdriver`, `chromedriver`, `geckodriver`)
+3. Remove Selenium Grid infrastructure
+4. Update CI pipelines to run only Playwright
+5. Remove `setUp` / `tearDown` boilerplate classes
+
+## Common Gotchas
+
+### Gotcha 1: `findElement` Throws, `locator()` Does Not
+
+In Selenium, `driver.findElement(By.id("missing"))` throws `NoSuchElementException` immediately. In Playwright, `page.locator('#missing')` returns a locator object without querying the DOM. It only throws when you perform an action on it and the element does not appear within the timeout.
+
+```typescript
+// This does NOT throw — locators are lazy
+const missing = page.locator('#does-not-exist');
+
+// This throws after timeout — because the action waits and the element never appears
+await missing.click(); // TimeoutError after actionTimeout
+```
+
+**Impact**: If your Selenium tests use try-catch around `findElement` to check element existence, replace with assertions:
+
+```typescript
+// Selenium pattern (do not replicate)
+// try { driver.findElement(By.id("error")); fail(); } catch (NoSuchElementException e) { /* expected */ }
+
+// Playwright equivalent
+await expect(page.locator('#error')).not.toBeVisible();
+```
+
+### Gotcha 2: `sendKeys` Appends, `fill` Replaces
+
+Selenium's `sendKeys("text")` appends to the existing value. If the field already contains "hello" and you `sendKeys("world")`, you get "helloworld". Playwright's `fill("text")` clears the field first, then sets the value. You get "text".
+
+```typescript
+// Selenium behavior: appends
+// element.sendKeys("world"); // field: "helloworld"
+
+// Playwright behavior: replaces
+await locator.fill('world'); // field: "world"
+
+// To replicate Selenium's append behavior:
+await locator.pressSequentially('world'); // types each character, appending to existing value
+```
+
+### Gotcha 3: No StaleElementReferenceException
+
+In Selenium, storing a `WebElement` reference and using it after the DOM changes throws `StaleElementReferenceException`. This is the single most common source of Selenium test flakiness.
+
+```java
+// Selenium — this can throw StaleElementReferenceException
+WebElement button = driver.findElement(By.id("submit"));
+// ... some action causes the DOM to re-render ...
+button.click(); // BOOM — StaleElementReferenceException
+```
+
+In Playwright, locators re-query the DOM on every action. Store locators freely.
+
+```typescript
+// Playwright — this always works
+const button = page.getByRole('button', { name: 'Submit' });
+// ... some action causes the DOM to re-render ...
+await button.click(); // Works — re-queries the DOM automatically
+```
+
+### Gotcha 4: No Global Driver State
+
+Selenium has a single `driver` instance with global state: the current frame, the current window, implicit wait timeout. Calling `switchTo().frame()` changes state for all subsequent calls. Forgetting to `switchTo().defaultContent()` causes every following `findElement` to fail.
+
+Playwright has no global state. `page.frameLocator()` returns a scoped object. `context.pages()` gives you all pages. Nothing changes the "current" context.
+
+```typescript
+// Selenium mental model: "Where am I now?"
+// driver.switchTo().frame("payment"); // I'm in the payment frame
+// driver.findElement(...);            // This looks in the payment frame
+// driver.switchTo().defaultContent(); // Now I'm back in the main page
+// ... forget this line and everything breaks
+
+// Playwright mental model: "I always say exactly where I'm looking"
+const paymentFrame = page.frameLocator('#payment');
+await paymentFrame.getByLabel('Card').fill('4242...'); // scoped to frame
+await page.getByRole('button', { name: 'Pay' }).click(); // main page — no switching
+```
+
+### Gotcha 5: Assertions Must Be Awaited
+
+In Selenium (Java), assertions are synchronous: `assertEquals("Dashboard", heading.getText())`. In Playwright, web-first assertions are async and must be awaited:
+
+```typescript
+// WRONG — assertion runs detached, test may pass before it resolves
+expect(page.getByRole('heading')).toHaveText('Dashboard'); // missing await!
+
+// CORRECT
+await expect(page.getByRole('heading')).toHaveText('Dashboard');
+```
+
+Missing `await` is the number one Playwright beginner mistake. Your linter should flag this. Enable `@typescript-eslint/no-floating-promises` or the Playwright ESLint plugin.
+
+### Gotcha 6: Parallel by Default
+
+Selenium tests typically run sequentially (one browser, one thread). Playwright Test runs test files in parallel by default. This means:
+
+- Tests must be isolated -- no shared state between test files
+- Each test gets its own browser context (fresh cookies, storage, session)
+- Database fixtures must not collide between parallel tests
+
+If your Selenium suite depends on execution order, you must fix that before migrating. See [core/test-organization.md](../core/test-organization.md) for isolation strategies.
+
+## What's Better in Playwright
+
+These are not just syntax differences. These are capabilities that Selenium does not have.
+
+### Auto-Waiting Everywhere
+
+Every action, every assertion, every navigation auto-waits. You write zero wait code. This alone eliminates 60-80% of Selenium test flakiness.
+
+### Trace Viewer
+
+When a test fails in CI, Playwright captures a trace: screenshots at every step, DOM snapshots, network requests, console logs. Open it with `npx playwright show-report` and step through the exact failure. Selenium has nothing comparable.
+
+```typescript
+// playwright.config.ts — enable traces on first retry
+export default defineConfig({
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+### Built-In Parallel Execution
+
+Playwright Test runs test files in parallel with zero configuration. No Selenium Grid. No TestNG parallel suite XML. No pytest-xdist.
+
+```bash
+# Run all tests in parallel (default)
+npx playwright test
+
+# Shard across CI machines
+npx playwright test --shard=1/4  # machine 1
+npx playwright test --shard=2/4  # machine 2
+```
+
+### Multiple Browsers, One API
+
+The same test runs on Chromium, Firefox, and WebKit without code changes. Configure in `playwright.config`:
+
+```typescript
+export default defineConfig({
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});
+```
+
+Selenium requires separate driver binaries and often browser-specific workarounds.
+
+### Network Interception
+
+Playwright can intercept, modify, and mock network requests natively. Selenium cannot.
+
+```typescript
+// Mock an API response — impossible in Selenium
+await page.route('**/api/users', (route) => {
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([{ name: 'Mock User' }]),
+  });
+});
+```
+
+### Browser Context Isolation
+
+Each test gets a fresh browser context (like an incognito window). Cookies, localStorage, and sessions are isolated between tests without restarting the browser. Selenium requires `driver.quit()` and `new ChromeDriver()` for true isolation.
+
+### Test Fixtures
+
+Playwright's fixture system provides dependency injection for test setup and teardown. Fixtures guarantee cleanup even if a test crashes. Selenium relies on `@BeforeEach` / `@AfterEach` which skip teardown on hard failures.
+
+```typescript
+// Custom fixture for authenticated user — reusable across all tests
+import { test as base } from '@playwright/test';
+
+export const test = base.extend({
+  authenticatedPage: async ({ page }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('admin@example.com');
+    await page.getByLabel('Password').fill('password');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.waitForURL('/dashboard');
+    await use(page);
+    // Cleanup runs automatically, even on crash
+  },
+});
+```
+
+### Codegen
+
+Generate tests by recording browser interactions:
+
+```bash
+npx playwright codegen https://myapp.com
+```
+
+This opens a browser and records your clicks, fills, and navigations as Playwright test code. No equivalent exists in Selenium.
+
+### UI Mode
+
+Debug tests visually with time-travel:
+
+```bash
+npx playwright test --ui
+```
+
+Step forward and backward through each action, see the DOM state, network requests, and console logs at every point. Selenium's closest equivalent is manual `Thread.sleep()` and screenshot debugging.
+
+## Related
+
+- [core/locators.md](../core/locators.md) -- locator strategy priority and patterns
+- [core/assertions-and-waiting.md](../core/assertions-and-waiting.md) -- auto-waiting and web-first assertions in depth
+- [core/configuration.md](../core/configuration.md) -- setting up `playwright.config`
+- [core/page-object-model.md](../core/page-object-model.md) -- page object patterns for Playwright
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- fixtures system for test setup and isolation
+- [core/test-organization.md](../core/test-organization.md) -- organizing tests for parallel execution
+- [migration/from-cypress.md](from-cypress.md) -- migrating from Cypress instead

--- a/engineering-team/playwright skill/playwright-cli/SKILL.md
+++ b/engineering-team/playwright skill/playwright-cli/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: playwright-cli
+description: Automates browser interactions for web testing, form filling, screenshots, and data extraction using playwright-cli. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, extract information from web pages, mock network requests, manage browser sessions, or generate test code.
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Browser Automation with playwright-cli
+
+> Comprehensive CLI-driven browser automation — navigate, interact, mock, debug, record, and generate tests without writing a single script file.
+
+## Quick Start
+
+```bash
+# Install and set up
+playwright-cli install --skills
+playwright-cli install-browser
+
+# Open a browser and navigate
+playwright-cli open https://playwright.dev
+
+# Take a snapshot to see interactive elements (refs like e1, e2, e3...)
+playwright-cli snapshot
+
+# Interact using element refs from the snapshot
+playwright-cli click e15
+playwright-cli fill e5 "search query"
+playwright-cli press Enter
+
+# Take a screenshot
+playwright-cli screenshot
+
+# Close the browser
+playwright-cli close
+```
+
+## Golden Rules
+
+1. **Always `snapshot` first** — identify element refs before interacting; never guess ref numbers
+2. **Use `fill` for inputs, `click` for buttons** — `type` sends keystrokes one-by-one, `fill` replaces the entire value
+3. **Named sessions for parallel work** — `-s=name` isolates cookies, storage, and tabs per session
+4. **Save auth state** — `state-save auth.json` after login, `state-load auth.json` to skip login next time
+5. **Trace before debugging** — `tracing-start` before the failing step, not after
+6. **`run-code` for advanced scenarios** — when CLI commands aren't enough, drop into full Playwright API
+7. **Clean up sessions** — `close` or `close-all` when done; `kill-all` for zombie processes
+8. **Descriptive filenames** — `screenshot --filename=checkout-step3.png` not `screenshot`
+9. **Mock external APIs only** — use `route` to intercept third-party services, not your own app
+10. **Persistent profiles for stateful flows** — `--persistent` keeps cookies and storage across restarts
+
+## Command Reference
+
+### Core Interaction
+
+```bash
+playwright-cli open [url]                    # Launch browser, optionally navigate
+playwright-cli goto <url>                    # Navigate to URL
+playwright-cli snapshot                      # Show page elements with refs
+playwright-cli snapshot --filename=snap.yaml # Save snapshot to file
+playwright-cli click <ref>                   # Click an element
+playwright-cli dblclick <ref>                # Double-click
+playwright-cli fill <ref> "value"            # Clear and fill input
+playwright-cli type "text"                   # Type keystroke by keystroke
+playwright-cli select <ref> "option-value"   # Select dropdown option
+playwright-cli check <ref>                   # Check a checkbox
+playwright-cli uncheck <ref>                 # Uncheck a checkbox
+playwright-cli hover <ref>                   # Hover over element
+playwright-cli drag <src-ref> <dst-ref>      # Drag and drop
+playwright-cli upload <ref> ./file.pdf       # Upload a file
+playwright-cli eval "document.title"         # Evaluate JS expression
+playwright-cli eval "el => el.textContent" <ref>  # Evaluate on element
+playwright-cli close                         # Close the browser
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back                       # Browser back button
+playwright-cli go-forward                    # Browser forward button
+playwright-cli reload                        # Reload current page
+```
+
+### Keyboard & Mouse
+
+```bash
+playwright-cli press Enter                   # Press a key
+playwright-cli press ArrowDown               # Arrow keys
+playwright-cli keydown Shift                 # Hold key down
+playwright-cli keyup Shift                   # Release key
+playwright-cli mousemove 150 300             # Move mouse to coordinates
+playwright-cli mousedown [right]             # Mouse button down
+playwright-cli mouseup [right]               # Mouse button up
+playwright-cli mousewheel 0 100              # Scroll (deltaX, deltaY)
+```
+
+### Dialogs
+
+```bash
+playwright-cli dialog-accept                 # Accept alert/confirm/prompt
+playwright-cli dialog-accept "text"          # Accept prompt with input
+playwright-cli dialog-dismiss                # Dismiss/cancel dialog
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list                      # List all open tabs
+playwright-cli tab-new [url]                 # Open new tab
+playwright-cli tab-select <index>            # Switch to tab by index
+playwright-cli tab-close [index]             # Close tab (current or by index)
+```
+
+### Screenshots & Media
+
+```bash
+playwright-cli screenshot                    # Screenshot current page
+playwright-cli screenshot <ref>              # Screenshot specific element
+playwright-cli screenshot --filename=pg.png  # Save with custom filename
+playwright-cli pdf --filename=page.pdf       # Save page as PDF
+playwright-cli video-start                   # Start video recording
+playwright-cli video-stop output.webm        # Stop and save video
+playwright-cli resize 1920 1080              # Resize viewport
+```
+
+### Storage & Auth
+
+```bash
+playwright-cli state-save [file.json]        # Save cookies + localStorage
+playwright-cli state-load <file.json>        # Restore saved state
+playwright-cli cookie-list [--domain=...]    # List cookies
+playwright-cli cookie-get <name>             # Get specific cookie
+playwright-cli cookie-set <name> <value> [opts]  # Set a cookie
+playwright-cli cookie-delete <name>          # Delete a cookie
+playwright-cli cookie-clear                  # Clear all cookies
+playwright-cli localstorage-list             # List localStorage items
+playwright-cli localstorage-get <key>        # Get localStorage value
+playwright-cli localstorage-set <key> <val>  # Set localStorage value
+playwright-cli localstorage-delete <key>     # Delete localStorage item
+playwright-cli localstorage-clear            # Clear all localStorage
+playwright-cli sessionstorage-list           # List sessionStorage
+playwright-cli sessionstorage-get <key>      # Get sessionStorage value
+playwright-cli sessionstorage-set <key> <val>    # Set sessionStorage value
+playwright-cli sessionstorage-delete <key>   # Delete sessionStorage item
+playwright-cli sessionstorage-clear          # Clear all sessionStorage
+```
+
+### Network Mocking
+
+```bash
+playwright-cli route "<pattern>" [opts]      # Intercept matching requests
+playwright-cli route-list                    # List active route overrides
+playwright-cli unroute "<pattern>"           # Remove specific route
+playwright-cli unroute                       # Remove all routes
+```
+
+### DevTools & Debugging
+
+```bash
+playwright-cli console [level]              # Show console messages
+playwright-cli network                      # Show network requests
+playwright-cli tracing-start                # Start trace recording
+playwright-cli tracing-stop                 # Stop and save trace
+playwright-cli run-code "async page => {}"  # Execute Playwright API code
+```
+
+### Sessions & Configuration
+
+```bash
+playwright-cli -s=<name> <command>          # Run command in named session
+playwright-cli list                         # List all active sessions
+playwright-cli close-all                    # Close all browsers
+playwright-cli kill-all                     # Force kill all processes
+playwright-cli delete-data                  # Delete session user data
+playwright-cli open --browser=firefox       # Use specific browser
+playwright-cli open --persistent            # Persist profile to disk
+playwright-cli open --profile=/path         # Custom profile directory
+playwright-cli open --config=config.json    # Use config file
+playwright-cli open --extension             # Connect via extension
+```
+
+## Guide Index
+
+### Getting Started
+
+| What you're doing | Guide |
+|---|---|
+| Core browser interaction | [core-commands.md](core-commands.md) |
+| Generating test code | [test-generation.md](test-generation.md) |
+| Screenshots, video, PDF | [screenshots-and-media.md](screenshots-and-media.md) |
+
+### Testing & Debugging
+
+| What you're doing | Guide |
+|---|---|
+| Tracing and debugging | [tracing-and-debugging.md](tracing-and-debugging.md) |
+| Network mocking & interception | [request-mocking.md](request-mocking.md) |
+| Running custom Playwright code | [running-custom-code.md](running-custom-code.md) |
+
+### State & Sessions
+
+| What you're doing | Guide |
+|---|---|
+| Cookies, localStorage, auth state | [storage-and-auth.md](storage-and-auth.md) |
+| Multi-session management | [session-management.md](session-management.md) |
+
+### Advanced
+
+| What you're doing | Guide |
+|---|---|
+| Device & environment emulation | [device-emulation.md](device-emulation.md) |
+| Complex multi-step workflows | [advanced-workflows.md](advanced-workflows.md) |

--- a/engineering-team/playwright skill/playwright-cli/advanced-workflows.md
+++ b/engineering-team/playwright skill/playwright-cli/advanced-workflows.md
@@ -1,0 +1,679 @@
+# Advanced Workflows
+
+> **When to use**: Complex multi-step automation scenarios — multi-page scraping, popup and new window handling, accessibility auditing, file downloads, authentication flows with OAuth, infinite scroll extraction, form wizard automation, and combining multiple CLI features together.
+> **Prerequisites**: [core-commands.md](core-commands.md), [running-custom-code.md](running-custom-code.md), [session-management.md](session-management.md)
+
+## Quick Reference
+
+```bash
+# Multi-page scraping
+playwright-cli run-code "async page => {
+  const data = [];
+  for (let i = 1; i <= 5; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    data.push(...items);
+  }
+  return data;
+}"
+
+# Handle popup window
+playwright-cli run-code "async page => {
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.click('a[target=_blank]')
+  ]);
+  return await popup.title();
+}"
+
+# Accessibility snapshot
+playwright-cli run-code "async page => {
+  return await page.accessibility.snapshot();
+}"
+```
+
+## Popup and New Window Handling
+
+When clicking links that open new windows or popups:
+
+### Capture Popup Content
+
+```bash
+playwright-cli run-code "async page => {
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.click('a[target=_blank]')
+  ]);
+
+  await popup.waitForLoadState();
+  const title = await popup.title();
+  const url = popup.url();
+
+  return { title, url };
+}"
+```
+
+### Interact with Popup
+
+```bash
+playwright-cli run-code "async page => {
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.click('#open-settings')
+  ]);
+
+  // Fill a form in the popup
+  await popup.fill('input[name=email]', 'user@example.com');
+  await popup.click('button:text(\"Save\")');
+
+  // Wait for popup to close
+  await popup.waitForEvent('close');
+  return 'Popup handled';
+}"
+```
+
+### OAuth Login with Popup
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://app.example.com/login');
+
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.click('button:text(\"Sign in with Google\")')
+  ]);
+
+  // Handle Google OAuth in the popup
+  await popup.fill('input[type=email]', 'user@gmail.com');
+  await popup.click('#identifierNext');
+  await popup.waitForSelector('input[type=password]', { state: 'visible' });
+  await popup.fill('input[type=password]', 'password');
+  await popup.click('#passwordNext');
+
+  // Popup closes after auth, main page redirects
+  await popup.waitForEvent('close');
+  await page.waitForURL('**/dashboard');
+
+  return 'OAuth login complete: ' + page.url();
+}"
+```
+
+## Multi-Page Navigation and Scraping
+
+### Paginated Data Extraction
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/products');
+  const allProducts = [];
+
+  while (true) {
+    // Extract data from current page
+    const products = await page.locator('.product-card').evaluateAll(cards =>
+      cards.map(card => ({
+        name: card.querySelector('.name')?.textContent?.trim(),
+        price: card.querySelector('.price')?.textContent?.trim(),
+        rating: card.querySelector('.rating')?.getAttribute('data-score')
+      }))
+    );
+    allProducts.push(...products);
+
+    // Check for next page
+    const nextBtn = page.locator('a.next-page');
+    if (await nextBtn.isVisible()) {
+      await nextBtn.click();
+      await page.waitForLoadState('networkidle');
+    } else {
+      break;
+    }
+  }
+
+  return { total: allProducts.length, products: allProducts };
+}"
+```
+
+### Infinite Scroll Extraction
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/feed');
+  const seen = new Set();
+  const items = [];
+  const maxItems = 100;
+
+  while (items.length < maxItems) {
+    // Collect visible items
+    const newItems = await page.locator('.feed-item').evaluateAll(
+      els => els.map(el => ({
+        id: el.getAttribute('data-id'),
+        text: el.textContent.trim()
+      }))
+    );
+
+    for (const item of newItems) {
+      if (item.id && !seen.has(item.id)) {
+        seen.add(item.id);
+        items.push(item);
+      }
+    }
+
+    // Scroll to bottom
+    const previousHeight = await page.evaluate(() => document.body.scrollHeight);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(2000);
+
+    // Check if we've reached the end
+    const newHeight = await page.evaluate(() => document.body.scrollHeight);
+    if (newHeight === previousHeight) break;
+  }
+
+  return { collected: items.length, items: items.slice(0, maxItems) };
+}"
+```
+
+### Multi-Site Data Aggregation
+
+```bash
+#!/bin/bash
+# Use named sessions for concurrent site scraping
+
+playwright-cli -s=site1 open https://news.example.com &
+playwright-cli -s=site2 open https://blog.example.com &
+playwright-cli -s=site3 open https://docs.example.com &
+wait
+
+# Extract headlines from each
+playwright-cli -s=site1 run-code "async page => {
+  return await page.locator('h2.headline').allTextContents();
+}"
+
+playwright-cli -s=site2 run-code "async page => {
+  return await page.locator('.post-title').allTextContents();
+}"
+
+playwright-cli -s=site3 run-code "async page => {
+  return await page.locator('.doc-title').allTextContents();
+}"
+
+playwright-cli close-all
+```
+
+## File Upload and Download
+
+### Download Files
+
+```bash
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+
+  const filename = download.suggestedFilename();
+  await download.saveAs('./downloads/' + filename);
+  return {
+    filename,
+    url: download.url()
+  };
+}"
+```
+
+### Download Multiple Files
+
+```bash
+playwright-cli run-code "async page => {
+  const downloadLinks = await page.locator('a.download').all();
+  const files = [];
+
+  for (const link of downloadLinks) {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      link.click()
+    ]);
+    const name = download.suggestedFilename();
+    await download.saveAs('./downloads/' + name);
+    files.push(name);
+  }
+
+  return files;
+}"
+```
+
+### Upload Files
+
+```bash
+# Simple upload via ref
+playwright-cli snapshot
+playwright-cli upload e5 ./document.pdf
+
+# Upload multiple files
+playwright-cli upload e5 ./photo1.jpg ./photo2.jpg ./photo3.jpg
+
+# Programmatic upload (for hidden file inputs)
+playwright-cli run-code "async page => {
+  const fileInput = page.locator('input[type=file]');
+  await fileInput.setInputFiles('./report.pdf');
+}"
+
+# Upload multiple files programmatically
+playwright-cli run-code "async page => {
+  const fileInput = page.locator('input[type=file]');
+  await fileInput.setInputFiles([
+    './document1.pdf',
+    './document2.pdf',
+    './image.png'
+  ]);
+}"
+
+# Clear file input
+playwright-cli run-code "async page => {
+  await page.locator('input[type=file]').setInputFiles([]);
+}"
+```
+
+### Drag-and-Drop File Upload
+
+```bash
+playwright-cli run-code "async page => {
+  // Create a fake file for drag-and-drop zones
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+  await page.dispatchEvent('.dropzone', 'drop', { dataTransfer });
+}"
+```
+
+## Accessibility Auditing
+
+### Accessibility Tree Snapshot
+
+```bash
+playwright-cli run-code "async page => {
+  const snapshot = await page.accessibility.snapshot();
+  return JSON.stringify(snapshot, null, 2);
+}"
+```
+
+### Check for Missing ARIA Labels
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    const issues = [];
+
+    // Images without alt text
+    document.querySelectorAll('img:not([alt])').forEach(img => {
+      issues.push({ type: 'img-no-alt', src: img.src.substring(0, 50) });
+    });
+
+    // Buttons without accessible names
+    document.querySelectorAll('button').forEach(btn => {
+      if (!btn.textContent.trim() && !btn.getAttribute('aria-label')) {
+        issues.push({ type: 'button-no-name', html: btn.outerHTML.substring(0, 80) });
+      }
+    });
+
+    // Form inputs without labels
+    document.querySelectorAll('input:not([type=hidden])').forEach(input => {
+      const id = input.id;
+      const hasLabel = id && document.querySelector(\`label[for=\${id}]\`);
+      const hasAriaLabel = input.getAttribute('aria-label') || input.getAttribute('aria-labelledby');
+      if (!hasLabel && !hasAriaLabel) {
+        issues.push({ type: 'input-no-label', name: input.name, type: input.type });
+      }
+    });
+
+    // Links without text
+    document.querySelectorAll('a').forEach(link => {
+      if (!link.textContent.trim() && !link.getAttribute('aria-label')) {
+        issues.push({ type: 'link-no-text', href: link.href.substring(0, 50) });
+      }
+    });
+
+    return { issueCount: issues.length, issues };
+  });
+}"
+```
+
+### Color Contrast Check
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    const getContrast = (rgb1, rgb2) => {
+      const luminance = (r, g, b) => {
+        const [rs, gs, bs] = [r, g, b].map(c => {
+          c = c / 255;
+          return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+      };
+      const l1 = luminance(...rgb1);
+      const l2 = luminance(...rgb2);
+      const lighter = Math.max(l1, l2);
+      const darker = Math.min(l1, l2);
+      return (lighter + 0.05) / (darker + 0.05);
+    };
+
+    const parseRGB = (str) => {
+      const match = str.match(/\d+/g);
+      return match ? match.slice(0, 3).map(Number) : [0, 0, 0];
+    };
+
+    const lowContrast = [];
+    document.querySelectorAll('p, span, a, button, label, h1, h2, h3, h4, h5, h6').forEach(el => {
+      const style = window.getComputedStyle(el);
+      const fg = parseRGB(style.color);
+      const bg = parseRGB(style.backgroundColor);
+      const ratio = getContrast(fg, bg);
+      if (ratio < 4.5) {
+        lowContrast.push({
+          text: el.textContent.trim().substring(0, 30),
+          ratio: ratio.toFixed(2),
+          fg: style.color,
+          bg: style.backgroundColor
+        });
+      }
+    });
+
+    return { lowContrastCount: lowContrast.length, elements: lowContrast.slice(0, 20) };
+  });
+}"
+```
+
+### Tab Order Verification
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    const focusable = Array.from(document.querySelectorAll(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex=\"-1\"])'
+    ));
+    return focusable.map((el, i) => ({
+      order: i + 1,
+      tag: el.tagName.toLowerCase(),
+      text: (el.textContent || el.getAttribute('aria-label') || el.name || '').trim().substring(0, 40),
+      tabIndex: el.tabIndex
+    }));
+  });
+}"
+```
+
+## Form Wizard Automation
+
+### Multi-Step Form
+
+```bash
+# Step 1: Personal Info
+playwright-cli open https://example.com/apply
+playwright-cli snapshot
+playwright-cli fill e1 "Jane"              # First name
+playwright-cli fill e2 "Doe"               # Last name
+playwright-cli fill e3 "jane@example.com"  # Email
+playwright-cli fill e4 "+1-555-0123"       # Phone
+playwright-cli click e5                     # Next
+
+# Step 2: Address
+playwright-cli snapshot
+playwright-cli fill e1 "123 Main Street"
+playwright-cli fill e2 "Apt 4B"
+playwright-cli fill e3 "Springfield"
+playwright-cli select e4 "IL"
+playwright-cli fill e5 "62701"
+playwright-cli click e6                     # Next
+
+# Step 3: Upload Documents
+playwright-cli snapshot
+playwright-cli upload e1 ./resume.pdf
+playwright-cli upload e2 ./cover-letter.pdf
+playwright-cli click e3                     # Next
+
+# Step 4: Review and Submit
+playwright-cli snapshot
+playwright-cli screenshot --filename=review-page.png
+playwright-cli check e1                     # Accept terms
+playwright-cli click e2                     # Submit
+playwright-cli snapshot                     # Confirmation page
+```
+
+### Dynamic Form with Conditional Fields
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/registration');
+
+  // Select account type — this shows/hides fields
+  await page.selectOption('#account-type', 'business');
+
+  // Wait for business fields to appear
+  await page.waitForSelector('#company-name', { state: 'visible' });
+
+  // Fill business-specific fields
+  await page.fill('#company-name', 'Acme Corp');
+  await page.fill('#tax-id', '12-3456789');
+  await page.fill('#company-size', '50-100');
+
+  // Fill common fields
+  await page.fill('#contact-name', 'Jane Doe');
+  await page.fill('#contact-email', 'jane@acme.com');
+
+  await page.click('button:text(\"Register\")');
+  await page.waitForURL('**/welcome');
+
+  return 'Registration complete';
+}"
+```
+
+## Data Extraction Patterns
+
+### Table Data Extraction
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/reports');
+
+  const data = await page.evaluate(() => {
+    const table = document.querySelector('table.data-table');
+    const headers = Array.from(table.querySelectorAll('thead th'))
+      .map(th => th.textContent.trim());
+    const rows = Array.from(table.querySelectorAll('tbody tr'))
+      .map(tr => {
+        const cells = Array.from(tr.querySelectorAll('td'))
+          .map(td => td.textContent.trim());
+        return Object.fromEntries(headers.map((h, i) => [h, cells[i]]));
+      });
+    return { headers, rowCount: rows.length, rows };
+  });
+
+  return JSON.stringify(data, null, 2);
+}"
+```
+
+### Extract Structured Data (JSON-LD, Meta Tags)
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    // JSON-LD structured data
+    const jsonLd = Array.from(document.querySelectorAll('script[type=\"application/ld+json\"]'))
+      .map(s => JSON.parse(s.textContent));
+
+    // Open Graph meta tags
+    const og = {};
+    document.querySelectorAll('meta[property^=\"og:\"]').forEach(m => {
+      og[m.getAttribute('property')] = m.content;
+    });
+
+    // Standard meta tags
+    const meta = {};
+    document.querySelectorAll('meta[name]').forEach(m => {
+      meta[m.name] = m.content;
+    });
+
+    return { jsonLd, openGraph: og, meta };
+  });
+}"
+```
+
+### Screenshot Every Link Target
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com');
+  const links = await page.locator('nav a').evaluateAll(
+    anchors => anchors.map(a => ({ text: a.textContent.trim(), href: a.href }))
+  );
+
+  for (const link of links) {
+    const safeName = link.text.toLowerCase().replace(/[^a-z0-9]/g, '-');
+    await page.goto(link.href);
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({ path: \`screenshots/\${safeName}.png\` });
+  }
+
+  return links.map(l => l.text);
+}"
+```
+
+## Error Recovery Patterns
+
+### Retry on Failure
+
+```bash
+playwright-cli run-code "async page => {
+  const maxRetries = 3;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await page.goto('https://flaky-site.example.com', { timeout: 15000 });
+      await page.waitForSelector('.content', { timeout: 5000 });
+      return 'Success on attempt ' + attempt;
+    } catch (error) {
+      if (attempt === maxRetries) throw error;
+      console.log(\`Attempt \${attempt} failed, retrying...\`);
+      await page.waitForTimeout(2000 * attempt); // Exponential backoff
+    }
+  }
+}"
+```
+
+### Dismiss Cookie Banners Automatically
+
+```bash
+playwright-cli run-code "async page => {
+  // Try common cookie consent selectors
+  const selectors = [
+    'button:text(\"Accept\")',
+    'button:text(\"Accept All\")',
+    'button:text(\"Accept Cookies\")',
+    'button:text(\"I Agree\")',
+    '#cookie-accept',
+    '.cookie-consent-accept',
+    '[data-testid=cookie-accept]'
+  ];
+
+  for (const sel of selectors) {
+    try {
+      const btn = page.locator(sel).first();
+      if (await btn.isVisible({ timeout: 1000 })) {
+        await btn.click();
+        return 'Dismissed cookie banner with: ' + sel;
+      }
+    } catch (e) {
+      // Try next selector
+    }
+  }
+  return 'No cookie banner found';
+}"
+```
+
+### Handle Unexpected Dialogs
+
+```bash
+# Set up auto-dismiss for any dialogs
+playwright-cli run-code "async page => {
+  page.on('dialog', async dialog => {
+    console.log(\`Auto-handled \${dialog.type()} dialog: \${dialog.message()}\`);
+    await dialog.dismiss();
+  });
+}"
+```
+
+## Combining CLI Features
+
+### Full E2E Test Workflow
+
+```bash
+#!/bin/bash
+set -e
+
+# 1. Start fresh session
+playwright-cli open https://app.example.com --persistent
+
+# 2. Set up monitoring
+playwright-cli run-code "async page => {
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.log('[ERROR]', msg.text());
+  });
+}"
+
+# 3. Start tracing
+playwright-cli tracing-start
+
+# 4. Log in
+playwright-cli goto https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "test@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli state-save auth-state.json
+
+# 5. Verify dashboard
+playwright-cli snapshot
+playwright-cli screenshot --filename=dashboard.png
+
+# 6. Test a feature
+playwright-cli click e5    # Navigate to feature
+playwright-cli snapshot
+playwright-cli fill e1 "test data"
+playwright-cli click e3    # Submit
+playwright-cli screenshot --filename=feature-result.png
+
+# 7. Stop tracing and clean up
+playwright-cli tracing-stop
+playwright-cli close
+
+echo "Test complete. Check screenshots/ and traces/"
+```
+
+### Comparison Testing Script
+
+```bash
+#!/bin/bash
+# Compare two environments
+
+STAGING="https://staging.example.com"
+PROD="https://www.example.com"
+PAGES=("/" "/pricing" "/about" "/features")
+
+for path in "${PAGES[@]}"; do
+  safePath=$(echo "$path" | tr '/' '-' | sed 's/^-//')
+  [ -z "$safePath" ] && safePath="home"
+
+  playwright-cli -s=staging open "${STAGING}${path}"
+  playwright-cli -s=staging screenshot --filename="compare-staging-${safePath}.png"
+
+  playwright-cli -s=prod open "${PROD}${path}"
+  playwright-cli -s=prod screenshot --filename="compare-prod-${safePath}.png"
+done
+
+playwright-cli close-all
+echo "Screenshots saved. Compare staging vs prod visually."
+```
+
+## Tips
+
+- **Start simple, add complexity** — begin with basic CLI commands, drop into `run-code` only when needed
+- **Save state checkpoints** — `state-save checkpoint.json` at key points so you can restore if something goes wrong
+- **Use named sessions for isolation** — never mix concerns in a single session
+- **Monitor console and network** — set up listeners early to catch errors as they happen
+- **Trace complex flows** — always trace when debugging multi-step workflows
+- **Error recovery is essential** — websites are flaky; build retry logic into complex scripts
+- **Clean up resources** — `close-all` at the end of every script; `kill-all` if things go wrong

--- a/engineering-team/playwright skill/playwright-cli/core-commands.md
+++ b/engineering-team/playwright skill/playwright-cli/core-commands.md
@@ -1,0 +1,375 @@
+# Core Commands
+
+> **When to use**: Starting browser automation sessions, navigating pages, interacting with elements, filling forms, and performing basic browser operations via the CLI.
+> **Prerequisites**: `playwright-cli install --skills && playwright-cli install-browser`
+
+## Quick Reference
+
+```bash
+playwright-cli open https://example.com     # Launch + navigate
+playwright-cli snapshot                      # See all interactive elements
+playwright-cli fill e1 "user@example.com"   # Fill an input field
+playwright-cli click e3                      # Click a button
+playwright-cli screenshot --filename=pg.png # Capture the page
+playwright-cli close                         # Done
+```
+
+## The Snapshot Workflow
+
+Every interaction starts with a **snapshot**. The snapshot command renders the page's accessibility tree and assigns short refs (like `e1`, `e2`, `e3`) to each interactive element.
+
+```bash
+playwright-cli open https://example.com/login
+playwright-cli snapshot
+# Output:
+# e1 [textbox "Email"]
+# e2 [textbox "Password"]
+# e3 [button "Sign In"]
+# e4 [link "Forgot password?"]
+# e5 [link "Create account"]
+```
+
+Use refs to target elements precisely:
+
+```bash
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "secretpassword"
+playwright-cli click e3
+```
+
+**Always re-snapshot after page changes** — refs are only valid for the current page state. After navigation, form submission, or dynamic content updates, take a new snapshot.
+
+```bash
+playwright-cli click e3          # Submit form
+playwright-cli snapshot          # Re-snapshot to see new page elements
+```
+
+### Saving Snapshots
+
+Save snapshots to YAML files for later reference or comparison:
+
+```bash
+playwright-cli snapshot --filename=before-submit.yaml
+playwright-cli click e3
+playwright-cli snapshot --filename=after-submit.yaml
+```
+
+## Opening & Closing Browsers
+
+### Basic Launch
+
+```bash
+# Open browser with blank page
+playwright-cli open
+
+# Open and navigate immediately
+playwright-cli open https://example.com
+
+# Open with specific browser engine
+playwright-cli open --browser=chrome      # Google Chrome
+playwright-cli open --browser=firefox     # Mozilla Firefox
+playwright-cli open --browser=webkit      # Safari/WebKit
+playwright-cli open --browser=msedge      # Microsoft Edge
+```
+
+### Persistent Profiles
+
+By default, each session runs in-memory — no cookies or storage persist after closing. Use `--persistent` to keep state across restarts:
+
+```bash
+# Auto-generated profile directory
+playwright-cli open https://example.com --persistent
+
+# Custom profile directory
+playwright-cli open https://example.com --profile=/tmp/my-profile
+
+# With a config file
+playwright-cli open https://example.com --config=my-config.json
+```
+
+### Browser Extension Mode
+
+Connect to an existing browser via extension instead of launching a new one:
+
+```bash
+playwright-cli open --extension
+```
+
+### Closing
+
+```bash
+playwright-cli close              # Close the current browser
+playwright-cli close-all          # Close all open browsers
+playwright-cli kill-all           # Force kill zombie processes
+playwright-cli delete-data        # Delete stored profile data
+```
+
+## Navigation
+
+```bash
+playwright-cli goto https://example.com/dashboard    # Navigate to URL
+playwright-cli go-back                                # Browser back
+playwright-cli go-forward                             # Browser forward
+playwright-cli reload                                 # Refresh page
+```
+
+### Waiting for Navigation
+
+After actions that trigger navigation (form submits, link clicks), the CLI waits for the page to reach `load` state before returning. If you need to wait for specific conditions, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.waitForURL('**/dashboard');
+}"
+
+# Wait for network to settle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+```
+
+## Element Interaction
+
+### Clicking
+
+```bash
+playwright-cli click e3            # Standard left click
+playwright-cli dblclick e7         # Double click
+playwright-cli hover e4            # Hover without clicking
+```
+
+### Form Input
+
+```bash
+# fill: clears existing value, then types the full value at once
+playwright-cli fill e5 "user@example.com"
+
+# type: sends keystrokes one by one (triggers keydown/keypress/keyup per char)
+playwright-cli type "search query"
+
+# select: choose dropdown option by value
+playwright-cli select e9 "option-value"
+
+# check/uncheck: toggle checkboxes
+playwright-cli check e12
+playwright-cli uncheck e12
+```
+
+**When to use `fill` vs `type`**:
+
+| Command | Behavior | Use when |
+|---------|----------|----------|
+| `fill` | Clears field, sets value at once | Forms, login fields, standard inputs |
+| `type` | Sends individual keystrokes | Autocomplete, search-as-you-type, custom inputs that listen for keydown events |
+
+### File Upload
+
+```bash
+playwright-cli upload e8 ./document.pdf
+playwright-cli upload e8 ./photo1.jpg ./photo2.jpg    # Multiple files
+```
+
+### Drag and Drop
+
+```bash
+playwright-cli drag e2 e8    # Drag element e2 onto element e8
+```
+
+### Viewport Resizing
+
+```bash
+playwright-cli resize 1920 1080    # Desktop
+playwright-cli resize 375 812      # iPhone X viewport
+playwright-cli resize 768 1024     # iPad viewport
+```
+
+## Keyboard Input
+
+### Single Key Presses
+
+```bash
+playwright-cli press Enter
+playwright-cli press Tab
+playwright-cli press Escape
+playwright-cli press Backspace
+playwright-cli press Delete
+playwright-cli press Space
+```
+
+### Arrow Keys
+
+```bash
+playwright-cli press ArrowUp
+playwright-cli press ArrowDown
+playwright-cli press ArrowLeft
+playwright-cli press ArrowRight
+```
+
+### Modifier Key Combos
+
+```bash
+playwright-cli press Control+a        # Select all
+playwright-cli press Control+c        # Copy
+playwright-cli press Control+v        # Paste
+playwright-cli press Control+z        # Undo
+playwright-cli press Meta+a           # Select all (macOS Cmd+A)
+playwright-cli press Shift+Tab        # Reverse tab
+playwright-cli press Alt+Enter        # Alt+Enter
+```
+
+### Hold and Release Keys
+
+For drag operations or multi-key sequences:
+
+```bash
+playwright-cli keydown Shift
+playwright-cli click e5              # Shift+click
+playwright-cli click e8              # Shift+click (range selection)
+playwright-cli keyup Shift
+```
+
+## Mouse Control
+
+For pixel-precise operations (canvas, maps, custom widgets):
+
+```bash
+playwright-cli mousemove 150 300     # Move cursor to coordinates
+playwright-cli mousedown             # Press left button
+playwright-cli mouseup               # Release left button
+playwright-cli mousedown right       # Right click down
+playwright-cli mouseup right         # Right click up
+playwright-cli mousewheel 0 100      # Scroll down 100px
+playwright-cli mousewheel 0 -100     # Scroll up 100px
+playwright-cli mousewheel 100 0      # Scroll right 100px
+```
+
+### Drawing on Canvas
+
+```bash
+playwright-cli open https://example.com/canvas-app
+playwright-cli mousemove 100 100
+playwright-cli mousedown
+playwright-cli mousemove 200 200
+playwright-cli mousemove 300 150
+playwright-cli mouseup
+```
+
+## Dialog Handling
+
+Dialogs (`alert`, `confirm`, `prompt`) block browser interaction. Handle them immediately:
+
+```bash
+# Accept an alert or confirm dialog
+playwright-cli dialog-accept
+
+# Accept a prompt dialog with input text
+playwright-cli dialog-accept "my response"
+
+# Dismiss/cancel a dialog
+playwright-cli dialog-dismiss
+```
+
+**Tip**: If you expect a dialog to appear from a click, configure handling via `run-code` before triggering the action:
+
+```bash
+playwright-cli run-code "async page => {
+  page.on('dialog', dialog => dialog.accept('confirmed'));
+}"
+playwright-cli click e5    # This triggers the dialog
+```
+
+## JavaScript Evaluation
+
+Execute JavaScript expressions directly in the page context:
+
+```bash
+# Simple expressions
+playwright-cli eval "document.title"
+playwright-cli eval "window.location.href"
+playwright-cli eval "document.querySelectorAll('li').length"
+
+# Evaluate on a specific element
+playwright-cli eval "el => el.textContent" e5
+playwright-cli eval "el => el.getAttribute('href')" e3
+playwright-cli eval "el => el.getBoundingClientRect()" e1
+
+# Complex evaluation
+playwright-cli eval "JSON.stringify(performance.timing)"
+playwright-cli eval "window.innerWidth + 'x' + window.innerHeight"
+```
+
+## Example Workflows
+
+### Login Flow
+
+```bash
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+
+playwright-cli fill e1 "admin@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot             # See the dashboard
+playwright-cli screenshot --filename=dashboard.png
+playwright-cli close
+```
+
+### Form Submission with Validation
+
+```bash
+playwright-cli open https://example.com/contact
+playwright-cli snapshot
+
+# Fill form fields
+playwright-cli fill e1 "Jane Doe"
+playwright-cli fill e2 "jane@example.com"
+playwright-cli fill e3 "+1-555-0123"
+playwright-cli select e4 "support"
+playwright-cli fill e5 "I need help with my account"
+playwright-cli check e6             # Agree to terms
+
+# Submit
+playwright-cli click e7
+playwright-cli snapshot             # Verify success message
+playwright-cli close
+```
+
+### Search and Navigate Results
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+
+playwright-cli fill e1 "playwright automation"
+playwright-cli press Enter
+playwright-cli snapshot             # See search results
+
+playwright-cli click e5             # Click first result
+playwright-cli snapshot             # See result page
+playwright-cli go-back              # Return to results
+playwright-cli close
+```
+
+### Multi-Tab Research
+
+```bash
+playwright-cli open https://docs.example.com
+playwright-cli tab-new https://api.example.com/reference
+playwright-cli tab-new https://github.com/example/repo
+
+playwright-cli tab-list             # See all 3 tabs
+playwright-cli tab-select 0         # Go to docs tab
+playwright-cli snapshot
+playwright-cli tab-select 2         # Go to GitHub tab
+playwright-cli snapshot
+
+playwright-cli close                # Closes all tabs
+```
+
+## Tips
+
+- **Snapshot frequently**: After every action that changes the page, re-snapshot to get fresh refs
+- **Use `fill` for forms**: It's faster and more reliable than `type` for standard inputs
+- **Viewport matters**: Use `resize` to test responsive layouts before taking screenshots
+- **Chain with `run-code`**: When CLI commands feel limiting, drop into the full Playwright API
+- **Check `console`**: Run `playwright-cli console` to see JavaScript errors that might explain unexpected behavior

--- a/engineering-team/playwright skill/playwright-cli/device-emulation.md
+++ b/engineering-team/playwright skill/playwright-cli/device-emulation.md
@@ -1,0 +1,475 @@
+# Device and Environment Emulation
+
+> **When to use**: Testing how your application behaves on different devices, screen sizes, geolocation, locales, timezones, color schemes, and network conditions — all from the CLI without needing physical devices.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage, [running-custom-code.md](running-custom-code.md) for `run-code` syntax
+
+## Quick Reference
+
+```bash
+# Device emulation via config
+playwright-cli open https://example.com --config=iphone.json
+
+# Viewport resizing
+playwright-cli resize 375 812                    # iPhone viewport
+playwright-cli resize 1920 1080                  # Desktop viewport
+
+# Geolocation
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 40.7128, longitude: -74.0060 });
+}"
+
+# Color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+```
+
+## Viewport Emulation
+
+The simplest form of device testing — set the viewport size to match a target device:
+
+### Common Viewport Sizes
+
+```bash
+# Desktop
+playwright-cli resize 1920 1080    # Full HD monitor
+playwright-cli resize 1440 900     # MacBook Pro 15"
+playwright-cli resize 1366 768     # Common laptop
+playwright-cli resize 2560 1440    # QHD / 2K monitor
+
+# Tablet
+playwright-cli resize 1024 768     # iPad landscape
+playwright-cli resize 768 1024     # iPad portrait
+playwright-cli resize 834 1194     # iPad Pro 11"
+playwright-cli resize 1194 834     # iPad Pro 11" landscape
+playwright-cli resize 820 1180     # iPad Air
+
+# Mobile
+playwright-cli resize 430 932      # iPhone 14 Pro Max
+playwright-cli resize 393 852      # iPhone 14 Pro
+playwright-cli resize 390 844      # iPhone 14 / 13 / 12
+playwright-cli resize 375 812      # iPhone X / 11
+playwright-cli resize 360 800      # Samsung Galaxy S21
+playwright-cli resize 412 915      # Pixel 7
+playwright-cli resize 320 568      # iPhone SE (1st gen)
+```
+
+### Test Responsive Breakpoints
+
+```bash
+# Common CSS breakpoints
+playwright-cli resize 320 568      # xs: Extra small
+playwright-cli screenshot --filename=responsive-xs.png
+
+playwright-cli resize 576 768      # sm: Small
+playwright-cli screenshot --filename=responsive-sm.png
+
+playwright-cli resize 768 1024     # md: Medium
+playwright-cli screenshot --filename=responsive-md.png
+
+playwright-cli resize 992 768      # lg: Large
+playwright-cli screenshot --filename=responsive-lg.png
+
+playwright-cli resize 1200 900     # xl: Extra large
+playwright-cli screenshot --filename=responsive-xl.png
+
+playwright-cli resize 1400 900     # xxl: Extra extra large
+playwright-cli screenshot --filename=responsive-xxl.png
+```
+
+## Full Device Emulation
+
+For accurate device testing, you need more than just viewport — device scale factor, user agent, touch support, and mobile behavior. Use a config file or `run-code`.
+
+### Config File Approach
+
+Create a config file for a specific device:
+
+**`iphone14.json`**
+```json
+{
+  "viewport": { "width": 390, "height": 844 },
+  "deviceScaleFactor": 3,
+  "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1",
+  "isMobile": true,
+  "hasTouch": true
+}
+```
+
+```bash
+playwright-cli open https://example.com --config=iphone14.json
+```
+
+**`pixel7.json`**
+```json
+{
+  "viewport": { "width": 412, "height": 915 },
+  "deviceScaleFactor": 2.625,
+  "userAgent": "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36",
+  "isMobile": true,
+  "hasTouch": true
+}
+```
+
+**`ipad-pro.json`**
+```json
+{
+  "viewport": { "width": 834, "height": 1194 },
+  "deviceScaleFactor": 2,
+  "userAgent": "Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1",
+  "isMobile": true,
+  "hasTouch": true
+}
+```
+
+### Programmatic Device Emulation
+
+Use `run-code` to check or modify device properties:
+
+```bash
+# Check current device properties
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => ({
+    userAgent: navigator.userAgent,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    devicePixelRatio: window.devicePixelRatio,
+    touchSupport: 'ontouchstart' in window,
+    platform: navigator.platform
+  }));
+}"
+```
+
+## Geolocation
+
+Override the browser's reported GPS location — test store locators, delivery zones, location-based content.
+
+### Set Location
+
+```bash
+# New York
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 40.7128, longitude: -74.0060 });
+}"
+
+# London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Tokyo
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 35.6762, longitude: 139.6503 });
+}"
+
+# Sydney
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: -33.8688, longitude: 151.2093 });
+}"
+
+# São Paulo
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: -23.5505, longitude: -46.6333 });
+}"
+```
+
+### Update Location Mid-Session
+
+Simulate a user moving between locations:
+
+```bash
+# Start in San Francisco
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+playwright-cli goto https://example.com/nearby-stores
+playwright-cli screenshot --filename=sf-stores.png
+
+# Move to Los Angeles
+playwright-cli run-code "async page => {
+  await page.context().setGeolocation({ latitude: 34.0522, longitude: -118.2437 });
+}"
+
+playwright-cli reload
+playwright-cli screenshot --filename=la-stores.png
+```
+
+### Clear Geolocation Override
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+### Geolocation via Config
+
+Set geolocation when opening the browser:
+
+**`geo-nyc.json`**
+```json
+{
+  "geolocation": { "latitude": 40.7128, "longitude": -74.0060 },
+  "permissions": ["geolocation"]
+}
+```
+
+```bash
+playwright-cli open https://example.com --config=geo-nyc.json
+```
+
+## Locale and Timezone
+
+Test internationalization by changing the browser's locale and timezone.
+
+### Via Config File
+
+**`locale-de.json`**
+```json
+{
+  "locale": "de-DE",
+  "timezoneId": "Europe/Berlin"
+}
+```
+
+**`locale-ja.json`**
+```json
+{
+  "locale": "ja-JP",
+  "timezoneId": "Asia/Tokyo"
+}
+```
+
+```bash
+playwright-cli open https://example.com --config=locale-de.json
+```
+
+### Verify Locale and Timezone
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => ({
+    language: navigator.language,
+    languages: navigator.languages,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    dateFormat: new Date('2024-01-15').toLocaleDateString(),
+    numberFormat: (1234567.89).toLocaleString(),
+    currencyFormat: new Intl.NumberFormat(navigator.language, {
+      style: 'currency',
+      currency: 'USD'
+    }).format(1234.56)
+  }));
+}"
+```
+
+### Common Locale + Timezone Combinations
+
+| Region | Locale | Timezone |
+|--------|--------|----------|
+| US East | `en-US` | `America/New_York` |
+| US West | `en-US` | `America/Los_Angeles` |
+| UK | `en-GB` | `Europe/London` |
+| Germany | `de-DE` | `Europe/Berlin` |
+| France | `fr-FR` | `Europe/Paris` |
+| Japan | `ja-JP` | `Asia/Tokyo` |
+| China | `zh-CN` | `Asia/Shanghai` |
+| India | `hi-IN` | `Asia/Kolkata` |
+| Brazil | `pt-BR` | `America/Sao_Paulo` |
+| Australia | `en-AU` | `Australia/Sydney` |
+| Arabia | `ar-SA` | `Asia/Riyadh` |
+
+## Color Scheme
+
+Test dark mode, light mode, and high contrast:
+
+```bash
+# Dark mode
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+playwright-cli screenshot --filename=dark-mode.png
+
+# Light mode
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+playwright-cli screenshot --filename=light-mode.png
+
+# System preference (no override)
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'no-preference' });
+}"
+```
+
+## Reduced Motion
+
+Test accessibility for users who prefer reduced motion:
+
+```bash
+# Enable reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Check if your CSS respects it
+playwright-cli run-code "async page => {
+  return await page.evaluate(() =>
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}"
+```
+
+## Forced Colors (High Contrast)
+
+Test Windows High Contrast mode:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ forcedColors: 'active' });
+}"
+playwright-cli screenshot --filename=high-contrast.png
+```
+
+## Permissions
+
+Grant or deny browser permissions:
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['notifications'], {
+    origin: 'https://example.com'
+  });
+}"
+
+# Clear all permissions (reset to defaults)
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+Available permissions: `geolocation`, `notifications`, `camera`, `microphone`, `clipboard-read`, `clipboard-write`, `payment-handler`, `midi`, `midi-sysex`, `ambient-light-sensor`, `accelerometer`, `gyroscope`, `magnetometer`, `background-sync`
+
+## Network Condition Emulation
+
+Simulate slow networks to test loading states and performance:
+
+```bash
+# Simulate slow 3G
+playwright-cli run-code "async page => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.emulateNetworkConditions', {
+    offline: false,
+    downloadThroughput: 500 * 1024 / 8,     // 500 kbps
+    uploadThroughput: 500 * 1024 / 8,        // 500 kbps
+    latency: 400                              // 400ms RTT
+  });
+}"
+
+# Simulate offline mode
+playwright-cli run-code "async page => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.emulateNetworkConditions', {
+    offline: true,
+    downloadThroughput: 0,
+    uploadThroughput: 0,
+    latency: 0
+  });
+}"
+
+# Restore normal network
+playwright-cli run-code "async page => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.emulateNetworkConditions', {
+    offline: false,
+    downloadThroughput: -1,
+    uploadThroughput: -1,
+    latency: 0
+  });
+}"
+```
+
+**Note**: CDP sessions only work with Chromium-based browsers.
+
+## Common Patterns
+
+### Multi-Device Screenshot Suite
+
+```bash
+#!/bin/bash
+URL="https://example.com"
+playwright-cli open $URL
+
+devices=("1920:1080:desktop" "768:1024:tablet" "375:812:mobile")
+for device in "${devices[@]}"; do
+  IFS=':' read -r w h name <<< "$device"
+  playwright-cli resize $w $h
+  playwright-cli screenshot --filename="device-$name.png"
+done
+
+playwright-cli close
+```
+
+### Geo-Based Content Testing
+
+```bash
+locations=("40.7128:-74.0060:nyc" "51.5074:-0.1278:london" "35.6762:139.6503:tokyo")
+
+for loc in "${locations[@]}"; do
+  IFS=':' read -r lat lng name <<< "$loc"
+  playwright-cli run-code "async page => {
+    await page.context().grantPermissions(['geolocation']);
+    await page.context().setGeolocation({ latitude: $lat, longitude: $lng });
+  }"
+  playwright-cli reload
+  playwright-cli screenshot --filename="geo-$name.png"
+done
+```
+
+### Accessibility Emulation Suite
+
+```bash
+playwright-cli open https://example.com
+
+# Standard view
+playwright-cli screenshot --filename=a11y-standard.png
+
+# Dark mode
+playwright-cli run-code "async page => { await page.emulateMedia({ colorScheme: 'dark' }); }"
+playwright-cli screenshot --filename=a11y-dark.png
+
+# High contrast
+playwright-cli run-code "async page => { await page.emulateMedia({ forcedColors: 'active' }); }"
+playwright-cli screenshot --filename=a11y-high-contrast.png
+
+# Reduced motion
+playwright-cli run-code "async page => { await page.emulateMedia({ reducedMotion: 'reduce', forcedColors: 'none' }); }"
+playwright-cli screenshot --filename=a11y-reduced-motion.png
+
+playwright-cli close
+```
+
+## Tips
+
+- **Viewport alone isn't device emulation** — real device testing needs user agent, touch support, and device scale factor via config files
+- **Geolocation requires permission** — always `grantPermissions(['geolocation'])` before `setGeolocation()`
+- **Locale/timezone must be set at open time** — use config files since they can't be changed mid-session
+- **CDP features are Chromium-only** — network throttling via CDP doesn't work in Firefox or WebKit
+- **Test the combination** — dark mode + reduced motion + specific locale together reveals issues that each alone won't catch

--- a/engineering-team/playwright skill/playwright-cli/request-mocking.md
+++ b/engineering-team/playwright skill/playwright-cli/request-mocking.md
@@ -1,0 +1,373 @@
+# Request Mocking
+
+> **When to use**: Intercepting, mocking, modifying, or blocking network requests during browser automation — API stubbing, simulating errors, testing offline behavior, removing tracking, or speeding up pages by blocking heavy assets.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Block all images
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock API response with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Add custom response headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Strip request headers (e.g., remove auth for testing)
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a specific route
+playwright-cli unroute "**/*.jpg"
+
+# Remove all routes
+playwright-cli unroute
+```
+
+## URL Patterns
+
+playwright-cli uses glob patterns for URL matching:
+
+| Pattern | Matches | Example URLs |
+|---------|---------|-------------|
+| `**/api/users` | Exact path on any origin | `https://api.example.com/api/users` |
+| `**/api/*/details` | Wildcard in path segment | `https://api.example.com/api/123/details` |
+| `**/*.{png,jpg,jpeg}` | Multiple file extensions | `https://cdn.example.com/hero.png` |
+| `**/search?q=*` | Query parameters | `https://example.com/search?q=test` |
+| `https://api.example.com/**` | All requests to a specific origin | `https://api.example.com/v2/users` |
+| `**/*` | All requests | Everything |
+
+## CLI Route Commands
+
+### Mock with Status Code
+
+```bash
+# Return 404 for all image requests
+playwright-cli route "**/*.jpg" --status=404
+
+# Return 503 Service Unavailable
+playwright-cli route "**/api/health" --status=503
+
+# Return 401 Unauthorized
+playwright-cli route "**/api/protected" --status=401
+```
+
+### Mock with JSON Response
+
+```bash
+# Simple JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]' --content-type=application/json
+
+# Mock a single resource
+playwright-cli route "**/api/users/1" --body='{"id":1,"name":"Alice","email":"alice@example.com"}' --content-type=application/json
+
+# Return empty array (no results scenario)
+playwright-cli route "**/api/search*" --body='[]' --content-type=application/json
+```
+
+### Mock with Custom Headers
+
+```bash
+# Set CORS headers for testing
+playwright-cli route "**/api/**" --body='{"ok":true}' --header="Access-Control-Allow-Origin: *" --header="X-Request-Id: mock-123"
+
+# Set caching headers
+playwright-cli route "**/static/**" --header="Cache-Control: max-age=3600"
+```
+
+### Remove Request Headers
+
+Strip headers from outgoing requests — useful for testing unauthenticated access:
+
+```bash
+# Remove authentication headers
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# Remove tracking headers
+playwright-cli route "**/*" --remove-header=x-tracking-id
+```
+
+### Manage Active Routes
+
+```bash
+# See what's currently being intercepted
+playwright-cli route-list
+
+# Remove a specific route
+playwright-cli unroute "**/*.jpg"
+
+# Clear all routes
+playwright-cli unroute
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or timed delays, use `run-code` to access the full Playwright route API.
+
+### Conditional Response Based on Request Body
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin' && body.password === 'secret') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ token: 'mock-jwt-token', user: { role: 'admin' } })
+      });
+    } else {
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Invalid credentials' })
+      });
+    }
+  });
+}"
+```
+
+### Conditional Response Based on HTTP Method
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/users', route => {
+    const method = route.request().method();
+    switch (method) {
+      case 'GET':
+        route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify([{ id: 1, name: 'Alice' }])
+        });
+        break;
+      case 'POST':
+        route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 2, name: 'New User' })
+        });
+        break;
+      case 'DELETE':
+        route.fulfill({ status: 204 });
+        break;
+      default:
+        route.continue();
+    }
+  });
+}"
+```
+
+### Modify a Real Response
+
+Let the real request go through, then modify the response before the page sees it:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user/profile', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+
+    // Override specific fields
+    json.isPremium = true;
+    json.subscription = 'enterprise';
+
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Add Headers to Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/**', async route => {
+    const response = await route.fetch();
+    const headers = { ...response.headers(), 'x-mock': 'true' };
+    await route.fulfill({ response, headers });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+# Internet disconnected
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+
+# Connection refused
+playwright-cli run-code "async page => {
+  await page.route('**/api/down', route => route.abort('connectionrefused'));
+}"
+
+# Timeout
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', route => route.abort('timedout'));
+}"
+
+# Connection reset
+playwright-cli run-code "async page => {
+  await page.route('**/api/reset', route => route.abort('connectionreset'));
+}"
+```
+
+Available abort reasons: `connectionrefused`, `timedout`, `connectionreset`, `internetdisconnected`, `blockedbyclient`, `failed`
+
+### Simulate Slow Responses (Latency)
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow-endpoint', async route => {
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: 'finally loaded' })
+    });
+  });
+}"
+```
+
+### Mock with Response from File
+
+```bash
+playwright-cli run-code "async page => {
+  const fs = require('fs');
+  await page.route('**/api/config', route => {
+    const body = fs.readFileSync('./fixtures/mock-config.json', 'utf8');
+    route.fulfill({
+      contentType: 'application/json',
+      body
+    });
+  });
+}"
+```
+
+### Request Counting and Verification
+
+```bash
+playwright-cli run-code "async page => {
+  let apiCallCount = 0;
+  await page.route('**/api/analytics', route => {
+    apiCallCount++;
+    route.continue();
+  });
+
+  // ... perform actions ...
+  // Later, check count:
+  return \`API was called \${apiCallCount} times\`;
+}"
+```
+
+## Common Patterns
+
+### Block Heavy Assets for Speed
+
+```bash
+# Block images, fonts, and stylesheets
+playwright-cli route "**/*.{png,jpg,jpeg,gif,svg,webp}" --status=404
+playwright-cli route "**/*.{woff,woff2,ttf,eot}" --status=404
+playwright-cli route "**/*.css" --status=404
+```
+
+### Block Third-Party Scripts
+
+```bash
+# Block analytics and tracking
+playwright-cli run-code "async page => {
+  await page.route('**/*', route => {
+    const url = route.request().url();
+    const blocked = [
+      'google-analytics.com',
+      'googletagmanager.com',
+      'facebook.net',
+      'hotjar.com',
+      'segment.io'
+    ];
+    if (blocked.some(domain => url.includes(domain))) {
+      route.abort('blockedbyclient');
+    } else {
+      route.continue();
+    }
+  });
+}"
+```
+
+### Mock GraphQL Requests
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/graphql', route => {
+    const { query } = route.request().postDataJSON();
+
+    if (query.includes('GetUser')) {
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: { user: { id: '1', name: 'Alice', email: 'alice@example.com' } }
+        })
+      });
+    } else if (query.includes('ListProducts')) {
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: { products: [{ id: '1', name: 'Widget', price: 9.99 }] }
+        })
+      });
+    } else {
+      route.continue();
+    }
+  });
+}"
+```
+
+### HAR-Based Replay
+
+Record real network traffic and replay it later — perfect for deterministic testing:
+
+```bash
+# Record all network traffic to a HAR file
+playwright-cli run-code "async page => {
+  await page.routeFromHAR('./recordings/api-traffic.har', {
+    update: true,
+    url: '**/api/**'
+  });
+  await page.goto('https://example.com');
+  // Interact with the page — all matching requests are recorded
+}"
+
+# Later, replay from the HAR file (no real network needed)
+playwright-cli run-code "async page => {
+  await page.routeFromHAR('./recordings/api-traffic.har', {
+    url: '**/api/**'
+  });
+  await page.goto('https://example.com');
+  // API responses come from the HAR file
+}"
+```
+
+### Mock WebSocket Messages
+
+```bash
+playwright-cli run-code "async page => {
+  const ws = await page.waitForEvent('websocket');
+  ws.on('framereceived', event => {
+    console.log('WS received:', event.payload);
+  });
+  ws.on('framesent', event => {
+    console.log('WS sent:', event.payload);
+  });
+}"
+```
+
+## Tips
+
+- **Order matters**: Routes are evaluated in the order they were added. More specific patterns should be added before catch-all patterns.
+- **`route.continue()`**: Lets the request proceed to the real server — use this in conditional routes for the "pass-through" case.
+- **`route.fetch()`**: Makes the real request and returns the response, so you can inspect or modify it before fulfilling.
+- **Performance**: Blocking images and third-party scripts can dramatically speed up page loads during automation.
+- **Cleanup**: Always `unroute` when done, or routes persist for the entire session and may interfere with later operations.

--- a/engineering-team/playwright skill/playwright-cli/running-custom-code.md
+++ b/engineering-team/playwright skill/playwright-cli/running-custom-code.md
@@ -1,0 +1,553 @@
+# Running Custom Playwright Code
+
+> **When to use**: When CLI commands aren't sufficient — geolocation, permissions, media emulation, waiting strategies, iframe interaction, file downloads, clipboard access, complex multi-step workflows, or any scenario requiring the full Playwright API.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Syntax: run-code accepts an async function with page as argument
+playwright-cli run-code "async page => {
+  // Full Playwright API available here
+  // page.context() for browser context operations
+  // Return a value to see it in output
+  return await page.title();
+}"
+```
+
+## Geolocation
+
+Override the browser's reported location — essential for testing location-based features like store locators, delivery zones, and weather apps.
+
+```bash
+# Grant permission and set location to New York
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 40.7128, longitude: -74.0060 });
+}"
+
+# London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# San Francisco
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Tokyo
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 35.6762, longitude: 139.6503 });
+}"
+
+# Update location mid-session (simulates user moving)
+playwright-cli run-code "async page => {
+  await page.context().setGeolocation({ latitude: 34.0522, longitude: -118.2437 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+Control browser permission grants — notifications, camera, microphone, clipboard, etc.
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for a specific origin only
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'], {
+    origin: 'https://example.com'
+  });
+}"
+
+# Revoke all permissions
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+Available permissions: `geolocation`, `notifications`, `camera`, `microphone`, `clipboard-read`, `clipboard-write`, `payment-handler`, `midi`, `midi-sysex`, `ambient-light-sensor`, `accelerometer`, `gyroscope`, `magnetometer`, `accessibility-events`, `background-sync`
+
+## Media Emulation
+
+Test how your app behaves under different media conditions — dark mode, reduced motion, print layout.
+
+### Color Scheme
+
+```bash
+# Dark mode
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Light mode
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# System preference (no override)
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'no-preference' });
+}"
+```
+
+### Reduced Motion
+
+```bash
+# Simulate prefers-reduced-motion: reduce
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Reset to no preference
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+}"
+```
+
+### Forced Colors (High Contrast)
+
+```bash
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ forcedColors: 'active' });
+}"
+```
+
+### Print Media
+
+```bash
+# Emulate print stylesheet (useful before taking PDF)
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+
+# Reset to screen
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'screen' });
+}"
+```
+
+### Combine Multiple Emulations
+
+```bash
+playwright-cli run-code "async page => {
+  await page.emulateMedia({
+    colorScheme: 'dark',
+    reducedMotion: 'reduce',
+    forcedColors: 'none'
+  });
+}"
+```
+
+## Locale and Timezone
+
+Override browser locale and timezone to test internationalization:
+
+```bash
+# Set locale (affects number formatting, date display, etc.)
+playwright-cli run-code "async page => {
+  // Locale is set at context creation; for existing context, use evaluate
+  return await page.evaluate(() => navigator.language);
+}"
+
+# For new contexts, set locale and timezone at open time:
+# playwright-cli open --config=locale-config.json
+# where locale-config.json contains: { "locale": "de-DE", "timezoneId": "Europe/Berlin" }
+```
+
+## Wait Strategies
+
+When the page needs time to load, render, or settle after an action.
+
+### Wait for Load States
+
+```bash
+# Wait for all network requests to finish
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for DOM content loaded
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('domcontentloaded');
+}"
+
+# Wait for full load (including images, stylesheets)
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('load');
+}"
+```
+
+### Wait for Elements
+
+```bash
+# Wait for a loading spinner to disappear
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.loading-spinner', { state: 'hidden' });
+}"
+
+# Wait for content to appear
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.search-results', { state: 'visible', timeout: 10000 });
+}"
+
+# Wait for element to be removed from DOM entirely
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.skeleton-loader', { state: 'detached' });
+}"
+```
+
+### Wait for URL Changes
+
+```bash
+playwright-cli run-code "async page => {
+  await page.waitForURL('**/dashboard');
+}"
+
+playwright-cli run-code "async page => {
+  await page.waitForURL(/.*\/order\/\d+/);
+}"
+```
+
+### Wait for Custom Conditions
+
+```bash
+# Wait for a JavaScript variable to be set
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait for specific number of elements
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => document.querySelectorAll('.item').length >= 10);
+}"
+
+# Wait with polling
+playwright-cli run-code "async page => {
+  await page.waitForFunction(
+    () => document.querySelector('.status')?.textContent === 'Complete',
+    { polling: 500, timeout: 30000 }
+  );
+}"
+```
+
+### Wait for Network Requests
+
+```bash
+# Wait for a specific API call to complete
+playwright-cli run-code "async page => {
+  const responsePromise = page.waitForResponse('**/api/users');
+  await page.click('button#load-users');
+  const response = await responsePromise;
+  return { status: response.status(), url: response.url() };
+}"
+
+# Wait for a request to be made
+playwright-cli run-code "async page => {
+  const requestPromise = page.waitForRequest('**/api/submit');
+  await page.click('button#submit');
+  const request = await requestPromise;
+  return request.postDataJSON();
+}"
+```
+
+## Frames and Iframes
+
+Interact with content inside iframes:
+
+```bash
+# Click a button inside an iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button.submit').click();
+}"
+
+# Fill a form inside an iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe[name=\"checkout\"]').contentFrame();
+  await frame.locator('input[name=\"card-number\"]').fill('4111111111111111');
+  await frame.locator('input[name=\"expiry\"]').fill('12/25');
+  await frame.locator('input[name=\"cvc\"]').fill('123');
+}"
+
+# Get all frame URLs
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => ({ name: f.name(), url: f.url() }));
+}"
+
+# Nested iframes
+playwright-cli run-code "async page => {
+  const outerFrame = page.locator('iframe#outer').contentFrame();
+  const innerFrame = outerFrame.locator('iframe#inner').contentFrame();
+  await innerFrame.locator('button').click();
+}"
+```
+
+## File Downloads
+
+```bash
+# Trigger download and save the file
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+  const filename = download.suggestedFilename();
+  await download.saveAs('./downloads/' + filename);
+  return 'Downloaded: ' + filename;
+}"
+
+# Download with custom path
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: 'Export CSV' }).click()
+  ]);
+  await download.saveAs('/tmp/export.csv');
+  return 'Saved to /tmp/export.csv';
+}"
+
+# Get download URL without saving
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('#download-btn')
+  ]);
+  return download.url();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard content
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+
+# Copy text from an element to clipboard
+playwright-cli run-code "async page => {
+  const text = await page.locator('.api-key').textContent();
+  await page.evaluate(t => navigator.clipboard.writeText(t), text);
+  return 'Copied: ' + text;
+}"
+```
+
+## Page Information
+
+```bash
+# Page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Full page HTML content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+
+# Browser information
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => ({
+    userAgent: navigator.userAgent,
+    language: navigator.language,
+    languages: navigator.languages,
+    cookiesEnabled: navigator.cookieEnabled,
+    onLine: navigator.onLine,
+    platform: navigator.platform,
+    screenSize: { width: screen.width, height: screen.height }
+  }));
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      title: document.title,
+      url: window.location.href,
+      elementCount: document.querySelectorAll('*').length,
+      scripts: document.querySelectorAll('script').length
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const selector = '.product-card';
+  const count = await page.evaluate(
+    sel => document.querySelectorAll(sel).length,
+    selector
+  );
+  return count + ' products found';
+}"
+
+# Modify the DOM
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    document.querySelector('.banner')?.remove();
+    document.body.style.zoom = '80%';
+  });
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch for optional elements
+playwright-cli run-code "async page => {
+  try {
+    await page.click('.cookie-consent-accept', { timeout: 2000 });
+    return 'Cookie banner dismissed';
+  } catch (e) {
+    return 'No cookie banner found';
+  }
+}"
+
+# Retry pattern
+playwright-cli run-code "async page => {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await page.click('.flaky-button', { timeout: 3000 });
+      return 'Clicked on attempt ' + attempt;
+    } catch (e) {
+      if (attempt === 3) throw e;
+      await page.waitForTimeout(1000);
+    }
+  }
+}"
+```
+
+## Complex Workflows
+
+### Login and Save Authentication State
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.fill('input[name=email]', 'user@example.com');
+  await page.fill('input[name=password]', 'secret');
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful, state saved to auth.json';
+}"
+```
+
+### Scrape Data from Multiple Pages
+
+```bash
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 5; i++) {
+    await page.goto(\`https://example.com/products?page=\${i}\`);
+    await page.waitForSelector('.product-card');
+    const items = await page.locator('.product-card').evaluateAll(cards =>
+      cards.map(card => ({
+        name: card.querySelector('.title')?.textContent?.trim(),
+        price: card.querySelector('.price')?.textContent?.trim(),
+        rating: card.querySelector('.rating')?.getAttribute('data-value')
+      }))
+    );
+    results.push(...items);
+  }
+  return JSON.stringify(results, null, 2);
+}"
+```
+
+### Fill Multi-Step Form (Wizard)
+
+```bash
+playwright-cli run-code "async page => {
+  // Step 1: Personal info
+  await page.fill('#firstName', 'Jane');
+  await page.fill('#lastName', 'Doe');
+  await page.fill('#email', 'jane@example.com');
+  await page.click('button:text(\"Next\")');
+
+  // Step 2: Address
+  await page.waitForSelector('#street');
+  await page.fill('#street', '123 Main St');
+  await page.fill('#city', 'Springfield');
+  await page.selectOption('#state', 'IL');
+  await page.fill('#zip', '62701');
+  await page.click('button:text(\"Next\")');
+
+  // Step 3: Confirm and submit
+  await page.waitForSelector('.review-summary');
+  await page.click('button:text(\"Submit\")');
+  await page.waitForURL('**/confirmation');
+
+  return 'Form submitted successfully';
+}"
+```
+
+### Infinite Scroll Data Extraction
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/feed');
+  const items = [];
+
+  while (items.length < 50) {
+    const newItems = await page.locator('.feed-item').evaluateAll(
+      els => els.map(el => el.textContent.trim())
+    );
+    items.push(...newItems.filter(item => !items.includes(item)));
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(1000);
+
+    // Check if we've reached the end
+    const hasMore = await page.locator('.load-more').isVisible().catch(() => false);
+    if (!hasMore && newItems.length === items.length) break;
+  }
+
+  return items.slice(0, 50);
+}"
+```
+
+## Tips
+
+- **Return values**: Always `return` data from `run-code` to see it in the CLI output
+- **`page.context()`**: Access browser context for permissions, cookies, storage, geolocation
+- **Error messages**: Playwright errors include element snapshots and call logs — read them carefully
+- **Combine with CLI**: Use `run-code` for setup (permissions, routes) then CLI commands for interaction
+- **Async/await**: All Playwright operations are async — always `await` them

--- a/engineering-team/playwright skill/playwright-cli/screenshots-and-media.md
+++ b/engineering-team/playwright skill/playwright-cli/screenshots-and-media.md
@@ -1,0 +1,393 @@
+# Screenshots and Media
+
+> **When to use**: Capturing visual evidence of page state — screenshots for verification, video recordings for demos or debugging, PDF exports for documentation, viewport resizing for responsive testing.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Screenshots
+playwright-cli screenshot                         # Full page screenshot
+playwright-cli screenshot e5                      # Element screenshot
+playwright-cli screenshot --filename=checkout.png # Custom filename
+
+# PDF
+playwright-cli pdf --filename=report.pdf          # Save page as PDF
+
+# Video
+playwright-cli video-start                        # Start recording
+playwright-cli video-stop demo.webm               # Stop and save
+
+# Viewport
+playwright-cli resize 1920 1080                   # Desktop
+playwright-cli resize 375 812                     # Mobile
+```
+
+## Screenshots
+
+### Page Screenshot
+
+Capture the entire visible viewport:
+
+```bash
+# Auto-generated filename
+playwright-cli screenshot
+
+# Custom filename
+playwright-cli screenshot --filename=homepage.png
+playwright-cli screenshot --filename=screenshots/checkout-step3.png
+```
+
+### Element Screenshot
+
+Capture a specific element only — useful for component-level verification:
+
+```bash
+# Screenshot a single element by ref
+playwright-cli snapshot          # Get refs first
+playwright-cli screenshot e5     # Capture just element e5
+
+# With custom filename
+playwright-cli screenshot e5 --filename=product-card.png
+```
+
+### Full-Page Screenshot
+
+Capture the entire scrollable page, not just the viewport:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.screenshot({ path: 'full-page.png', fullPage: true });
+  return 'Saved full-page screenshot';
+}"
+```
+
+### Screenshot with Options
+
+Use `run-code` for advanced screenshot options:
+
+```bash
+# Full page with quality settings (JPEG)
+playwright-cli run-code "async page => {
+  await page.screenshot({
+    path: 'optimized.jpg',
+    type: 'jpeg',
+    quality: 80,
+    fullPage: true
+  });
+}"
+
+# Clip to specific region
+playwright-cli run-code "async page => {
+  await page.screenshot({
+    path: 'header-region.png',
+    clip: { x: 0, y: 0, width: 1280, height: 200 }
+  });
+}"
+
+# With transparent background (for elements with transparency)
+playwright-cli run-code "async page => {
+  await page.screenshot({
+    path: 'transparent.png',
+    omitBackground: true
+  });
+}"
+
+# Screenshot with mask (hide dynamic content)
+playwright-cli run-code "async page => {
+  await page.screenshot({
+    path: 'masked.png',
+    mask: [
+      page.locator('.timestamp'),
+      page.locator('.user-avatar'),
+      page.locator('.ad-banner')
+    ]
+  });
+}"
+
+# Disable animations before screenshot
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    document.querySelectorAll('*').forEach(el => {
+      el.style.animation = 'none';
+      el.style.transition = 'none';
+    });
+  });
+  await page.screenshot({ path: 'no-animations.png' });
+}"
+```
+
+### Element Screenshot with Options
+
+```bash
+playwright-cli run-code "async page => {
+  const element = page.getByTestId('pricing-card');
+  await element.screenshot({
+    path: 'pricing-card.png',
+    omitBackground: true
+  });
+}"
+```
+
+## Responsive Screenshots
+
+Capture how the page looks at different viewport sizes:
+
+```bash
+# Desktop (1920x1080)
+playwright-cli resize 1920 1080
+playwright-cli screenshot --filename=desktop.png
+
+# Laptop (1366x768)
+playwright-cli resize 1366 768
+playwright-cli screenshot --filename=laptop.png
+
+# Tablet landscape (1024x768)
+playwright-cli resize 1024 768
+playwright-cli screenshot --filename=tablet-landscape.png
+
+# Tablet portrait (768x1024)
+playwright-cli resize 768 1024
+playwright-cli screenshot --filename=tablet-portrait.png
+
+# Mobile (375x812 — iPhone X)
+playwright-cli resize 375 812
+playwright-cli screenshot --filename=mobile.png
+
+# Mobile small (320x568 — iPhone SE)
+playwright-cli resize 320 568
+playwright-cli screenshot --filename=mobile-small.png
+```
+
+### Automated Responsive Screenshots
+
+```bash
+playwright-cli run-code "async page => {
+  const viewports = [
+    { name: 'desktop', width: 1920, height: 1080 },
+    { name: 'laptop', width: 1366, height: 768 },
+    { name: 'tablet', width: 768, height: 1024 },
+    { name: 'mobile', width: 375, height: 812 },
+    { name: 'mobile-sm', width: 320, height: 568 }
+  ];
+
+  for (const vp of viewports) {
+    await page.setViewportSize({ width: vp.width, height: vp.height });
+    await page.waitForTimeout(500);  // Allow layout to settle
+    await page.screenshot({ path: \`responsive-\${vp.name}.png\` });
+  }
+  return 'Captured ' + viewports.length + ' responsive screenshots';
+}"
+```
+
+## PDF Export
+
+Generate PDF documents from web pages — useful for reports, invoices, and documentation.
+
+```bash
+# Basic PDF
+playwright-cli pdf --filename=page.pdf
+```
+
+### Advanced PDF Options
+
+```bash
+# PDF with custom options
+playwright-cli run-code "async page => {
+  await page.pdf({
+    path: 'report.pdf',
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '1cm', right: '1cm', bottom: '1cm', left: '1cm' }
+  });
+  return 'PDF saved';
+}"
+
+# Letter format with header/footer
+playwright-cli run-code "async page => {
+  await page.pdf({
+    path: 'document.pdf',
+    format: 'Letter',
+    printBackground: true,
+    displayHeaderFooter: true,
+    headerTemplate: '<div style=\"font-size:10px; text-align:center; width:100%;\">Company Report</div>',
+    footerTemplate: '<div style=\"font-size:10px; text-align:center; width:100%;\">Page <span class=\"pageNumber\"></span> of <span class=\"totalPages\"></span></div>',
+    margin: { top: '2cm', bottom: '2cm', left: '1cm', right: '1cm' }
+  });
+}"
+
+# Landscape PDF
+playwright-cli run-code "async page => {
+  await page.pdf({
+    path: 'landscape.pdf',
+    landscape: true,
+    format: 'A4',
+    printBackground: true
+  });
+}"
+
+# Specific pages only
+playwright-cli run-code "async page => {
+  await page.pdf({
+    path: 'partial.pdf',
+    pageRanges: '1-3',
+    format: 'A4'
+  });
+}"
+```
+
+**Note**: PDF generation only works with Chromium-based browsers, not Firefox or WebKit.
+
+### Print Stylesheet Preview
+
+Before generating a PDF, switch to print media to see the print layout:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+playwright-cli screenshot --filename=print-preview.png
+playwright-cli pdf --filename=output.pdf
+```
+
+## Video Recording
+
+Record browser sessions as WebM video files.
+
+### Basic Recording
+
+```bash
+# Start recording
+playwright-cli video-start
+
+# Perform actions (everything is recorded)
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test input"
+playwright-cli click e5
+
+# Stop and save
+playwright-cli video-stop demo.webm
+```
+
+### Recording with Descriptive Names
+
+```bash
+playwright-cli video-start
+# ... login flow ...
+playwright-cli video-stop recordings/login-flow-2024-01-15.webm
+
+playwright-cli video-start
+# ... checkout flow ...
+playwright-cli video-stop recordings/checkout-happy-path.webm
+```
+
+### Use Cases
+
+| Scenario | Benefit |
+|----------|---------|
+| Bug reproduction | Share exact steps with developers |
+| Demo creation | Show feature flows to stakeholders |
+| Documentation | Record UI walkthroughs |
+| QA evidence | Prove a test scenario was completed |
+| Debugging | Watch what happened frame-by-frame |
+
+## Viewport Management
+
+Control the browser viewport for responsive testing:
+
+```bash
+# Common desktop sizes
+playwright-cli resize 1920 1080    # Full HD
+playwright-cli resize 1440 900     # MacBook Pro 15"
+playwright-cli resize 1366 768     # Common laptop
+playwright-cli resize 1280 720     # HD
+
+# Tablet sizes
+playwright-cli resize 1024 768     # iPad landscape
+playwright-cli resize 768 1024     # iPad portrait
+playwright-cli resize 834 1194     # iPad Pro 11"
+
+# Mobile sizes
+playwright-cli resize 430 932      # iPhone 14 Pro Max
+playwright-cli resize 390 844      # iPhone 14
+playwright-cli resize 375 812      # iPhone X/11/12/13
+playwright-cli resize 360 800      # Galaxy S21
+playwright-cli resize 320 568      # iPhone SE
+```
+
+## Common Patterns
+
+### Before/After Comparison
+
+```bash
+# Before action
+playwright-cli screenshot --filename=before.png
+playwright-cli click e5
+# After action
+playwright-cli screenshot --filename=after.png
+```
+
+### Full Documentation Suite
+
+```bash
+playwright-cli open https://app.example.com
+
+# Login page
+playwright-cli screenshot --filename=docs/01-login.png
+
+# Fill and submit
+playwright-cli fill e1 "demo@example.com"
+playwright-cli fill e2 "demo-password"
+playwright-cli screenshot --filename=docs/02-login-filled.png
+
+playwright-cli click e3
+playwright-cli screenshot --filename=docs/03-dashboard.png
+
+# Navigate to settings
+playwright-cli goto https://app.example.com/settings
+playwright-cli screenshot --filename=docs/04-settings.png
+
+# Generate PDF of documentation page
+playwright-cli goto https://app.example.com/docs
+playwright-cli pdf --filename=docs/user-guide.pdf
+```
+
+### Dark Mode vs Light Mode Screenshots
+
+```bash
+playwright-cli open https://example.com
+
+# Light mode
+playwright-cli run-code "async page => { await page.emulateMedia({ colorScheme: 'light' }); }"
+playwright-cli screenshot --filename=light-mode.png
+
+# Dark mode
+playwright-cli run-code "async page => { await page.emulateMedia({ colorScheme: 'dark' }); }"
+playwright-cli screenshot --filename=dark-mode.png
+```
+
+### Cross-Browser Screenshot Comparison
+
+```bash
+#!/bin/bash
+URL="https://example.com"
+
+for browser in chrome firefox webkit; do
+  playwright-cli -s=$browser open $URL --browser=$browser
+  playwright-cli -s=$browser screenshot --filename="comparison-$browser.png"
+done
+
+playwright-cli close-all
+```
+
+## Tips
+
+- **Always set viewport before screenshotting** — `resize` before `screenshot` for consistent dimensions
+- **Use descriptive filenames** — `checkout-step3-error.png` not `screenshot-1.png`
+- **Create output directories first** — `mkdir -p screenshots/` before using subdirectory paths
+- **Full-page for long content** — use `fullPage: true` via `run-code` for scrollable pages
+- **Mask dynamic content** — hide timestamps, avatars, and ads to get deterministic screenshots
+- **Print media before PDF** — `emulateMedia({ media: 'print' })` to see what the PDF will look like
+- **Video adds overhead** — only record when needed; tracing is lighter for debugging

--- a/engineering-team/playwright skill/playwright-cli/session-management.md
+++ b/engineering-team/playwright skill/playwright-cli/session-management.md
@@ -1,0 +1,352 @@
+# Session Management
+
+> **When to use**: Running multiple isolated browser sessions concurrently, managing persistent profiles, comparing different browser states side by side, parallel scraping, or A/B testing flows.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Named sessions: each has independent cookies, storage, tabs
+playwright-cli -s=auth open https://app.example.com/login
+playwright-cli -s=public open https://example.com
+
+# Interact within a session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+
+# List all active sessions
+playwright-cli list
+
+# Clean up
+playwright-cli -s=auth close
+playwright-cli close-all             # Close everything
+playwright-cli kill-all              # Force kill zombie processes
+```
+
+## Named Sessions
+
+Use the `-s=<name>` flag to create isolated browser instances. Each named session has its own:
+
+- Cookies
+- localStorage / sessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+### Creating Sessions
+
+```bash
+# Create a session for authentication testing
+playwright-cli -s=admin open https://app.example.com/login
+
+# Create a separate session for a different user
+playwright-cli -s=viewer open https://app.example.com/login
+
+# All commands in a session are isolated
+playwright-cli -s=admin fill e1 "admin@company.com"
+playwright-cli -s=admin fill e2 "admin-password"
+playwright-cli -s=admin click e3
+
+playwright-cli -s=viewer fill e1 "viewer@company.com"
+playwright-cli -s=viewer fill e2 "viewer-password"
+playwright-cli -s=viewer click e3
+```
+
+### Default Session
+
+When `-s` is omitted, all commands share a single default session:
+
+```bash
+# These all use the same default session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli close
+```
+
+## Session Isolation
+
+Sessions are fully independent — actions in one session never affect another:
+
+```bash
+# Session A logs in as admin
+playwright-cli -s=admin open https://app.example.com
+playwright-cli -s=admin fill e1 "admin@example.com"
+playwright-cli -s=admin fill e2 "admin-pass"
+playwright-cli -s=admin click e3
+
+# Session B visits the same site — NOT logged in
+playwright-cli -s=guest open https://app.example.com
+playwright-cli -s=guest snapshot
+# Shows the login page, not the admin dashboard
+
+# Session C can use a completely different browser
+playwright-cli -s=firefox-test open https://app.example.com --browser=firefox
+```
+
+## Session Commands
+
+```bash
+# List all active sessions with their status
+playwright-cli list
+
+# Close a specific named session
+playwright-cli -s=mysession close
+
+# Close the default session
+playwright-cli close
+
+# Close ALL sessions at once
+playwright-cli close-all
+
+# Force kill all browser daemon processes (for stuck/zombie browsers)
+playwright-cli kill-all
+
+# Delete persistent profile data for a session
+playwright-cli -s=mysession delete-data
+
+# Delete default session data
+playwright-cli delete-data
+```
+
+## Persistent Profiles
+
+By default, sessions run **in-memory** — all cookies, storage, and browsing data are lost when the session closes. Use `--persistent` to save state to disk.
+
+### Auto-Generated Profile
+
+```bash
+# Playwright-cli manages the profile directory automatically
+playwright-cli -s=myapp open https://example.com --persistent
+
+# Close and reopen — cookies and storage are preserved
+playwright-cli -s=myapp close
+playwright-cli -s=myapp open https://example.com --persistent
+# Still logged in!
+```
+
+### Custom Profile Directory
+
+```bash
+# Specify exactly where to store profile data
+playwright-cli -s=myapp open https://example.com --profile=/tmp/my-browser-profile
+
+# Useful for sharing profiles between sessions
+playwright-cli -s=session-a open https://example.com --profile=/shared/profile
+playwright-cli -s=session-a close
+playwright-cli -s=session-b open https://example.com --profile=/shared/profile
+```
+
+### Cleaning Up Persistent Data
+
+```bash
+# Remove stored profile data (must close the session first)
+playwright-cli -s=myapp close
+playwright-cli -s=myapp delete-data
+```
+
+## Session Configuration
+
+Configure browser engine and options per session:
+
+```bash
+# Different browsers for different sessions
+playwright-cli -s=chrome-test open https://example.com --browser=chrome
+playwright-cli -s=firefox-test open https://example.com --browser=firefox
+playwright-cli -s=webkit-test open https://example.com --browser=webkit
+playwright-cli -s=edge-test open https://example.com --browser=msedge
+
+# With config file
+playwright-cli -s=configured open https://example.com --config=my-config.json
+
+# Headed mode (visible browser window)
+playwright-cli -s=visible open https://example.com --headed
+
+# Connect to existing browser via extension
+playwright-cli -s=extension open --extension
+```
+
+## Environment Variable
+
+Set a default session name so all commands use it without the `-s` flag:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+
+# These now use "mysession" automatically
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Common Patterns
+
+### Multi-User Role Testing
+
+Test the same application as different user roles simultaneously:
+
+```bash
+# Admin session
+playwright-cli -s=admin open https://app.example.com/login
+playwright-cli -s=admin snapshot
+playwright-cli -s=admin fill e1 "admin@company.com"
+playwright-cli -s=admin fill e2 "admin-pass"
+playwright-cli -s=admin click e3
+
+# Regular user session
+playwright-cli -s=user open https://app.example.com/login
+playwright-cli -s=user fill e1 "user@company.com"
+playwright-cli -s=user fill e2 "user-pass"
+playwright-cli -s=user click e3
+
+# Compare what each role sees
+playwright-cli -s=admin snapshot     # Should show admin panel
+playwright-cli -s=user snapshot      # Should NOT show admin panel
+
+playwright-cli -s=admin screenshot --filename=admin-view.png
+playwright-cli -s=user screenshot --filename=user-view.png
+```
+
+### Concurrent Scraping
+
+Scrape multiple sites in parallel for speed:
+
+```bash
+#!/bin/bash
+
+# Launch all browsers concurrently
+playwright-cli -s=site1 open https://site1.example.com &
+playwright-cli -s=site2 open https://site2.example.com &
+playwright-cli -s=site3 open https://site3.example.com &
+wait
+
+# Collect data from each
+playwright-cli -s=site1 snapshot --filename=site1.yaml
+playwright-cli -s=site2 snapshot --filename=site2.yaml
+playwright-cli -s=site3 snapshot --filename=site3.yaml
+
+# Take screenshots
+playwright-cli -s=site1 screenshot --filename=site1.png
+playwright-cli -s=site2 screenshot --filename=site2.png
+playwright-cli -s=site3 screenshot --filename=site3.png
+
+# Clean up
+playwright-cli close-all
+```
+
+### A/B Testing Comparison
+
+```bash
+# Variant A
+playwright-cli -s=variant-a open "https://app.example.com?variant=a"
+playwright-cli -s=variant-a screenshot --filename=variant-a.png
+
+# Variant B
+playwright-cli -s=variant-b open "https://app.example.com?variant=b"
+playwright-cli -s=variant-b screenshot --filename=variant-b.png
+
+# Compare side by side
+playwright-cli close-all
+```
+
+### Cross-Browser Testing
+
+Run the same flow in multiple browsers to verify compatibility:
+
+```bash
+#!/bin/bash
+
+for browser in chrome firefox webkit; do
+  playwright-cli -s=$browser open https://example.com --browser=$browser
+  playwright-cli -s=$browser snapshot
+  playwright-cli -s=$browser screenshot --filename="$browser-home.png"
+
+  playwright-cli -s=$browser goto https://example.com/features
+  playwright-cli -s=$browser screenshot --filename="$browser-features.png"
+done
+
+playwright-cli close-all
+```
+
+### Authenticated State Sharing Across Sessions
+
+```bash
+# Log in once and save state
+playwright-cli -s=login open https://app.example.com/login
+playwright-cli -s=login fill e1 "user@example.com"
+playwright-cli -s=login fill e2 "password123"
+playwright-cli -s=login click e3
+playwright-cli -s=login state-save auth.json
+playwright-cli -s=login close
+
+# Reuse auth state in multiple sessions
+playwright-cli -s=session-a open https://app.example.com
+playwright-cli -s=session-a state-load auth.json
+playwright-cli -s=session-a goto https://app.example.com/dashboard
+
+playwright-cli -s=session-b open https://app.example.com
+playwright-cli -s=session-b state-load auth.json
+playwright-cli -s=session-b goto https://app.example.com/settings
+```
+
+## Best Practices
+
+### 1. Name Sessions Semantically
+
+```bash
+# Good: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+playwright-cli -s=checkout-flow open https://shop.example.com
+
+# Avoid: Generic names
+playwright-cli -s=s1 open https://github.com
+playwright-cli -s=test open https://docs.example.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Close individual sessions when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or close all at once
+playwright-cli close-all
+
+# If browsers become unresponsive
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Persistent Data
+
+```bash
+# Remove old persistent profiles to free disk space
+playwright-cli -s=old-session delete-data
+```
+
+### 4. Use Default Session for Single-Task Work
+
+Don't create named sessions when you only need one browser:
+
+```bash
+# Simple single-session workflow — no -s flag needed
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli close
+```
+
+### 5. Combine with State Management
+
+For long-running tasks, save state periodically:
+
+```bash
+playwright-cli -s=long-task open https://app.example.com --persistent
+# ... many interactions ...
+playwright-cli -s=long-task state-save checkpoint.json
+# ... more interactions ...
+# If something goes wrong, restore:
+playwright-cli -s=long-task state-load checkpoint.json
+```

--- a/engineering-team/playwright skill/playwright-cli/storage-and-auth.md
+++ b/engineering-team/playwright skill/playwright-cli/storage-and-auth.md
@@ -1,0 +1,487 @@
+# Storage and Authentication
+
+> **When to use**: Managing cookies, localStorage, sessionStorage, browser storage state, saving and restoring authentication, or testing storage-dependent features.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Save all browser state (cookies + localStorage) to file
+playwright-cli state-save auth.json
+
+# Restore state in a new session
+playwright-cli state-load auth.json
+
+# Quick cookie operations
+playwright-cli cookie-list
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# localStorage
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-get theme
+playwright-cli localstorage-clear
+
+# sessionStorage
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-clear
+```
+
+## Storage State (Save & Restore)
+
+The most powerful feature — save the entire browser state (cookies + localStorage for all origins) to a JSON file, then restore it later to skip login flows.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific file
+playwright-cli state-save auth.json
+playwright-cli state-save ./states/admin-session.json
+```
+
+### Restore Storage State
+
+```bash
+# Load state from file
+playwright-cli state-load auth.json
+
+# Navigate after loading — cookies and localStorage are already set
+playwright-cli goto https://app.example.com/dashboard
+# Already authenticated!
+```
+
+### Storage State File Format
+
+The saved JSON contains both cookies and localStorage:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" },
+        { "name": "auth_token", "value": "jwt.token.here" }
+      ]
+    }
+  ]
+}
+```
+
+## Authentication Pattern
+
+The most common workflow — log in once, save state, reuse across sessions.
+
+### Step 1: Log In and Save
+
+```bash
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+
+playwright-cli fill e1 "admin@example.com"
+playwright-cli fill e2 "secure-password"
+playwright-cli click e3
+
+# Wait for redirect to confirm login succeeded
+playwright-cli run-code "async page => {
+  await page.waitForURL('**/dashboard');
+  return 'Login successful: ' + page.url();
+}"
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+playwright-cli close
+```
+
+### Step 2: Reuse Auth State
+
+```bash
+# New session — skip login entirely
+playwright-cli open https://app.example.com
+playwright-cli state-load auth.json
+playwright-cli goto https://app.example.com/dashboard
+# Already logged in as admin!
+
+playwright-cli snapshot    # See the dashboard
+```
+
+### Multi-Role Authentication
+
+```bash
+# Save state for each role
+playwright-cli open https://app.example.com/login
+playwright-cli fill e1 "admin@example.com"
+playwright-cli fill e2 "admin-pass"
+playwright-cli click e3
+playwright-cli state-save admin-auth.json
+playwright-cli close
+
+playwright-cli open https://app.example.com/login
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "user-pass"
+playwright-cli click e3
+playwright-cli state-save user-auth.json
+playwright-cli close
+
+# Now use them
+playwright-cli -s=admin open https://app.example.com
+playwright-cli -s=admin state-load admin-auth.json
+playwright-cli -s=admin goto https://app.example.com/admin
+
+playwright-cli -s=user open https://app.example.com
+playwright-cli -s=user state-load user-auth.json
+playwright-cli -s=user goto https://app.example.com/profile
+```
+
+### OAuth / SSO Authentication
+
+For OAuth flows that involve redirects and popups:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.goto('https://app.example.com/login');
+
+  // Click 'Login with Google'
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.click('button:text(\"Login with Google\")')
+  ]);
+
+  // Fill credentials in the popup
+  await popup.fill('input[type=email]', 'user@gmail.com');
+  await popup.click('#identifierNext');
+  await popup.fill('input[type=password]', 'password');
+  await popup.click('#passwordNext');
+
+  // Wait for popup to close and main page to redirect
+  await popup.waitForEvent('close');
+  await page.waitForURL('**/dashboard');
+
+  // Save authenticated state
+  await page.context().storageState({ path: 'oauth-auth.json' });
+  return 'OAuth login complete';
+}"
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get a Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+playwright-cli cookie-get __cf_bm
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with full options
+playwright-cli cookie-set session abc123 \
+  --domain=example.com \
+  --path=/ \
+  --httpOnly \
+  --secure \
+  --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+playwright-cli cookie-delete __cf_bm
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies at Once
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    {
+      name: 'session_id',
+      value: 'sess_abc123',
+      domain: 'example.com',
+      path: '/',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Strict'
+    },
+    {
+      name: 'preferences',
+      value: JSON.stringify({ theme: 'dark', lang: 'en' }),
+      domain: 'example.com',
+      path: '/'
+    },
+    {
+      name: 'tracking_opt_out',
+      value: 'true',
+      domain: '.example.com',
+      path: '/'
+    }
+  ]);
+}"
+```
+
+### Advanced: Read All Cookies Programmatically
+
+```bash
+playwright-cli run-code "async page => {
+  const cookies = await page.context().cookies();
+  return cookies.map(c => ({
+    name: c.name,
+    value: c.value.substring(0, 20) + '...',
+    domain: c.domain,
+    httpOnly: c.httpOnly,
+    secure: c.secure,
+    expires: new Date(c.expires * 1000).toISOString()
+  }));
+}"
+```
+
+## Local Storage
+
+### List All Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get a Value
+
+```bash
+playwright-cli localstorage-get theme
+playwright-cli localstorage-get auth_token
+```
+
+### Set a Value
+
+```bash
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-set language en-US
+
+# Set JSON values (quote the JSON)
+playwright-cli localstorage-set user_settings '{"theme":"dark","fontSize":14,"sidebar":true}'
+```
+
+### Delete an Item
+
+```bash
+playwright-cli localstorage-delete auth_token
+```
+
+### Clear All
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Bulk Operations
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('user_name', 'Jane Doe');
+    localStorage.setItem('preferences', JSON.stringify({
+      theme: 'dark',
+      notifications: true,
+      language: 'en'
+    }));
+    localStorage.setItem('onboarding_complete', 'true');
+  });
+}"
+```
+
+### Advanced: Read All localStorage
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    const items = {};
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      items[key] = localStorage.getItem(key);
+    }
+    return items;
+  });
+}"
+```
+
+## Session Storage
+
+Session storage is per-tab and cleared when the tab closes.
+
+### List All Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get / Set / Delete
+
+```bash
+playwright-cli sessionstorage-get form_step
+playwright-cli sessionstorage-set form_step 3
+playwright-cli sessionstorage-set form_data '{"name":"Jane","email":"jane@example.com"}'
+playwright-cli sessionstorage-delete form_step
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+IndexedDB requires `run-code` for access:
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases.map(db => ({ name: db.name, version: db.version }));
+  });
+}"
+```
+
+### Delete a Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(dbName => {
+    indexedDB.deleteDatabase(dbName);
+  }, 'myDatabase');
+  return 'Database deleted';
+}"
+```
+
+### Read Data from an Object Store
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open('myDatabase');
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('myStore', 'readonly');
+        const store = tx.objectStore('myStore');
+        const getAll = store.getAll();
+        getAll.onsuccess = () => resolve(getAll.result);
+        getAll.onerror = () => reject(getAll.error);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  });
+}"
+```
+
+## Common Patterns
+
+### Token Refresh Testing
+
+```bash
+# Set an expired token to test refresh logic
+playwright-cli localstorage-set auth_token "expired-jwt-token"
+playwright-cli localstorage-set token_expiry "1609459200"
+
+# Navigate to trigger token refresh
+playwright-cli goto https://app.example.com/dashboard
+
+# Check if token was refreshed
+playwright-cli localstorage-get auth_token
+```
+
+### Feature Flag Testing
+
+```bash
+# Enable a feature flag via localStorage
+playwright-cli localstorage-set feature_flags '{"newCheckout":true,"darkMode":true,"betaFeatures":false}'
+
+# Reload to apply
+playwright-cli reload
+playwright-cli snapshot
+```
+
+### Clear Everything and Start Fresh
+
+```bash
+playwright-cli cookie-clear
+playwright-cli localstorage-clear
+playwright-cli sessionstorage-clear
+playwright-cli reload
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up state manually
+playwright-cli open https://example.com
+playwright-cli cookie-set session abc123 --domain=example.com
+playwright-cli localstorage-set user john
+playwright-cli localstorage-set theme dark
+
+# Save everything
+playwright-cli state-save my-session.json
+
+# Later — restore state in a new session
+playwright-cli open https://example.com
+playwright-cli state-load my-session.json
+playwright-cli reload
+# Cookies and localStorage are restored
+```
+
+## Security Notes
+
+- **Never commit auth state files** — add `*.auth-state.json` and `auth.json` to `.gitignore`
+- **Delete state files after use** — `rm auth.json` when done with automation
+- **Use environment variables for credentials** — never hardcode passwords in scripts
+- **In-memory sessions are safer** — default sessions don't persist to disk, reducing exposure
+- **Rotate saved states** — auth tokens expire; regenerate state files regularly
+- **Avoid saving state on shared machines** — storage state files contain session tokens and personal data

--- a/engineering-team/playwright skill/playwright-cli/test-generation.md
+++ b/engineering-team/playwright skill/playwright-cli/test-generation.md
@@ -1,0 +1,336 @@
+# Test Generation
+
+> **When to use**: Generating Playwright test code from interactive CLI sessions — recording user flows, building test scaffolds, converting manual testing into automated tests.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Every CLI action outputs the equivalent Playwright code
+playwright-cli open https://example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+# Output: await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Output: await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Output: await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## How It Works
+
+Every action you perform with `playwright-cli` automatically generates the corresponding Playwright TypeScript code in the output. This code uses the same **role-based locators** that Playwright recommends for production tests.
+
+The workflow:
+
+1. **Open a page** → generates `await page.goto(url)`
+2. **Take a snapshot** → see element refs and their accessible roles
+3. **Interact** → each action generates one line of Playwright code
+4. **Collect the code** → assemble generated lines into a complete test
+
+## Recording a Flow
+
+### Example: Login Flow
+
+```bash
+playwright-cli open https://example.com/login
+# Ran Playwright code:
+# await page.goto('https://example.com/login');
+
+playwright-cli snapshot
+# Output:
+# e1 [textbox "Email"]
+# e2 [textbox "Password"]
+# e3 [button "Sign In"]
+# e4 [link "Forgot password?"]
+
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+### Assemble into a Test
+
+Collect the generated code and wrap it in a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('user can log in', async ({ page }) => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions (not generated — you add these)
+  await expect(page).toHaveURL(/.*dashboard/);
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+```javascript
+const { test, expect } = require('@playwright/test');
+
+test('user can log in', async ({ page }) => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await expect(page).toHaveURL(/.*dashboard/);
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+## Locator Strategies in Generated Code
+
+The generated code uses Playwright's recommended locator hierarchy:
+
+| Priority | Locator Type | Example | When used |
+|----------|-------------|---------|-----------|
+| 1 | Role-based | `getByRole('button', { name: 'Submit' })` | Elements with ARIA roles |
+| 2 | Label-based | `getByLabel('Email')` | Form inputs with labels |
+| 3 | Placeholder | `getByPlaceholder('Search...')` | Inputs with placeholder text |
+| 4 | Text-based | `getByText('Welcome back')` | Static text content |
+| 5 | Test ID | `getByTestId('submit-btn')` | Elements with `data-testid` |
+
+These locators are **resilient to markup changes** — they mirror how users perceive the page rather than relying on CSS selectors or XPath.
+
+## Recording Complex Flows
+
+### E-Commerce Checkout
+
+```bash
+playwright-cli open https://shop.example.com
+
+# Browse products
+playwright-cli snapshot
+playwright-cli click e5                # "Add to Cart" button
+# await page.getByRole('button', { name: 'Add to Cart' }).click();
+
+playwright-cli click e12               # Cart icon
+# await page.getByRole('link', { name: 'Cart' }).click();
+
+playwright-cli snapshot
+playwright-cli click e3                # "Proceed to Checkout"
+# await page.getByRole('button', { name: 'Proceed to Checkout' }).click();
+
+# Shipping info
+playwright-cli snapshot
+playwright-cli fill e1 "Jane Doe"
+# await page.getByRole('textbox', { name: 'Full Name' }).fill('Jane Doe');
+playwright-cli fill e2 "123 Main St"
+# await page.getByRole('textbox', { name: 'Address' }).fill('123 Main St');
+playwright-cli fill e3 "Springfield"
+# await page.getByRole('textbox', { name: 'City' }).fill('Springfield');
+playwright-cli select e4 "IL"
+# await page.getByRole('combobox', { name: 'State' }).selectOption('IL');
+playwright-cli fill e5 "62701"
+# await page.getByRole('textbox', { name: 'ZIP Code' }).fill('62701');
+playwright-cli click e6               # "Continue to Payment"
+```
+
+### Multi-Step Wizard
+
+```bash
+playwright-cli open https://example.com/onboarding
+
+# Step 1
+playwright-cli snapshot
+playwright-cli fill e1 "Acme Corp"
+playwright-cli select e2 "technology"
+playwright-cli click e3    # Next
+
+# Step 2
+playwright-cli snapshot
+playwright-cli check e1    # Feature checkbox
+playwright-cli check e3    # Another feature
+playwright-cli click e5    # Next
+
+# Step 3
+playwright-cli snapshot
+playwright-cli click e2    # "Complete Setup"
+```
+
+### Search with Dynamic Results
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+
+playwright-cli fill e1 "playwright testing"
+# await page.getByRole('searchbox', { name: 'Search' }).fill('playwright testing');
+
+playwright-cli press Enter
+# await page.keyboard.press('Enter');
+
+playwright-cli snapshot    # See search results — new refs assigned
+
+playwright-cli click e3    # First result
+# await page.getByRole('link', { name: 'Getting Started with Playwright' }).click();
+```
+
+## Adding Assertions
+
+Generated code captures **actions** but not **assertions**. Always add assertions manually to create meaningful tests.
+
+### Common Assertions to Add
+
+```typescript
+// URL changed after navigation
+await expect(page).toHaveURL(/.*dashboard/);
+await expect(page).toHaveURL('https://example.com/success');
+
+// Element is visible
+await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+await expect(page.getByText('Order confirmed')).toBeVisible();
+
+// Element contains text
+await expect(page.getByTestId('total')).toHaveText('$99.99');
+await expect(page.getByRole('alert')).toContainText('saved');
+
+// Element has specific attribute
+await expect(page.getByRole('button', { name: 'Submit' })).toBeDisabled();
+await expect(page.getByRole('checkbox')).toBeChecked();
+
+// Element count
+await expect(page.getByRole('listitem')).toHaveCount(5);
+
+// Page title
+await expect(page).toHaveTitle(/Dashboard/);
+
+// Screenshot comparison
+await expect(page).toHaveScreenshot('checkout.png');
+```
+
+### Where to Place Assertions
+
+```typescript
+test('complete checkout flow', async ({ page }) => {
+  await page.goto('https://shop.example.com/products');
+
+  // Action: Add item to cart
+  await page.getByRole('button', { name: 'Add to Cart' }).click();
+
+  // Assertion: Cart badge updates
+  await expect(page.getByTestId('cart-count')).toHaveText('1');
+
+  // Action: Go to cart
+  await page.getByRole('link', { name: 'Cart' }).click();
+
+  // Assertion: Correct page
+  await expect(page).toHaveURL(/.*cart/);
+  await expect(page.getByRole('heading', { name: 'Your Cart' })).toBeVisible();
+
+  // Action: Proceed to checkout
+  await page.getByRole('button', { name: 'Checkout' }).click();
+
+  // Action: Fill shipping
+  await page.getByRole('textbox', { name: 'Full Name' }).fill('Jane Doe');
+  await page.getByRole('textbox', { name: 'Address' }).fill('123 Main St');
+  await page.getByRole('button', { name: 'Place Order' }).click();
+
+  // Assertion: Order confirmed
+  await expect(page.getByText('Order confirmed')).toBeVisible();
+  await expect(page.getByTestId('order-number')).toBeVisible();
+});
+```
+
+## Best Practices
+
+### 1. Explore Before Recording
+
+Take a snapshot first to understand the page structure. Don't blindly click — know what elements are available:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the elements, plan your flow, then start interacting
+```
+
+### 2. Use Semantic Locators
+
+The generated code already prefers role-based locators. If you see CSS selectors in generated output, consider filing an issue — role-based locators are more resilient:
+
+```typescript
+// Generated (good — semantic, resilient)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid writing manually (fragile — breaks if CSS changes)
+await page.locator('#submit-btn').click();
+await page.locator('.btn.btn-primary').click();
+```
+
+### 3. Keep Tests Focused
+
+One test = one user behavior. Don't record an entire session into a single test:
+
+```typescript
+// Good: Focused test
+test('user can add item to cart', async ({ page }) => {
+  // Just the add-to-cart flow
+});
+
+test('user can complete checkout', async ({ page }) => {
+  // Just the checkout flow (use auth state to skip login)
+});
+
+// Bad: Monolith test
+test('user journey', async ({ page }) => {
+  // Login + browse + add to cart + checkout + verify email...
+});
+```
+
+### 4. Parameterize Test Data
+
+Replace hardcoded values from the recording with variables or test data:
+
+```typescript
+// Instead of hardcoded values from recording
+test('registration', async ({ page }) => {
+  const user = {
+    name: 'Jane Doe',
+    email: `test+${Date.now()}@example.com`,
+    password: 'SecurePass123!'
+  };
+
+  await page.goto('/register');
+  await page.getByRole('textbox', { name: 'Name' }).fill(user.name);
+  await page.getByRole('textbox', { name: 'Email' }).fill(user.email);
+  await page.getByRole('textbox', { name: 'Password' }).fill(user.password);
+  await page.getByRole('button', { name: 'Create Account' }).click();
+
+  await expect(page).toHaveURL(/.*welcome/);
+});
+```
+
+### 5. Add Wait Strategies for Flaky Steps
+
+If a recorded action depends on async content loading, add explicit waits:
+
+```typescript
+// Before clicking a dynamically loaded element
+await page.waitForSelector('.results-loaded');
+await page.getByRole('link', { name: 'First Result' }).click();
+
+// Or use Playwright's auto-waiting (preferred)
+await expect(page.getByRole('link', { name: 'First Result' })).toBeVisible();
+await page.getByRole('link', { name: 'First Result' }).click();
+```
+
+## Tips
+
+- **Generated code is a starting point** — always review, add assertions, and parameterize before committing to your test suite
+- **Re-snapshot after dynamic changes** — refs change when the DOM updates
+- **Combine with `state-save`** — record a login flow once, save state, then start all other recordings from the authenticated state
+- **Use `--filename` for snapshots** — save before/after snapshots for complex flows to help write assertions later

--- a/engineering-team/playwright skill/playwright-cli/tracing-and-debugging.md
+++ b/engineering-team/playwright skill/playwright-cli/tracing-and-debugging.md
@@ -1,0 +1,421 @@
+# Tracing and Debugging
+
+> **When to use**: Debugging failing actions, analyzing performance bottlenecks, capturing execution evidence, understanding why an interaction didn't work, or inspecting network and console activity during automation.
+> **Prerequisites**: [core-commands.md](core-commands.md) for basic CLI usage
+
+## Quick Reference
+
+```bash
+# Trace a session
+playwright-cli tracing-start
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+
+# View console messages
+playwright-cli console                # All levels
+playwright-cli console error          # Errors only
+playwright-cli console warning        # Warnings only
+
+# View network activity
+playwright-cli network
+```
+
+## Tracing
+
+Traces capture **everything** — DOM snapshots, screenshots, network activity, console logs, and timing — for every action during a session.
+
+### Basic Usage
+
+```bash
+# Start recording before the flow you want to debug
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e4
+playwright-cli fill e7 "test data"
+playwright-cli click e9
+
+# Stop and save the trace
+playwright-cli tracing-stop
+```
+
+### What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Every click, fill, hover, keyboard input, navigation — with timing |
+| **DOM Snapshots** | Full DOM state before and after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All HTTP requests, responses, headers, bodies, timing |
+| **Console** | All `console.log`, `console.warn`, `console.error` messages |
+| **Timing** | Precise duration for each operation |
+| **Source** | Which command triggered each action |
+
+### Trace Output Files
+
+When tracing is active, Playwright creates a `traces/` directory:
+
+**`trace-{timestamp}.trace`** — Main trace file containing:
+- Action log with DOM snapshots
+- Screenshots at each step
+- Timing information
+- Console messages
+
+**`trace-{timestamp}.network`** — Network activity:
+- All HTTP requests and responses
+- Request/response headers and bodies
+- DNS, connect, TLS, TTFB, download timing
+- Resource sizes and failed requests
+
+**`resources/`** — Cached assets for trace replay:
+- Images, fonts, stylesheets, scripts
+- Response bodies for offline replay
+
+### Viewing Traces
+
+Open traces in Playwright's Trace Viewer — a rich GUI for step-by-step debugging:
+
+```bash
+# Open trace in the Trace Viewer web app
+npx playwright show-trace traces/trace-123456.trace
+
+# Or use the online Trace Viewer
+# Upload trace file to: https://trace.playwright.dev
+```
+
+The Trace Viewer shows:
+- **Timeline**: Step-by-step actions with screenshots
+- **DOM Snapshot**: Inspect elements at each step (like DevTools)
+- **Network**: Waterfall view of all requests
+- **Console**: Log messages with timestamps
+- **Source**: The code that triggered each action
+
+## Console Monitoring
+
+View JavaScript console output from the page — essential for catching errors:
+
+```bash
+# Show all console messages
+playwright-cli console
+
+# Filter by severity level
+playwright-cli console error         # Only errors
+playwright-cli console warning       # Only warnings
+playwright-cli console info          # Only info messages
+playwright-cli console log           # Only log messages
+```
+
+### Common Debugging Pattern
+
+```bash
+playwright-cli open https://app.example.com
+playwright-cli snapshot
+playwright-cli click e5              # Something unexpected happens
+
+# Check if there were JavaScript errors
+playwright-cli console error
+# Output might show:
+# [error] TypeError: Cannot read properties of undefined (reading 'map')
+# [error] Uncaught ReferenceError: processData is not defined
+```
+
+### Watch Console During Interaction
+
+Use `run-code` to set up continuous console monitoring:
+
+```bash
+playwright-cli run-code "async page => {
+  page.on('console', msg => {
+    if (msg.type() === 'error' || msg.type() === 'warning') {
+      console.log(\`[\${msg.type()}] \${msg.text()}\`);
+    }
+  });
+}"
+# Now interact — errors and warnings will print as they occur
+playwright-cli click e5
+playwright-cli fill e3 "test"
+```
+
+### Capture Uncaught Exceptions
+
+```bash
+playwright-cli run-code "async page => {
+  page.on('pageerror', error => {
+    console.log('Uncaught exception:', error.message);
+  });
+}"
+```
+
+## Network Monitoring
+
+View all network requests made by the page:
+
+```bash
+playwright-cli network
+```
+
+### Watch Network in Real-Time
+
+```bash
+playwright-cli run-code "async page => {
+  page.on('request', request => {
+    console.log(\`>> \${request.method()} \${request.url()}\`);
+  });
+  page.on('response', response => {
+    console.log(\`<< \${response.status()} \${response.url()}\`);
+  });
+}"
+
+# Now interact — requests will print as they happen
+playwright-cli click e5
+```
+
+### Monitor Failed Requests
+
+```bash
+playwright-cli run-code "async page => {
+  page.on('requestfailed', request => {
+    console.log(\`FAILED: \${request.method()} \${request.url()} - \${request.failure()?.errorText}\`);
+  });
+}"
+```
+
+### Inspect a Specific Response
+
+```bash
+playwright-cli run-code "async page => {
+  const response = await page.waitForResponse('**/api/users');
+  return {
+    status: response.status(),
+    statusText: response.statusText(),
+    headers: response.headers(),
+    body: await response.json()
+  };
+}"
+```
+
+## Debugging Strategies
+
+### Strategy 1: Snapshot Before and After
+
+The simplest debugging approach — see what changed:
+
+```bash
+playwright-cli snapshot --filename=before.yaml
+playwright-cli click e5
+playwright-cli snapshot --filename=after.yaml
+# Compare the two snapshots to understand what changed
+```
+
+### Strategy 2: Trace the Failing Flow
+
+Start tracing before the step that fails:
+
+```bash
+playwright-cli tracing-start
+
+# Reproduce the issue
+playwright-cli goto https://app.example.com/checkout
+playwright-cli fill e1 "Jane Doe"
+playwright-cli click e5    # This step fails
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when the click was attempted
+```
+
+### Strategy 3: Check Element State
+
+When an interaction fails, check what state the element is actually in:
+
+```bash
+# Is the element visible?
+playwright-cli eval "el => window.getComputedStyle(el).display" e5
+playwright-cli eval "el => window.getComputedStyle(el).visibility" e5
+playwright-cli eval "el => el.getBoundingClientRect()" e5
+
+# Is it covered by another element?
+playwright-cli eval "el => {
+  const rect = el.getBoundingClientRect();
+  const topEl = document.elementFromPoint(rect.x + rect.width/2, rect.y + rect.height/2);
+  return topEl === el ? 'Element is on top' : 'Covered by: ' + topEl?.tagName + '.' + topEl?.className;
+}" e5
+
+# Is it disabled?
+playwright-cli eval "el => el.disabled" e5
+playwright-cli eval "el => el.getAttribute('aria-disabled')" e5
+```
+
+### Strategy 4: Console + Network Combined
+
+```bash
+# Set up monitoring for both console and network
+playwright-cli run-code "async page => {
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.log('[CONSOLE]', msg.text());
+  });
+  page.on('requestfailed', req => {
+    console.log('[NETWORK]', req.method(), req.url(), req.failure()?.errorText);
+  });
+  page.on('response', resp => {
+    if (resp.status() >= 400) {
+      console.log('[HTTP ERROR]', resp.status(), resp.url());
+    }
+  });
+}"
+
+# Now interact and watch for errors
+playwright-cli click e5
+playwright-cli fill e3 "test"
+```
+
+### Strategy 5: Wait and Retry
+
+If actions fail due to timing, add explicit waits:
+
+```bash
+# Wait for element to be actionable
+playwright-cli run-code "async page => {
+  await page.locator('#dynamic-button').waitFor({ state: 'visible', timeout: 10000 });
+}"
+playwright-cli snapshot
+playwright-cli click e5
+
+# Wait for page to settle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+playwright-cli snapshot
+```
+
+## Performance Analysis
+
+### Measure Page Load Time
+
+```bash
+playwright-cli run-code "async page => {
+  const timing = await page.evaluate(() => {
+    const t = performance.timing;
+    return {
+      dns: t.domainLookupEnd - t.domainLookupStart,
+      tcp: t.connectEnd - t.connectStart,
+      ttfb: t.responseStart - t.requestStart,
+      download: t.responseEnd - t.responseStart,
+      domParsing: t.domInteractive - t.domLoading,
+      domComplete: t.domComplete - t.domLoading,
+      total: t.loadEventEnd - t.navigationStart
+    };
+  });
+  return timing;
+}"
+```
+
+### Analyze with Navigation Timing API
+
+```bash
+playwright-cli run-code "async page => {
+  const entries = await page.evaluate(() => {
+    return performance.getEntriesByType('navigation').map(e => ({
+      type: e.type,
+      redirectTime: e.redirectEnd - e.redirectStart,
+      dnsTime: e.domainLookupEnd - e.domainLookupStart,
+      connectTime: e.connectEnd - e.connectStart,
+      tlsTime: e.secureConnectionStart > 0 ? e.connectEnd - e.secureConnectionStart : 0,
+      requestTime: e.responseStart - e.requestStart,
+      responseTime: e.responseEnd - e.responseStart,
+      domProcessing: e.domComplete - e.domInteractive,
+      loadTime: e.loadEventEnd - e.loadEventStart,
+      totalTime: e.loadEventEnd - e.startTime
+    }));
+  });
+  return entries;
+}"
+```
+
+### List Slow Resources
+
+```bash
+playwright-cli run-code "async page => {
+  const resources = await page.evaluate(() => {
+    return performance.getEntriesByType('resource')
+      .map(r => ({ name: r.name.split('/').pop(), duration: Math.round(r.duration), size: r.transferSize }))
+      .sort((a, b) => b.duration - a.duration)
+      .slice(0, 10);
+  });
+  return resources;
+}"
+```
+
+## Trace vs Video vs Screenshot
+
+Choose the right capture method:
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | `.trace` file | `.webm` video | `.png` image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **Console logs** | Yes | No | No |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos, documentation | Quick capture |
+
+### Decision Guide
+
+- **Something failed and you don't know why** → Trace
+- **Need to show a flow to someone** → Video
+- **Need to verify visual state** → Screenshot
+- **Need to analyze performance** → Trace (has network waterfall)
+- **CI artifact for failed test** → Trace + Screenshot
+
+## Best Practices
+
+### 1. Start Tracing BEFORE the Problem
+
+Trace the entire flow leading up to the failure, not just the failing step:
+
+```bash
+playwright-cli tracing-start
+# Reproduce the full flow from the beginning
+playwright-cli open https://app.example.com
+playwright-cli fill e1 "user@example.com"
+playwright-cli click e3
+# ... all steps leading to the failure ...
+playwright-cli tracing-stop
+```
+
+### 2. Use Console Monitoring Proactively
+
+Start console monitoring at the beginning of any debugging session:
+
+```bash
+playwright-cli run-code "async page => {
+  page.on('console', msg => console.log(\`[\${msg.type()}] \${msg.text()}\`));
+  page.on('pageerror', err => console.log('[EXCEPTION]', err.message));
+}"
+```
+
+### 3. Clean Up Old Traces
+
+Traces consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+### 4. Combine Techniques
+
+The most effective debugging combines multiple approaches:
+
+```bash
+playwright-cli tracing-start           # Capture everything
+playwright-cli console error           # Watch for JS errors
+playwright-cli network                 # Watch for failed requests
+playwright-cli snapshot                # See current state
+# ... interact and debug ...
+playwright-cli tracing-stop            # Save trace for detailed analysis
+```

--- a/engineering-team/playwright skill/pom/SKILL.md
+++ b/engineering-team/playwright skill/pom/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: playwright-pom
+description: Page Object Model patterns for Playwright — when to use POM, how to structure page objects, and when fixtures or helpers are a better fit.
+---
+
+# Playwright Page Object Model
+
+> Structure your test code for maintainability — know when POM helps and when simpler patterns win.
+
+**2 guides** covering Page Object Model implementation and the decision framework for choosing between POM, fixtures, and helpers.
+
+## Guide Index
+
+| Topic | Guide |
+|---|---|
+| Page Object Model patterns | [page-object-model.md](page-object-model.md) |
+| POM vs fixtures vs helpers | [pom-vs-fixtures-vs-helpers.md](pom-vs-fixtures-vs-helpers.md) |

--- a/engineering-team/playwright skill/pom/page-object-model.md
+++ b/engineering-team/playwright skill/pom/page-object-model.md
@@ -1,0 +1,921 @@
+# Page Object Model
+
+> **When to use**: Any page or component is touched by more than one test file, or a single test file interacts with more than two distinct UI regions.
+
+Page objects encapsulate **actions**, not locators. A test should read like a user story: `await loginPage.login('admin', 'secret')`, never `await loginPage.usernameInput.fill('admin')`. The POM is a boundary between "what the user does" and "how the UI is structured." Assertions stay in tests, never inside page objects.
+
+## Quick Reference
+
+| Concept | Rule |
+|---|---|
+| Locators | Defined as `readonly` properties in the constructor or as getters. Never exposed raw to tests. |
+| Actions | Public methods that perform a user-visible behavior. Return `Promise<void>` or the next page object. |
+| Assertions | **Never** inside page objects. Tests own all `expect()` calls. |
+| Navigation | Methods that navigate return the destination page object, not `void`. |
+| State | Page objects are stateless. No caching locator text, no tracking "current step." |
+| Constructor | Takes `Page` (or `Locator` for components). Nothing else. No URLs, no test data. |
+| Naming | `LoginPage`, `DashboardPage`, `NavbarComponent`. File: `login.page.ts`, `navbar.component.ts`. |
+
+## Patterns
+
+### 1. Basic POM Class
+
+**Use when**: A page has 3+ interactions across multiple tests.
+**Avoid when**: A page is used in a single test file with trivial interactions -- use a helper function instead.
+
+**TypeScript**
+
+```typescript
+// tests/pages/login.page.ts
+import { type Page, type Locator } from '@playwright/test';
+
+export class LoginPage {
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(private readonly page: Page) {
+    this.usernameInput = page.getByLabel('Username');
+    this.passwordInput = page.getByLabel('Password');
+    this.submitButton = page.getByRole('button', { name: 'Sign in' });
+    this.errorMessage = page.getByRole('alert');
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async login(username: string, password: string) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}
+```
+
+**JavaScript**
+
+```javascript
+// tests/pages/login.page.js
+// @ts-check
+
+export class LoginPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+    this.usernameInput = page.getByLabel('Username');
+    this.passwordInput = page.getByLabel('Password');
+    this.submitButton = page.getByRole('button', { name: 'Sign in' });
+    this.errorMessage = page.getByRole('alert');
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async login(username, password) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}
+```
+
+**Test usage**
+
+```typescript
+// tests/auth.spec.ts
+import { test, expect } from '@playwright/test';
+import { LoginPage } from './pages/login.page';
+
+test('successful login redirects to dashboard', async ({ page }) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.login('admin', 'password123');
+
+  await expect(page).toHaveURL('/dashboard');
+});
+
+test('invalid credentials show error', async ({ page }) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.login('admin', 'wrong');
+
+  await expect(loginPage.errorMessage).toBeVisible();
+  await expect(loginPage.errorMessage).toHaveText('Invalid credentials');
+});
+```
+
+### 2. Component Objects
+
+**Use when**: A UI element (navbar, sidebar, modal, form, table) appears on multiple pages.
+**Avoid when**: The component is page-specific and never reused.
+
+Components take a `Locator` (their root container), not a `Page`. This scopes all queries to the component's DOM subtree and allows composing components into page objects.
+
+**TypeScript**
+
+```typescript
+// tests/components/navbar.component.ts
+import { type Locator } from '@playwright/test';
+
+export class NavbarComponent {
+  readonly profileMenu: Locator;
+  readonly searchInput: Locator;
+  readonly notificationBell: Locator;
+
+  constructor(private readonly root: Locator) {
+    this.profileMenu = root.getByRole('button', { name: 'Profile' });
+    this.searchInput = root.getByRole('searchbox');
+    this.notificationBell = root.getByRole('button', { name: 'Notifications' });
+  }
+
+  async search(query: string) {
+    await this.searchInput.fill(query);
+    await this.searchInput.press('Enter');
+  }
+
+  async openProfile() {
+    await this.profileMenu.click();
+  }
+
+  async openNotifications() {
+    await this.notificationBell.click();
+  }
+}
+
+// tests/components/modal.component.ts
+import { type Locator } from '@playwright/test';
+
+export class ModalComponent {
+  readonly title: Locator;
+  readonly closeButton: Locator;
+  readonly confirmButton: Locator;
+  readonly cancelButton: Locator;
+
+  constructor(private readonly root: Locator) {
+    this.title = root.getByRole('heading');
+    this.closeButton = root.getByRole('button', { name: 'Close' });
+    this.confirmButton = root.getByRole('button', { name: 'Confirm' });
+    this.cancelButton = root.getByRole('button', { name: 'Cancel' });
+  }
+
+  async confirm() {
+    await this.confirmButton.click();
+  }
+
+  async cancel() {
+    await this.cancelButton.click();
+  }
+
+  async close() {
+    await this.closeButton.click();
+  }
+}
+
+// tests/pages/dashboard.page.ts
+import { type Page } from '@playwright/test';
+import { NavbarComponent } from '../components/navbar.component';
+import { ModalComponent } from '../components/modal.component';
+
+export class DashboardPage {
+  readonly navbar: NavbarComponent;
+  readonly deleteModal: ModalComponent;
+
+  constructor(private readonly page: Page) {
+    this.navbar = new NavbarComponent(page.getByRole('navigation'));
+    this.deleteModal = new ModalComponent(page.getByRole('dialog'));
+  }
+
+  async goto() {
+    await this.page.goto('/dashboard');
+  }
+
+  async deleteItem(name: string) {
+    await this.page.getByRole('row', { name }).getByRole('button', { name: 'Delete' }).click();
+    await this.deleteModal.confirm();
+  }
+}
+```
+
+**JavaScript**
+
+```javascript
+// tests/components/navbar.component.js
+// @ts-check
+
+export class NavbarComponent {
+  /** @param {import('@playwright/test').Locator} root */
+  constructor(root) {
+    this.root = root;
+    this.profileMenu = root.getByRole('button', { name: 'Profile' });
+    this.searchInput = root.getByRole('searchbox');
+    this.notificationBell = root.getByRole('button', { name: 'Notifications' });
+  }
+
+  async search(query) {
+    await this.searchInput.fill(query);
+    await this.searchInput.press('Enter');
+  }
+
+  async openProfile() {
+    await this.profileMenu.click();
+  }
+
+  async openNotifications() {
+    await this.notificationBell.click();
+  }
+}
+
+// tests/pages/dashboard.page.js
+// @ts-check
+import { NavbarComponent } from '../components/navbar.component.js';
+import { ModalComponent } from '../components/modal.component.js';
+
+export class DashboardPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+    this.navbar = new NavbarComponent(page.getByRole('navigation'));
+    this.deleteModal = new ModalComponent(page.getByRole('dialog'));
+  }
+
+  async goto() {
+    await this.page.goto('/dashboard');
+  }
+
+  async deleteItem(name) {
+    await this.page.getByRole('row', { name }).getByRole('button', { name: 'Delete' }).click();
+    await this.deleteModal.confirm();
+  }
+}
+```
+
+### 3. Page Object with Navigation
+
+**Use when**: An action on one page navigates to a different page (form submission, link click, redirect).
+**Avoid when**: Navigation is uncertain (might fail validation and stay on the same page).
+
+When a method causes navigation, return the destination page object. This creates a typed chain that mirrors the user flow and catches stale page object usage at the call site.
+
+**TypeScript**
+
+```typescript
+// tests/pages/login.page.ts
+import { type Page } from '@playwright/test';
+import { DashboardPage } from './dashboard.page';
+
+export class LoginPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  /** Returns DashboardPage on success. Call only when credentials are valid. */
+  async loginAs(username: string, password: string): Promise<DashboardPage> {
+    await this.page.getByLabel('Username').fill(username);
+    await this.page.getByLabel('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Sign in' }).click();
+    await this.page.waitForURL('/dashboard');
+    return new DashboardPage(this.page);
+  }
+
+  /** Use for invalid credential tests -- stays on login page. */
+  async loginExpectingError(username: string, password: string) {
+    await this.page.getByLabel('Username').fill(username);
+    await this.page.getByLabel('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Sign in' }).click();
+  }
+}
+
+// tests/pages/dashboard.page.ts
+import { type Page } from '@playwright/test';
+import { SettingsPage } from './settings.page';
+
+export class DashboardPage {
+  constructor(private readonly page: Page) {}
+
+  async gotoSettings(): Promise<SettingsPage> {
+    await this.page.getByRole('link', { name: 'Settings' }).click();
+    await this.page.waitForURL('/settings');
+    return new SettingsPage(this.page);
+  }
+}
+```
+
+**JavaScript**
+
+```javascript
+// tests/pages/login.page.js
+// @ts-check
+import { DashboardPage } from './dashboard.page.js';
+
+export class LoginPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  /** @returns {Promise<DashboardPage>} */
+  async loginAs(username, password) {
+    await this.page.getByLabel('Username').fill(username);
+    await this.page.getByLabel('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Sign in' }).click();
+    await this.page.waitForURL('/dashboard');
+    return new DashboardPage(this.page);
+  }
+
+  async loginExpectingError(username, password) {
+    await this.page.getByLabel('Username').fill(username);
+    await this.page.getByLabel('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Sign in' }).click();
+  }
+}
+```
+
+**Test usage showing the navigation chain**
+
+```typescript
+// tests/settings.spec.ts
+import { test, expect } from '@playwright/test';
+import { LoginPage } from './pages/login.page';
+
+test('user can navigate from login to settings', async ({ page }) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+
+  const dashboard = await loginPage.loginAs('admin', 'password123');
+  const settings = await dashboard.gotoSettings();
+
+  await expect(page).toHaveURL('/settings');
+});
+```
+
+### 4. Page Object as Fixture
+
+**Use when**: Page objects are used in 3+ test files. This is the recommended approach for mature test suites.
+**Avoid when**: Early prototyping with rapidly changing pages.
+
+Fixtures eliminate boilerplate instantiation, provide automatic cleanup, and make POMs available via destructuring -- identical to built-in `page` and `request` fixtures.
+
+**TypeScript**
+
+```typescript
+// tests/fixtures.ts
+import { test as base } from '@playwright/test';
+import { LoginPage } from './pages/login.page';
+import { DashboardPage } from './pages/dashboard.page';
+import { SettingsPage } from './pages/settings.page';
+
+type PageObjects = {
+  loginPage: LoginPage;
+  dashboardPage: DashboardPage;
+  settingsPage: SettingsPage;
+};
+
+export const test = base.extend<PageObjects>({
+  loginPage: async ({ page }, use) => {
+    await use(new LoginPage(page));
+  },
+  dashboardPage: async ({ page }, use) => {
+    await use(new DashboardPage(page));
+  },
+  settingsPage: async ({ page }, use) => {
+    await use(new SettingsPage(page));
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+**JavaScript**
+
+```javascript
+// tests/fixtures.js
+// @ts-check
+import { test as base } from '@playwright/test';
+import { LoginPage } from './pages/login.page.js';
+import { DashboardPage } from './pages/dashboard.page.js';
+import { SettingsPage } from './pages/settings.page.js';
+
+export const test = base.extend({
+  loginPage: async ({ page }, use) => {
+    await use(new LoginPage(page));
+  },
+  dashboardPage: async ({ page }, use) => {
+    await use(new DashboardPage(page));
+  },
+  settingsPage: async ({ page }, use) => {
+    await use(new SettingsPage(page));
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+**Test usage**
+
+```typescript
+// tests/auth.spec.ts
+import { test, expect } from './fixtures';
+
+test('successful login redirects to dashboard', async ({ loginPage, page }) => {
+  await loginPage.goto();
+  await loginPage.login('admin', 'password123');
+
+  await expect(page).toHaveURL('/dashboard');
+});
+```
+
+**Advanced: fixture that performs setup**
+
+```typescript
+// tests/fixtures.ts
+import { test as base } from '@playwright/test';
+import { DashboardPage } from './pages/dashboard.page';
+
+export const test = base.extend<{ authenticatedDashboard: DashboardPage }>({
+  authenticatedDashboard: async ({ page }, use) => {
+    // Setup: navigate and authenticate
+    await page.goto('/login');
+    await page.getByLabel('Username').fill('admin');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('/dashboard');
+
+    await use(new DashboardPage(page));
+
+    // Teardown (optional): logout, clean up test data
+    await page.goto('/logout');
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+### 5. Factory Functions
+
+**Use when**: A page has few actions and no shared state. Simpler than a class, still encapsulates actions.
+**Avoid when**: The page has 5+ methods or needs component composition.
+
+Factory functions are a lightweight alternative for simple pages. They return an object with action methods, avoiding class ceremony.
+
+**TypeScript**
+
+```typescript
+// tests/pages/error.page.ts
+import { type Page } from '@playwright/test';
+
+export function createErrorPage(page: Page) {
+  return {
+    errorHeading: page.getByRole('heading', { name: 'Something went wrong' }),
+    retryButton: page.getByRole('button', { name: 'Retry' }),
+
+    async goto() {
+      await page.goto('/error');
+    },
+
+    async retry() {
+      await page.getByRole('button', { name: 'Retry' }).click();
+    },
+
+    async goHome() {
+      await page.getByRole('link', { name: 'Go home' }).click();
+      await page.waitForURL('/');
+    },
+  };
+}
+```
+
+**JavaScript**
+
+```javascript
+// tests/pages/error.page.js
+// @ts-check
+
+/** @param {import('@playwright/test').Page} page */
+export function createErrorPage(page) {
+  return {
+    errorHeading: page.getByRole('heading', { name: 'Something went wrong' }),
+    retryButton: page.getByRole('button', { name: 'Retry' }),
+
+    async goto() {
+      await page.goto('/error');
+    },
+
+    async retry() {
+      await page.getByRole('button', { name: 'Retry' }).click();
+    },
+
+    async goHome() {
+      await page.getByRole('link', { name: 'Go home' }).click();
+      await page.waitForURL('/');
+    },
+  };
+}
+```
+
+**Test usage**
+
+```typescript
+// tests/error.spec.ts
+import { test, expect } from '@playwright/test';
+import { createErrorPage } from './pages/error.page';
+
+test('retry button reloads the page', async ({ page }) => {
+  const errorPage = createErrorPage(page);
+  await errorPage.goto();
+  await errorPage.retry();
+
+  await expect(page).not.toHaveURL('/error');
+});
+```
+
+### 6. Getter Pattern for Dynamic Locators
+
+**Use when**: Locators depend on dynamic content (parameterized rows, nth items, content that changes after page load).
+**Avoid when**: All locators are static and known at construction time -- use constructor assignment instead.
+
+Getters create the locator fresh on each access. This avoids stale references when the DOM changes after the page object is constructed.
+
+**TypeScript**
+
+```typescript
+// tests/pages/users.page.ts
+import { type Page, type Locator } from '@playwright/test';
+
+export class UsersPage {
+  constructor(private readonly page: Page) {}
+
+  /** Static locators -- fine in constructor or as getters, either works. */
+  get addUserButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add user' });
+  }
+
+  get userRows(): Locator {
+    return this.page.getByRole('row').filter({ hasNot: this.page.getByRole('columnheader') });
+  }
+
+  /** Dynamic locator -- must be a method since it takes a parameter. */
+  userRow(name: string): Locator {
+    return this.page.getByRole('row', { name });
+  }
+
+  userDeleteButton(name: string): Locator {
+    return this.userRow(name).getByRole('button', { name: 'Delete' });
+  }
+
+  async goto() {
+    await this.page.goto('/admin/users');
+  }
+
+  async deleteUser(name: string) {
+    await this.userDeleteButton(name).click();
+    // Wait for row to disappear, confirming deletion
+    await this.userRow(name).waitFor({ state: 'hidden' });
+  }
+
+  async addUser() {
+    await this.addUserButton.click();
+  }
+}
+```
+
+**JavaScript**
+
+```javascript
+// tests/pages/users.page.js
+// @ts-check
+
+export class UsersPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+  }
+
+  get addUserButton() {
+    return this.page.getByRole('button', { name: 'Add user' });
+  }
+
+  get userRows() {
+    return this.page.getByRole('row').filter({ hasNot: this.page.getByRole('columnheader') });
+  }
+
+  userRow(name) {
+    return this.page.getByRole('row', { name });
+  }
+
+  userDeleteButton(name) {
+    return this.userRow(name).getByRole('button', { name: 'Delete' });
+  }
+
+  async goto() {
+    await this.page.goto('/admin/users');
+  }
+
+  async deleteUser(name) {
+    await this.userDeleteButton(name).click();
+    await this.userRow(name).waitFor({ state: 'hidden' });
+  }
+
+  async addUser() {
+    await this.addUserButton.click();
+  }
+}
+```
+
+### 7. Directory Structure
+
+Use this layout. Adapt folder names to your convention, but keep the separation between pages, components, and fixtures.
+
+```
+tests/
+  fixtures.ts              # Custom test with POM fixtures
+  auth.spec.ts             # Test files at top level or in feature folders
+  dashboard.spec.ts
+  pages/                   # One file per page
+    login.page.ts
+    dashboard.page.ts
+    settings.page.ts
+    users.page.ts
+  components/              # Reusable UI components
+    navbar.component.ts
+    modal.component.ts
+    sidebar.component.ts
+    data-table.component.ts
+```
+
+Rules:
+- **One class per file.** File name matches the class: `LoginPage` lives in `login.page.ts`.
+- **Pages vs components**: Pages own a full route (`/login`, `/dashboard`). Components are embedded in pages (`NavbarComponent`, `ModalComponent`).
+- **No barrel files** (`index.ts` re-exporting everything). Import directly from the file. Barrel files create circular dependency traps and slow down IDE tooling.
+- **`fixtures.ts` at `tests/` root.** Every spec imports `test` and `expect` from `./fixtures` instead of `@playwright/test`.
+
+### 8. Handling Async Initialization
+
+**Use when**: A page object needs async setup before it is usable (waiting for API data to load, waiting for animations to settle, waiting for a specific element to appear).
+**Avoid when**: The page is ready immediately after `goto()`.
+
+Never put `await` in a constructor. Use a static factory method instead.
+
+**TypeScript**
+
+```typescript
+// tests/pages/analytics.page.ts
+import { type Page, type Locator } from '@playwright/test';
+
+export class AnalyticsPage {
+  readonly chart: Locator;
+  readonly dateRange: Locator;
+
+  private constructor(private readonly page: Page) {
+    this.chart = page.locator('[data-testid="analytics-chart"]');
+    this.dateRange = page.getByLabel('Date range');
+  }
+
+  /** Use this instead of `new AnalyticsPage()`. Waits for chart data to load. */
+  static async create(page: Page): Promise<AnalyticsPage> {
+    const analyticsPage = new AnalyticsPage(page);
+    await page.goto('/analytics');
+    // Wait for the async content that makes this page "ready"
+    await analyticsPage.chart.waitFor({ state: 'visible' });
+    return analyticsPage;
+  }
+
+  async selectDateRange(range: string) {
+    await this.dateRange.click();
+    await this.page.getByRole('option', { name: range }).click();
+    // Wait for chart to update after date change
+    await this.chart.waitFor({ state: 'visible' });
+  }
+}
+```
+
+**JavaScript**
+
+```javascript
+// tests/pages/analytics.page.js
+// @ts-check
+
+export class AnalyticsPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+    this.chart = page.locator('[data-testid="analytics-chart"]');
+    this.dateRange = page.getByLabel('Date range');
+  }
+
+  /** @param {import('@playwright/test').Page} page */
+  static async create(page) {
+    const analyticsPage = new AnalyticsPage(page);
+    await page.goto('/analytics');
+    await analyticsPage.chart.waitFor({ state: 'visible' });
+    return analyticsPage;
+  }
+
+  async selectDateRange(range) {
+    await this.dateRange.click();
+    await this.page.getByRole('option', { name: range }).click();
+    await this.chart.waitFor({ state: 'visible' });
+  }
+}
+```
+
+**As a fixture**
+
+```typescript
+// tests/fixtures.ts
+import { test as base } from '@playwright/test';
+import { AnalyticsPage } from './pages/analytics.page';
+
+export const test = base.extend<{ analyticsPage: AnalyticsPage }>({
+  analyticsPage: async ({ page }, use) => {
+    const analyticsPage = await AnalyticsPage.create(page);
+    await use(analyticsPage);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+## Decision Guide
+
+```
+How complex is the page?
+│
+├── 1-2 interactions, single test file
+│   └── No POM. Inline locators in the test are fine.
+│
+├── 3-5 interactions OR 2+ test files use it
+│   ├── Few methods, no composition needed
+│   │   └── Factory function (Pattern 5)
+│   └── Multiple methods, needs component composition
+│       └── Full POM class (Pattern 1 + 2)
+│
+├── Used across 3+ test files
+│   └── POM class + fixture injection (Pattern 4)
+│
+└── Page requires async setup before usable
+    └── Static factory method (Pattern 8) + fixture
+```
+
+| Factor | Simple helper | Factory function | POM class | POM + fixture |
+|---|---|---|---|---|
+| Page complexity | 1-2 actions | 3-5 actions | 5+ actions | 5+ actions |
+| Reuse across files | 1 file | 1-2 files | 2+ files | 3+ files |
+| Component composition | No | No | Yes | Yes |
+| Team size | Solo | Small | Any | Any |
+| Setup ceremony | None | Low | Medium | Medium (once) |
+| Recommended for | Quick prototypes | Simple pages | Standard choice | Mature suites |
+
+## Anti-Patterns
+
+### God Object
+
+One page object for the entire application or a page object with 30+ methods covering unrelated features.
+
+```typescript
+// BAD: one class for everything
+class AppPage {
+  async login() { /* ... */ }
+  async addToCart() { /* ... */ }
+  async checkout() { /* ... */ }
+  async changePassword() { /* ... */ }
+  async viewAnalytics() { /* ... */ }
+  // 40 more methods...
+}
+```
+
+Fix: Split by page or feature. One class per logical page. Compose shared UI into component objects.
+
+### Assertions Inside Page Objects
+
+```typescript
+// BAD: page object owns the assertion
+class LoginPage {
+  async loginAndVerify(username: string, password: string) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+    // This assertion belongs in the test, not here
+    await expect(this.page).toHaveURL('/dashboard');
+  }
+}
+
+// GOOD: page object performs action, test asserts
+class LoginPage {
+  async login(username: string, password: string) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}
+
+// In test:
+await loginPage.login('admin', 'pass');
+await expect(page).toHaveURL('/dashboard');
+```
+
+Exception: `waitForURL()` or `waitFor()` calls inside POM methods that ensure navigation completed are fine -- those are synchronization, not assertion.
+
+### Deeply Nested Inheritance
+
+```typescript
+// BAD: inheritance chain
+class BasePage { /* ... */ }
+class AuthenticatedPage extends BasePage { /* ... */ }
+class AdminPage extends AuthenticatedPage { /* ... */ }
+class SuperAdminPage extends AdminPage { /* ... */ }
+```
+
+Fix: Use composition. Create component objects for shared UI (navbar, sidebar) and compose them into page objects. Prefer `has-a` over `is-a`.
+
+```typescript
+// GOOD: composition
+class AdminPage {
+  readonly navbar: NavbarComponent;
+  readonly sidebar: AdminSidebarComponent;
+
+  constructor(private readonly page: Page) {
+    this.navbar = new NavbarComponent(page.getByRole('navigation'));
+    this.sidebar = new AdminSidebarComponent(page.getByRole('complementary'));
+  }
+}
+```
+
+### Storing State in Page Objects
+
+```typescript
+// BAD: tracking state
+class CartPage {
+  private itemCount = 0;
+
+  async addItem(name: string) {
+    await this.page.getByRole('button', { name: `Add ${name}` }).click();
+    this.itemCount++; // State goes stale if the UI changes independently
+  }
+
+  getCount() {
+    return this.itemCount; // Lies if another tab or API call modified the cart
+  }
+}
+```
+
+Fix: Read state from the DOM when needed. The page is the source of truth, not your JavaScript variable.
+
+```typescript
+// GOOD: read from DOM
+class CartPage {
+  async addItem(name: string) {
+    await this.page.getByRole('button', { name: `Add ${name}` }).click();
+  }
+
+  get itemCount(): Locator {
+    return this.page.getByTestId('cart-count');
+  }
+}
+
+// In test:
+await cartPage.addItem('Widget');
+await expect(cartPage.itemCount).toHaveText('1');
+```
+
+### Exposing Raw Locators as the Primary API
+
+```typescript
+// BAD: test manipulates locators directly
+const loginPage = new LoginPage(page);
+await loginPage.usernameInput.fill('admin');
+await loginPage.passwordInput.fill('secret');
+await loginPage.submitButton.click();
+
+// GOOD: test calls an action
+const loginPage = new LoginPage(page);
+await loginPage.login('admin', 'secret');
+```
+
+Exposing locators as `readonly` properties for assertions is acceptable (`expect(loginPage.errorMessage).toBeVisible()`). The anti-pattern is requiring tests to orchestrate multi-step interactions through raw locators.
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| Locator times out but element exists | POM constructed before navigation; locator attached to wrong page state | Move `goto()` before POM construction, or use getter pattern (Pattern 6) |
+| Circular import between page objects | `LoginPage` imports `DashboardPage` which imports `LoginPage` | Break the cycle: use lazy `import()` in the navigation method, or have the test create the destination POM |
+| Fixture not available in test | Test imports `test` from `@playwright/test` instead of `./fixtures` | Always import `test` and `expect` from your custom fixtures file |
+| TypeScript error: property does not exist on fixture | Fixture type not declared in `test.extend<>()` generic | Add the POM type to the generic parameter: `test.extend<{ loginPage: LoginPage }>()` |
+| POM methods feel duplicated across similar pages | Multiple pages share the same form structure | Extract a component object for the shared form, compose into each page |
+| `page.goto()` in constructor causes "cannot use await" | Constructors cannot be async | Use static factory method (Pattern 8) |
+
+## Related
+
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- how `test.extend()` works in depth, fixture scoping, teardown
+- [core/locators.md](../core/locators.md) -- choosing the right locator strategy for POM properties
+- [core/pom-vs-fixtures-vs-helpers.md](../core/pom-vs-fixtures-vs-helpers.md) -- expanded decision framework for when to use each approach
+- [core/test-organization.md](../core/test-organization.md) -- file and folder conventions for the broader test suite

--- a/engineering-team/playwright skill/pom/pom-vs-fixtures-vs-helpers.md
+++ b/engineering-team/playwright skill/pom/pom-vs-fixtures-vs-helpers.md
@@ -1,0 +1,937 @@
+# Page Objects vs Fixtures vs Helpers
+
+> **When to use**: When deciding how to organize reusable test code in a Playwright project.
+> **Prerequisites**: [core/page-object-model.md](../core/page-object-model.md), [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md)
+
+## Quick Answer
+
+**Use all three.** Most projects benefit from a hybrid approach:
+
+- **Page objects** for UI interaction (pages and components with 5+ interactions)
+- **Custom fixtures** for test infrastructure (auth state, database, API clients, anything with lifecycle)
+- **Helper functions** for stateless utilities (generate data, format values, simple waits)
+
+If you are only going to use one pattern, use **custom fixtures** -- they handle setup/teardown, compose well, and Playwright is built around them. But you should use all three.
+
+## Comparison Table
+
+| Aspect | Page Objects | Custom Fixtures | Helper Functions |
+|---|---|---|---|
+| **Primary purpose** | Encapsulate UI interactions for a page or component | Provide shared resources with setup/teardown lifecycle | Stateless utility operations |
+| **Setup/teardown** | Manual (constructor / methods) | Built-in (`use()` callback with automatic teardown) | None (stateless) |
+| **Type safety** | Full class-based typing | Full typing via `test.extend<T>()` generics | Full typing via function signatures |
+| **Composability** | Compose via constructor injection or fixture wiring | Compose by depending on other fixtures | Compose by calling other functions |
+| **Learning curve** | Low (plain classes) | Medium (Playwright-specific `test.extend` API) | Lowest (plain functions) |
+| **Test readability** | High -- `loginPage.signIn(user)` reads like intent | High -- `{ adminPage }` declares dependencies | Medium -- utility calls mixed with test logic |
+| **Debugging experience** | Good -- step into class methods | Best -- fixtures appear in traces and reports | Good -- step into functions |
+| **IDE support** | Excellent -- autocomplete on class methods | Excellent -- autocomplete on fixture parameters | Excellent -- autocomplete on function params |
+| **State management** | Holds page reference and locators as instance state | Manages resource lifecycle (create, provide, cleanup) | No state (pure functions) |
+| **Best for** | Pages with many interactions reused across files | Resources that need setup AND teardown | Simple, reusable logic with no side effects |
+
+## Decision Flowchart
+
+```
+What kind of reusable code are you writing?
+|
++-- Does it interact with a page or component in the browser?
+|   |
+|   +-- Does the page/component have 5+ interactions (fill, click, navigate, assert)?
+|   |   |
+|   |   +-- YES: Is it used in 3+ test files?
+|   |   |   +-- YES --> PAGE OBJECT
+|   |   |   +-- NO --> Inline the interactions or use a small helper function
+|   |   |
+|   |   +-- NO (< 5 interactions) --> HELPER FUNCTION
+|   |
+|   +-- Does it need setup before the test AND cleanup after?
+|       +-- YES --> CUSTOM FIXTURE (wraps a page object or resource)
+|       +-- NO --> PAGE OBJECT method or HELPER FUNCTION
+|
++-- Does it manage a resource with lifecycle (create/destroy)?
+|   |
+|   +-- Examples: auth state, database connection, API client,
+|   |   test user, browser context, temporary files
+|   |
+|   +-- YES --> CUSTOM FIXTURE (always)
+|
++-- Is it a stateless utility? (no browser, no side effects)
+|   |
+|   +-- Examples: generate random email, format date, build URL,
+|   |   create test data object, parse response
+|   |
+|   +-- YES --> HELPER FUNCTION
+|
++-- Not sure?
+    +-- Start with a HELPER FUNCTION
+    +-- Promote to PAGE OBJECT when interactions grow
+    +-- Promote to FIXTURE when lifecycle management is needed
+```
+
+## When to Use Page Objects
+
+**Best for**: Pages or components with 5+ interactions that appear in 3+ test files. Encapsulate navigation, form filling, action sequences, and element locators into a single class that reads like user intent.
+
+**TypeScript**
+
+```typescript
+// page-objects/checkout.page.ts
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class CheckoutPage {
+  readonly page: Page;
+  readonly cardNumber: Locator;
+  readonly expiry: Locator;
+  readonly cvc: Locator;
+  readonly payButton: Locator;
+  readonly promoCodeInput: Locator;
+  readonly orderTotal: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.cardNumber = page.getByLabel('Card number');
+    this.expiry = page.getByLabel('Expiry');
+    this.cvc = page.getByLabel('CVC');
+    this.payButton = page.getByRole('button', { name: 'Pay now' });
+    this.promoCodeInput = page.getByLabel('Promo code');
+    this.orderTotal = page.getByTestId('order-total');
+  }
+
+  async goto() {
+    await this.page.goto('/checkout');
+  }
+
+  async fillPaymentDetails(card: { number: string; expiry: string; cvc: string }) {
+    await this.cardNumber.fill(card.number);
+    await this.expiry.fill(card.expiry);
+    await this.cvc.fill(card.cvc);
+  }
+
+  async pay() {
+    await this.payButton.click();
+    await this.page.waitForURL('**/confirmation');
+  }
+
+  async applyPromoCode(code: string) {
+    await this.promoCodeInput.fill(code);
+    await this.page.getByRole('button', { name: 'Apply' }).click();
+    await expect(this.page.getByText('Code applied')).toBeVisible();
+  }
+
+  async expectTotal(amount: string) {
+    await expect(this.orderTotal).toHaveText(amount);
+  }
+}
+```
+
+```typescript
+// tests/checkout/payment.spec.ts
+import { test, expect } from '@playwright/test';
+import { CheckoutPage } from '../page-objects/checkout.page';
+
+test('should complete checkout with valid card', async ({ page }) => {
+  const checkout = new CheckoutPage(page);
+  await checkout.goto();
+  await checkout.fillPaymentDetails({
+    number: '4242424242424242',
+    expiry: '12/28',
+    cvc: '123',
+  });
+  await checkout.pay();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('should apply promo code and update total', async ({ page }) => {
+  const checkout = new CheckoutPage(page);
+  await checkout.goto();
+  await checkout.applyPromoCode('SAVE20');
+  await checkout.expectTotal('$79.99');
+});
+```
+
+**JavaScript**
+
+```javascript
+// page-objects/checkout.page.js
+const { expect } = require('@playwright/test');
+
+class CheckoutPage {
+  constructor(page) {
+    this.page = page;
+    this.cardNumber = page.getByLabel('Card number');
+    this.expiry = page.getByLabel('Expiry');
+    this.cvc = page.getByLabel('CVC');
+    this.payButton = page.getByRole('button', { name: 'Pay now' });
+    this.promoCodeInput = page.getByLabel('Promo code');
+    this.orderTotal = page.getByTestId('order-total');
+  }
+
+  async goto() {
+    await this.page.goto('/checkout');
+  }
+
+  async fillPaymentDetails(card) {
+    await this.cardNumber.fill(card.number);
+    await this.expiry.fill(card.expiry);
+    await this.cvc.fill(card.cvc);
+  }
+
+  async pay() {
+    await this.payButton.click();
+    await this.page.waitForURL('**/confirmation');
+  }
+
+  async applyPromoCode(code) {
+    await this.promoCodeInput.fill(code);
+    await this.page.getByRole('button', { name: 'Apply' }).click();
+    await expect(this.page.getByText('Code applied')).toBeVisible();
+  }
+
+  async expectTotal(amount) {
+    await expect(this.orderTotal).toHaveText(amount);
+  }
+}
+
+module.exports = { CheckoutPage };
+```
+
+```javascript
+// tests/checkout/payment.spec.js
+const { test, expect } = require('@playwright/test');
+const { CheckoutPage } = require('../page-objects/checkout.page');
+
+test('should complete checkout with valid card', async ({ page }) => {
+  const checkout = new CheckoutPage(page);
+  await checkout.goto();
+  await checkout.fillPaymentDetails({
+    number: '4242424242424242',
+    expiry: '12/28',
+    cvc: '123',
+  });
+  await checkout.pay();
+  await expect(page.getByText('Payment successful')).toBeVisible();
+});
+
+test('should apply promo code and update total', async ({ page }) => {
+  const checkout = new CheckoutPage(page);
+  await checkout.goto();
+  await checkout.applyPromoCode('SAVE20');
+  await checkout.expectTotal('$79.99');
+});
+```
+
+**Key principles for page objects:**
+- One class per logical page or component, not per URL
+- Constructor takes `Page` (and optionally other page objects for composition)
+- Locators are `readonly` properties assigned in the constructor
+- Methods represent user-intent actions (`signIn`, `addToCart`), not low-level clicks
+- Navigation methods (`goto`) belong on the page object
+- Assertions can live on the page object when they verify page-specific state
+
+## When to Use Custom Fixtures
+
+**Best for**: Shared resources that need setup before the test and teardown after -- auth state, database connections, API clients, test users, seeded data, custom browser contexts. Anything with a lifecycle belongs in a fixture.
+
+**TypeScript**
+
+```typescript
+// fixtures/base.fixture.ts
+import { test as base, expect } from '@playwright/test';
+import { CheckoutPage } from '../page-objects/checkout.page';
+import { DashboardPage } from '../page-objects/dashboard.page';
+
+// Define types for all custom fixtures
+type MyFixtures = {
+  checkoutPage: CheckoutPage;
+  dashboardPage: DashboardPage;
+  authenticatedPage: ReturnType<typeof base['page']> extends Promise<infer P> ? P : never;
+  testUser: { email: string; password: string; id: string };
+  apiClient: { get: (path: string) => Promise<Response>; post: (path: string, data: unknown) => Promise<Response> };
+};
+
+export const test = base.extend<MyFixtures>({
+  // Fixture that wraps a page object — created fresh for each test
+  checkoutPage: async ({ page }, use) => {
+    const checkoutPage = new CheckoutPage(page);
+    await use(checkoutPage);
+    // No teardown needed — page closes automatically
+  },
+
+  dashboardPage: async ({ page }, use) => {
+    const dashboardPage = new DashboardPage(page);
+    await use(dashboardPage);
+  },
+
+  // Fixture with real setup AND teardown — creates a test user, cleans up after
+  testUser: async ({ request }, use) => {
+    // Setup: create a user via API
+    const response = await request.post('/api/test/users', {
+      data: {
+        email: `test-${Date.now()}@example.com`,
+        password: 'TestPass123!',
+      },
+    });
+    const user = await response.json();
+
+    // Provide the user to the test
+    await use(user);
+
+    // Teardown: delete the user (runs even if test fails)
+    await request.delete(`/api/test/users/${user.id}`);
+  },
+
+  // Fixture that depends on another fixture
+  authenticatedPage: async ({ page, testUser }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(testUser.email);
+    await page.getByLabel('Password').fill(testUser.password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page).toHaveURL('/dashboard');
+
+    await use(page);
+    // Teardown: logout (optional — browser context is destroyed anyway)
+  },
+
+  // API client fixture with lifecycle
+  apiClient: async ({ request }, use) => {
+    const client = {
+      get: (path: string) => request.get(`/api${path}`),
+      post: (path: string, data: unknown) => request.post(`/api${path}`, { data }),
+    };
+
+    await use(client);
+    // Teardown runs automatically when request fixture tears down
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/dashboard/widgets.spec.ts
+import { test, expect } from '../../fixtures/base.fixture';
+
+// testUser and authenticatedPage are set up automatically by the fixture system
+test('authenticated user sees dashboard widgets', async ({ authenticatedPage }) => {
+  await expect(authenticatedPage.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(authenticatedPage.getByTestId('revenue-widget')).toBeVisible();
+  await expect(authenticatedPage.getByTestId('orders-widget')).toBeVisible();
+});
+
+test('user can refresh dashboard data', async ({ authenticatedPage, dashboardPage }) => {
+  await authenticatedPage.getByRole('button', { name: 'Refresh' }).click();
+  await expect(authenticatedPage.getByText('Updated just now')).toBeVisible();
+});
+
+// testUser fixture creates AND cleans up the user automatically
+test('new user sees onboarding prompt', async ({ authenticatedPage, testUser }) => {
+  await expect(authenticatedPage.getByText(`Welcome, ${testUser.email}`)).toBeVisible();
+  await expect(authenticatedPage.getByRole('dialog', { name: 'Get started' })).toBeVisible();
+});
+```
+
+**JavaScript**
+
+```javascript
+// fixtures/base.fixture.js
+const { test: base, expect } = require('@playwright/test');
+const { CheckoutPage } = require('../page-objects/checkout.page');
+const { DashboardPage } = require('../page-objects/dashboard.page');
+
+const test = base.extend({
+  checkoutPage: async ({ page }, use) => {
+    const checkoutPage = new CheckoutPage(page);
+    await use(checkoutPage);
+  },
+
+  dashboardPage: async ({ page }, use) => {
+    const dashboardPage = new DashboardPage(page);
+    await use(dashboardPage);
+  },
+
+  testUser: async ({ request }, use) => {
+    const response = await request.post('/api/test/users', {
+      data: {
+        email: `test-${Date.now()}@example.com`,
+        password: 'TestPass123!',
+      },
+    });
+    const user = await response.json();
+
+    await use(user);
+
+    await request.delete(`/api/test/users/${user.id}`);
+  },
+
+  authenticatedPage: async ({ page, testUser }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(testUser.email);
+    await page.getByLabel('Password').fill(testUser.password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page).toHaveURL('/dashboard');
+
+    await use(page);
+  },
+
+  apiClient: async ({ request }, use) => {
+    const client = {
+      get: (path) => request.get(`/api${path}`),
+      post: (path, data) => request.post(`/api${path}`, { data }),
+    };
+
+    await use(client);
+  },
+});
+
+module.exports = { test, expect };
+```
+
+```javascript
+// tests/dashboard/widgets.spec.js
+const { test, expect } = require('../../fixtures/base.fixture');
+
+test('authenticated user sees dashboard widgets', async ({ authenticatedPage }) => {
+  await expect(authenticatedPage.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(authenticatedPage.getByTestId('revenue-widget')).toBeVisible();
+  await expect(authenticatedPage.getByTestId('orders-widget')).toBeVisible();
+});
+
+test('new user sees onboarding prompt', async ({ authenticatedPage, testUser }) => {
+  await expect(authenticatedPage.getByText(`Welcome, ${testUser.email}`)).toBeVisible();
+  await expect(authenticatedPage.getByRole('dialog', { name: 'Get started' })).toBeVisible();
+});
+```
+
+**Key principles for custom fixtures:**
+- Use `test.extend()` to define fixtures -- never use module-level variables
+- The `use()` callback separates setup (before) from teardown (after)
+- Teardown runs even if the test fails or crashes -- this is the main advantage over `afterEach`
+- Fixtures compose: one fixture can depend on another (`authenticatedPage` depends on `testUser`)
+- Fixtures are lazy: they are only created when a test actually requests them
+- Wrap page objects in fixtures to get automatic lifecycle management
+- Fixtures appear in Playwright traces, making debugging easier
+
+## When to Use Helper Functions
+
+**Best for**: Stateless utility operations -- generating test data, formatting values, building URLs, parsing responses, creating simple wait conditions. Pure functions with no side effects and no browser interaction.
+
+**TypeScript**
+
+```typescript
+// helpers/test-data.ts
+import { randomUUID } from 'node:crypto';
+
+export function generateEmail(prefix = 'test'): string {
+  return `${prefix}-${Date.now()}-${randomUUID().slice(0, 8)}@example.com`;
+}
+
+export function generateUser(overrides: Partial<TestUser> = {}): TestUser {
+  return {
+    email: generateEmail(),
+    password: 'TestPass123!',
+    firstName: 'Test',
+    lastName: 'User',
+    ...overrides,
+  };
+}
+
+interface TestUser {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+}
+
+export function formatCurrency(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function buildApiUrl(path: string, params: Record<string, string> = {}): string {
+  const url = new URL(path, 'http://localhost:3000');
+  Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+  return url.toString();
+}
+```
+
+```typescript
+// helpers/assertions.ts
+import { type Page, expect } from '@playwright/test';
+
+/**
+ * Wait for all network requests to settle.
+ * Use sparingly — prefer specific assertions over blanket network waits.
+ */
+export async function waitForNetworkIdle(page: Page, timeout = 5000): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout });
+}
+
+/**
+ * Assert that a toast notification appears and then disappears.
+ */
+export async function expectToast(page: Page, message: string): Promise<void> {
+  const toast = page.getByRole('status').filter({ hasText: message });
+  await expect(toast).toBeVisible();
+  await expect(toast).toBeHidden({ timeout: 10000 });
+}
+```
+
+```typescript
+// tests/settings/profile.spec.ts
+import { test, expect } from '@playwright/test';
+import { generateEmail, generateUser } from '../../helpers/test-data';
+import { expectToast } from '../../helpers/assertions';
+
+test('should update user email', async ({ page }) => {
+  const newEmail = generateEmail('updated');
+
+  await page.goto('/settings/profile');
+  await page.getByLabel('Email').fill(newEmail);
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expectToast(page, 'Profile updated');
+  await expect(page.getByLabel('Email')).toHaveValue(newEmail);
+});
+
+test('should display user info', async ({ page }) => {
+  const user = generateUser({ firstName: 'Jane', lastName: 'Doe' });
+  // ... use user data in test setup
+});
+```
+
+**JavaScript**
+
+```javascript
+// helpers/test-data.js
+const { randomUUID } = require('node:crypto');
+
+function generateEmail(prefix = 'test') {
+  return `${prefix}-${Date.now()}-${randomUUID().slice(0, 8)}@example.com`;
+}
+
+function generateUser(overrides = {}) {
+  return {
+    email: generateEmail(),
+    password: 'TestPass123!',
+    firstName: 'Test',
+    lastName: 'User',
+    ...overrides,
+  };
+}
+
+function formatCurrency(cents) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function buildApiUrl(path, params = {}) {
+  const url = new URL(path, 'http://localhost:3000');
+  Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+  return url.toString();
+}
+
+module.exports = { generateEmail, generateUser, formatCurrency, buildApiUrl };
+```
+
+```javascript
+// helpers/assertions.js
+const { expect } = require('@playwright/test');
+
+async function waitForNetworkIdle(page, timeout = 5000) {
+  await page.waitForLoadState('networkidle', { timeout });
+}
+
+async function expectToast(page, message) {
+  const toast = page.getByRole('status').filter({ hasText: message });
+  await expect(toast).toBeVisible();
+  await expect(toast).toBeHidden({ timeout: 10000 });
+}
+
+module.exports = { waitForNetworkIdle, expectToast };
+```
+
+```javascript
+// tests/settings/profile.spec.js
+const { test, expect } = require('@playwright/test');
+const { generateEmail, generateUser } = require('../../helpers/test-data');
+const { expectToast } = require('../../helpers/assertions');
+
+test('should update user email', async ({ page }) => {
+  const newEmail = generateEmail('updated');
+
+  await page.goto('/settings/profile');
+  await page.getByLabel('Email').fill(newEmail);
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expectToast(page, 'Profile updated');
+  await expect(page.getByLabel('Email')).toHaveValue(newEmail);
+});
+```
+
+**Key principles for helper functions:**
+- Pure functions with no side effects -- given the same input, always the same output
+- No browser state -- helpers that need `page` should take it as a parameter, not store it
+- If a helper grows to need setup/teardown, promote it to a fixture
+- If a helper grows to encapsulate many page interactions, promote it to a page object
+- Keep helpers small and focused -- one function, one job
+
+## Combining Approaches
+
+The recommended hybrid approach for real projects. This is what a well-organized Playwright project looks like.
+
+**Project structure:**
+
+```
+tests/
++-- fixtures/
+|   +-- auth.fixture.ts       # Custom fixtures: authenticatedPage, testUser, adminUser
+|   +-- db.fixture.ts          # Custom fixtures: database, seedData
+|   +-- base.fixture.ts        # Combines all fixtures, re-exports test and expect
++-- page-objects/
+|   +-- login.page.ts          # Page object: LoginPage
+|   +-- dashboard.page.ts      # Page object: DashboardPage
+|   +-- checkout.page.ts       # Page object: CheckoutPage
+|   +-- components/
+|       +-- data-table.component.ts  # Reusable component object
+|       +-- modal.component.ts
++-- helpers/
+|   +-- test-data.ts            # Helper: generateEmail, generateUser, generateOrder
+|   +-- assertions.ts           # Helper: expectToast, expectTableRowCount
+|   +-- api.ts                  # Helper: createProductViaApi, deleteAllTestData
++-- e2e/
+|   +-- auth/
+|   |   +-- login.spec.ts
+|   |   +-- signup.spec.ts
+|   +-- checkout/
+|   |   +-- cart.spec.ts
+|   |   +-- payment.spec.ts
+|   +-- dashboard/
+|       +-- widgets.spec.ts
+playwright.config.ts
+```
+
+**How the three approaches work together:**
+
+**TypeScript**
+
+```typescript
+// fixtures/base.fixture.ts — the glue layer
+import { test as base } from '@playwright/test';
+import { LoginPage } from '../page-objects/login.page';
+import { DashboardPage } from '../page-objects/dashboard.page';
+import { CheckoutPage } from '../page-objects/checkout.page';
+import { generateUser } from '../helpers/test-data';
+
+type Fixtures = {
+  loginPage: LoginPage;
+  dashboardPage: DashboardPage;
+  checkoutPage: CheckoutPage;
+  testUser: { email: string; password: string; id: string };
+  authenticatedPage: import('@playwright/test').Page;
+};
+
+export const test = base.extend<Fixtures>({
+  // Page objects wrapped in fixtures for convenience
+  loginPage: async ({ page }, use) => {
+    await use(new LoginPage(page));
+  },
+
+  dashboardPage: async ({ page }, use) => {
+    await use(new DashboardPage(page));
+  },
+
+  checkoutPage: async ({ page }, use) => {
+    await use(new CheckoutPage(page));
+  },
+
+  // Resource fixture with lifecycle — uses helpers for data generation
+  testUser: async ({ request }, use) => {
+    const userData = generateUser();
+    const response = await request.post('/api/test/users', { data: userData });
+    const user = await response.json();
+    await use(user);
+    await request.delete(`/api/test/users/${user.id}`);
+  },
+
+  // Composed fixture: depends on page object + resource fixture
+  authenticatedPage: async ({ loginPage, testUser }, use) => {
+    await loginPage.goto();
+    await loginPage.signIn(testUser.email, testUser.password);
+    await use(loginPage.page);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+```typescript
+// tests/e2e/checkout/payment.spec.ts — clean test using all three
+import { test, expect } from '../../../fixtures/base.fixture';
+import { generateEmail } from '../../../helpers/test-data';
+import { expectToast } from '../../../helpers/assertions';
+
+test.describe('Checkout Payment', () => {
+  test('authenticated user completes purchase', async ({ authenticatedPage, checkoutPage }) => {
+    // authenticatedPage: fixture handled login + user creation + cleanup
+    // checkoutPage: page object encapsulates checkout UI interactions
+    await checkoutPage.goto();
+    await checkoutPage.fillPaymentDetails({
+      number: '4242424242424242',
+      expiry: '12/28',
+      cvc: '123',
+    });
+    await checkoutPage.pay();
+    await expectToast(authenticatedPage, 'Payment successful');  // helper for common assertion
+  });
+
+  test('guest user enters email at checkout', async ({ checkoutPage }) => {
+    const email = generateEmail('guest');  // helper for test data
+    await checkoutPage.goto();
+    await checkoutPage.page.getByLabel('Guest email').fill(email);
+    await checkoutPage.fillPaymentDetails({
+      number: '4242424242424242',
+      expiry: '12/28',
+      cvc: '123',
+    });
+    await checkoutPage.pay();
+  });
+});
+```
+
+**JavaScript**
+
+```javascript
+// fixtures/base.fixture.js
+const { test: base } = require('@playwright/test');
+const { LoginPage } = require('../page-objects/login.page');
+const { DashboardPage } = require('../page-objects/dashboard.page');
+const { CheckoutPage } = require('../page-objects/checkout.page');
+const { generateUser } = require('../helpers/test-data');
+
+const test = base.extend({
+  loginPage: async ({ page }, use) => {
+    await use(new LoginPage(page));
+  },
+
+  dashboardPage: async ({ page }, use) => {
+    await use(new DashboardPage(page));
+  },
+
+  checkoutPage: async ({ page }, use) => {
+    await use(new CheckoutPage(page));
+  },
+
+  testUser: async ({ request }, use) => {
+    const userData = generateUser();
+    const response = await request.post('/api/test/users', { data: userData });
+    const user = await response.json();
+    await use(user);
+    await request.delete(`/api/test/users/${user.id}`);
+  },
+
+  authenticatedPage: async ({ loginPage, testUser }, use) => {
+    await loginPage.goto();
+    await loginPage.signIn(testUser.email, testUser.password);
+    await use(loginPage.page);
+  },
+});
+
+module.exports = { test, expect: require('@playwright/test').expect };
+```
+
+```javascript
+// tests/e2e/checkout/payment.spec.js
+const { test, expect } = require('../../../fixtures/base.fixture');
+const { generateEmail } = require('../../../helpers/test-data');
+const { expectToast } = require('../../../helpers/assertions');
+
+test.describe('Checkout Payment', () => {
+  test('authenticated user completes purchase', async ({ authenticatedPage, checkoutPage }) => {
+    await checkoutPage.goto();
+    await checkoutPage.fillPaymentDetails({
+      number: '4242424242424242',
+      expiry: '12/28',
+      cvc: '123',
+    });
+    await checkoutPage.pay();
+    await expectToast(authenticatedPage, 'Payment successful');
+  });
+
+  test('guest user enters email at checkout', async ({ checkoutPage }) => {
+    const email = generateEmail('guest');
+    await checkoutPage.goto();
+    await checkoutPage.page.getByLabel('Guest email').fill(email);
+    await checkoutPage.fillPaymentDetails({
+      number: '4242424242424242',
+      expiry: '12/28',
+      cvc: '123',
+    });
+    await checkoutPage.pay();
+  });
+});
+```
+
+**Summary of the hybrid approach:**
+
+| Layer | Pattern | Responsibility |
+|---|---|---|
+| **Test file** | `test()` | Describes behavior, orchestrates the three layers |
+| **Fixtures** | `test.extend()` | Resource lifecycle -- setup, provide, teardown |
+| **Page objects** | Classes | UI interaction -- navigation, actions, locators |
+| **Helpers** | Functions | Utilities -- data generation, formatting, common assertions |
+
+## Anti-Patterns
+
+### Using only page objects for everything
+
+```typescript
+// BAD: page object managing auth state, database, AND UI
+class LoginPage {
+  async createTestUser() { /* API call to create user */ }
+  async deleteTestUser() { /* API call to delete user */ }
+  async seedDatabase() { /* database setup */ }
+  async signIn(email: string, password: string) { /* UI interaction */ }
+}
+```
+
+**Problem:** Page objects should only encapsulate UI interaction. Resource lifecycle (create user, seed database) belongs in fixtures where teardown is guaranteed.
+
+**Fix:** Move `createTestUser` and `deleteTestUser` into a `testUser` fixture. Keep only `signIn` in the page object.
+
+---
+
+### Page objects that are just locator containers
+
+```typescript
+// BAD: no methods, no encapsulation — just a bag of locators
+class LoginPage {
+  emailInput = this.page.getByLabel('Email');
+  passwordInput = this.page.getByLabel('Password');
+  submitButton = this.page.getByRole('button', { name: 'Sign in' });
+
+  constructor(private page: Page) {}
+}
+
+// Test still does all the work
+test('login', async ({ page }) => {
+  const login = new LoginPage(page);
+  await login.emailInput.fill('user@example.com');
+  await login.passwordInput.fill('pass');
+  await login.submitButton.click();
+});
+```
+
+**Problem:** This adds a layer of indirection with no benefit. The test is not more readable than using locators directly.
+
+**Fix:** Add intent-revealing methods. If the page is simple enough that locators suffice, skip the page object entirely.
+
+```typescript
+// GOOD: methods express user intent
+class LoginPage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async signIn(email: string, password: string) {
+    await this.page.getByLabel('Email').fill(email);
+    await this.page.getByLabel('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Sign in' }).click();
+    await this.page.waitForURL('**/dashboard');
+  }
+}
+```
+
+---
+
+### Fixtures that do too much
+
+```typescript
+// BAD: one giant fixture that sets up everything
+test.extend({
+  everything: async ({ page, request }, use) => {
+    // Creates user, seeds products, sets up payment method, navigates to dashboard,
+    // opens settings modal, enables feature flags, creates admin user...
+    const user = await createUser(request);
+    const products = await seedProducts(request, 50);
+    await setupPayment(request, user.id);
+    await page.goto('/dashboard');
+    await enableFeatureFlags(request, ['new-ui', 'beta-checkout']);
+    const admin = await createAdminUser(request);
+
+    await use({ user, products, admin, page });
+
+    // Massive teardown
+    await deleteUser(request, user.id);
+    await deleteUser(request, admin.id);
+    await deleteProducts(request, products);
+    await disableFeatureFlags(request, ['new-ui', 'beta-checkout']);
+  },
+});
+```
+
+**Problem:** Every test pays the cost of full setup even when it only needs a user. Debugging is hard because the fixture does too many things.
+
+**Fix:** Break into small, composable fixtures. Each fixture does one thing.
+
+```typescript
+// GOOD: small, composable fixtures
+test.extend({
+  testUser: async ({ request }, use) => { /* create + cleanup user */ },
+  adminUser: async ({ request }, use) => { /* create + cleanup admin */ },
+  seededProducts: async ({ request }, use) => { /* seed + cleanup products */ },
+  featureFlags: async ({ request }, use) => { /* enable + disable flags */ },
+});
+```
+
+---
+
+### Helpers with side effects
+
+```typescript
+// BAD: "helper" that modifies database and stores state
+let createdUserId: string;
+
+export async function createTestUser(request: APIRequestContext) {
+  const response = await request.post('/api/users', { data: { email: 'test@example.com' } });
+  const user = await response.json();
+  createdUserId = user.id;  // Module-level state — shared across tests!
+  return user;
+}
+
+export async function cleanupTestUser(request: APIRequestContext) {
+  await request.delete(`/api/users/${createdUserId}`);
+}
+```
+
+**Problem:** Module-level state leaks between parallel tests. Cleanup is not guaranteed if the test crashes. This is a fixture pretending to be a helper.
+
+**Fix:** If it has side effects and needs cleanup, make it a fixture.
+
+---
+
+### Over-abstracting simple operations
+
+```typescript
+// BAD: helper for a one-liner that adds no clarity
+export async function clickButton(page: Page, name: string) {
+  await page.getByRole('button', { name }).click();
+}
+
+// BAD: page object for a page with 2 interactions
+class ConfirmationPage {
+  constructor(private page: Page) {}
+  async expectSuccess() {
+    await expect(this.page.getByText('Success')).toBeVisible();
+  }
+}
+```
+
+**Problem:** Adds indirection without improving readability or reducing duplication. `page.getByRole('button', { name: 'Submit' }).click()` is already clear.
+
+**Fix:** Only abstract when there is real duplication (3+ usages) or real complexity (5+ interactions). Inline simple operations.
+
+## Related
+
+- [core/page-object-model.md](../core/page-object-model.md) -- detailed page object patterns and examples
+- [core/fixtures-and-hooks.md](../core/fixtures-and-hooks.md) -- complete guide to Playwright fixtures and lifecycle hooks
+- [core/test-organization.md](../core/test-organization.md) -- file structure and naming conventions
+- [core/test-architecture.md](../core/test-architecture.md) -- when to write E2E vs API vs component tests


### PR DESCRIPTION
Adds [testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill) to the Development & Code Tools section.

70+ structured Playwright testing skill for AI agents — covers end-to-end tests, page object models, CI/CD setup, Cypress/Selenium migration, and CLI automation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
