### PR TITLE
fix: add GA snippet for Search Console verification

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VHRY2VKY9K"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VHRY2VKY9K');
+</script>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,9 +69,6 @@ extra:
     - icon: fontawesome/brands/medium
       link: https://alirezarezvani.medium.com
       name: Medium
-  analytics:
-    provider: google
-    property: G-VHRY2VKY9K
   generator: false
 
 extra_css:


### PR DESCRIPTION
Adds raw gtag.js snippet to page head via theme override so Google Search Console can verify site ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
