### PR TITLE
Add Prism Scanner — security scanner for agent skills/plugins/MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See [orchestration/ORCHESTRATION.md](orchestration/ORCHESTRATION.md) for the ful
 | **database-schema-designer** | Requirements → migrations, types, seed data, RLS policies |
 | **migration-architect** | Migration planner, compatibility checker, rollback generator |
 | **skill-security-auditor** | 🔒 Security gate — scan skills for malicious code before installation |
+| **[prism-scanner](https://github.com/aidongise-cell/prism-scanner)** | 🔒 Agent security scanner — 39+ detection rules, AST taint tracking, A-F grading for skills/plugins/MCP servers |
 | **ci-cd-pipeline-builder** | Analyze stack → generate GitHub Actions / GitLab CI configs |
 | **mcp-server-builder** | Build MCP servers from OpenAPI specs |
 | **pr-review-expert** | Blast radius analysis, security scan, coverage delta |


### PR DESCRIPTION
## Summary

Adds [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) to the Engineering skills table alongside skill-security-auditor.

**Prism Scanner** is an open-source (Apache 2.0) security scanner for AI Agent skills, plugins, and MCP servers:

- **39+ detection rules**: AST taint tracking, malicious signatures, metadata analysis, system residue
- **A-F grading** with actionable recommendations
- **Full lifecycle**: pre-install + post-uninstall cleanup
- **Multi-platform**: ClawHub, MCP, npm, pip

Install: `pip install prism-scanner` or `npx skills add aidongise-cell/prism-scanner`