### PR TITLE
fix(ci): handle fork PRs in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-quality-gate.yml
+++ b/.github/workflows/ci-quality-gate.yml
@@ -31,6 +31,9 @@ jobs:
             echo "target_ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "repository_dispatch" && -n "${{ github.event.client_payload.ref }}" ]]; then
             echo "target_ref=${{ github.event.client_payload.ref }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Use commit SHA for PRs — branch names from forks don't exist in the base repo
+            echo "target_ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           else
             echo "target_ref=${{ github.head_ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -114,6 +114,7 @@ jobs:
 
       - name: Post fallback review note (quota/timeout)
         if: steps.claude-review.outcome != 'success'
+        continue-on-error: true  # Fork PRs have read-only GITHUB_TOKEN
         uses: actions/github-script@v7
         with:
           script: |
@@ -129,3 +130,13 @@ jobs:
               - Proceed with manual review to unblock
               `
             })
+
+      - name: Write review status to job summary
+        if: steps.claude-review.outcome != 'success'
+        run: |
+          echo "## ⚠️ Automated Review Skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The Claude review could not complete." >> "$GITHUB_STEP_SUMMARY"
+          echo "For fork PRs this is expected — OIDC tokens are unavailable." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Retry from the Actions tab, or proceed with manual review." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/skill-security-audit.yml
+++ b/.github/workflows/skill-security-audit.yml
@@ -191,8 +191,17 @@ jobs:
           echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           echo "exit_code=$OVERALL_EXIT" >> "$GITHUB_OUTPUT"
 
+      - name: Post audit results to job summary
+        if: always()
+        run: |
+          REPORT_FILE="${{ steps.audit.outputs.report_file }}"
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Post audit results as PR comment
         if: always()
+        continue-on-error: true  # Fork PRs have read-only GITHUB_TOKEN
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Fork-based PRs (like PR #498) caused all CI checks to fail due to:
- ci-quality-gate: checkout failed because fork branch names don't exist
  in the base repo. Now uses commit SHA for PR events.
- skill-security-audit: comment posting failed with read-only GITHUB_TOKEN.
  Now continues on error and writes results to job summary as fallback.
- claude-code-review: fallback comment step failed silently. Now continues
  on error and writes status to job summary.

https://claude.ai/code/session_01X1RKFAkEwxgg6gQvJG1KCa