### PR TITLE
Add OpenDivination to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 |---------|-------------|
 | [**Claude Code Skills & Agents Factory**](https://github.com/alirezarezvani/claude-code-skills-agents-factory) | Methodology for building skills at scale |
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
+| [**OpenDivination**](https://github.com/amenti-labs/opendivination) | Tarot and I Ching skill plus Python SDK with auditable entropy provenance, guided QRNG setup, and optional resonance mode |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
 
 ---


### PR DESCRIPTION
## Summary
- add OpenDivination to the Related Projects table

## Why
OpenDivination is a complementary public skill and SDK rather than a competing bundle of coding skills. It seems like a reasonable fit for the related-projects section because it is installable, agent-oriented, and has a clear niche around tarot and I Ching with auditable entropy provenance.