### PR TITLE
fix: use CLAUDE_PLUGIN_ROOT for error-capture hook path resolution

### DIFF
--- a/engineering-team/self-improving-agent/hooks/hooks.json
+++ b/engineering-team/self-improving-agent/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/error-capture.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/error-capture.sh"
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `hooks.json` in `self-improving-agent` uses a relative path `./hooks/error-capture.sh` for the PostToolUse hook command. Claude Code resolves this relative to the **project working directory**, not the plugin root directory. Since the plugin lives in `~/.claude/plugins/cache/`, the script is never found.

This causes a silent failure on **every Bash tool call**:
```
Hook PostToolUse:Bash error: /bin/sh: 1: ./hooks/error-capture.sh: not found
```

## Fix

Replace the relative path with `${CLAUDE_PLUGIN_ROOT}`:

```diff
- "command": "./hooks/error-capture.sh"
+ "command": "${CLAUDE_PLUGIN_ROOT}/hooks/error-capture.sh"
```

`${CLAUDE_PLUGIN_ROOT}` is a Claude Code environment variable that resolves to the installed plugin's root directory, ensuring the hook is found regardless of the project working directory.

## Testing

- [x] Verified the path pattern matches other working plugins that use `${CLAUDE_PLUGIN_ROOT}`
- [x] Confirmed `error-capture.sh` exists at `hooks/error-capture.sh` relative to plugin root

Fixes #392