### PR TITLE
fix(self-improving-agent): remove broken relative hook paths from doc…

### DIFF
--- a/engineering-team/self-improving-agent/CLAUDE.md
+++ b/engineering-team/self-improving-agent/CLAUDE.md
@@ -62,7 +62,10 @@ Shows line counts, topic files, stale entries, and recommendations.
 
 The `error-capture.sh` hook fires on `PostToolUse` (Bash only). It detects command failures and appends structured entries to auto-memory. Zero overhead on successful commands.
 
-To enable:
+When you install this plugin via `/plugin install self-improving-agent@claude-code-skills`, the hook is registered automatically from `.claude-plugin/hooks.json` — you don't need to configure anything manually.
+
+If you ever need to wire it up by hand (e.g. you copied the skill directly instead of installing as a plugin), use the `${CLAUDE_PLUGIN_ROOT}` variable so the path resolves against the plugin root rather than your current working directory:
+
 ```json
 // .claude/settings.json
 {
@@ -71,9 +74,11 @@ To enable:
       "matcher": "Bash",
       "hooks": [{
         "type": "command",
-        "command": "./skills/self-improving-agent/hooks/error-capture.sh"
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/error-capture.sh"
       }]
     }]
   }
 }
 ```
+
+**Do not use a relative path like `./hooks/error-capture.sh`** — Claude Code resolves hook commands against the user's current working directory, not the plugin root. A relative path will silently fail (non-blocking) in every session started outside the plugin install dir.

--- a/engineering-team/self-improving-agent/hooks/error-capture.sh
+++ b/engineering-team/self-improving-agent/hooks/error-capture.sh
@@ -3,18 +3,27 @@
 # Fires on PostToolUse (Bash) to detect command failures.
 # Zero output on success — only captures when errors are detected.
 #
-# Install: Add to .claude/settings.json:
-# {
-#   "hooks": {
-#     "PostToolUse": [{
-#       "matcher": "Bash",
-#       "hooks": [{
-#         "type": "command",
-#         "command": "./skills/self-improving-agent/hooks/error-capture.sh"
+# When installed via `/plugin install self-improving-agent@claude-code-skills`
+# this hook is registered automatically from the plugin's hooks.json. No
+# manual wiring is required.
+#
+# If you need to wire it up manually, use ${CLAUDE_PLUGIN_ROOT} — a relative
+# path like ./hooks/error-capture.sh resolves against your current working
+# directory, not the plugin root, and will silently fail in every session
+# started outside the plugin install dir.
+#
+#   .claude/settings.json:
+#   {
+#     "hooks": {
+#       "PostToolUse": [{
+#         "matcher": "Bash",
+#         "hooks": [{
+#           "type": "command",
+#           "command": "${CLAUDE_PLUGIN_ROOT}/hooks/error-capture.sh"
+#         }]
 #       }]
-#     }]
+#     }
 #   }
-# }
 
 set -e
 


### PR DESCRIPTION
Closes #506.

## The report

@ajanatka reported that `engineering-team/self-improving-agent/hooks/hooks.json` used a relative command path:

```json
"command": "./hooks/error-capture.sh"
```

…which fails silently (non-blocking) in any Claude Code session started outside the plugin directory, since Claude Code resolves hook commands against the user's cwd, not the plugin root.

## Partial pre-existing fix

Commit `217b199` (which closed #392) **already fixed** the two functional files:
- `engineering-team/self-improving-agent/hooks/hooks.json` ✅ uses `${CLAUDE_PLUGIN_ROOT}`
- `engineering-team/self-improving-agent/settings.json` ✅ uses `${CLAUDE_PLUGIN_ROOT}`

So the actual hook-installation mechanism is correct on main. But two stale examples in the documentation layer were still teaching users to reproduce the bug:

1. **`engineering-team/self-improving-agent/CLAUDE.md` line 74** — "To enable" example block with `./skills/self-improving-agent/hooks/error-capture.sh`
2. **`engineering-team/self-improving-agent/hooks/error-capture.sh` header comment** — install example with the same broken path

A user copying either example into their own `.claude/settings.json` would hit exactly the failure mode described in #506.

## Fix

Rewrote both example blocks to use `${CLAUDE_PLUGIN_ROOT}/hooks/error-capture.sh`, plus:

- **Added an "installed via /plugin" note to CLAUDE.md** clarifying that manual hook wiring is NOT needed when the plugin is installed normally — the hook is registered automatically from the plugin's `hooks.json`. This removes the main reason users would copy-paste the example in the first place.
- **Added explicit warnings** ("Do not use a relative path like `./hooks/error-capture.sh`") in both files, explaining why the bug happens.
- The `error-capture.sh` script logic itself is unchanged.

## Test plan

- [x] `grep -rn "\./hooks/error\|\./skills/self-improving-agent/hooks" engineering-team/self-improving-agent/` → only matches are the intentional "do not use this" warnings
- [x] `bash -n engineering-team/self-improving-agent/hooks/error-capture.sh` → syntax OK
- [x] Both `hooks/hooks.json` and `settings.json` already use `${CLAUDE_PLUGIN_ROOT}` (pre-existing from #392 fix)
- [ ] Reviewer: install the plugin via `/plugin install self-improving-agent@claude-code-skills`, start a session from `~/` (outside plugin dir), run any Bash tool call, confirm no "No such file or directory" in hook progress

## Commits

- `84ec346` — fix(self-improving-agent): remove broken relative hook paths from docs (#506)

Fixes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)