### PR TITLE
feat(engineering): add autocad-expert and automotive-embedded skills

### DIFF
--- a/engineering/autocad-expert/SKILL.md
+++ b/engineering/autocad-expert/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: "autocad-expert"
+description: "Use when the user asks to create engineering drawings, manage CAD layers, set up dimensions and annotations, work with AutoCAD blocks, configure plot styles, or export DWG/DXF/PDF files."
+---
+
+# AutoCAD Expert
+
+## Overview
+
+A comprehensive AutoCAD skill for 2D engineering drafting, layer management, annotation, block creation, and plot-ready output. Covers architectural, mechanical, civil, and electrical disciplines following ASME Y14.5 and ISO 128 standards.
+
+## Core Competencies
+
+### 2D Drafting
+- **Geometry Creation**: Lines, polylines, arcs, circles, splines with exact coordinates
+- - **Editing Commands**: Trim, extend, offset, fillet, chamfer, array, mirror, stretch
+  - - **Coordinate Systems**: World vs User Coordinate System; absolute, relative, polar input
+    - - **Object Snaps**: Endpoint, midpoint, center, intersection, perpendicular, tangent
+      - - **Precision Drawing**: Ortho, polar tracking, grid snap, object snap tracking
+       
+        - ### Layer Management
+        - - **Layer Standards**: Industry naming (A-WALL-CONSTR, M-PIPE-SUPL, E-POWR-LITE)
+          - - **Layer Properties**: Color, linetype, lineweight, plot style, transparency
+            - - **Layer States**: Save and restore visibility configs for review sets
+              - - **Layer Filters**: Property and group filters for large drawings
+                - - **Audit & Cleanup**: Purge unused layers; enforce with CAD Standards Checker
+                 
+                  - ### Dimensioning & Annotation
+                  - - **Dimension Types**: Linear, aligned, angular, radius, diameter, ordinate, baseline
+                    - - **GD&T**: Geometric tolerances per ASME Y14.5 using TOLERANCE command
+                      - - **Annotative Scaling**: Annotative dimensions and text for automatic viewport scaling
+                        - - **Text & Tables**: MTEXT, DTEXT, TABLE; field codes for dynamic values
+                          - - **Leaders**: MLEADER with arrowhead styles; standard callout blocks
+                           
+                            - ### Block Library
+                            - - **Static Blocks**: Title blocks, north arrows, section markers, standard symbols
+                              - - **Dynamic Blocks**: Parameters and actions for parametric components (doors, valves)
+                                - - **Block Attributes**: ATTDEF, ATTEDIT, ATTEXT for automated BOMs and schedules
+                                  - - **Xrefs**: Attach, overlay, bind, and reload external references
+                                   
+                                    - ### Sheet & Plot Setup
+                                    - - **Layouts**: Model space vs paper space; multiple layouts per project
+                                      - - **Viewports**: MVIEW, VPCLIP, VPLAYER for per-viewport layer overrides
+                                        - - **Plot Styles**: CTB (color-dependent) vs STB (named); lineweight mapping
+                                          - - **Publish**: Multi-sheet PDF/DWF export via PUBLISH command
+                                           
+                                            - ## Decision Framework
+                                           
+                                            - | Gate | Question | Action |
+                                            - |------|----------|--------|
+                                            - | Discipline | Architecture, mechanical, civil, or electrical? | Apply discipline layer standard |
+                                            - | Units | Imperial (inches) or metric (mm)? | Set at file creation with UNITS |
+                                            - | Output | PDF, DWF, or physical plot? | Define plot style and page setup |
+                                            - | Version | Minimum DWG version required? | SAVEAS to compatible format |
+                                            - | Scale | Drawing scale for annotation? | Set annotative scale or DIMSCALE |
+                                           
+                                            - ## Command Quick Reference
+                                           
+                                            - | Category | Command | Alias | Purpose |
+                                            - |----------|---------|-------|---------|
+                                            - | Draw | LINE | L | Create line segments |
+                                            - | Draw | POLYLINE | PL | Connected polyline |
+                                            - | Draw | CIRCLE | C | Create circle |
+                                            - | Edit | TRIM | TR | Trim to boundary |
+                                            - | Edit | OFFSET | O | Offset by distance |
+                                            - | Edit | ARRAY | AR | Rectangular or polar array |
+                                            - | Annotation | DIMLINEAR | DLI | Linear dimension |
+                                            - | Annotation | MTEXT | MT | Multiline text |
+                                            | Annotation | MLEADER | MLD | Multileader callout |
+| Layer | LAYER | LA | Layer Properties Manager |
+| Block | BLOCK | B | Define block |
+                                   
+| Block | INSERT | I | Insert block || Block | XREF | XR | External reference manager |
+| Plot | PUBLISH | — | Multi-sheet publish |
+
+## Layer Naming Conventions
+
+| Discipline | Prefix | Example | Content |
+|-----------|--------|---------|---------|
+| Architecture | A- | A-WALL-CONSTR | Construction walls |
+| Mechanical | M- | M-PIPE-SUPL | Supply piping |
+| Electrical | E- | E-POWR-LITE | Power/lighting |
+| Civil | C- | C-ROAD-CNTR | Road centerlines |
+| Structural | S- | S-BEAM-WIDE | Wide flange beams |
+| General | G- | G-ANNO-DIMS | Dimensions |
+
+## Risk & Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Objects won't trim | Boundary not co-planar | Check Z elevation; use edge mode |
+| Wrong dimension value | Snap to wrong point | Use OSNAP overrides; verify endpoint |
+| Plot is blank | Layer frozen or viewport off | Check LAYER visibility; activate viewport |
+| Xref not loading | Path broken | XREF RELOAD; verify path and DWG version |
+| Hatch invisible | Boundary not closed | Use BOUNDARY to create closed polyline |
+| Slow performance | Proxy objects or duplicates | OVERKILL; PURGE unused objects |
+
+## Standard Workflow
+
+```
+Standards Setup  -> Set units, layers, dim styles, text styles
+Template (DWT)   -> Save preconfigured template for reuse
+Drawing          -> Geometry on correct layers with precision
+Annotation       -> Dimensions, text, symbols at annotative scale
+Blocks           -> Standard symbols; dynamic components
+Layout/Plot      -> Viewports, plot style, page setup
+Output           -> Publish to PDF/DWF or plot to printer
+```
+
+## Related Skills
+
+| Combination | Workflow |
+|-------------|----------|
+| AutoCAD + Revit | DWG underlays for BIM coordination |
+| AutoCAD + Civil 3D | Survey and alignment data exchange |
+| AutoCAD + Inventor | 2D drawings from 3D parametric model |
+| AutoCAD + SolidWorks | DWG/DXF interchange for mechanical |
+
+## Cross-References
+
+- **automotive-embedded** — embedded C/C++ for vehicle systems using CAD-generated schematics
+- - **database-designer** — store drawing metadata, revision history, and BOM data
+  - - **spec-driven-workflow** — drive CAD drawing requirements from specifications

--- a/engineering/automotive-embedded/SKILL.md
+++ b/engineering/automotive-embedded/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: "automotive-embedded"
+description: "Use when the user asks to write safety-critical automotive embedded C/C++ code, apply MISRA C:2012 or AUTOSAR C++14 guidelines, implement ISO 26262 functional safety, work with CAN/LIN/Ethernet protocols, write CAPL scripts for CANoe, or configure RTOS tasks for vehicle ECUs."
+---
+
+# Automotive Embedded C/C++
+
+## Overview
+
+A comprehensive skill for AI-assisted development of safety-critical automotive embedded software. Covers MISRA C:2012, AUTOSAR C++14, ISO 26262 functional safety, ISO 21434 cybersecurity, CAN/LIN/Ethernet protocols, RTOS patterns, and Vector CANoe/CAPL toolchain.
+
+## Core Competencies
+
+### Coding Standards
+- **MISRA C:2012**: Mandatory, required, and advisory rules for safety-critical C
+- - **AUTOSAR C++14**: Adaptive platform guidelines for modern C++ in vehicles
+  - - **CERT C**: Secure coding to prevent memory corruption and undefined behavior
+    - - **Rule Enforcement**: Static analysis integration (PC-lint, Polyspace, Coverity, LDRA)
+     
+      - ### Functional Safety — ISO 26262
+      - - **ASIL Decomposition**: Assign ASIL A–D to software components based on hazard analysis
+        - - **Safety Architecture**: Freedom from interference; software component independence
+          - - **Safe State Design**: Define safe state transitions for fault reactions
+            - - **Diagnostic Coverage**: Fault detection and handling; watchdog patterns
+              - - **SW-C Design**: AUTOSAR Software Component modeling for safety-critical functions
+               
+                - ### Cybersecurity — ISO 21434
+                - - **Secure Coding**: Input validation, bounds checking, integer overflow prevention
+                  - - **Key Management**: Hardware Security Module (HSM) integration patterns
+                    - - **Secure Boot**: Trust chain verification for ECU firmware
+                      - - **Attack Surface Reduction**: Minimal interfaces; disable unused communication stacks
+                       
+                        - ### RTOS & Real-Time Patterns
+                        - - **Task Design**: Fixed-priority preemptive scheduling; AUTOSAR OS tasks
+                          - - **Timing Constraints**: Worst-case execution time (WCET) analysis and deadlines
+                            - - **Resource Management**: Mutex, semaphore, event flag usage; priority inversion prevention
+                              - - **Memory Protection**: MPU configuration; stack overflow detection
+                                - - **Interrupt Handling**: ISR design rules; deferred processing patterns
+                                 
+                                  - ### Communication Protocols
+                                  - - **CAN**: Frame types, arbitration, error handling; Classic CAN and CAN FD
+                                    - - **LIN**: Master/slave schedule tables; diagnostic frames
+                                      - - **Automotive Ethernet**: DoIP, SOME/IP service discovery, AVB/TSN
+                                        - - **UDS (ISO 14229)**: Diagnostic services; session management; security access
+                                          - - **XCP**: Calibration and measurement protocol for A2L/DBC integration
+                                           
+                                            - ### Vector CANoe / CAPL
+                                            - - **CAPL Scripts**: Event-driven simulation nodes; message handlers; timer events
+                                              - - **Test Automation**: vTESTstudio test cases; CAPL test modules
+                                                - - **DBC Files**: Message and signal definitions; value tables
+                                                  - - **Diagnostic Sessions**: UDS test sequences in CAPL
+                                                    - - **Measurement & Calibration**: XCP/A2L integration; signal panel configuration
+                                                     
+                                                      - ## Decision Framework
+                                                     
+                                                      - | Gate | Question | Action |
+                                                      - |------|----------|--------|
+                                                      - | ASIL Level | What is the ASIL target (A/B/C/D)? | Apply appropriate safety architecture |
+                                                      - | Language | C or C++? | Apply MISRA C:2012 or AUTOSAR C++14 |
+                                                      - | OS | Bare-metal or RTOS (AUTOSAR OS / FreeRTOS)? | Choose task/ISR patterns accordingly |
+                                                      - | Protocol | CAN, LIN, or Ethernet? | Select appropriate driver and stack |
+                                                      - | Toolchain | GCC, Green Hills, TASKING, or IAR? | Configure compiler flags and linker |
+                                                      - | Analysis | PC-lint, Polyspace, Coverity, or LDRA? | Set up rule configuration file |
+                                                     
+                                                      - ## MISRA C:2012 Key Rules
+                                                     
+                                                      - | Rule | Category | Description |
+                                                      - |------|----------|-------------|
+                                                      - | Dir 1.1 | Required | Any implementation-defined behavior shall be documented |
+                                                      - | Rule 1.3 | Required | No undefined behavior |
+                                                      - | Rule 2.1 | Required | A project shall not contain unreachable code |
+                                                      - | Rule 8.4 | Required | Compatible declaration for every function with external linkage |
+                                                      - | Rule 10.1 | Required | Operands of inappropriate essential type |
+                                                      - | Rule 11.3 | Required | No cast between pointer to object and pointer to different type |
+                                                      - | Rule 14.4 | Required | Controlling expression of if/loop must be Boolean |
+                                                      - | Rule 15.5 | Advisory | A function should have a single point of exit |
+                                                      - | Rule 17.7 | Required | Return value of non-void function must be used |
+                                                     
+                                                      - ## Code Patterns
+                                                     
+                                                      - ### Safe State Machine
+                                                      - ```c
+                                                        typedef enum {
+                                                            STATE_INIT,
+                                                            STATE_NORMAL,
+                                                            STATE_FAULT,
+                                                            STATE_SAFE
+                                                        } EcuState_t;
+
+                                                        static EcuState_t currentState = STATE_INIT;
+
+                                                        void ECU_HandleFault(void) {
+                                                            /* Transition to SAFE state on any unrecoverable fault */
+                                                            currentState = STATE_SAFE;
+                                                            /* Disable actuators, set safe outputs */
+                                                            Actuator_DisableAll();
+                                                        }
+                                                        ```
+
+                                                        ### CAN Receive Handler (MISRA-compliant)
+                                                        ```c
+                                                        void CAN_RxCallback(uint32_t msgId, const uint8_t *data, uint8_t dlc) {
+                                                            if ((data == NULL) || (dlc == 0U)) {
+                                                                return; /* Guard: invalid frame */
+                                                            }
+                                                            if (msgId == SPEED_MSG_ID) {
+                                                                vehicleSpeed_kph = (uint16_t)((uint16_t)data[0] | ((uint16_t)data[1] << 8U));
+                                                            }
+                                                        }
+                                                        ```
+
+                                                        ### RTOS Task with Deadline Monitoring
+                                                        ```c
+                                                        void VehicleControl_Task(void *pvParameters) {
+                                                            TickType_t xLastWakeTime = xTaskGetTickCount();
+                                                            const TickType_t xPeriod = pdMS_TO_TICKS(10U); /* 10 ms cycle */
+
+                                                            for (;;) {
+                                                                SensorData_Read();
+                                                                ControlAlgorithm_Execute();
+                                                                Actuator_SetOutput();
+                                                                vTaskDelayUntil(&xLastWakeTime, xPeriod);
+                                                            }
+                                                        }
+                                                        ```
+
+                                                        ### CAPL Script — CAN Message Handler
+                                                        ```capl
+                                                        on message 0x100 {
+                                                          float speed;
+                                                          speed = this.word(0) * 0.1;
+                                                          write("Vehicle speed: %.1f km/h", speed);
+                                                        }
+
+                                                        on timer periodicTimer {
+                                                          message 0x200 reqMsg;
+                                                          reqMsg.word(0) = 0x0000;
+                                                          output(reqMsg);
+                                                          setTimer(periodicTimer, 100); /* restart 100ms timer */
+                                                        }
+                                                        ```
+
+                                                        ## Static Analysis Configuration
+
+                                                        | Tool | Config File | Key Settings |
+                                                        |------|------------|--------------|
+                                                        | PC-lint Plus | lnt/au-misra-c.lnt | Enable MISRA 2012 mandatory + required |
+                                                        | Polyspace | polyspace.cfg | ASIL B or higher; prove absence of RTE |
+                                                        | Coverity | coverity-config.xml | Enable CERT C checkers + misra_c_2012 |
+                                                        | LDRA | ldra.cfg | Enable all MISRA required + advisory |
+
+                                                        ## Standards Reference
+
+                                                        | Standard | Scope | Key Parts |
+                                                        |----------|-------|-----------|
+                                                        | MISRA C:2012 | C coding guidelines | Mandatory, Required, Advisory rules |
+                                                        | AUTOSAR C++14 | C++ for adaptive platform | Core type safety, templates, concurrency |
+                                                        | ISO 26262:2018 | Functional safety, road vehicles | Parts 4 (system), 6 (SW), 8 (processes) |
+                                                        | ISO 21434:2021 | Cybersecurity engineering | Secure development lifecycle, TARA |
+                                                        | ISO 14229 (UDS) | Unified Diagnostic Services | Session, security, DTC management |
+                                                        | SAE J1939 | Heavy vehicle CAN protocol | PGN definitions, address claiming |
+
+                                                        ## Troubleshooting
+
+                                                        | Problem | Cause | Solution |
+                                                        |---------|-------|----------|
+                                                        | Stack overflow | Task stack undersized | Increase stack; use uxTaskGetStackHighWaterMark |
+                                                        | CAN bus-off | Persistent TX errors | Check termination; verify baud rate; reset CAN controller |
+                                                        | MISRA violation flood | Legacy code integrated | Suppress with documented deviations; isolate in wrapper |
+                                                        | Polyspace orange check | Unbounded pointer arithmetic | Add array bounds check; use MISRA Rule 18.1 pattern |
+                                                        | UDS security access fail | Wrong seed/key algorithm | Verify SecurityAccess plugin config; check byte order |
+                                                        | Priority inversion | Mutex held by low-priority task | Use priority inheritance mutex or priority ceiling protocol |
+
+                                                        ## Cross-References
+
+                                                        - **autocad-expert** — CAD schematics and wiring harness drawings for vehicle systems
+                                                        - - **spec-driven-workflow** — translate AUTOSAR SWC specifications into code
+                                                          - - **ci-cd-pipeline-builder** — integrate static analysis and HIL test into CI pipeline
+                                                            - - **database-designer** — store calibration data, DTC definitions, and diagnostic logs

--- a/engineering/embedded-systems-engineer/SKILL.md
+++ b/engineering/embedded-systems-engineer/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: "embedded-systems-engineer"
+description: "Use when the user asks to write firmware for microcontrollers (ARM Cortex-M, STM32, ESP32, AVR), implement RTOS tasks with FreeRTOS or Zephyr, design hardware interfaces (I2C, SPI, UART, CAN), optimize for resource constraints, or debug embedded systems."
+---
+
+# Embedded Systems Engineer
+
+## Overview
+
+Elite firmware development skill for resource-constrained embedded systems. Covers bare-metal and RTOS programming (FreeRTOS, Zephyr), ARM Cortex-M / STM32 / ESP32 microcontrollers, hardware protocols, power optimization, and field debugging.
+
+## Core Competencies
+
+### Microcontroller Platforms
+- **ARM Cortex-M**: M0/M3/M4/M7 core features, NVIC, SysTick, MPU
+- - **STM32**: HAL/LL drivers, CubeMX configuration, HRTIM, ADC, DMA
+  - - **ESP32**: FreeRTOS integration, WiFi/BLE stack, deep sleep modes
+    - - **AVR/PIC**: Legacy 8-bit patterns; migrating to ARM
+     
+      - ### RTOS — FreeRTOS & Zephyr
+      - - **Tasks**: Priority-based preemptive scheduling; stack sizing
+        - - **Synchronization**: Mutex (priority inheritance), Semaphore, EventGroup
+          - - **Communication**: Queue, StreamBuffer, MessageBuffer; Zbus for Zephyr
+            - - **Power**: Tickless idle, device PM suspend/resume, sleep states
+              - - **Zephyr-Specific**: Devicetree, Kconfig, West workspace, SMF state machines
+               
+                - ### Hardware Interfaces
+                - - **I2C**: Master/slave; clock stretching; multi-master arbitration
+                  - - **SPI**: CPOL/CPHA modes; DMA transfers; chip select management
+                    - - **UART**: Baud rate config; DMA circular buffer; hardware flow control
+                      - - **CAN/CAN-FD**: Frame types, filters, error handling; ISO-TP
+                        - - **USB**: CDC-ACM, HID device classes; DFU for firmware updates
+                         
+                          - ### Memory & Resource Management
+                          - - **Static allocation only**: No malloc in production firmware
+                            - - **Memory pools**: Fixed-size blocks for predictable heap-like usage
+                              - - **Stack analysis**: uxTaskGetStackHighWaterMark; worst-case estimation
+                                - - **Flash optimization**: Const data in ROM; XIP configuration
+                                  - - **DMA**: Free CPU during data transfers; double-buffer patterns
+                                   
+                                    - ### Debugging & Diagnostics
+                                    - - **JTAG/SWD**: GDB + OpenOCD; breakpoints, watchpoints, live variables
+                                      - - **UART logging**: Compile-time log levels; deferred logging for speed
+                                        - - **Circular trace buffer**: Overwrites old entries; post-mortem analysis
+                                          - - **LED blink codes**: Error state indication in field deployments
+                                            - - **Core dumps**: Zephyr core dump for crash analysis
+                                             
+                                              - ## Design Hierarchy
+                                             
+                                              - ```
+                                                1. Resource Constraints  -> RAM/flash budget; power budget
+                                                2. Real-Time Requirements-> Hard deadlines; interrupt latency
+                                                3. Reliability & Safety  -> Watchdog; fail-safe states; CRC checks
+                                                4. Debuggability         -> JTAG; UART log; trace buffers; assert macros
+                                                5. Hardware Abstraction  -> HAL layer; BSP; driver layer separation
+                                                ```
+
+                                                ## Decision Framework
+
+                                                | Gate | Question | Action |
+                                                |------|----------|--------|
+                                                | Platform | MCU family and constraints? | Choose HAL/LL vs register direct |
+                                                | OS | Bare-metal or RTOS? | FreeRTOS if >2 tasks; Zephyr for connectivity |
+                                                | Memory | RAM available for RTOS overhead? | FreeRTOS ~10KB; Zephyr ~20KB minimum |
+                                                | Power | Battery-powered? | Tickless idle + device PM |
+                                                | Safety | ASIL or IEC 62304? | Add to automotive-embedded or misra-automotive-c skill |
+                                                | Debug | Production or development build? | Strip logs; enable asserts; size optimize |
+
+                                                ## Zephyr RTOS Key Patterns
+
+                                                ### Devicetree Node
+                                                ```dts
+                                                /* Board overlay for STM32 UART */
+                                                &usart1 {
+                                                    status = "okay";
+                                                    current-speed = <115200>;
+                                                    pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+                                                };
+                                                ```
+
+                                                ### FreeRTOS Task
+                                                ```c
+                                                static void SensorTask(void *pvParameters)
+                                                {
+                                                    TickType_t xLastWake = xTaskGetTickCount();
+                                                    for (;;) {
+                                                        Sensor_Sample();
+                                                        vTaskDelayUntil(&xLastWake, pdMS_TO_TICKS(10U));
+                                                    }
+                                                }
+                                                /* Stack and priority */
+                                                xTaskCreate(SensorTask, "Sensor", 256U, NULL, 3U, NULL);
+                                                ```
+
+                                                ### Zephyr Thread
+                                                ```c
+                                                K_THREAD_DEFINE(sensor_tid, 1024,
+                                                                sensor_thread_fn, NULL, NULL, NULL,
+                                                                5, 0, 0);
+                                                ```
+
+                                                ### ISR-Safe Queue Send
+                                                ```c
+                                                /* From ISR: use FromISR variant */
+                                                BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+                                                xQueueSendFromISR(xEventQueue, &event, &xHigherPriorityTaskWoken);
+                                                portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+                                                ```
+
+                                                ## Troubleshooting
+
+                                                | Problem | Cause | Solution |
+                                                |---------|-------|----------|
+                                                | Stack overflow | Undersized task stack | Increase stack; check high-water mark |
+                                                | Priority inversion | Mutex held by low-priority task | Use priority-inheritance mutex |
+                                                | Spurious ISR | Interrupt not cleared | Clear pending flag first in ISR |
+                                                | DMA transfer corrupt | Cache coherency | Flush/invalidate D-cache around DMA buffers |
+                                                | Watchdog reset loop | Main task blocked | Refresh WDT only from main loop |
+                                                | I2C hang | Missing STOP condition | Software reset I2C peripheral |
+                                                | ESP32 crash | Stack overflow or heap fragmentation | Increase stack; use static allocation |
+
+                                                ## Power Optimization
+
+                                                | Technique | Saving | Notes |
+                                                |-----------|--------|-------|
+                                                | Tickless idle | 30–60% | Disable SysTick during idle |
+                                                | Clock gating | 10–20% | Disable unused peripheral clocks |
+                                                | Voltage scaling | 20–40% | Reduce Vcore at low frequencies |
+                                                | Deep sleep | 90%+ | Retain RAM; GPIO wakeup |
+                                                | DMA vs CPU copy | 5–15% | Free CPU for sleep during transfers |
+
+                                                ## Cross-References
+
+                                                - **automotive-embedded** — MISRA/AUTOSAR/ISO 26262 for safety-critical automotive firmware
+                                                - - **misra-automotive-c** — live MISRA C:2012 code review for embedded C
+                                                  - - **ci-cd-pipeline-builder** — automate firmware builds, unit tests, and HIL in CI
+                                                    - - **autocad-expert** — hardware enclosure and PCB layout documentation

--- a/engineering/misra-automotive-c/SKILL.md
+++ b/engineering/misra-automotive-c/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: "misra-automotive-c"
+description: "Use when the user says 'misra check', 'misra review', 'automotive c', 'embedded c review', or pastes C code for safety-critical automotive review. Scans for MISRA C:2012 violations, reports rule numbers with ASIL classification, and provides compliant replacements."
+---
+
+# MISRA Automotive C — Live Code Reviewer
+
+## Overview
+
+An interactive MISRA C:2012 code review skill for automotive embedded C. When triggered, it scans pasted C code, flags every violation with rule number, category (Mandatory/Required/Advisory), ASIL level (A–D), and provides a ready-to-use compliant replacement for every non-compliant line.
+
+## Trigger Phrases
+
+Activate with any of:
+- `misra check` / `misra review` / `check misra`
+- - `automotive c` / `embedded c review`
+  - - `iso 26262` / `asil`
+    - - Paste C code — reviewer will offer a check automatically
+     
+      - ## Review Workflow
+     
+      - For every code snippet, perform these steps in order:
+     
+      - 1. **Scan Mandatory rules** — violations that are never permitted under any circumstances
+        2. 2. **Scan Required rules** — violations that require formal deviation documentation
+           3. 3. **Scan Advisory rules** — best-practice recommendations
+              4. 4. **For each violation, report:**
+                 5.    - MISRA C:2012 rule number and directive
+                       -    - Category: Mandatory / Required / Advisory
+                            -    - ASIL classification: A / B / C / D
+                                 -    - The exact non-compliant line
+                                      -    - Plain-English explanation of why it violates the rule
+                                           -    - A ready-to-use MISRA-compliant replacement with explanation
+                                                - 5. **Output a summary table** with total counts by category and ASIL level
+                                                 
+                                                  6. ## Output Format
+                                                 
+                                                  7. ```
+                                                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                                                     VIOLATION #<N>
+                                                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                                                     Rule     : MISRA C:2012 Rule <X.Y>
+                                                     Category : Mandatory | Required | Advisory
+                                                     ASIL     : A | B | C | D
+                                                     Location : <function name or line context>
+
+                                                     Non-Compliant:
+                                                       <original code line>
+
+                                                     Why it violates:
+                                                       <plain English explanation>
+
+                                                     MISRA-Compliant Replacement:
+                                                       <corrected code>
+
+                                                     Explanation of fix:
+                                                       <why this replacement satisfies the rule>
+                                                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                                                     ```
+
+                                                     ## Key Rules Reference
+
+                                                     ### Mandatory Rules (never permitted)
+                                                     | Rule | Topic | Common Violation |
+                                                     |------|-------|-----------------|
+                                                     | 1.3 | Undefined behavior | Signed integer overflow, unsequenced side effects |
+                                                     | 2.1 | Unreachable code | Dead code after return statement |
+                                                     | 13.6 | sizeof side effects | sizeof(x++) — side effect in sizeof |
+                                                     | 17.3 | Implicit function declaration | Calling undeclared function |
+                                                     | 18.1 | Pointer arithmetic bounds | Array index without bounds check |
+
+                                                     ### Required Rules (key selection)
+                                                     | Rule | Topic | Common Violation |
+                                                     |------|-------|-----------------|
+                                                     | D.4.6 | Fixed-width types | Using `int`, `long` instead of `int16_t`, `uint32_t` |
+                                                     | 8.4 | External linkage declaration | Function used externally without header prototype |
+                                                     | 10.1 | Essential type category | Mixing signed/unsigned in arithmetic |
+                                                     | 11.3 | Pointer casting | Casting `uint8_t*` to `uint16_t*` |
+                                                     | 14.4 | Controlling expression | Non-Boolean in if/while condition |
+                                                     | 15.5 | Single exit | Multiple return statements in function |
+                                                     | 17.7 | Return value used | Ignoring return value of non-void function |
+
+                                                     ### Type Rules — Fixed-Width Essentials
+                                                     ```c
+                                                     /* VIOLATION: uses basic 'int' type */
+                                                     int compute_speed(int raw_adc) { ... }
+
+                                                     /* COMPLIANT: fixed-width types, portable across compilers */
+                                                     int16_t compute_speed(uint16_t raw_adc) { ... }
+                                                     ```
+
+                                                     ### Memory Rules
+                                                     ```c
+                                                     /* VIOLATION: dynamic allocation not permitted */
+                                                     uint8_t *buf = (uint8_t *)malloc(64);
+
+                                                     /* COMPLIANT: static allocation */
+                                                     static uint8_t buf[64];
+                                                     ```
+
+                                                     ### Control Flow Rules
+                                                     ```c
+                                                     /* VIOLATION: goto not permitted (Rule 15.1) */
+                                                     goto error_handler;
+
+                                                     /* COMPLIANT: structured error handling */
+                                                     if (status != OK) {
+                                                         Error_Handle(status);
+                                                     }
+                                                     ```
+
+                                                     ### Pointer Rules
+                                                     ```c
+                                                     /* VIOLATION: pointer cast between incompatible types (Rule 11.3) */
+                                                     uint16_t val = *((uint16_t *)byte_ptr);
+
+                                                     /* COMPLIANT: use memcpy for type-punning */
+                                                     uint16_t val;
+                                                     (void)memcpy(&val, byte_ptr, sizeof(uint16_t));
+                                                     ```
+
+                                                     ## ASIL Mapping
+
+                                                     | ASIL | Risk Level | Typical Systems | Rule Strictness |
+                                                     |------|-----------|-----------------|-----------------|
+                                                     | A | Lowest | Comfort systems, HVAC | Mandatory + selected Required |
+                                                     | B | Low-Medium | Body control, lighting | + more Required rules |
+                                                     | C | Medium-High | Chassis, braking assist | + most Required + key Advisory |
+                                                     | D | Highest | Airbags, ABS, steering | Full Mandatory + Required |
+
+                                                     ## Common Automotive Patterns
+
+                                                     ### Safe Sensor Read with Bounds Check
+                                                     ```c
+                                                     /* MISRA-compliant sensor read with validation */
+                                                     static int16_t Sensor_ReadTemp(void)
+                                                     {
+                                                         int16_t raw;
+                                                         int16_t temp_degC;
+
+                                                         raw = ADC_Read(TEMP_CHANNEL);
+
+                                                         /* Rule 14.3: controlling expression must be Boolean */
+                                                         if ((raw >= TEMP_RAW_MIN) && (raw <= TEMP_RAW_MAX)) {
+                                                             temp_degC = (int16_t)(((int32_t)raw * TEMP_SCALE) / TEMP_DIVISOR);
+                                                         } else {
+                                                             temp_degC = TEMP_FAULT_VALUE;
+                                                             Fault_Set(FAULT_TEMP_SENSOR);
+                                                         }
+                                                         return temp_degC;
+                                                     }
+                                                     ```
+
+                                                     ### ISR with Fixed Types
+                                                     ```c
+                                                     /* MISRA-compliant ISR */
+                                                     void TIM2_IRQHandler(void)
+                                                     {
+                                                         static uint16_t tick_count = 0U;
+
+                                                         tick_count++;
+                                                         if (tick_count >= TICK_OVERFLOW_MAX) {
+                                                             tick_count = 0U;
+                                                         }
+                                                         TIM2->SR &= ~TIM_SR_UIF;  /* clear interrupt flag */
+                                                     }
+                                                     ```
+
+                                                     ## Known Limitations
+
+                                                     - This skill performs AI-assisted review — not a substitute for certified MISRA checkers (PC-lint Plus, Helix QAC, Polyspace, CodeSonar)
+                                                     - - Undecidable rules requiring full program analysis may produce incomplete results on snippets
+                                                       - - MISRA C:2023 amendments (AMD2–AMD4) are not covered — base C:2012 rules apply
+                                                         - - For formal compliance certification, use alongside a certified static analysis tool
+                                                          
+                                                           - ## Cross-References
+                                                          
+                                                           - - **automotive-embedded** — full RTOS, CAN/LIN, ISO 26262, and CAPL skill
+                                                             - - **ci-cd-pipeline-builder** — automate MISRA checks in CI with PC-lint or Polyspace
+                                                               - - **spec-driven-workflow** — generate MISRA-compliant code from formal specifications

--- a/engineering/solidworks-expert/SKILL.md
+++ b/engineering/solidworks-expert/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: "solidworks-expert"
+description: "Use when the user asks to model parts or assemblies in SolidWorks, create engineering drawings with GD&T, design sheet metal flat patterns, run FEA simulation, export STEP/IGES/STL, or troubleshoot SolidWorks rebuild errors."
+---
+
+# SolidWorks Expert
+
+## Overview
+
+Parametric 3D CAD skill for SolidWorks: part modeling, assembly design, engineering drawings, sheet metal, weldments, and FEA simulation. Follows ASME Y14.5-2018 for GD&T and supports DFM guidance.
+
+## Core Competencies
+
+### Part Modeling
+- Extrude, Revolve, Sweep, Loft, Shell, Rib features
+- - Fillet, Chamfer, Draft, Hole Wizard, Thread
+  - - Fully constrained sketches with design intent
+    - - Configurations and Design Tables for parametric variants
+     
+      - ### Assembly Design
+      - - Bottom-up (parts first) and top-down (in-context) workflows
+        - - Mates: Coincident, Concentric, Distance, Angle, Gear, Cam, Slot
+          - - Interference Detection; Large Assembly Mode with SpeedPak
+           
+            - ### Engineering Drawings
+            - - Views: Front, Top, Section, Detail, Broken-out, Isometric
+              - - GD&T per ASME Y14.5-2018: form, orientation, location, runout
+                - - Auto-generated Bill of Materials; title block linked to properties
+                 
+                  - ### Sheet Metal
+                  - - Base Flange, Edge Flange, Miter Flange, Hem
+                    - - Flat Pattern with bend lines for laser/punch
+                      - - K-Factor and bend allowance tables
+                       
+                        - ### Simulation (COSMOSWorks / Simulation)
+                        - - Static FEA: Von Mises stress, displacement, factor of safety
+                          - - Thermal: temperature distribution, heat flux
+                            - - Frequency: natural frequencies and mode shapes
+                              - - Curvature-based mesh with refinement at stress concentrations
+                               
+                                - ## Decision Framework
+                               
+                                - | Gate | Question | Action |
+                                - |------|----------|--------|
+                                - | Scope | Single part, assembly, or drawing? | Choose document type |
+                                - | Approach | Bottom-up or top-down? | Define assembly strategy |
+                                - | Output | Prototype, production, mold/tooling? | Select manufacturing method |
+                                - | Format | SW native, STEP, IGES, or STL? | Plan export strategy |
+                                - | Tolerance | Fit critical? | Apply GD&T per ASME Y14.5 |
+                               
+                                - ## Workflow
+                               
+                                - ```
+                                  Concept       -> Constrained 2D sketch with dimensions
+                                  Part Design   -> Base feature + dependent features
+                                  Validation    -> Interference check, mass properties, FEA
+                                  Assembly      -> Mates; top-down for contextual parts
+                                  Documentation -> Drawings with dims, tolerances, BOM, notes
+                                  Mfg Prep      -> Sheet metal flat patterns; mold tooling
+                                  Release       -> PDM check-in; STEP/PDF export
+                                  ```
+
+                                  ## Troubleshooting
+
+                                  | Problem | Cause | Solution |
+                                  |---------|-------|----------|
+                                  | Rebuild fails | Over-constrained sketch | Rollback bar; fix sketch first |
+                                  | Mate won't apply | Components misaligned | Move closer; use SmartMates |
+                                  | Fillet fails | Edge radius too small | Variable Radius Fillet |
+                                  | Large assembly slow | Too many loaded parts | Large Assembly Mode; SpeedPak |
+                                  | Drawing dims wrong | View misaligned | Orient view; verify ref geometry |
+                                  | Missing material | Custom material absent | Add to custom library |
+
+                                  ## Interoperability
+
+                                  | Format | Use Case |
+                                  |--------|----------|
+                                  | STEP AP214 | Neutral 3D exchange with any CAD |
+                                  | IGES | Legacy CAD interchange |
+                                  | STL | 3D printing and prototyping |
+                                  | DXF/DWG | 2D drawing exchange with AutoCAD |
+                                  | Parasolid | Native kernel for NX and Solid Edge |
+                                  | 3D PDF | Review without CAD license |
+
+                                  ## Cross-References
+
+                                  - **autocad-expert** — 2D DWG layout drawings and wiring harness documentation
+                                  - - **automotive-embedded** — ECU and sensor housing mechanical packaging
+                                    - - **spec-driven-workflow** — requirements-driven mechanical design


### PR DESCRIPTION
## Summary

Adds two new engineering skills sourced from public GitHub skill repositories.
## Checklist

- [ ] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [ ] Scripts (if any) run with `--help` without errors
- [ ] No hardcoded API keys, tokens, or secrets
- [ ] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

<!-- How did you verify this works? -->
