### PR TITLE
fix: remove invalid "skills" field from plugin.json causing failed-to-load

### DIFF
--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./",
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent"
 }


### PR DESCRIPTION
## Problem

On recent Claude Code CLI versions, `self-improving-agent@claude-code-skills` shows `Status: ✘ failed to load` in `claude plugin list` output, even after `claude plugin update`, `claude plugin disable`+`enable`, and full restart.

As a result, the 5 sub-skills (`/si:review`, `/si:promote`, `/si:extract`, `/si:status`, `/si:remember`) fail to register. The two agents (`si:memory-analyst`, `si:skill-extractor`) still load since they live under `agents/`.

## Root Cause

`engineering-team/self-improving-agent/.claude-plugin/plugin.json` declares:

```json
"skills": "./",
```

This field is rejected by Claude Code's plugin schema validator:

```
$ claude plugin validate .
✘ Found 1 error:
  ❯ skills: Invalid input
```

Comparing against 15+ working plugins in the ecosystem (autoresearch, claude-mem, codex, superpowers, data, finance, equity-research, etc.), **none declare a `skills` field in plugin.json** — the loader auto-discovers `skills/<name>/SKILL.md` by convention.

The string `"./"` is not a valid schema value; arrays such as `["./", "skills/"]` are also rejected (verified locally).

## Fix

Remove the `"skills": "./"` line. No replacement needed — the loader auto-discovers sub-skills under the conventional `skills/` directory.

## Verification

After applying the fix locally:

```
$ claude plugin validate <plugin-path>
✔ Validation passed with warnings

$ claude plugin list | grep -A3 self-improving
  ❯ self-improving-agent@claude-code-skills
    Version: 2.3.0
    Status: ✔ enabled
```

Remaining warnings are unrelated: two agent files in `agents/` lack YAML frontmatter. They load but have no metadata. Can be addressed separately.

## Environment

- Claude Code CLI: latest stable as of 2026-04-18
- Plugin version: 2.3.0
- OS: macOS (darwin 24.1.0); expected to affect all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)