### PR TITLE
fix: integrate playwright-pro across all platforms

### DIFF
--- a/.codex/skills-index.json
+++ b/.codex/skills-index.json
@@ -3,7 +3,7 @@
   "name": "claude-code-skills",
   "description": "Production-ready skill packages for AI agents - Marketing, Engineering, Product, C-Level, PM, and RA/QM",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "total_skills": 61,
+  "total_skills": 62,
   "skills": [
     {
       "name": "contract-and-proposal-writer",
@@ -70,6 +70,12 @@
       "source": "../../engineering-team/ms365-tenant-manager",
       "category": "engineering",
       "description": "Microsoft 365 tenant administration for Global Administrators. Automate M365 tenant setup, Office 365 admin tasks, Azure AD user management, Exchange Online configuration, Teams administration, and security policies. Generate PowerShell scripts for bulk operations, Conditional Access policies, license management, and compliance reporting. Use for M365 tenant manager, Office 365 admin, Azure AD users, Global Administrator, tenant configuration, or Microsoft 365 automation."
+    },
+    {
+      "name": "playwright-pro",
+      "source": "../../engineering-team/playwright-pro",
+      "category": "engineering",
+      "description": "Production-grade Playwright testing toolkit. Generate tests, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55 templates, 3 agents, smart reporting."
     },
     {
       "name": "senior-architect",
@@ -384,7 +390,7 @@
       "description": "Executive leadership and advisory skills"
     },
     "engineering": {
-      "count": 21,
+      "count": 22,
       "source": "../../engineering-team",
       "description": "Software engineering and technical skills"
     },

--- a/.codex/skills/playwright-pro
+++ b/.codex/skills/playwright-pro
@@ -1,0 +1,1 @@
+../../engineering-team/playwright-pro

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Claude Skills Library
 
-**86 production-ready skill packages for Claude Code, OpenAI Codex, and OpenClaw** — reusable expertise bundles that transform AI agents into specialized professionals across engineering, product, marketing, compliance, and more.
+**87+ production-ready skill packages for Claude Code, OpenAI Codex, and OpenClaw** — reusable expertise bundles that transform AI agents into specialized professionals across engineering, product, marketing, compliance, and more.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/Skills-86-brightgreen.svg)](#skills-overview)
+[![Skills](https://img.shields.io/badge/Skills-87-brightgreen.svg)](#skills-overview)
 [![Stars](https://img.shields.io/github/stars/alirezarezvani/claude-skills?style=flat)](https://github.com/alirezarezvani/claude-skills/stargazers)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1)](https://getskillcheck.com)
 
@@ -40,6 +40,7 @@ Skills are modular instruction packages that give AI agents domain expertise the
 
 # Or install individual skills
 /plugin install skill-security-auditor@claude-code-skills       # Security scanner
+/plugin install playwright-pro@claude-code-skills                  # Playwright testing toolkit
 /plugin install content-creator@claude-code-skills              # Single skill
 ```
 
@@ -67,11 +68,12 @@ git clone https://github.com/alirezarezvani/claude-skills.git
 
 ## Skills Overview
 
-**86 skills across 9 domains:**
+**87+ skills across 9 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|
 | **🔧 Engineering — Core** | 21 | Architecture, frontend, backend, fullstack, QA, DevOps, SecOps, AI/ML, data | [engineering-team/](engineering-team/) |
+| **🎭 Playwright Pro** | 9+3 | Test generation, flaky fix, Cypress/Selenium migration, TestRail, BrowserStack, 55 templates | [engineering-team/playwright-pro](engineering-team/playwright-pro/) |
 | **⚡ Engineering — POWERFUL** | 25 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder | [engineering/](engineering/) |
 | **🎯 Product** | 8 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder | [product-team/](product-team/) |
 | **📣 Marketing** | 7 | Content creator, demand gen, PMM strategy, ASO, social media, campaign analytics, prompt engineering | [marketing-skill/](marketing-skill/) |

--- a/engineering-team/playwright-pro/SKILL.md
+++ b/engineering-team/playwright-pro/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: playwright-pro
+description: "Production-grade Playwright testing toolkit. Generate tests, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55 templates, 3 agents, smart reporting."
+---
+
+# Playwright Pro
+
+Production-grade Playwright testing toolkit for AI coding agents.
+
+## Available Commands
+
+When installed as a Claude Code plugin, these are available as `/pw:` commands:
+
+| Command | What it does |
+|---|---|
+| `/pw:init` | Set up Playwright — detects framework, generates config, CI, first test |
+| `/pw:generate <spec>` | Generate tests from user story, URL, or component |
+| `/pw:review` | Review tests for anti-patterns and coverage gaps |
+| `/pw:fix <test>` | Diagnose and fix failing or flaky tests |
+| `/pw:migrate` | Migrate from Cypress or Selenium to Playwright |
+| `/pw:coverage` | Analyze what's tested vs. what's missing |
+| `/pw:testrail` | Sync with TestRail — read cases, push results |
+| `/pw:browserstack` | Run on BrowserStack, pull cross-browser reports |
+| `/pw:report` | Generate test report in your preferred format |
+
+## Golden Rules
+
+1. `getByRole()` over CSS/XPath — resilient to markup changes
+2. Never `page.waitForTimeout()` — use web-first assertions
+3. `expect(locator)` auto-retries; `expect(await locator.textContent())` does not
+4. Isolate every test — no shared state between tests
+5. `baseURL` in config — zero hardcoded URLs
+6. Retries: `2` in CI, `0` locally
+7. Traces: `'on-first-retry'` — rich debugging without slowdown
+8. Fixtures over globals — `test.extend()` for shared state
+9. One behavior per test — multiple related assertions are fine
+10. Mock external services only — never mock your own app
+
+## Locator Priority
+
+```
+1. getByRole()        — buttons, links, headings, form elements
+2. getByLabel()       — form fields with labels
+3. getByText()        — non-interactive text
+4. getByPlaceholder() — inputs with placeholder
+5. getByTestId()      — when no semantic option exists
+6. page.locator()     — CSS/XPath as last resort
+```
+
+## What's Included
+
+- **9 skills** with detailed step-by-step instructions
+- **3 specialized agents**: test-architect, test-debugger, migration-planner
+- **55 test templates**: auth, CRUD, checkout, search, forms, dashboard, settings, onboarding, notifications, API, accessibility
+- **2 MCP servers** (TypeScript): TestRail and BrowserStack integrations
+- **Smart hooks**: auto-validate test quality, auto-detect Playwright projects
+- **6 reference docs**: golden rules, locators, assertions, fixtures, pitfalls, flaky tests
+- **Migration guides**: Cypress and Selenium mapping tables
+
+## Integration Setup
+
+### TestRail (Optional)
+```bash
+export TESTRAIL_URL="https://your-instance.testrail.io"
+export TESTRAIL_USER="your@email.com"
+export TESTRAIL_API_KEY="your-api-key"
+```
+
+### BrowserStack (Optional)
+```bash
+export BROWSERSTACK_USERNAME="your-username"
+export BROWSERSTACK_ACCESS_KEY="your-access-key"
+```
+
+## Quick Reference
+
+See `reference/` directory for:
+- `golden-rules.md` — The 10 non-negotiable rules
+- `locators.md` — Complete locator priority with cheat sheet
+- `assertions.md` — Web-first assertions reference
+- `fixtures.md` — Custom fixtures and storageState patterns
+- `common-pitfalls.md` — Top 10 mistakes and fixes
+- `flaky-tests.md` — Diagnosis commands and quick fixes
+
+See `templates/README.md` for the full template index.


### PR DESCRIPTION
Ensures playwright-pro is properly registered across all three platforms.

## What was missing

| Platform | Gap | Fix |
|---|---|---|
| **Claude Code** | ✅ Already in marketplace.json | No change needed |
| **Codex CLI** | ❌ Missing symlink + index entry | Added `.codex/skills/playwright-pro` symlink + updated `skills-index.json` |
| **OpenClaw** | ❌ Missing root `SKILL.md` | Added `engineering-team/playwright-pro/SKILL.md` |
| **ClawHub** | ❌ YAML frontmatter broken | Fixed to single-line description |
| **README** | ❌ Not mentioned anywhere | Added to Skills Overview, install section, updated badge count to 87+ |

## Verification

- `scripts/openclaw-install.sh` → auto-discovers SKILL.md ✅
- `scripts/sync-codex-skills.py` → creates symlink + index entry ✅  
- `scripts/codex-install.sh` → installs via symlink ✅
- `.claude-plugin/marketplace.json` → already has entry ✅
- ClawHub → published as `playwright-pro@1.1.0` ✅
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
