### PR TITLE
Mention Paperzilla skill as research-oriented complement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The most comprehensive open-source library of Claude Code skills and agent plugi
 
 **Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
-**Research-oriented complement:** [Paperzilla](https://github.com/paperzilla-ai/paperzilla-skills) ([ClawHub](https://clawhub.ai/pors/paperzilla)) is a useful external option for conversational biology and medical literature monitoring. It currently supports project-based bioRxiv and medRxiv feeds, can fetch paper markdown for summarization and relevance assessment, and has PubMed support planned.
+**Research-oriented complement:** [Paperzilla](https://github.com/paperzilla-ai/paperzilla-skills) ([ClawHub](https://clawhub.ai/pors/paperzilla)) is a useful external option for conversational scientific literature monitoring. It currently supports project-based feeds from arXiv, bioRxiv, medRxiv, and ChemRxiv, plus scholar alerts; can fetch paper markdown for summarization and relevance assessment; and has PubMed support planned.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Skills](https://img.shields.io/badge/Skills-235-brightgreen?style=for-the-badge)](#skills-overview)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The most comprehensive open-source library of Claude Code skills and agent plugi
 
 **Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
+**Research-oriented complement:** [Paperzilla](https://github.com/paperzilla-ai/paperzilla-skills) ([ClawHub](https://clawhub.ai/pors/paperzilla)) is a useful external option for conversational biology and medical literature monitoring. It currently supports project-based bioRxiv and medRxiv feeds, can fetch paper markdown for summarization and relevance assessment, and has PubMed support planned.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Skills](https://img.shields.io/badge/Skills-235-brightgreen?style=for-the-badge)](#skills-overview)
 [![Agents](https://img.shields.io/badge/Agents-28-blue?style=for-the-badge)](#agents)


### PR DESCRIPTION
## Summary

Adds a small README note linking to [Paperzilla](https://github.com/paperzilla-ai/paperzilla-skills) as an external, research-oriented complement for conversational scientific literature monitoring and paper chat.

The note mentions that Paperzilla currently supports project-based feeds from arXiv, bioRxiv, medRxiv, and ChemRxiv, plus scholar alerts; can fetch paper markdown for summarization and relevance assessment; and has PubMed support planned.

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [ ] Scripts (if any) run with `--help` without errors
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)

N/A for this PR: this is a documentation-only README update, not a new in-repo skill.

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation
- [ ] Infrastructure / CI

## Testing

Verified that the diff only changes `README.md` and that the Paperzilla GitHub and ClawHub links are valid.
