### PR TITLE
fix(marketplace): restore agenthub entry + branch cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -419,6 +419,28 @@
         "express"
       ],
       "category": "product"
+    },
+    {
+      "name": "agenthub",
+      "source": "./engineering/agenthub",
+      "description": "Multi-agent collaboration — spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any task that benefits from diverse solutions. 7 slash commands (/hub:init, /hub:spawn, /hub:status, /hub:eval, /hub:merge, /hub:board, /hub:run), agent templates, DAG-based orchestration, LLM judge mode, message board coordination.",
+      "version": "2.1.2",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "multi-agent",
+        "collaboration",
+        "parallel",
+        "git-dag",
+        "orchestration",
+        "competition",
+        "worktree",
+        "content-generation",
+        "research",
+        "optimization"
+      ],
+      "category": "development"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Restores the agenthub marketplace entry that was lost during PR #369 merge conflict resolution
- Total plugins: 21 → 22

This is the only remaining commit after PR #371 merged dev → main.

## Verification
- [x] All 22 plugin source paths valid
- [x] agenthub entry has correct version (2.1.2), source, keywords
- [x] marketplace.json valid JSON
- [x] All deliverables from this session confirmed on dev: AgentHub, code-to-prd, /plugin-audit, /code-to-prd, SEO fixes, broken link fixes, security auditor fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)