### PR TITLE
Add 3 skills: local-tts, security-audit, boycott-filter

### DIFF
--- a/engineering/local-tts/SKILL.md
+++ b/engineering/local-tts/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: "local-tts"
+description: "Use when the user asks to generate speech, say something out loud, create a voiceover, clone a voice, or convert text to audio. Runs 100% locally via VoxCPM2 — 30 languages, voice design, voice cloning. No API calls, no cost."
+---
+
+# Local TTS — Offline Text-to-Speech
+
+**Tier:** POWERFUL
+**Category:** Engineering
+**Tags:** TTS, voice, audio, voice-cloning, offline, Apple Silicon, VoxCPM2
+
+## Overview
+
+Local TTS brings text-to-speech, voice design, and voice cloning to Claude Code — entirely offline. Powered by VoxCPM2 (2B params, Apache-2.0), it runs on Apple Silicon via Metal (MPS). No API keys, no cloud, no cost.
+
+## Three Modes
+
+### 1. Text-to-Speech
+Write text, get a 48 kHz wav file. 30 languages auto-detected.
+
+### 2. Voice Design
+Describe a voice in natural language — age, gender, accent, emotion — and the model generates it. No reference audio needed.
+
+### 3. Voice Cloning
+Provide a 3-10 second reference clip. The model reproduces the timbre, accent, and emotional tone. Combinable with style guidance.
+
+## Setup
+
+```bash
+# Install the plugin
+/plugin marketplace add vdk888/local-tts
+/plugin install local-tts@local-tts-marketplace
+
+# First use creates a Python venv and downloads the model (~10 GB one-time)
+```
+
+## Requirements
+
+- macOS with Apple Silicon (M1/M2/M3/M4) or Linux with CUDA
+- Python 3.10+
+- ~10 GB free disk space
+
+## Links
+
+- **GitHub:** https://github.com/vdk888/local-tts
+- **Demo video:** https://bubble-sentinel.netlify.app/local-tts.html
+- **License:** Apache-2.0
+- **Author:** [Bubble Invest](https://bubbleinvest.org)

--- a/engineering/security-audit/SKILL.md
+++ b/engineering/security-audit/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "security-audit"
+description: "Use when the user asks to audit security, scan for secrets, check for CVEs, detect identity tampering, or harden infrastructure. Five modules covering agent identity, infrastructure, secrets, dependencies, and multi-project dispatch."
+---
+
+# Bubble Sentinel — Security Audit
+
+**Tier:** POWERFUL
+**Category:** Engineering
+**Tags:** security, audit, secret-scanning, CVE, tamper-detection, infrastructure
+
+## Overview
+
+Automated security audit suite for Claude Code agent deployments. Five independent modules: identity tamper detection (SHA-256 snapshots), infrastructure hardening (SSH, firewall, OS updates), secret scanning (17 regex patterns), dependency CVE checking (npm, pip, cargo), and multi-project dispatch.
+
+## Key Features
+
+- **Identity Audit:** Tracks SHA-256 snapshots of agent identity/config files. CRITICAL alert on any modification.
+- **Infrastructure Audit:** SSH config, firewall status, OS updates, file permissions, environment secrets. macOS + Linux.
+- **Secret Scanner:** AWS keys, Anthropic/OpenAI tokens, Stripe keys, GitHub PATs, private keys, database URLs, custom patterns.
+- **Dependency Checker:** npm audit (v6+v7), Python via OSV API, Rust via cargo-audit.
+- **Project Dispatcher:** Cycle through registered projects with auto-detection (code vs documents).
+
+## Setup
+
+```bash
+/plugin marketplace add vdk888/bubble-sentinel
+/plugin install bubble-sentinel@bubble-sentinel
+```
+
+## Requirements
+
+- Python 3.7+ (stdlib only — zero external dependencies)
+- macOS or Linux
+- npm in PATH for Node.js dependency auditing (optional)
+
+## Links
+
+- **GitHub:** https://github.com/vdk888/bubble-sentinel (private — access via subscription)
+- **Product page:** https://bubble-sentinel.netlify.app/sentinel.html
+- **License:** MIT
+- **Author:** [Bubble Invest](https://bubbleinvest.org)

--- a/productivity/boycott-filter/SKILL.md
+++ b/productivity/boycott-filter/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: "boycott-filter"
+description: "Use when the user complains about a brand, says 'never buying from X again', wants to block a company, or mentions a boycott. Manages a personal boycott list conversationally, synced to a Chrome extension that warns you on matching pages."
+---
+
+# Boycott Filter — Personal Brand Boycott Manager
+
+**Tier:** STANDARD
+**Category:** Productivity
+**Tags:** boycott, chrome-extension, consumer, privacy, shopping, brands
+
+## Overview
+
+Ads on YouTube, Disney+, and every other platform have become so intrusive they achieve the opposite of their goal. Boycott Filter turns your frustration into action: tell your AI agent which brands to avoid, and a Chrome extension warns you every time you're about to give them money.
+
+## Features
+
+- **Conversational management** — just complain to your agent, it handles the rest
+- **Reason tracking** — your own words shown back as a reminder
+- **Brand aliases** — boycott a parent company, catch all subsidiaries
+- **Chrome extension** — red warning banner + badge on every matching page
+- **Offline capable** — extension caches the list locally
+- **Local & private** — everything runs on your machine
+
+## Setup
+
+```bash
+/plugin marketplace add vdk888/boycott-filter
+/plugin install boycott-filter@boycott-filter-marketplace
+```
+
+## Requirements
+
+- Node.js 18+
+- Chrome browser
+
+## Links
+
+- **GitHub:** https://github.com/vdk888/boycott-filter
+- **License:** MIT
+- **Author:** [Bubble Invest](https://bubbleinvest.org)


### PR DESCRIPTION
## Summary

Three production-tested skills from Bubble Invest:

- **local-tts** (engineering/) — Offline text-to-speech via VoxCPM2. 30 languages, voice design, voice cloning. Runs on Apple Silicon. Apache-2.0.
- **security-audit** (engineering/) — 5-module security audit for Claude Code agents: identity tamper detection, infrastructure hardening, secret scanning, CVE checking, multi-project dispatch. Python stdlib only. MIT.
- **boycott-filter** (productivity/) — Personal brand boycott list managed conversationally through Claude Code + Chrome extension. MIT.

All three are live in production at Bubble Invest and published on GitHub:
- https://github.com/vdk888/local-tts
- https://github.com/vdk888/bubble-sentinel
- https://github.com/vdk888/boycott-filter

## Test plan
- [x] All skills tested in production across multiple Claude Code sessions
- [x] SKILL.md files follow community format with frontmatter
- [x] Each skill has working install instructions
- [x] No external dependencies for security-audit (Python stdlib only)

Resubmission of #524, now targeting `dev` branch as required.