### PR TITLE
fix(agile-product-owner): add standalone plugin.json + marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -680,6 +680,26 @@
         "discipline"
       ],
       "category": "development"
+    },
+    {
+      "name": "agile-product-owner",
+      "source": "./product-team/agile-product-owner",
+      "description": "Agile product ownership for backlog management and sprint execution. INVEST-compliant user story generation, acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool and 2 reference guides.",
+      "version": "2.3.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "agile",
+        "scrum",
+        "product-owner",
+        "user-stories",
+        "sprint-planning",
+        "backlog",
+        "acceptance-criteria",
+        "epic-breakdown"
+      ],
+      "category": "product"
     }
   ]
 }

--- a/product-team/agile-product-owner/.claude-plugin/plugin.json
+++ b/product-team/agile-product-owner/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "agile-product-owner",
+  "description": "Agile product ownership for backlog management and sprint execution. User story generation (INVEST-compliant), acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool.",
+  "version": "2.3.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": "./"
+}


### PR DESCRIPTION
## Summary

- Adds standalone `.claude-plugin/plugin.json` so the skill can be installed individually via `/plugin install agile-product-owner@claude-code-skills`
- Adds marketplace entry (36th plugin, category: product)

Previously, `agile-product-owner` was only available as part of the `product-skills` domain bundle. Now it's also installable as a standalone plugin.

Follow-up to PR #521 which improved the skill's frontmatter (not_for boundaries, triggers, differentiators section).

## Cross-tool availability

| Platform | Status |
|---|---|
| Claude Code (standalone) | ✅ NEW — plugin.json + marketplace entry |
| Claude Code (bundle) | ✅ already in product-skills bundle |
| Codex CLI | ✅ in skills-index.json |
| Gemini CLI | ✅ in skills-index.json |
| Hermes Agent | ✅ discoverable via sync-hermes-skills.py |
| Top-level agent | ✅ agents/product/cs-agile-product-owner.md |

## Security

Audit: PASS (0 critical, 0 high)

## Test plan

- [x] `plugin.json` valid JSON, only allowed fields
- [x] marketplace.json valid JSON (36 plugins, 0 missing sources)
- [x] Codex/Gemini/Hermes sync scripts confirm presence
- [x] `user_story_generator.py --help` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)