### PR TITLE
Add HubSpot Admin Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 | [**Claude Code Skills & Agents Factory**](https://github.com/alirezarezvani/claude-code-skills-agents-factory) | Methodology for building skills at scale |
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
+| [**HubSpot Admin Skills**](https://github.com/TomGranot/hubspot-admin-skills) | 32 Claude Code skills for auditing, cleaning, enriching, and automating HubSpot CRM — full audit → plan → execute → maintain workflow with Python scripts |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [HubSpot Admin Skills](https://github.com/TomGranot/hubspot-admin-skills) to the Related Projects table in README
- 32 Claude Code skills for auditing, cleaning, enriching, and automating HubSpot CRM
- Full audit, plan, execute, and maintain workflow with Python scripts and workflow builder guidance

## Why

HubSpot Admin Skills is a domain-specific skill collection for CRM administration — a category not currently covered in this repository. It follows the same skill-based paradigm (SKILL.md + Python scripts) and complements the existing marketing and business-growth skill domains.

## Checklist
- [x] Targets dev branch
- [x] Minimal change — single line addition to Related Projects table
- [x] No modifications to skill directories, scripts, or generated files