### PR TITLE
fix(ci): break long compileall line to pass yamllint

### DIFF
--- a/.github/workflows/ci-quality-gate.yml
+++ b/.github/workflows/ci-quality-gate.yml
@@ -77,7 +77,10 @@ jobs:
 
       - name: Python syntax check (blocking)
         run: |
-          python -m compileall marketing-skill product-team c-level-advisor engineering-team ra-qm-team engineering business-growth finance project-management scripts
+          python -m compileall \
+            marketing-skill product-team c-level-advisor \
+            engineering-team ra-qm-team engineering \
+            business-growth finance project-management scripts
 
       - name: Run test suite
         run: |


### PR DESCRIPTION
## Summary\n\n- Splits the `python -m compileall` command in `ci-quality-gate.yml` across multiple lines to stay under the 160-character yamllint limit (was 166 chars)\n- This was a pre-existing issue surfaced after the fork PR checkout fix in #499\n\n## Test plan\n\n- [ ] Verify yamllint passes on all workflow files\n- [ ] Verify `python -m compileall` still compiles the same directories\n\nhttps://claude.ai/code/session_01X1RKFAkEwxgg6gQvJG1KCa