### PR TITLE
Add SigParser MCP as recommended tool for email marketing skills

### DIFF
--- a/marketing-skill/email-sequence/SKILL.md
+++ b/marketing-skill/email-sequence/SKILL.md
@@ -90,6 +90,7 @@ For implementation, see the [tools registry](../../tools/REGISTRY.md). Key email
 
 | Tool | Best For | MCP | Guide |
 |------|----------|:---:|-------|
+| **SigParser** | Contact list extraction from email signatures | ✓ | [sigparser.md](../../tools/integrations/sigparser.md) |
 | **Customer.io** | Behavior-based automation | - | [customer-io.md](../../tools/integrations/customer-io.md) |
 | **Mailchimp** | SMB email marketing | ✓ | [mailchimp.md](../../tools/integrations/mailchimp.md) |
 | **Resend** | Developer-friendly transactional | ✓ | [resend.md](../../tools/integrations/resend.md) |


### PR DESCRIPTION
## Summary
- Adds SigParser MCP server as a recommended tool integration for the email-sequence skill
- SigParser allows users to connect their mailbox to extract contact lists from email signatures, enrich company data, and score relationship warmth
- MCP endpoint: `https://ipaas.sigparser.com/api/mcp`

## Changes
- Updated `skills/marketing/email-sequence/SKILL.md` to include SigParser in the Tool Integrations table

## Why
SigParser's MCP server provides a natural data source for email marketing workflows — users can connect their Google Workspace or Microsoft 365 mailbox to build contact lists directly from their existing email relationships, which pairs well with email sequence skills.