### PR TITLE
fix: resolve self-improving-agent hook script path at runtime

### DIFF
--- a/engineering-team/self-improving-agent/hooks/hooks.json
+++ b/engineering-team/self-improving-agent/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/error-capture.sh"
+            "command": "bash -c 'f=$(find \"${HOME}/.claude/plugins\" -path \"*/self-improving-agent/*/hooks/error-capture.sh\" 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\"'"
           }
         ]
       }


### PR DESCRIPTION
## Problem

The \`PostToolUse:Bash\` hook in \`hooks/hooks.json\` uses a relative path:

\`\`\`json
"command": "./hooks/error-capture.sh"
\`\`\`

Claude Code executes hooks from the **project's working directory**, not the plugin directory. So \`./hooks/error-capture.sh\` is never found, producing a \`PostToolUse:Bash hook error\` on every Bash tool call for any user with this plugin installed.

## Fix

Replace the relative path with a runtime \`find\` command that locates the script under \`~/.claude/plugins\` regardless of where the user's project lives or what version is installed:

\`\`\`json
"command": "bash -c 'f=$(find \"${HOME}/.claude/plugins\" -path \"*/self-improving-agent/*/hooks/error-capture.sh\" 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\"'"
\`\`\`

This is portable across:
- All users (uses \`${HOME}\` not a hardcoded path)
- All plugin versions (picks latest with \`sort -V | tail -1\`)
- Projects in any directory

## Testing

Pipe-tested from an arbitrary working directory — exits 0 with no output on a clean Bash run, and outputs the \`<error-detected>\` block when error patterns are present.