### PR TITLE
feat: add playwright-pro to marketplace registry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     "homepage": "https://github.com/alirezarezvani/claude-skills",
     "repository": "https://github.com/alirezarezvani/claude-skills",
     "metadata": {
-        "description": "86 production-ready skill packages across 9 domains: marketing, engineering, engineering-advanced, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
+        "description": "87+ production-ready skill packages across 9 domains: marketing, engineering, engineering-advanced, product, C-level advisory, project management, regulatory compliance, business growth, and finance",
         "version": "2.0.0"
     },
     "plugins": [
@@ -303,6 +303,29 @@
                 "pre-install"
             ],
             "category": "security"
+        },
+        {
+            "name": "playwright-pro",
+            "source": "./engineering-team/playwright-pro",
+            "description": "Production-grade Playwright testing toolkit. 9 skills, 3 agents, 55 templates, TestRail + BrowserStack MCP integrations. Generate tests, fix flaky failures, migrate from Cypress/Selenium.",
+            "version": "1.0.0",
+            "author": {
+                "name": "Alireza Rezvani"
+            },
+            "keywords": [
+                "playwright",
+                "testing",
+                "e2e",
+                "qa",
+                "test-automation",
+                "browserstack",
+                "testrail",
+                "cross-browser",
+                "migration",
+                "cypress",
+                "selenium"
+            ],
+            "category": "development"
         }
     ]
 }


### PR DESCRIPTION
Adds the playwright-pro plugin to the Claude Code marketplace registry.

After merge, users can install with:
```
/plugin marketplace add alirezarezvani/claude-skills
/plugin install playwright-pro@claude-code-skills
```

Total marketplace plugins: 17
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
