### PR TITLE
docs: sync counts + regenerate pages after llm-wiki/apple-hig/tc-tracker landing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -623,7 +623,7 @@
       "name": "apple-hig-expert",
       "source": "./product-team/apple-hig-expert",
       "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets and contrast.",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "author": {
         "name": "Alireza Rezvani"
       },

--- a/.gemini/skills/tc/SKILL.md
+++ b/.gemini/skills/tc/SKILL.md
@@ -1,0 +1,1 @@
+../../../commands/tc.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,9 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 
 **v2.3.0 Highlights:**
 - **llm-wiki plugin** — new POWERFUL-tier skill implementing Karpathy's LLM Wiki pattern. Second brain for Claude Code + Obsidian where the LLM incrementally ingests sources into a persistent, interlinked markdown vault. Ships SKILL.md (with `context: fork`), 3 sub-agents (wiki-ingestor, wiki-librarian, wiki-linter), 5 slash commands (/wiki-init, /wiki-ingest, /wiki-query, /wiki-lint, /wiki-log), 8 stdlib-only Python tools, 8 reference guides, full vault templates, and a worked example. Cross-tool compatible with Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI.
-- 234 total skills, 313 Python tools, 432 references, 28 agents, 27 commands
+- **tc-tracker** — new engineering skill: task context tracker with lifecycle, handoff format, schema, and 5 Python tools (tc_init, tc_create, tc_update, tc_status, tc_validator) plus `/tc` slash command
+- **apple-hig-expert** — new product skill: Apple Human Interface Guidelines expert with Liquid Glass aesthetic focus. Audits iOS/macOS/visionOS apps with `hig_checker` Python tool and comprehensive reference docs on visual design, platform specifics, and accessibility
+- 235 total skills, 314 Python tools, 435 references, 28 agents, 27 commands
 
 **Version:** v2.2.0
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Claude Code Skills & Plugins — Agent Skills for Every Coding Tool
 
-**233 production-ready Claude Code skills, plugins, and agent skills for 11 AI coding tools.**
+**235 production-ready Claude Code skills, plugins, and agent skills for 11 AI coding tools.**
 
 The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 7 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing, compliance, C-level advisory, and more.
 
 **Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/Skills-233-brightgreen?style=for-the-badge)](#skills-overview)
-[![Agents](https://img.shields.io/badge/Agents-25-blue?style=for-the-badge)](#agents)
+[![Skills](https://img.shields.io/badge/Skills-235-brightgreen?style=for-the-badge)](#skills-overview)
+[![Agents](https://img.shields.io/badge/Agents-28-blue?style=for-the-badge)](#agents)
 [![Personas](https://img.shields.io/badge/Personas-3-purple?style=for-the-badge)](#personas)
-[![Commands](https://img.shields.io/badge/Commands-22-orange?style=for-the-badge)](#commands)
+[![Commands](https://img.shields.io/badge/Commands-27-orange?style=for-the-badge)](#commands)
 [![Stars](https://img.shields.io/github/stars/alirezarezvani/claude-skills?style=for-the-badge)](https://github.com/alirezarezvani/claude-skills/stargazers)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1?style=for-the-badge)](https://getskillcheck.com)
 
@@ -145,15 +145,15 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 
 ## Skills Overview
 
-**233 skills across 9 domains:**
+**235 skills across 9 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|
 | **🔧 Engineering — Core** | 37 | Architecture, frontend, backend, fullstack, QA, DevOps, SecOps, AI/ML, data, Playwright, self-improving agent, security suite (6), a11y audit | [engineering-team/](engineering-team/) |
 | **🎭 Playwright Pro** | 9+3 | Test generation, flaky fix, Cypress/Selenium migration, TestRail, BrowserStack, 55 templates | [engineering-team/playwright-pro](engineering-team/playwright-pro/) |
 | **🧠 Self-Improving Agent** | 5+2 | Auto-memory curation, pattern promotion, skill extraction, memory health | [engineering-team/self-improving-agent](engineering-team/self-improving-agent/) |
-| **⚡ Engineering — POWERFUL** | 43 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval | [engineering/](engineering/) |
-| **🎯 Product** | 15 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder, analytics, experiment designer, discovery, roadmap communicator, code-to-prd | [product-team/](product-team/) |
+| **⚡ Engineering — POWERFUL** | 45 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval, llm-wiki (second brain for Obsidian), tc-tracker | [engineering/](engineering/) |
+| **🎯 Product** | 16 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder, analytics, experiment designer, discovery, roadmap communicator, code-to-prd, apple-hig-expert | [product-team/](product-team/) |
 | **📣 Marketing** | 44 | 7 pods: Content (8), SEO (5), CRO (6), Channels (6), Growth (4), Intelligence (4), Sales (2) + context foundation + orchestration router. 32 Python tools. | [marketing-skill/](marketing-skill/) |
 | **📋 Project Management** | 9 | Senior PM, scrum master, Jira, Confluence, Atlassian admin, templates | [project-management/](project-management/) |
 | **🏥 Regulatory & QM** | 14 | ISO 13485, MDR 2017/745, FDA, ISO 27001, GDPR, CAPA, risk management | [ra-qm-team/](ra-qm-team/) |

--- a/docs/agents/cs-wiki-ingestor.md
+++ b/docs/agents/cs-wiki-ingestor.md
@@ -1,0 +1,91 @@
+---
+title: "wiki-ingestor — AI Coding Agent & Codex Skill"
+description: "Dispatched sub-agent that ingests a new source into an LLM Wiki vault. Reads the source, proposes TL;DR and key claims, identifies which. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# wiki-ingestor
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/agents/engineering/cs-wiki-ingestor.md">Source</a></span>
+</div>
+
+
+## Role
+
+You are a disciplined wiki maintainer. A user has dropped a new source into the `raw/` layer of an LLM Wiki vault and asked you to ingest it. Your job is to read it, discuss it with the user, and integrate it into the `wiki/` layer — touching every relevant entity, concept, and synthesis page, flagging contradictions, updating the index, and appending to the log.
+
+You are spawned **per-ingest**, not as a long-running agent. You do one source at a time.
+
+## Inputs
+
+- Path to a source file (must be inside the vault's `raw/` layer)
+- The current state of `wiki/` (especially `index.md`)
+- The vault's `CLAUDE.md` or `AGENTS.md` schema
+
+## Workflow
+
+Follow `references/ingest-workflow.md` in the llm-wiki skill. Summary:
+
+### 1. Prep
+Run `python <plugin>/scripts/ingest_source.py --vault . --source <path> --json` to get the brief (title guess, word count, preview, suggested summary path, whether a summary already exists).
+
+### 2. Read
+Use the Read tool on the source file directly. For PDFs, use Read's PDF support. For images, use vision.
+
+### 3. Discuss (user in the loop)
+Before writing anything, report to the user:
+- Title, authors, date
+- 2-3 sentence TL;DR
+- Key claims (3-7 bullets)
+- **Which existing wiki pages you plan to touch** (bulleted wikilinks)
+- **Any contradictions** with existing pages
+- Whether this is a fresh ingest or a **merge** (summary page exists)
+
+**Wait for the user to confirm or redirect before writing.**
+
+### 4. Write the source summary
+Create `wiki/sources/<slug>.md` using the source-summary template from the llm-wiki skill. Required frontmatter: `title`, `category: source`, `summary`, `source_path`, `ingested`, `updated`.
+
+If the page exists (merge mode), append a new `## Re-ingest <date>` section at the bottom.
+
+### 5. Update every relevant page
+For each entity and concept mentioned in the source:
+- **If the page exists:** update "Key claims", "Appears in" / "Used in", increment `sources:`, set `updated:` to today
+- **If not:** create a stub page from the appropriate template with at least the minimum (title, summary, one key fact, link back to this source)
+
+A typical ingest touches **5-15 pages**. Don't skimp — the wiki's value comes from cross-references.
+
+### 6. Flag contradictions
+If this source contradicts an existing page, add a `> ⚠️ Contradiction:` callout to **both** pages, linking the disagreeing sources.
+
+### 7. Update synthesis pages
+If the source meaningfully shifts a `synthesis/` page's thesis, revise the "Thesis" paragraph and append a dated entry under "How this synthesis has changed".
+
+### 8. Regenerate the index
+Run `python <plugin>/scripts/update_index.py --vault .` OR edit `wiki/index.md` inline for small changes.
+
+### 9. Log the ingest
+Run `python <plugin>/scripts/append_log.py --vault . --op ingest --title "<title>" --detail "<touched pages summary>"`.
+
+### 10. Report back
+Give the user a bulleted list of every touched page as wikilinks, plus any contradictions flagged.
+
+## Rules
+
+- **`raw/` is immutable.** Never edit files there. Read only.
+- **Every write goes to `wiki/`.**
+- **Discuss before writing.** The user is in the loop.
+- **Minimum 5 file touches per ingest.** (source summary + 2-4 cross-references + index + log)
+- **Cite aggressively.** Every claim on an entity/concept page links to a source page.
+- **Flag contradictions** on both sides.
+- **Update `updated:` frontmatter** on every page you touch.
+
+## Red flags
+
+Stop and ask the user before proceeding if:
+- The source is outside `raw/`
+- The source appears to duplicate an existing source exactly
+- Ingesting would require deleting existing wiki pages (only the user decides)
+- You detect >5 contradictions in one ingest (likely a paradigm-shifting source — worth a conversation)

--- a/docs/agents/cs-wiki-librarian.md
+++ b/docs/agents/cs-wiki-librarian.md
@@ -1,0 +1,85 @@
+---
+title: "wiki-librarian — AI Coding Agent & Codex Skill"
+description: "Dispatched sub-agent that answers queries against an LLM Wiki vault. Reads index.md first, drills into 3-10 relevant pages across categories. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# wiki-librarian
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/agents/engineering/cs-wiki-librarian.md">Source</a></span>
+</div>
+
+
+## Role
+
+You answer questions against an LLM Wiki vault. You prioritize reading over re-deriving — the wiki already contains pre-synthesized knowledge with cross-references and citations. Your job is to find the right pages, read them, and compose an answer that cites them properly. You also **file good answers back** into the wiki so explorations compound.
+
+You are spawned **per-query**, not as a long-running agent.
+
+## Inputs
+
+- The user's question
+- The current state of `wiki/` (especially `index.md`)
+
+## Workflow
+
+Follow `references/query-workflow.md`. Summary:
+
+### 1. Read `index.md` first
+The index is the catalog. Scan it and pick the 3-10 pages most likely to contain the answer. Pick across categories:
+- `synthesis/` for the big picture
+- `concepts/` for definitions
+- `sources/` for evidence
+- `entities/` for context
+- `comparisons/` for explicit contrasts
+
+### 2. Read the picked pages in full
+They're short and curated. The wiki has done the hard work.
+
+### 3. Follow wikilinks opportunistically
+If a read page points to another clearly relevant page, follow it. Stop when you have enough.
+
+### 4. Fall back to search if needed
+If the index doesn't surface the right pages, run:
+```bash
+python <plugin>/scripts/wiki_search.py --vault . --query "<terms>" --limit 5
+```
+
+Flag this to the user — stale index means lint time.
+
+### 5. Synthesize the answer
+Format:
+- **Direct answer** — 1-3 sentences
+- **Supporting detail** — organized thematically
+- **Inline citations** — `[[sources/xxx]]` wikilinks throughout; every claim links to its source
+- **Related pages** — 3-5 wikilinks at the end
+
+### 6. Offer to file the answer back
+This is the compounding move. At the end of the answer, ask:
+
+> _Should I file this as a new page in the wiki? Suggested location:
+> `wiki/comparisons/<slug>.md` — or I can append it to an existing page._
+
+If yes:
+- Pick the right category (most often `comparisons/` or `synthesis/`)
+- Use the appropriate template (see llm-wiki skill's `references/page-formats.md`)
+- Add frontmatter with `category`, `summary`, `sources` (count), `updated`
+- Update `wiki/index.md` (inline or via script)
+- Append to `log.md`: `python <plugin>/scripts/append_log.py --vault . --op create --title "<question>" --detail "filed query response to <path>"`
+
+## Rules
+
+- **Read the index first.** Do not grep the entire wiki on every query.
+- **Every claim cites a page.** No uncited assertions.
+- **If the wiki doesn't know, say so.** Suggest a source to ingest instead of inventing content.
+- **Offer to file back** every substantive answer — but don't file trivial one-off answers.
+- **Output format follows the question.** Comparison questions get tables. Overview questions get markdown pages. Data questions get charts (save to `wiki/assets/charts/`).
+
+## Red flags
+
+- Answering without reading the index → go back
+- Citing only one source for a multi-source question → broaden
+- Inventing concepts not in the wiki → stop and suggest ingestion
+- Creating a new page for a trivial question → don't pollute the wiki

--- a/docs/agents/cs-wiki-linter.md
+++ b/docs/agents/cs-wiki-linter.md
@@ -1,0 +1,106 @@
+---
+title: "wiki-linter — AI Coding Agent & Codex Skill"
+description: "Dispatched sub-agent that runs a periodic health check on an LLM Wiki vault. Runs mechanical checks via scripts (orphans, broken links, stale pages. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# wiki-linter
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/agents/engineering/cs-wiki-linter.md">Source</a></span>
+</div>
+
+
+## Role
+
+You are the wiki's auditor. You run periodic health checks and surface problems for the user to fix — contradictions, orphans, stale pages, missing cross-references, concepts lacking their own page. You do NOT silently auto-fix structural issues; you report and suggest. The user decides what to fix.
+
+You are spawned **per-lint-pass**, not as a long-running agent.
+
+## Workflow
+
+Follow `references/lint-workflow.md`. Three passes.
+
+### Pass 1 — Mechanical (scripts)
+
+Run both:
+
+```bash
+python <plugin>/scripts/lint_wiki.py --vault . --json > /tmp/lint.json
+python <plugin>/scripts/graph_analyzer.py --vault . --json > /tmp/graph.json
+```
+
+Parse the JSON. Capture:
+- Orphans (zero inbound links)
+- Broken links (wikilinks pointing to non-existent pages)
+- Stale pages (`updated:` older than 90 days)
+- Missing frontmatter (pages without title/category/summary)
+- Duplicate titles
+- Log gap (no entries in 14+ days)
+- Connected components (more than 1 = disconnected islands)
+- Hubs (high-fan-out or high-fan-in pages)
+- Sinks (no outbound links)
+
+### Pass 2 — Semantic (you read and think)
+
+The scripts can't catch these. You must read.
+
+**A. Contradictions.** Scan pages whose `updated:` is recent. For each, check whether it contradicts any related page. If so, add a `> ⚠️ Contradiction:` callout to both.
+
+**B. Stale claims.** For each flagged stale page, ask: has a newer source invalidated a claim? Suggest re-ingest or a new source hunt.
+
+**C. Concepts mentioned without their own page.** Grep for concept-shaped nouns that appear across 3+ pages as plain text (not wikilinks). Suggest new concept pages.
+
+**D. Cross-reference gaps.** For each recently-touched page, check if every entity/concept mentioned is a wikilink. Promote plain-text mentions to wikilinks where appropriate.
+
+**E. Index drift.** Compare `index.md` against actual wiki contents. If out of sync, suggest regeneration.
+
+### Pass 3 — Report
+
+Produce a markdown report:
+
+```markdown
+# Wiki lint — <date>
+
+**Total pages:** N  **Components:** N  **Last log:** <date>
+
+## Found
+- ⚠️ <N> contradictions (list with wikilinks)
+- <N> orphan pages
+- <N> broken links
+- <N> stale pages
+- <N> concepts mentioned across 3+ pages without their own page
+- <N> pages with missing frontmatter
+- <other findings>
+
+## Suggested actions
+1. Investigate contradiction between [[sources/a]] and [[sources/b]]
+2. Create concept page for "<name>" (mentioned in N sources)
+3. Re-ingest [[sources/c]] — stale + contradicted by newer sources
+4. Fix broken link in [[concepts/x]]
+5. Cross-reference the N orphans (most belong under [[synthesis/overview]])
+
+Want me to run these in order, or pick specific ones?
+```
+
+Then append a log entry:
+
+```bash
+python <plugin>/scripts/append_log.py --vault . --op lint --title "<date> health check" --detail "<findings summary>"
+```
+
+## Rules
+
+- **Report, don't silently fix.** The user decides what to change.
+- **Prioritize by impact.** Contradictions > broken links > orphans > stale > style issues.
+- **Use both scripts.** Mechanical + graph both reveal different problems.
+- **Suggest actions** — never just dump findings without recommendations.
+- **Always log the pass.** The log tracks wiki health over time.
+
+## Red flags
+
+- Auto-fixing structural issues without asking → stop
+- Skipping semantic pass because "the scripts look clean" → do the read-and-think pass anyway
+- Reporting without suggestions → add suggestions
+- Not updating `log.md` → always log

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,13 +1,13 @@
 ---
 title: "AI Coding Agents — Agent-Native Orchestrators & Codex Skills"
-description: "25 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
+description: "28 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-robot: Agents
 
-<p class="domain-count">25 agents that orchestrate skills across domains</p>
+<p class="domain-count">28 agents that orchestrate skills across domains</p>
 
 </div>
 
@@ -32,6 +32,24 @@ description: "25 agent-native orchestrators for Claude Code, Codex CLI, and Gemi
     C-Level Advisory
 
 -   :material-rocket-launch:{ .lg .middle } **[Senior Engineer](cs-senior-engineer.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
+-   :material-rocket-launch:{ .lg .middle } **[wiki-ingestor](cs-wiki-ingestor.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
+-   :material-rocket-launch:{ .lg .middle } **[wiki-librarian](cs-wiki-librarian.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
+-   :material-rocket-launch:{ .lg .middle } **[wiki-linter](cs-wiki-linter.md)**
 
     ---
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Slash Commands — AI Coding Agent Commands & Codex Shortcuts"
-description: "22 slash commands for Claude Code, Codex CLI, and Gemini CLI — sprint planning, tech debt analysis, PRDs, OKRs, and more."
+description: "28 slash commands for Claude Code, Codex CLI, and Gemini CLI — sprint planning, tech debt analysis, PRDs, OKRs, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-console: Slash Commands
 
-<p class="domain-count">22 commands for quick access to common operations</p>
+<p class="domain-count">28 commands for quick access to common operations</p>
 
 </div>
 
@@ -127,6 +127,12 @@ description: "22 slash commands for Claude Code, Codex CLI, and Gemini CLI — s
 
     Create a sprint plan with prioritized stories and capacity guardrails.
 
+-   :material-console:{ .lg .middle } **[`/tc`](tc.md)**
+
+    ---
+
+    Dispatch a TC (Technical Change) command. Arguments: $ARGUMENTS.
+
 -   :material-console:{ .lg .middle } **[`/tdd`](tdd.md)**
 
     ---
@@ -144,5 +150,35 @@ description: "22 slash commands for Claude Code, Codex CLI, and Gemini CLI — s
     ---
 
     Generate structured user stories with acceptance criteria, story points, and sprint capacity planning.
+
+-   :material-console:{ .lg .middle } **[`/wiki-ingest`](wiki-ingest.md)**
+
+    ---
+
+    Ingest a new source into the LLM Wiki. This is the most-used command.
+
+-   :material-console:{ .lg .middle } **[`/wiki-init`](wiki-init.md)**
+
+    ---
+
+    Bootstrap a new LLM Wiki vault. Creates raw/, wiki/{entities,concepts,sources,comparisons,synthesis}, the index and l...
+
+-   :material-console:{ .lg .middle } **[`/wiki-lint`](wiki-lint.md)**
+
+    ---
+
+    Health-check the wiki. Surfaces orphan pages, broken wikilinks, stale claims, missing frontmatter, contradictions, an...
+
+-   :material-console:{ .lg .middle } **[`/wiki-log`](wiki-log.md)**
+
+    ---
+
+    Show recent entries from wiki/log.md. Every LLM operation on the wiki leaves a standardized entry:
+
+-   :material-console:{ .lg .middle } **[`/wiki-query`](wiki-query.md)**
+
+    ---
+
+    Ask the wiki a question. The librarian reads index.md first, picks relevant pages across categories, synthesizes an a...
 
 </div>

--- a/docs/commands/tc.md
+++ b/docs/commands/tc.md
@@ -1,0 +1,152 @@
+---
+title: "/tc — Slash Command for AI Coding Agents"
+description: "Track technical changes with structured records, a state machine, and session handoff. Usage: /tc. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /tc
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/tc.md">Source</a></span>
+</div>
+
+
+Dispatch a TC (Technical Change) command. Arguments: `$ARGUMENTS`.
+
+If `$ARGUMENTS` is empty, print this menu and stop:
+
+```
+/tc init                       Initialize TC tracking in this project
+/tc create <name>              Create a new TC record
+/tc update <tc-id> [...]       Update fields, status, files, handoff
+/tc status [tc-id]             Show one TC or the registry summary
+/tc resume <tc-id>             Resume a TC from a previous session
+/tc close <tc-id>              Transition a TC to deployed
+/tc export                     Re-render derived artifacts
+/tc dashboard                  Re-render the registry summary
+```
+
+Otherwise, parse `$ARGUMENTS` as `<subcommand> <rest>` and dispatch to the matching protocol below. All scripts live at `engineering/tc-tracker/scripts/`.
+
+## Subcommands
+
+### `init`
+
+1. Run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_init.py --root . --json
+   ```
+2. If status is `already_initialized`, report current statistics and stop.
+3. Otherwise report what was created and suggest `/tc create <name>` as the next step.
+
+### `create <name>`
+
+1. Parse `<name>` as a kebab-case slug. If missing, ask the user for one.
+2. Prompt the user (one question at a time) for:
+   - Title (5-120 chars)
+   - Scope: `feature | bugfix | refactor | infrastructure | documentation | hotfix | enhancement`
+   - Priority: `critical | high | medium | low` (default `medium`)
+   - Summary (10+ chars)
+   - Motivation
+3. Run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_create.py --root . \
+     --name "<slug>" --title "<title>" --scope <scope> --priority <priority> \
+     --summary "<summary>" --motivation "<motivation>" --json
+   ```
+4. Report the new TC ID and the path to the record.
+
+### `update <tc-id> [intent]`
+
+1. If `<tc-id>` is missing, list active TCs (status `in_progress` or `blocked`) from `tc_status.py --all` and ask which one.
+2. Determine the user's intent from natural language:
+   - **Status change** → `--set-status <state>` with `--reason "<why>"`
+   - **Add files** → one or more `--add-file path[:action]`
+   - **Add a test** → `--add-test "<title>" --test-procedure "<step>" --test-expected "<result>"`
+   - **Update handoff** → any combination of `--handoff-progress`, `--handoff-next`, `--handoff-blocker`, `--handoff-context`
+   - **Add a note** → `--note "<text>"`
+   - **Add a tag** → `--tag <tag>`
+3. Run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_update.py --root . --tc-id <tc-id> [flags] --json
+   ```
+4. If exit code is non-zero, surface the error verbatim. The state machine and validator will reject invalid moves — do not retry blindly.
+
+### `status [tc-id]`
+
+- If `<tc-id>` is provided:
+  ```bash
+  python3 engineering/tc-tracker/scripts/tc_status.py --root . --tc-id <tc-id>
+  ```
+- Otherwise:
+  ```bash
+  python3 engineering/tc-tracker/scripts/tc_status.py --root . --all
+  ```
+
+### `resume <tc-id>`
+
+1. Run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_status.py --root . --tc-id <tc-id> --json
+   ```
+2. Display the handoff block prominently: `progress_summary`, `next_steps` (numbered), `blockers`, `key_context`.
+3. Ask: "Resume <tc-id> and pick up at next step 1? (y/n)"
+4. If yes, run an update to record the resumption:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_update.py --root . --tc-id <tc-id> \
+     --note "Session resumed" --reason "session handoff"
+   ```
+5. Begin executing the first item in `next_steps`. Do NOT re-derive context — trust the handoff.
+
+### `close <tc-id>`
+
+1. Read the record via `tc_status.py --tc-id <tc-id> --json`.
+2. Verify the current status is `tested`. If not, refuse and tell the user which transitions are still required.
+3. Check `test_cases`: warn if any are `pending`, `fail`, or `blocked`.
+4. Ask the user:
+   - "Who is approving? (your name, or 'self')"
+   - "Approval notes (optional):"
+   - "Test coverage status: none / partial / full"
+5. Run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_update.py --root . --tc-id <tc-id> \
+     --set-status deployed --reason "Approved by <approver>" --note "Approval: <approver> — <notes>"
+   ```
+   Then directly edit the `approval` block via a follow-up update if your script version supports it; otherwise instruct the user to record approval in `notes`.
+6. Report: "TC-NNN closed and deployed."
+
+### `export`
+
+There is no automatic HTML export in this skill. Re-validate everything instead:
+
+1. Read the registry.
+2. For each record, run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_validator.py --record <path> --json
+   ```
+3. Run:
+   ```bash
+   python3 engineering/tc-tracker/scripts/tc_validator.py --registry docs/TC/tc_registry.json --json
+   ```
+4. Report: total records validated, any errors, paths to anything invalid.
+
+### `dashboard`
+
+Run the all-records summary:
+```bash
+python3 engineering/tc-tracker/scripts/tc_status.py --root . --all
+```
+
+## Iron Rules
+
+1. **Never edit `tc_record.json` by hand.** Always use `tc_update.py` so revision history is appended and validation runs.
+2. **Never skip the state machine.** Walk forward through states even if it feels redundant.
+3. **Never delete a TC.** History is append-only — add a final revision and tag it `[CANCELLED]`.
+4. **Background bookkeeping.** When mid-task, spawn a background subagent to update the TC. Do not pause coding to do paperwork.
+5. **Validate before reporting success.** If a script exits non-zero, surface the error and stop.
+
+## Related Skills
+
+- `engineering/tc-tracker` — Full SKILL.md with schema reference, lifecycle diagrams, and the handoff format.
+- `engineering/changelog-generator` — Pair with TC tracker: TCs for the per-change audit trail, changelog for user-facing release notes.
+- `engineering/tech-debt-tracker` — For tracking long-lived debt rather than discrete code changes.

--- a/docs/commands/wiki-ingest.md
+++ b/docs/commands/wiki-ingest.md
@@ -1,0 +1,58 @@
+---
+title: "/wiki-ingest — Slash Command for AI Coding Agents"
+description: "Ingest a source file from raw/ into the LLM Wiki — read, discuss, write summary page, update cross-references across 5-15 pages, regenerate index. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /wiki-ingest
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/wiki-ingest.md">Source</a></span>
+</div>
+
+
+Ingest a new source into the LLM Wiki. This is the most-used command.
+
+The flow: read the source → discuss TL;DR and key claims with you → write a source summary page → update every relevant entity and concept page → flag contradictions → update `index.md` → append to `log.md`.
+
+A typical ingest touches **5-15 wiki pages**. You (the user) are in the loop: the ingestor proposes changes and waits for your confirmation before writing.
+
+## Usage
+
+```
+/wiki-ingest <path>
+/wiki-ingest raw/papers/monosemanticity.pdf
+/wiki-ingest raw/articles/2026-04-01-interpretability-post.md
+```
+
+## What happens
+
+1. **Prep** — runs `scripts/ingest_source.py` to get title, preview, and suggested summary path
+2. **Read** — reads the source directly
+3. **Discuss** — reports TL;DR, key claims, which pages will be touched, any contradictions
+4. **Confirm** — waits for your go-ahead (or redirects)
+5. **Write** — creates the source summary, updates 5-15 pages, flags contradictions
+6. **Index** — runs `scripts/update_index.py` or edits `wiki/index.md` inline
+7. **Log** — runs `scripts/append_log.py --op ingest --title "<title>"`
+8. **Report** — bulleted wikilinks to every touched page
+
+## Sub-agent
+
+This command dispatches the `wiki-ingestor` sub-agent for the heavy lifting. See `agents/wiki-ingestor.md`.
+
+## Scripts
+
+- `engineering/llm-wiki/scripts/ingest_source.py` — source prep (metadata + preview)
+- `engineering/llm-wiki/scripts/update_index.py` — regenerate index
+- `engineering/llm-wiki/scripts/append_log.py` — log the ingest
+
+## Rules
+
+- The source must be inside the vault's `raw/` layer. If it isn't, the command will ask you to move it first.
+- `raw/` is immutable — the ingestor reads only.
+- If a summary page already exists, the ingestor enters **merge mode** and appends a re-ingest section.
+
+## Skill Reference
+
+→ `engineering/llm-wiki/SKILL.md`
+→ `engineering/llm-wiki/references/ingest-workflow.md`

--- a/docs/commands/wiki-init.md
+++ b/docs/commands/wiki-init.md
@@ -1,0 +1,66 @@
+---
+title: "/wiki-init — Slash Command for AI Coding Agents"
+description: "Bootstrap a fresh LLM Wiki vault with the three-layer structure, schema files, and starter templates. Usage /wiki-init <path> --topic '<topic>'. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /wiki-init
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/wiki-init.md">Source</a></span>
+</div>
+
+
+Bootstrap a new LLM Wiki vault. Creates `raw/`, `wiki/{entities,concepts,sources,comparisons,synthesis}`, the index and log, and installs the schema file(s) for your LLM CLI of choice.
+
+## Usage
+
+```
+/wiki-init <path> --topic "<one-line topic>"
+/wiki-init <path> --topic "<topic>" --tool <claude-code|codex|cursor|antigravity|opencode|gemini-cli|all>
+/wiki-init <path> --topic "<topic>" --force    # overwrite non-empty dir
+```
+
+## Examples
+
+```
+/wiki-init ~/vaults/research --topic "LLM interpretability"
+/wiki-init ./book-wiki --topic "The Power Broker — Robert Caro" --tool all
+/wiki-init ~/vaults/founders --topic "SaaS founder playbook" --tool codex
+```
+
+## What it creates
+
+```
+<path>/
+├── raw/
+│   └── assets/
+├── wiki/
+│   ├── index.md              # from template
+│   ├── log.md                # from template
+│   ├── entities/
+│   ├── concepts/
+│   ├── sources/
+│   ├── comparisons/
+│   ├── synthesis/
+│   └── .templates/           # page templates for reference
+├── CLAUDE.md                 # if --tool claude-code or all
+├── AGENTS.md                 # if --tool codex|cursor|antigravity|opencode|gemini-cli|all
+├── .cursorrules              # if --tool cursor or all
+└── .gitignore
+```
+
+## Next steps
+
+After init:
+1. Open the vault in Obsidian
+2. Drop a source into `raw/`
+3. Run `/wiki-ingest raw/<your-file>`
+
+## Script
+
+- `engineering/llm-wiki/scripts/init_vault.py`
+
+## Skill Reference
+
+→ `engineering/llm-wiki/SKILL.md`

--- a/docs/commands/wiki-lint.md
+++ b/docs/commands/wiki-lint.md
@@ -1,0 +1,89 @@
+---
+title: "/wiki-lint — Slash Command for AI Coding Agents"
+description: "Run a health check on the LLM Wiki vault — mechanical checks (orphans, broken links, stale pages, missing frontmatter, log gap, duplicates) plus. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /wiki-lint
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/wiki-lint.md">Source</a></span>
+</div>
+
+
+Health-check the wiki. Surfaces orphan pages, broken wikilinks, stale claims, missing frontmatter, contradictions, and structural drift. **Reports, doesn't silently fix** — you decide what to change.
+
+Run this weekly, after batch ingests, and always before sharing the wiki.
+
+## Usage
+
+```
+/wiki-lint
+/wiki-lint --stale-days 60
+/wiki-lint --log-gap-days 7
+```
+
+## What happens
+
+### Pass 1 — Mechanical (scripts)
+
+- `scripts/lint_wiki.py` — orphans, broken links, stale pages, missing frontmatter, duplicate titles, log gap
+- `scripts/graph_analyzer.py` — hubs, sinks, connected components, graph stats
+
+### Pass 2 — Semantic (LLM reads and thinks)
+
+- Contradictions between recently-updated pages
+- Stale claims superseded by newer sources
+- Concepts mentioned in plain text across 3+ pages without their own page
+- Cross-reference gaps (entities mentioned but not wikilinked)
+- Index drift (index.md out of sync with wiki/)
+
+### Pass 3 — Report
+
+A markdown report grouped by severity:
+
+```markdown
+# Wiki lint — <date>
+
+**Total pages:** N  **Components:** N  **Last log:** <date>
+
+## Found
+- ⚠️ <N> contradictions (list)
+- <N> orphans
+- <N> broken links
+- <N> stale pages
+- ...
+
+## Suggested actions
+1. Investigate contradiction between [[sources/a]] and [[sources/b]]
+2. Create concept page for "<name>"
+3. Fix broken link in [[concepts/x]]
+4. Re-ingest [[sources/c]] — stale + contradicted
+5. ...
+```
+
+Then appends a `lint` entry to `log.md`.
+
+## Sub-agent
+
+Dispatches the `wiki-linter` sub-agent. See `agents/wiki-linter.md`.
+
+## Scripts
+
+- `engineering/llm-wiki/scripts/lint_wiki.py`
+- `engineering/llm-wiki/scripts/graph_analyzer.py`
+- `engineering/llm-wiki/scripts/append_log.py`
+
+## Frequency
+
+| Trigger | Pass |
+|---|---|
+| Weekly | Mechanical only — fast |
+| After batch ingest | Full (mechanical + semantic) |
+| Monthly | Full + structural review |
+| Before sharing | Full + extra review |
+
+## Skill Reference
+
+→ `engineering/llm-wiki/SKILL.md`
+→ `engineering/llm-wiki/references/lint-workflow.md`

--- a/docs/commands/wiki-log.md
+++ b/docs/commands/wiki-log.md
@@ -1,0 +1,70 @@
+---
+title: "/wiki-log — Slash Command for AI Coding Agents"
+description: "Show recent entries from the LLM Wiki log (wiki/log.md). Uses the standardized ## [YYYY-MM-DD] header format so grep + tail works. Usage /wiki-log. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /wiki-log
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/wiki-log.md">Source</a></span>
+</div>
+
+
+Show recent entries from `wiki/log.md`. Every LLM operation on the wiki leaves a standardized entry:
+
+```
+## [YYYY-MM-DD] <op> | <title>
+<optional detail>
+```
+
+## Usage
+
+```
+/wiki-log                            # last 10 entries
+/wiki-log --last 20
+/wiki-log --op ingest --last 10      # only ingest entries
+/wiki-log --op lint                  # recent lint passes
+/wiki-log --since 2026-04-01
+```
+
+## What it does
+
+Parses `wiki/log.md` and prints matching entries. No LLM involvement needed — this is essentially:
+
+```bash
+grep "^## \[" wiki/log.md | tail -N
+```
+
+…plus optional filters for op type and date range.
+
+## Valid ops
+
+- `ingest` — a source was read and integrated
+- `query` — a question was answered (when filed back)
+- `lint` — a health check ran
+- `create` — a new page was created outside an ingest
+- `update` — a page was updated outside an ingest
+- `delete` — a page was removed
+- `note` — freeform note (contradictions flagged, thesis revisions, etc.)
+
+## Example output
+
+```
+## [2026-04-11] lint | weekly health check
+3 contradictions, 12 orphans, 2 broken links. Fixed broken links; left contradictions for next session.
+
+## [2026-04-10] ingest | Anthropic Monosemanticity
+Added sources/monosemanticity.md. Updated concepts/sparse-autoencoder, concepts/polysemanticity, entities/anthropic.
+
+## [2026-04-09] query | SAE vs probing
+Filed back to comparisons/sae-vs-probing.md.
+```
+
+## Scripts
+
+- Uses `grep` + `tail` directly on `wiki/log.md`. No dedicated script needed; that's the point of the standardized header format.
+
+## Skill Reference
+
+→ `engineering/llm-wiki/SKILL.md`

--- a/docs/commands/wiki-query.md
+++ b/docs/commands/wiki-query.md
@@ -1,0 +1,64 @@
+---
+title: "/wiki-query — Slash Command for AI Coding Agents"
+description: "Query the LLM Wiki — reads index.md first, drills into 3-10 relevant pages, synthesizes an answer with inline [[wikilink]] citations, and offers to. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /wiki-query
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/wiki-query.md">Source</a></span>
+</div>
+
+
+Ask the wiki a question. The librarian reads `index.md` first, picks relevant pages across categories, synthesizes an answer with citations, and offers to file the answer back into the wiki so your explorations compound.
+
+## Usage
+
+```
+/wiki-query "<your question>"
+/wiki-query "what does the wiki say about sparse autoencoders?"
+/wiki-query "compare monosemanticity and polysemanticity across my sources"
+/wiki-query "which sources disagree on scaling laws?"
+/wiki-query "give me a comparison table of SAE vs linear probing"
+```
+
+## What happens
+
+1. **Index-first read** — reads `wiki/index.md` to find relevant pages
+2. **Drill-in** — reads 3-10 pages in full (synthesis + concepts + sources + entities)
+3. **Follow links** — opportunistically follows wikilinks between pages
+4. **Fallback search** — if the index isn't enough, runs `scripts/wiki_search.py` (BM25)
+5. **Synthesize** — composes a direct answer + supporting detail + inline `[[sources/xxx]]` citations + "Related pages" section
+6. **Offer to file back** — asks whether to save this as a new wiki page (usually in `comparisons/` or `synthesis/`)
+
+## Output formats
+
+The answer's format follows the question:
+
+| Question shape | Output |
+|---|---|
+| "What is X?" | Markdown explanation with citations |
+| "A vs B" | Comparison table |
+| "Give me a slide deck on X" | Markdown synthesis → `/wiki-marp` to render |
+| "Chart the trend in X" | Python script + saved chart in `wiki/assets/charts/` |
+
+## Sub-agent
+
+This command dispatches the `wiki-librarian` sub-agent. See `agents/wiki-librarian.md`.
+
+## Scripts
+
+- `engineering/llm-wiki/scripts/wiki_search.py` — BM25 fallback search
+- `engineering/llm-wiki/scripts/append_log.py` — log filed answers
+
+## Rules
+
+- **Read the index first.** No grep-everything.
+- **Every claim cites a page** with a `[[wikilink]]`.
+- **Offer to file the answer back** — but only for substantive answers worth keeping.
+
+## Skill Reference
+
+→ `engineering/llm-wiki/SKILL.md`
+→ `engineering/llm-wiki/references/query-workflow.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Install Agent Skills — Codex, Gemini CLI, OpenClaw Setup
-description: "How to install 233 Claude Code skills and agent plugins for 11 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more."
+description: "How to install 235 Claude Code skills and agent plugins for 11 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more."
 ---
 
 # Getting Started
@@ -182,7 +182,7 @@ AI-augmented development. Optimize for SEO.
 
 ## Python Tools
 
-All 305 tools use the standard library only — zero pip installs, all verified.
+All 314 tools use the standard library only — zero pip installs, all verified.
 
 ```bash
 # Security audit a skill before installing
@@ -254,7 +254,7 @@ See the [Skills & Agents Factory](https://github.com/alirezarezvani/claude-code-
     Yes. Run `./scripts/gemini-install.sh` to set up skills for Gemini CLI. A sync script (`scripts/sync-gemini-skills.py`) generates the skills index automatically.
 
 ??? question "Does this work with Cursor, Windsurf, Aider, or other tools?"
-    Yes. All 233 skills can be converted to native formats for Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. Run `./scripts/convert.sh --tool all` and then install with `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](integrations.md) for details.
+    Yes. All 235 skills can be converted to native formats for Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. Run `./scripts/convert.sh --tool all` and then install with `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](integrations.md) for details.
 
 ??? question "Can I use Agent Skills in ChatGPT?"
     Yes. We have [6 Custom GPTs](custom-gpts.md) that bring Agent Skills directly into ChatGPT — no installation needed. Just click and start chatting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-title: 233 Agent Skills for Codex, Gemini CLI & OpenClaw
-description: "233 production-ready Claude Code skills and agent plugins for 11 AI coding tools. Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Cursor, and OpenClaw."
+title: 235 Agent Skills for Codex, Gemini CLI & OpenClaw
+description: "235 production-ready Claude Code skills and agent plugins for 11 AI coding tools. Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Cursor, and OpenClaw."
 hide:
   - toc
   - edit
@@ -14,7 +14,7 @@ hide:
 
 # Agent Skills
 
-233 production-ready skills, 25 agents, 3 personas, and an orchestration protocol for AI coding tools.
+235 production-ready skills, 28 agents, 3 personas, and an orchestration protocol for AI coding tools.
 { .hero-subtitle }
 
 [Get Started](getting-started.md){ .md-button .md-button--primary }
@@ -49,7 +49,7 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-toolbox:{ .lg .middle } **233 Skills**
+-   :material-toolbox:{ .lg .middle } **235 Skills**
 
     ---
 
@@ -57,7 +57,7 @@ hide:
 
     [:octicons-arrow-right-24: Browse skills](skills/)
 
--   :material-robot:{ .lg .middle } **25 Agents**
+-   :material-robot:{ .lg .middle } **28 Agents**
 
     ---
 
@@ -81,7 +81,7 @@ hide:
 
     [:octicons-arrow-right-24: Learn patterns](orchestration.md)
 
--   :material-language-python:{ .lg .middle } **305 Python Tools**
+-   :material-language-python:{ .lg .middle } **314 Python Tools**
 
     ---
 
@@ -89,7 +89,7 @@ hide:
 
     [:octicons-arrow-right-24: Getting started](getting-started.md)
 
--   :material-puzzle-outline:{ .lg .middle } **28 Plugins**
+-   :material-puzzle-outline:{ .lg .middle } **30 Plugins**
 
     ---
 
@@ -97,7 +97,7 @@ hide:
 
     [:octicons-arrow-right-24: Plugin marketplace](plugins/)
 
--   :material-console:{ .lg .middle } **22 Commands**
+-   :material-console:{ .lg .middle } **27 Commands**
 
     ---
 
@@ -143,7 +143,7 @@ hide:
 
     Agent designer, RAG architect, database designer, CI/CD builder, MCP server builder, security auditor, tech debt tracker
 
-    [:octicons-arrow-right-24: 43 skills](skills/engineering/)
+    [:octicons-arrow-right-24: 45 skills](skills/engineering/)
 
 -   :material-bullseye-arrow:{ .lg .middle } **Product**
 
@@ -151,7 +151,7 @@ hide:
 
     Product manager, agile PO, strategist, UX researcher, UI design system, landing pages, SaaS scaffolder, analytics, experiment designer
 
-    [:octicons-arrow-right-24: 15 skills](skills/product-team/)
+    [:octicons-arrow-right-24: 16 skills](skills/product-team/)
 
 -   :material-bullhorn:{ .lg .middle } **Marketing**
 

--- a/docs/skills/engineering/index.md
+++ b/docs/skills/engineering/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Engineering - POWERFUL Skills — Agent Skills & Codex Plugins"
-description: "56 engineering - powerful skills — advanced agent-native skill and Claude Code plugin for AI agent design, infrastructure, and automation. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+description: "58 engineering - powerful skills — advanced agent-native skill and Claude Code plugin for AI agent design, infrastructure, and automation. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-rocket-launch: Engineering - POWERFUL
 
-<p class="domain-count">56 skills in this domain</p>
+<p class="domain-count">58 skills in this domain</p>
 
 </div>
 
@@ -167,6 +167,12 @@ description: "56 engineering - powerful skills — advanced agent-native skill a
 
     > Originally contributed by chad848(https://github.com/chad848) — enhanced and integrated by the claude-skills team.
 
+-   **[LLM Wiki — Second Brain for Claude Code + Obsidian](llm-wiki.md)**
+
+    ---
+
+    Inspired by Andrej Karpathy's LLM Wiki pattern (gist(https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94...
+
 -   **[MCP Server Builder](mcp-server-builder.md)**
 
     ---
@@ -268,6 +274,12 @@ description: "56 engineering - powerful skills — advanced agent-native skill a
     ---
 
     python3 scripts/hypothesistester.py --test ztest \
+
+-   **[TC Tracker](tc-tracker.md)**
+
+    ---
+
+    Track every code change with structured JSON records, an enforced state machine, and a session handoff format that le...
 
 -   **[Tech Debt Tracker](tech-debt-tracker.md)**
 

--- a/docs/skills/engineering/llm-wiki.md
+++ b/docs/skills/engineering/llm-wiki.md
@@ -1,0 +1,183 @@
+---
+title: "LLM Wiki — Second Brain for Claude Code + Obsidian — Agent Skill for Codex & OpenClaw"
+description: "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# LLM Wiki — Second Brain for Claude Code + Obsidian
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-identifier: `llm-wiki`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install engineering-advanced-skills</code>
+</div>
+
+
+Inspired by Andrej Karpathy's LLM Wiki pattern ([gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)). This skill turns Claude Code (or any agent CLI) into a disciplined wiki maintainer that **incrementally builds and maintains** a persistent, interlinked Obsidian vault as you feed it sources. The knowledge compounds — cross-references, contradictions, and synthesis are already there when you query.
+
+## Core principle
+
+Most LLM+docs workflows are **RAG**: retrieve fragments at query time, synthesize from scratch, forget. The wiki is **compounding**: sources are read once, integrated into a persistent markdown knowledge base, and kept current. You curate and ask; the LLM reads, files, cross-references, and maintains.
+
+> Obsidian is the IDE. The LLM is the programmer. The wiki is the codebase.
+
+## When to use
+
+- **Personal**: track goals, health, psychology, journaling, self-improvement
+- **Research**: deep dives over weeks on a topic — papers, articles, reports, evolving thesis
+- **Book companion**: file chapters as you read; build a fan-wiki-style companion for characters, themes, plot threads
+- **Business/team**: internal wiki fed by Slack, meeting notes, calls — LLM does maintenance nobody else wants to do
+- **Competitive analysis, due diligence, trip planning, course notes, hobby deep-dives**
+
+**Do NOT use when:** you need one-shot Q&A over a fixed document (use RAG), you don't plan to add sources over time, or you don't want Obsidian in the loop.
+
+## Architecture (three layers)
+
+```
+vault/
+├── raw/                    # Layer 1 — IMMUTABLE source of truth
+│   ├── <source files>      # Articles, papers, PDFs, images, data
+│   └── assets/             # Downloaded images from clipped articles
+├── wiki/                   # Layer 2 — LLM-owned knowledge base
+│   ├── index.md            # Content catalog (LLM updates every ingest)
+│   ├── log.md              # Append-only timeline (## [YYYY-MM-DD] <op> | <title>)
+│   ├── entities/           # Person/Org/Place pages
+│   ├── concepts/           # Ideas, theories, frameworks
+│   ├── sources/            # One summary page per ingested source
+│   ├── comparisons/        # Cross-source analysis pages
+│   └── synthesis/          # High-level syntheses, theses, overviews
+├── CLAUDE.md               # Schema + conventions (Claude Code)
+└── AGENTS.md               # Same content, for Codex/Cursor/Antigravity
+```
+
+- **Layer 1 (raw/)** — you own. LLM only reads; never writes.
+- **Layer 2 (wiki/)** — LLM owns. It creates, updates, and cross-references pages. You read it.
+- **Layer 3 (CLAUDE.md / AGENTS.md)** — the *schema*. Conventions, workflows, frontmatter rules. Co-evolved by you and the LLM.
+
+## Three core operations
+
+1. **Ingest** — LLM reads a source, discusses takeaways with you, writes a source summary, updates 10-15 relevant pages, updates index, appends to log. See `references/ingest-workflow.md`.
+2. **Query** — LLM reads `index.md` first, drills into relevant pages, synthesizes with citations. Good answers get **filed back into the wiki** so explorations compound. See `references/query-workflow.md`.
+3. **Lint** — Health check: contradictions, stale claims, orphan pages, missing cross-refs, concepts mentioned but lacking their own page, data gaps to fill with web search. See `references/lint-workflow.md`.
+
+## Quick start
+
+```bash
+# 1. Initialize a vault (in Obsidian's vault directory)
+python scripts/init_vault.py --path ~/vaults/research --topic "LLM interpretability"
+
+# 2. Drop a source into raw/, then ingest
+/wiki-ingest ~/vaults/research/raw/anthropic-monosemanticity.pdf
+
+# 3. Ask questions (answers can be re-filed into the wiki)
+/wiki-query "how does monosemanticity compare to mechanistic interpretability?"
+
+# 4. Periodic health check
+/wiki-lint
+
+# 5. See the timeline
+/wiki-log --last 10
+```
+
+## Slash commands (this plugin ships)
+
+| Command | Purpose |
+|---|---|
+| `/wiki-init` | Bootstrap a fresh vault with schema files + starter structure |
+| `/wiki-ingest <path>` | Read a source, discuss, update wiki, log it |
+| `/wiki-query <question>` | Search wiki, synthesize answer, offer to file back |
+| `/wiki-lint` | Run health check — contradictions, orphans, stale claims, gaps |
+| `/wiki-log` | Show recent log entries (uses unix tools on `log.md`) |
+
+## Sub-agents (this plugin ships)
+
+| Agent | When dispatched |
+|---|---|
+| `wiki-ingestor` | Delegated ingest flow — reads source, proposes updates, applies after your approval |
+| `wiki-linter` | Runs the health-check workflow independently, reports findings |
+| `wiki-librarian` | Answers queries using index-first search, synthesizes with citations |
+
+## Python tools (`scripts/`)
+
+All tools are **standard library only** (no pip installs). Run with `python scripts/<tool>.py --help`.
+
+| Script | Purpose |
+|---|---|
+| `init_vault.py` | Create folder structure + seed CLAUDE.md, AGENTS.md, index.md, log.md |
+| `ingest_source.py` | Helper: extract text/frontmatter from a source file, ready for LLM review |
+| `update_index.py` | Regenerate `index.md` from wiki page frontmatter (category, date, source count) |
+| `append_log.py` | Append a standardized log entry `## [YYYY-MM-DD] <op> \| <title>` |
+| `wiki_search.py` | BM25 search over wiki pages (standalone fallback when index.md isn't enough) |
+| `lint_wiki.py` | Find orphans (no inbound links), stale pages, missing cross-refs, broken links |
+| `graph_analyzer.py` | Compute link graph stats — hubs, orphans, clusters, disconnected components |
+| `export_marp.py` | Render a wiki page (or subtree) to a Marp slide deck |
+
+## Cross-tool compatibility
+
+The vault's **schema** lives in CLAUDE.md (Claude Code) or AGENTS.md (Codex/Cursor/Antigravity/OpenCode). The same content works in both. This plugin ships both templates. For per-tool setup instructions see `references/cross-tool-setup.md`.
+
+```
+CLAUDE.md       → Claude Code
+AGENTS.md       → Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI
+.cursorrules    → legacy Cursor (pre-AGENTS.md)
+```
+
+The scripts are pure Python stdlib → run identically everywhere. Only the loader file changes per tool.
+
+## Obsidian setup (recommended)
+
+- **Obsidian Web Clipper** — browser extension; converts web articles to markdown and drops them in `raw/`
+- **Download images locally** — Settings → Files and links → Attachment folder path = `raw/assets/`. Settings → Hotkeys → bind "Download attachments for current file" to `Ctrl+Shift+D`
+- **Graph view** — see hubs/orphans; essential for spotting structural problems
+- **Marp plugin** — Markdown-based slide decks directly from wiki pages
+- **Dataview plugin** — dynamic tables/lists over page frontmatter (tags, dates, source counts)
+- **Git** — the vault is a plain markdown repo; version it
+
+Full setup walkthrough: `references/obsidian-setup.md`
+
+## Why this works (vs plain RAG)
+
+| Plain RAG | LLM Wiki |
+|---|---|
+| Rediscover knowledge each query | Knowledge accumulates |
+| Cross-references re-computed every time | Cross-references pre-written and maintained |
+| Contradictions surface only if you ask | Contradictions flagged during ingest |
+| Exploration disappears into chat history | Good answers re-filed as new pages |
+| Scales by embeddings infrastructure | Scales by markdown + `index.md` + optional local search |
+
+At ~100 sources / hundreds of pages, `index.md` + filesystem search is enough. Past that, layer in a local search tool like [qmd](https://github.com/tobi/qmd) or use `scripts/wiki_search.py`.
+
+## Related skills (chains via `context: fork`)
+
+This skill is marked `context: fork` so other skills can chain into it:
+
+- **`para-memory-files`** — PARA-method memory; complementary as long-term personal memory that feeds sources into the wiki
+- **`obsidian-vault`** (mattpocock) — lightweight Obsidian note helper; this skill is the maintained-wiki layer on top
+- **`rag-design`** — when wiki outgrows ~500 pages, use rag-design to bolt on a retrieval layer
+- **`mcp-design`** — expose the wiki as an MCP tool
+- **`agent-communication`** — for multi-agent wiki maintenance (ingestor + linter + librarian)
+
+## Reference docs
+
+- `references/wiki-schema.md` — full vault layout, page frontmatter, naming conventions
+- `references/page-formats.md` — entity, concept, source, comparison, synthesis templates
+- `references/ingest-workflow.md` — the detailed ingest flow the wiki-ingestor agent follows
+- `references/query-workflow.md` — query patterns, citation format, re-filing answers
+- `references/lint-workflow.md` — health-check heuristics
+- `references/obsidian-setup.md` — Obsidian plugins, hotkeys, vault config
+- `references/cross-tool-setup.md` — per-tool setup (Codex, Cursor, Antigravity, etc.)
+- `references/memex-principles.md` — Bush's Memex, why the LLM changes the maintenance math
+
+## Templates (`assets/`)
+
+- `CLAUDE.md.template`, `AGENTS.md.template`, `.cursorrules.template` — schema loaders per tool
+- `index.md.template`, `log.md.template` — starter index and log
+- `page-templates/` — entity, concept, source-summary, comparison, synthesis
+- `example-vault/` — small worked example you can study or copy
+
+## Iron rule
+
+**The LLM never edits files in `raw/`.** Ever. Sources are immutable. All LLM writes go to `wiki/`. If you need to correct a source, do it in `raw/` yourself — then re-ingest.

--- a/docs/skills/engineering/tc-tracker.md
+++ b/docs/skills/engineering/tc-tracker.md
@@ -1,0 +1,218 @@
+---
+title: "TC Tracker — Agent Skill for Codex & OpenClaw"
+description: "Use when the user asks to track technical changes, create change records, manage TC lifecycles, or hand off work between AI sessions. Covers. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# TC Tracker
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-identifier: `tc-tracker`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install engineering-advanced-skills</code>
+</div>
+
+
+Track every code change with structured JSON records, an enforced state machine, and a session handoff format that lets a new AI session resume work cleanly when a previous one expires.
+
+## Overview
+
+A Technical Change (TC) is a structured record that captures **what** changed, **why** it changed, **who** changed it, **when** it changed, **how it was tested**, and **where work stands** for the next session. Records live as JSON in `docs/TC/` inside the target project, validated against a strict schema and a state machine.
+
+**Use this skill when the user:**
+- Asks to "track this change" or wants an audit trail for code modifications
+- Wants to hand off in-progress work to a future AI session
+- Needs structured release notes that go beyond commit messages
+- Onboards an existing project and wants retroactive change documentation
+- Asks for `/tc init`, `/tc create`, `/tc update`, `/tc status`, `/tc resume`, or `/tc close`
+
+**Do NOT use this skill when:**
+- The user only wants a changelog from git history (use `engineering/changelog-generator`)
+- The user only wants to track tech debt items (use `engineering/tech-debt-tracker`)
+- The change is trivial (typo, formatting) and won't affect behavior
+
+## Storage Layout
+
+Each project stores TCs at `{project_root}/docs/TC/`:
+
+```
+docs/TC/
+├── tc_config.json          # Project settings
+├── tc_registry.json        # Master index + statistics
+├── records/
+│   └── TC-001-04-05-26-user-auth/
+│       └── tc_record.json  # Source of truth
+└── evidence/
+    └── TC-001/             # Log snippets, command output, screenshots
+```
+
+## TC ID Convention
+
+- **Parent TC:** `TC-NNN-MM-DD-YY-functionality-slug` (e.g., `TC-001-04-05-26-user-authentication`)
+- **Sub-TC:** `TC-NNN.A` or `TC-NNN.A.1` (letter = revision, digit = sub-revision)
+- `NNN` is sequential, `MM-DD-YY` is the creation date, slug is kebab-case.
+
+## State Machine
+
+```
+planned -> in_progress -> implemented -> tested -> deployed
+   |            |              |           |          |
+   +-> blocked -+              +- in_progress <-------+
+        |                          (rework / hotfix)
+        +-> planned
+```
+
+> See [references/lifecycle.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/references/lifecycle.md) for the full transition table and recovery flows.
+
+## Workflow Commands
+
+The skill ships five Python scripts that perform deterministic, stdlib-only operations on TC records. Each one supports `--help` and `--json`.
+
+### 1. Initialize tracking in a project
+
+```bash
+python3 scripts/tc_init.py --project "My Project" --root .
+```
+
+Creates `docs/TC/`, `docs/TC/records/`, `docs/TC/evidence/`, `tc_config.json`, and `tc_registry.json`. Idempotent — re-running reports "already initialized" with current stats.
+
+### 2. Create a new TC record
+
+```bash
+python3 scripts/tc_create.py \
+  --root . \
+  --name "user-authentication" \
+  --title "Add JWT-based user authentication" \
+  --scope feature \
+  --priority high \
+  --summary "Adds JWT login + middleware" \
+  --motivation "Required for protected endpoints"
+```
+
+Generates the next sequential TC ID, creates the record directory, writes a fully populated `tc_record.json` (status `planned`, R1 creation revision), and updates the registry.
+
+### 3. Update a TC record
+
+```bash
+# Status transition (validated against the state machine)
+python3 scripts/tc_update.py --root . --tc-id TC-001-04-05-26-user-auth \
+  --set-status in_progress --reason "Starting implementation"
+
+# Add a file
+python3 scripts/tc_update.py --root . --tc-id TC-001-04-05-26-user-auth \
+  --add-file src/auth.py:created
+
+# Append handoff data
+python3 scripts/tc_update.py --root . --tc-id TC-001-04-05-26-user-auth \
+  --handoff-progress "JWT middleware wired up" \
+  --handoff-next "Write integration tests" \
+  --handoff-next "Update README"
+```
+
+Every change appends a sequential `R<n>` revision entry, refreshes `updated`, and re-validates against the schema before writing atomically (`.tmp` then rename).
+
+### 4. View status
+
+```bash
+# Single TC
+python3 scripts/tc_status.py --root . --tc-id TC-001-04-05-26-user-auth
+
+# All TCs (registry summary)
+python3 scripts/tc_status.py --root . --all --json
+```
+
+### 5. Validate a record or registry
+
+```bash
+python3 scripts/tc_validator.py --record docs/TC/records/TC-001-.../tc_record.json
+python3 scripts/tc_validator.py --registry docs/TC/tc_registry.json
+```
+
+Validator enforces the schema, checks state-machine legality, verifies sequential `R<n>` and `T<n>` IDs, and asserts approval consistency (`approved=true` requires `approved_by` and `approved_date`).
+
+> See [references/tc-schema.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/references/tc-schema.md) for the full schema.
+
+## Slash-Command Dispatcher
+
+The repo ships a `/tc` slash command at `commands/tc.md` that dispatches to these scripts based on subcommand:
+
+| Command | Action |
+|---------|--------|
+| `/tc init` | Run `tc_init.py` for the current project |
+| `/tc create <name>` | Prompt for fields, run `tc_create.py` |
+| `/tc update <tc-id>` | Apply user-described changes via `tc_update.py` |
+| `/tc status [tc-id]` | Run `tc_status.py` |
+| `/tc resume <tc-id>` | Display handoff, archive prior session, start a new one |
+| `/tc close <tc-id>` | Transition to `deployed`, set approval |
+| `/tc export` | Re-render all derived artifacts |
+| `/tc dashboard` | Re-render the registry summary |
+
+The slash command is the user interface; the Python scripts are the engine.
+
+## Session Handoff Format
+
+The handoff block lives at `session_context.handoff` inside each TC and is the single most important field for AI continuity. It contains:
+
+- `progress_summary` — what has been done
+- `next_steps` — ordered list of remaining actions
+- `blockers` — anything preventing progress
+- `key_context` — critical decisions, gotchas, patterns the next bot must know
+- `files_in_progress` — files being edited and their state (`editing`, `needs_review`, `partially_done`, `ready`)
+- `decisions_made` — architectural decisions with rationale and timestamp
+
+> See [references/handoff-format.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/references/handoff-format.md) for the full structure and fill-out rules.
+
+## Validation Rules (Always Enforced)
+
+1. **State machine** — only valid transitions are allowed.
+2. **Sequential IDs** — `revision_history` uses `R1, R2, R3...`; `test_cases` uses `T1, T2, T3...`.
+3. **Append-only history** — revision entries are never modified or deleted.
+4. **Approval consistency** — `approved=true` requires `approved_by` and `approved_date`.
+5. **TC ID format** — must match `TC-NNN-MM-DD-YY-slug`.
+6. **Sub-TC ID format** — must match `TC-NNN.A` or `TC-NNN.A.N`.
+7. **Atomic writes** — JSON is written to `.tmp` then renamed.
+8. **Registry stats** — recomputed on every registry write.
+
+## Non-Blocking Bookkeeping Pattern
+
+TC tracking must NOT interrupt the main workflow.
+
+- **Never stop to update TC records inline.** Keep coding.
+- At natural milestones, spawn a background subagent to update the record.
+- Surface questions only when genuinely needed ("This work doesn't match any active TC — create one?"), and ask once per session, not per file.
+- At session end, write a final handoff block before closing.
+
+## Retroactive Bulk Creation
+
+For onboarding an existing project with undocumented history, build a `retro_changelog.json` (one entry per logical change) and feed it to `tc_create.py` in a loop, or extend the script for batch mode. Group commits by feature, not by file.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad | Do this instead |
+|--------------|--------------|-----------------|
+| Editing `revision_history` to "fix" a typo | History is append-only — tampering destroys the audit trail | Add a new revision that corrects the field |
+| Skipping the state machine ("just set status to deployed") | Bypasses validation and hides skipped phases | Walk through `in_progress -> implemented -> tested -> deployed` |
+| Creating one TC per file changed | Fragments related work and explodes the registry | One TC per logical unit (feature, fix, refactor) |
+| Updating TC inline between every code edit | Slows the main agent, wastes context | Spawn a background subagent at milestones |
+| Marking `approved=true` without `approved_by` | Validator will reject; misleading audit trail | Always set `approved_by` and `approved_date` together |
+| Overwriting `tc_record.json` directly with a text editor | Risks corruption mid-write and skips validation | Use `tc_update.py` (atomic write + schema check) |
+| Putting secrets in `notes` or evidence | Records are committed to the repo | Reference an env var or external secret store |
+| Reusing TC IDs after deletion | Breaks the sequential guarantee and confuses history | Increment forward only — never recycle |
+| Letting `next_steps` go stale | Defeats the purpose of handoff | Update on every milestone, even if it's "nothing changed" |
+
+## Cross-References
+
+- `engineering/changelog-generator` — Generates Keep-a-Changelog release notes from Conventional Commits. Pair it with TC tracker: TC for the granular per-change audit trail, changelog for user-facing release notes.
+- `engineering/tech-debt-tracker` — For tracking long-lived debt items rather than discrete code changes.
+- `engineering/focused-fix` — When a bug fix needs systematic feature-wide repair, run `/focused-fix` first then capture the result as a TC.
+- `project-management/decision-log` — Architectural decisions made inside a TC's `decisions_made` block can also be promoted to a project-wide decision log.
+- `engineering-team/code-reviewer` — Pre-merge review fits naturally into the `tested -> deployed` transition; capture the reviewer in `approval.approved_by`.
+
+## References in This Skill
+
+- [references/tc-schema.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/references/tc-schema.md) — Full JSON schema for TC records and the registry.
+- [references/lifecycle.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/references/lifecycle.md) — State machine, valid transitions, and recovery flows.
+- [references/handoff-format.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/tc-tracker/references/handoff-format.md) — Session handoff structure and best practices.

--- a/docs/skills/product-team/apple-hig-expert.md
+++ b/docs/skills/product-team/apple-hig-expert.md
@@ -1,0 +1,95 @@
+---
+title: "Apple HIG Expert — Agent Skill for Product Teams"
+description: "Expert guidance on Apple Human Interface Guidelines (HIG). Covers iOS, macOS, and visionOS with 2026 Liquid Glass aesthetics and accessibility-first. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Apple HIG Expert
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-lightbulb-outline: Product</span>
+<span class="meta-badge">:material-identifier: `apple-hig-expert`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install product-skills</code>
+</div>
+
+
+You are a Senior Apple Design Lead with decades of experience shipping award-winning apps on the App Store. Your goal is to help users design and audit apps that feel natively integrated into the Apple ecosystem while pushing the boundaries of the **Liquid Glass** aesthetic.
+
+## Before Starting
+
+**Check for context first:**
+If `product-context.md` or `ios-design-context.md` exists, read it before asking questions.
+
+Gather this context:
+1. **Platform Target**: iOS, macOS, watchOS, or visionOS?
+2. **Current State**: New project or auditing an existing mockup?
+3. **App Category**: Utility, Productivity, Game, Social, etc.?
+
+## How This Skill Works
+
+This skill supports 2 primary modes:
+
+### Mode 1: Design from Scratch
+When starting fresh. Focus on atomic design, layout primitives, and navigation paradigms that align with Apple's core philosophies (Clarity, Deference, Depth).
+
+### Mode 2: HIG Audit 
+When reviewing mockups or code. Use the [templates/hig-audit-template.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/templates/hig-audit-template.md) to systematically identify violations and refinement opportunities.
+
+## Core Design Principles (2026)
+
+### 1. Liquid Glass Aesthetic
+Modern Apple design emphasizes translucency and fluid motion.
+- **Translucency**: Use materials (thin, thick, ultra-thin) to create hierarchy.
+- **Depth**: Layers should reflect z-axis relationships.
+- **Fluidity**: Interactions should feel like physical objects responding to touch/eyes.
+
+### 2. Accessibility First
+Design for everyone from Day 1.
+- **VoiceOver**: All elements must have semantic descriptions.
+- **Tap Targets**: Minimum 44x44 points for all interactive elements.
+- **Contrast**: Ensure legibility against translucent backgrounds.
+
+## Workflows
+
+### Phase 1: Navigation & Layout
+Choose the right navigation pattern (Sidebars for macOS, Tab Bars for iOS, Ornaments for visionOS).
+See [references/platform-specifics.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/references/platform-specifics.md) for details.
+
+### Phase 2: Visual Styling
+Apply typography (San Francisco family) and semantic colors. 
+See [references/visual-design.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/references/visual-design.md).
+
+### Phase 3: Final Audit
+Run the `hig_checker.py` tool to automate contrast and layout checks.
+
+## Proactive Triggers
+
+Surface these issues WITHOUT being asked:
+- **Low Contrast**: Translucent layers masking text legibility.
+- **Tiny Targets**: Interactive elements smaller than 44pt.
+- **Missing Semantics**: Buttons with icons but no accessibility labels.
+- **Density Overload**: Layouts that ignore white space/deference.
+
+## Output Artifacts
+
+| When you ask for... | You get... |
+|---------------------|------------|
+| "Audit my iOS app" | Detailed HIG Scorecard (0-100) with prioritized fixes. |
+| "Design a visionOS ornament" | Spatial design specs with depth and gaze-contingent hover rules. |
+| "Accessibility check" | Compliance report for VoiceOver, Dynamic Type, and Contrast. |
+
+## Communication
+
+All output follows the structured communication standard:
+- **Bottom line first** — HIG compliance status before the details.
+- **What + Why + How** — e.g., "Increase padding (What) because targets are too small (Why). Use 12pt margins (How)."
+- **Confidence tagging** — 🟢 verified / 🟡 medium / 🔴 assumed.
+
+## Related Skills
+
+- **ui-design-system**: For creating token-based components. NOT for platform-specific HIG rules.
+- **ux-researcher-designer**: For persona validation. NOT for visual styling.
+- **landing-page-generator**: For web-based marketing pages.

--- a/docs/skills/product-team/index.md
+++ b/docs/skills/product-team/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Product Skills — Agent Skills & Codex Plugins"
-description: "16 product skills — product management agent skill and Claude Code plugin for PRDs, discovery, analytics, and roadmaps. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+description: "17 product skills — product management agent skill and Claude Code plugin for PRDs, discovery, analytics, and roadmaps. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-lightbulb-outline: Product
 
-<p class="domain-count">16 skills in this domain</p>
+<p class="domain-count">17 skills in this domain</p>
 
 </div>
 
@@ -22,6 +22,12 @@ description: "16 product skills — product management agent skill and Claude Co
     ---
 
     Backlog management and sprint execution toolkit for product owners, including user story generation, acceptance crite...
+
+-   **[Apple HIG Expert](apple-hig-expert.md)**
+
+    ---
+
+    You are a Senior Apple Design Lead with decades of experience shipping award-winning apps on the App Store. Your goal...
 
 -   **[Code → PRD: Reverse-Engineer Any Codebase into Product Requirements](code-to-prd.md)**
 

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-advanced-skills",
-  "description": "44 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, self-eval, llm-cost-optimizer, prompt-governance, llm-wiki (second brain for Obsidian + Claude Code, Karpathy pattern), and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
+  "description": "45 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, self-eval, llm-cost-optimizer, prompt-governance, llm-wiki (second brain for Obsidian + Claude Code, Karpathy pattern), tc-tracker (task context tracker with lifecycle and handoff format), and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
   "version": "2.3.0",
   "author": {
     "name": "Alireza Rezvani",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,8 @@ nav:
       - "Terraform Patterns": skills/engineering/terraform-patterns.md
       - "Helm Chart Builder": skills/engineering/helm-chart-builder.md
       - "Docker Development": skills/engineering/docker-development.md
+      - "LLM Wiki": skills/engineering/llm-wiki.md
+      - "TC Tracker": skills/engineering/tc-tracker.md
       - AgentHub:
         - "AgentHub": skills/engineering/agenthub.md
         - "/hub:init": skills/engineering/agenthub-init.md
@@ -246,6 +248,8 @@ nav:
       - "SaaS Scaffolder": skills/product-team/saas-scaffolder.md
       - "UI Design System": skills/product-team/ui-design-system.md
       - "UX Researcher & Designer": skills/product-team/ux-researcher-designer.md
+      - "Apple HIG Expert": skills/product-team/apple-hig-expert.md
+      - "Spec to Repo": skills/product-team/spec-to-repo.md
     - Marketing:
       - Overview: skills/marketing-skill/index.md
       - "A/B Test Setup": skills/marketing-skill/ab-test-setup.md
@@ -422,3 +426,4 @@ nav:
     - "/wiki-query": commands/wiki-query.md
     - "/wiki-lint": commands/wiki-lint.md
     - "/wiki-log": commands/wiki-log.md
+    - "/tc": commands/tc.md

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "product-skills",
-  "description": "14 production-ready product skills: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "description": "16 production-ready product skills: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer, apple-hig-expert (Apple Human Interface Guidelines), spec-to-repo. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
+  "version": "2.3.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/product-team/CLAUDE.md
+++ b/product-team/CLAUDE.md
@@ -1,6 +1,6 @@
 # Product Team Skills - Claude Code Guidance
 
-This guide covers the 15 production-ready product management skills and their Python automation tools.
+This guide covers the 16 production-ready product management skills and their Python automation tools.
 
 ## Product Skills Overview
 
@@ -20,6 +20,7 @@ This guide covers the 15 production-ready product management skills and their Py
 13. **code-to-prd/** - Reverse-engineer any codebase into PRD (2 tools: codebase_analyzer, prd_scaffolder)
 14. **research-summarizer/** - Research synthesis and summarization (1 tool)
 15. **apple-hig-expert/** - Apple Human Interface Guidelines compliance and design (1 tool: hig_checker)
+16. **spec-to-repo/** - Convert a spec document into a scaffolded repository
 
 **Total Tools:** 17 Python automation tools
 
@@ -312,6 +313,6 @@ python roadmap-communicator/scripts/changelog_generator.py --from v1.0.0 --to HE
 ---
 
 **Last Updated:** April 9, 2026
-**Skills Deployed:** 15/15 product skills production-ready
+**Skills Deployed:** 16/16 product skills production-ready
 **Total Tools:** 17 Python automation tools
 **Agents:** 5 | **Commands:** 8

--- a/product-team/apple-hig-expert/.claude-plugin/plugin.json
+++ b/product-team/apple-hig-expert/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "apple-hig-expert",
+  "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets, contrast, and accessibility validation. Reference docs cover visual design, platform specifics (iOS/macOS/visionOS), and accessibility best practices.",
+  "version": "2.3.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": "./"
+}


### PR DESCRIPTION
Follow-up to #508. Runs the full `/update-docs` pipeline after llm-wiki merged, sweeping in documentation for `apple-hig-expert` and `tc-tracker` (which landed earlier on dev).

## What this does

Brings every count in the repo into alignment with actual disk state after three new skills landed:

- `engineering/llm-wiki` (from #508)
- `product-team/apple-hig-expert` (from #503)
- `engineering/tc-tracker` (from #498)

**Totals:** 235 skills, 314 Python tools, 435 references, 28 agents, 27 commands.

## Fixes

### Missing plugin manifest for apple-hig-expert

`apple-hig-expert` was registered in `.claude-plugin/marketplace.json` but lacked its own `.claude-plugin/plugin.json` inside the skill directory, so it couldn't be installed as a standalone plugin. Created the manifest at `product-team/apple-hig-expert/.claude-plugin/plugin.json` (v2.3.0, same schema as other plugin entries). Bumped the marketplace entry from v2.2.0 → v2.3.0.

### spec-to-repo missing from product-team/CLAUDE.md

`product-team/CLAUDE.md` listed 15 skills but the directory actually contains 16 (the 15 from dev's merge plus `spec-to-repo`, which was never added to the list). Fixed count and added entry.

### Engineering POWERFUL count

`engineering/.claude-plugin/plugin.json` said 44 skills after my llm-wiki bump but didn't account for tc-tracker landing in parallel. Fixed to 45, added tc-tracker to the description.

## Files touched (27)

**Root docs (5):** CLAUDE.md (scope line, v2.3.0 highlights block with new tc-tracker + apple-hig bullets, footer), README.md (badges, tagline, skill table), docs/index.md (title, hero, grid cards, domain cards), docs/getting-started.md (description, tool count, FAQ), mkdocs.yml (nav entries for 3 new skills + `/tc` command)

**Plugin manifests (4):** `.claude-plugin/marketplace.json`, `engineering/.claude-plugin/plugin.json`, `product-team/.claude-plugin/plugin.json`, `product-team/apple-hig-expert/.claude-plugin/plugin.json` (NEW)

**Domain docs (1):** `product-team/CLAUDE.md` (15 → 16, spec-to-repo added)

**Auto-regenerated MkDocs pages (14):** 3 new skill pages, 3 new agent pages, 6 new command pages, 2 index pages updated

**Sync artifacts (2):** `.codex/skills-index.json` already updated in #508, `.gemini/skills/tc/SKILL.md` symlink added

## Test plan

- [x] `python3 scripts/sync-codex-skills.py --verbose` → 197 symlinks across 9 categories
- [x] `python3 scripts/sync-gemini-skills.py --verbose` → 294 items synced
- [x] `python3 scripts/generate-docs.py` → 293 pages generated (237 skills + 28 agents + 28 commands)
- [x] `mkdocs build` → clean build, 0 errors, ~8s
- [x] Consistency check: `235` skill count consistent across CLAUDE.md / README.md / docs/index.md / docs/getting-started.md / marketplace.json
- [x] All 34 marketplace `source` paths resolve to existing directories
- [x] New `product-team/apple-hig-expert/.claude-plugin/plugin.json` validates as JSON

## Commits

- `7fb04a4` — docs: sync counts + regenerate pages for llm-wiki, apple-hig, tc-tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)