### PR TITLE
fix(agile-product-owner): add boundaries and triggers

### DIFF
--- a/product-team/agile-product-owner/SKILL.md
+++ b/product-team/agile-product-owner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: "agile-product-owner"
 description: Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.
+not_for: Kanban-only workflows, waterfall project planning, general task management, non-Scrum agile frameworks (SAFe, LeSS) without adaptation
 triggers:
   - write user story
   - create acceptance criteria
@@ -9,6 +10,9 @@ triggers:
   - break down epic
   - prioritize backlog
   - sprint planning
+  - backlog grooming
+  - sprint retrospective
+  - definition of done
   - INVEST criteria
   - Given When Then
   - user story template
@@ -24,6 +28,7 @@ Backlog management and sprint execution toolkit for product owners, including us
 
 ## Table of Contents
 
+- [What Makes This Skill Different](#what-makes-this-skill-different)
 - [User Story Generation Workflow](#user-story-generation-workflow)
 - [Acceptance Criteria Patterns](#acceptance-criteria-patterns)
 - [Epic Breakdown Workflow](#epic-breakdown-workflow)
@@ -33,6 +38,14 @@ Backlog management and sprint execution toolkit for product owners, including us
 - [Tools](#tools)
 
 ---
+
+## What Makes This Skill Different
+
+- **Capacity math that aligns with reality:** sprint capacity is based on velocity × availability factor, not hope.
+- **Acceptance criteria scaled by story size:** minimum AC counts map to story points to avoid under-spec'ing large items.
+- **Weighted prioritization that stays consistent:** value 40%, impact 30%, risk 15%, effort 15% keeps tradeoffs explicit.
+- **Systematic epic splitting techniques:** five concrete split patterns prevent oversized stories.
+- **INVEST validation baked into workflows:** every story includes a validation step, not just guidance.
 
 ## User Story Generation Workflow
 


### PR DESCRIPTION
## Summary

Fixes #504.

Adds a not_for boundary, three trigger keywords, and a short differentiation section so the skill is selected and scoped correctly.

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [x] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [x] Scripts (if any) run with `--help` without errors
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [x] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [x] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

Not run (content-only update).