### PR TITLE
Add Skills宝 (skilery.com) to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 |---------|-------------|
 | [**Claude Code Skills & Agents Factory**](https://github.com/alirezarezvani/claude-code-skills-agents-factory) | Methodology for building skills at scale |
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
+| [**Skills宝 (skilery.com)**](https://skilery.com) | Chinese AI Skills marketplace for one-stop search and install across Claude Code, OpenCode, and more platforms |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
 
 ---


### PR DESCRIPTION
Adds [Skills宝](https://skilery.com) to the Related Projects table as a Chinese AI Skills marketplace for one-stop search and install across Claude Code, OpenCode, and more platforms.\n\nRefs #559