### PR TITLE
fix: resolve self-improving-agent hook script path at runtime

### DIFF
--- a/engineering-team/self-improving-agent/hooks/hooks.json
+++ b/engineering-team/self-improving-agent/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/error-capture.sh"
+            "command": "bash -c 'f=$(find \"${HOME}/.claude/plugins\" -path \"*/self-improving-agent/*/hooks/error-capture.sh\" 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\"'"
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `hooks.json` for `self-improving-agent` uses a relative path to invoke `error-capture.sh`:

```json
"command": "./hooks/error-capture.sh"
```

Claude Code executes hook commands from the **project working directory**, not the plugin directory. This causes the hook to silently fail (or error) for all users because the relative path resolves against whatever project the user has open.

## Fix

Replace the relative path with a portable runtime path resolution using `find`:

```json
"command": "bash -c 'f=$(find \"${HOME}/.claude/plugins\" -path \"*/self-improving-agent/*/hooks/error-capture.sh\" 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\"'"
```

This approach:
- Uses `${HOME}` (works for any user, not hardcoded)
- Searches the standard plugin cache location (`~/.claude/plugins`)
- Uses `sort -V | tail -1` to pick the latest installed version
- Silently exits (no error) if the plugin isn't installed

## Testing

Verified the `find` command resolves the correct path on a system with the plugin installed at `~/.claude/plugins/cache/claude-code-skills/self-improving-agent/1.0.0/`.