### PR TITLE
Add product-manager-skills to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ python3 engineering/skill-security-auditor/scripts/skill_security_auditor.py /pa
 |---------|-------------|
 | [**Claude Code Skills & Agents Factory**](https://github.com/alirezarezvani/claude-code-skills-agents-factory) | Methodology for building skills at scale |
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
+| [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds **product-manager-skills** by [Digidai](https://github.com/Digidai) to the Related Projects table
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks
- Covers product discovery, strategy, delivery, 32 SaaS metrics with formulas, PM career coaching (IC to CPO), and AI product craft
- Pure Markdown, zero scripts — installs via `clawhub install product-manager-skills`

**Source:** https://github.com/Digidai/product-manager-skills
**ClawHub:** https://clawhub.ai/Digidai/product-manager-skills
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
