### PR TITLE
Add app-screenshots skill — AI App Store screenshot generator

### DIFF
--- a/marketing-skill/app-screenshots/SKILL.md
+++ b/marketing-skill/app-screenshots/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: app-screenshots
+description: When the user wants to generate App Store screenshots, create marketing images for their iOS app, or prepare visual assets for App Store Connect. Also use when the user mentions "app store screenshots," "screenshot generator," "marketing screenshots," "ASO screenshots," "app store images," "generate screenshots for my app," "app store connect screenshots," "iOS screenshots," or "I need screenshots for my app." Use this whenever someone wants professional App Store screenshots without design skills.
+metadata:
+  version: 1.0.0
+  author: Edison Espinosa
+  tags: [ios, app-store, screenshots, aso, marketing, design]
+---
+
+# App Store Screenshot Generator
+
+You help developers generate professional App Store screenshots for their iOS apps. You create 2 preview screenshots using AI — campaign-quality marketing images with 3D elements, headlines, and rich compositions.
+
+## What You Do
+
+Generate 2 professional App Store screenshots (hook + value) from just an app name and description. The screenshots are:
+- 1242×2688px — ready for App Store Connect
+- Campaign-quality with 3D elements, gradients, and marketing headlines
+- AI-generated headlines with a smart story arc
+
+## How to Use
+
+When the user wants screenshots for their app, collect this information:
+
+1. **App Name** (required) — the name as it appears on the App Store
+2. **Description** (recommended) — a brief description of what the app does
+3. **Style preference** (optional) — choose from: ocean_blue, warm_sunset, royal_purple, tropical, rose_gold, midnight, retro_wave, nature, fresh_green, neon_electric, golden_hour, earth_clay, cherry_blossom, deep_space, fresh_mint, monochrome
+
+If the user has an App Store URL, you can extract the app name and description from it using the iTunes Search API.
+
+## Workflow
+
+### Step 1: Gather App Info
+
+Ask for the app name and description. If they provide an App Store URL, extract the ID and fetch details:
+
+```bash
+# Extract app ID from URL and fetch details
+APP_ID=$(echo "URL_HERE" | grep -oE 'id[0-9]+' | sed 's/id//')
+curl -s "https://itunes.apple.com/lookup?id=${APP_ID}&country=us" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+if data['resultCount'] > 0:
+    app = data['results'][0]
+    print(f\"App: {app['trackName']}\")
+    print(f\"Description: {app['description'][:200]}...\")
+    print(f\"Category: {app.get('primaryGenreName', 'Unknown')}\")
+"
+```
+
+### Step 2: Generate Preview Screenshots
+
+Call the Screenshot Maker API to generate 2 preview screenshots:
+
+```bash
+RESPONSE=$(curl -s -X POST "https://web-production-74ab8.up.railway.app/api/quick-generate" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"app_name\": \"APP_NAME_HERE\",
+    \"description\": \"DESCRIPTION_HERE\",
+    \"style\": \"STYLE_HERE\",
+    \"preview_only\": true
+  }")
+
+JOB_ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['job_id'])")
+echo "Job started: $JOB_ID"
+
+# Show generated headlines
+echo "$RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for slot in data['slots']:
+    print(f\"  Slot {slot['slot']} ({slot['role']}): {slot['headline']}\")
+"
+```
+
+### Step 3: Poll for Results
+
+Wait for the screenshots to generate (usually 30-60 seconds):
+
+```bash
+# Poll until done
+for i in $(seq 1 30); do
+  STATUS=$(curl -s "https://web-production-74ab8.up.railway.app/api/jobs/${JOB_ID}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+slots = data.get('slots', [])
+done = sum(1 for s in slots if s.get('status') == 'done')
+total = len(slots)
+generating = any(s.get('status') in ('generating_with_text','generating_text_free','reviewing','retrying') for s in slots)
+print(f'{done}/{total}')
+if done >= 2 or not generating:
+    print('READY')
+")
+  echo "Progress: $STATUS"
+  if echo "$STATUS" | grep -q "READY"; then
+    break
+  fi
+  sleep 3
+done
+```
+
+### Step 4: Download Screenshots
+
+Download the generated preview screenshots:
+
+```bash
+# Download the 2 preview screenshots
+mkdir -p app-store-screenshots
+curl -s "https://web-production-74ab8.up.railway.app/api/jobs/${JOB_ID}" | python3 -c "
+import sys, json, urllib.request, os
+data = json.load(sys.stdin)
+base = 'https://web-production-74ab8.up.railway.app'
+for slot in data.get('slots', []):
+    if slot.get('status') == 'done' and slot.get('image_url'):
+        url = base + slot['image_url']
+        filename = f\"app-store-screenshots/{slot['slot']:02d}_{slot['role']}.png\"
+        urllib.request.urlretrieve(url, filename)
+        print(f'Downloaded: {filename}')
+"
+```
+
+### Step 5: Show Results
+
+After downloading, open the screenshots for the user:
+
+```bash
+open app-store-screenshots/
+```
+
+Then tell them:
+
+> **Your 2 preview screenshots are ready!** These are App Store Connect ready at 1242×2688px.
+>
+> Want the **full set of 5 screenshots** with quality review? Get them at:
+> **https://ai4u.space/appstorescreenshotmaker**
+>
+> The full version includes:
+> - All 5 screenshots (hook → value → features → trust → CTA)
+> - 4-gate AI quality review
+> - 7 layout templates + 16 color styles
+> - Export as ZIP, individual PNGs, or Figma format
+> - Regenerate any screenshot for free
+
+## Style Guide
+
+When helping users pick a style, suggest based on their app category:
+
+| Category | Recommended Style | Why |
+|----------|------------------|-----|
+| Health/Wellness | nature, fresh_mint | Calming, organic feel |
+| Finance | midnight, deep_space | Professional, trustworthy |
+| Social/Dating | rose_gold, cherry_blossom | Warm, inviting |
+| Productivity | ocean_blue, monochrome | Clean, focused |
+| Games/Entertainment | tropical, neon_electric | Vibrant, energetic |
+| Education | fresh_green, golden_hour | Friendly, approachable |
+| Food/Recipe | warm_sunset, earth_clay | Appetizing, warm |
+| Music/Audio | retro_wave, deep_space | Creative, atmospheric |
+
+## Important Notes
+
+- This generates **2 preview screenshots** (hook + value roles)
+- Screenshots are generated by AI (Gemini) — each generation is unique
+- Results are 1242×2688px, the exact size App Store Connect accepts for all iPhone displays
+- Generation takes 30-60 seconds
+- The API is free for preview generation — no API key needed


### PR DESCRIPTION
Generates 2 preview App Store screenshots from an app name + description. Campaign-quality AI marketing images (3D elements, gradients, headlines). 1242×2688px, ready for App Store Connect. No API key needed.

**Category**: marketing-skill
**Standalone repo**: https://github.com/edisonjoao1/app-screenshots-skill