### PR TITLE
ci: enforce dev as PR target, add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What does this PR add or change? -->
+
+## Checklist
+
+- [ ] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
+- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
+- [ ] Scripts (if any) run with `--help` without errors
+- [ ] No hardcoded API keys, tokens, or secrets
+- [ ] No vendor-locked dependencies without open-source fallback
+- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)
+
+## Type of Change
+
+- [ ] New skill
+- [ ] Improvement to existing skill
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Infrastructure / CI
+
+## Testing
+
+<!-- How did you verify this works? -->

--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -1,0 +1,57 @@
+---
+name: Enforce PR Target Branch
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-target:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PRs targeting main from non-maintainers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            // Maintainers who can PR to main directly
+            const maintainers = ['alirezarezvani'];
+
+            if (maintainers.includes(author)) {
+              console.log(`✅ ${author} is a maintainer — PR to main allowed.`);
+              return;
+            }
+
+            const message = `👋 Hi @${author}, thanks for your contribution!
+
+            All community PRs should target the \`dev\` branch, not \`main\`. The \`main\` branch is reserved for releases.
+
+            **How to fix:**
+            1. Close this PR
+            2. Reopen it targeting \`dev\` instead of \`main\`
+
+            Or I can do it for you — just click "Edit" at the top right of this PR and change the base branch to \`dev\`.
+
+            See our [Contributing Guide](https://github.com/alirezarezvani/claude-skills/blob/dev/CONTRIBUTING.md) for details.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: message.split('\n').map(l => l.trim()).join('\n'),
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });
+
+            core.setFailed(`PR #${pr.number} targets main. Closed automatically.`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 Thank you for your interest in contributing to the Claude Skills Library! This repository aims to democratize professional expertise through reusable, production-ready skill packages for Claude AI.
 
+## ⚠️ Important: Always Target `dev`
+
+**All PRs must target the `dev` branch.** PRs targeting `main` will be automatically closed.
+
+```bash
+# Fork the repo, then:
+git checkout -b feat/my-new-skill origin/dev
+# ... make your changes ...
+# Open PR → base: dev (NOT main)
+```
+
+The `main` branch is reserved for releases and is maintained by the project owner.
+
 ## 🎯 Ways to Contribute
 
 ### 1. Create New Skills


### PR DESCRIPTION
Prevents community PRs from targeting main:

- **GitHub Actions workflow** that auto-closes PRs targeting `main` from non-maintainers with a friendly redirect message
- **PR template** with checklist (target branch, SKILL.md, no secrets, etc.)
- **CONTRIBUTING.md** updated with prominent `dev` branch rule

Maintainers (alirezarezvani) can still PR to main for releases.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alirezarezvani/claude-skills/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
