### PR TITLE
Add Community Skills section with qr-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,18 @@ Each skill is a folder with a `SKILL.md` (frontmatter + instructions), optional 
 
 ---
 
+## Community Skills
+
+External skills built by the community:
+
+| Skill | Description | Platform | Install |
+|-------|-------------|----------|---------|
+| [**qr-bridge**](https://github.com/Vicky-v7/qr-bridge) | Decode QR codes, trace redirect chains, detect WeChat/WeCom/Taobao/Douyin/Xiaohongshu gates, and explain why links fail. macOS native (CoreImage), zero dependencies, ~10ms. | macOS | `claude install-skill https://github.com/Vicky-v7/qr-bridge` |
+
+> Want to add your skill here? Open a PR targeting `dev` — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary

- Adds a **Community Skills** section to the README for external skills built by the community
- First entry: **qr-bridge** — a macOS native QR code decoder that traces redirect chains and detects WeChat/WeCom/Taobao/Douyin/Xiaohongshu platform gates
- Zero dependencies, ~10ms decoding via CoreImage
- Repo: https://github.com/Vicky-v7/qr-bridge

## Why a "Community Skills" section?

The current README covers skills that live in this repo. A Community Skills section provides a lightweight way to surface quality external skills without requiring them to be merged into the monorepo, encouraging ecosystem growth.

## Test plan

- [ ] Verify README table renders correctly
- [ ] Verify link to qr-bridge repo works
- [ ] Verify install command works: `claude install-skill https://github.com/Vicky-v7/qr-bridge`