### PR TITLE
Add toprank to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 | [**Claude Code Skills & Agents Factory**](https://github.com/alirezarezvani/claude-code-skills-agents-factory) | Methodology for building skills at scale |
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
+| [**toprank**](https://github.com/nowork-studio/toprank) | 9 SEO and Google Ads skills for Claude Code — connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag, schema markup, and keyword bid fixes to source or CMS. MIT, 107 stars |
 
 ---
 


### PR DESCRIPTION
Resubmission of #516 targeting `dev` branch as requested by the bot (previous PR closed automatically because it targeted main).

Adds **toprank** under Related Projects.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It gives Claude Code direct access to Google Search Console, PageSpeed Insights, and the Google Ads API, then ships fixes — meta tag rewrites, JSON-LD schema markup, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost.

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests

- Source: https://github.com/nowork-studio/toprank
- Install: `/plugin marketplace add nowork-studio/toprank`