### PR TITLE
fix(c-level-skills): rename SKILL.md name to match plugin.json

### DIFF
--- a/c-level-advisor/SKILL.md
+++ b/c-level-advisor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "c-level-advisor"
+name: "c-level-skills"
 description: "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support."
 license: MIT
 metadata:


### PR DESCRIPTION
## Problem

Claude Code's \`/plugin\` UI reports \`✘ 1 error\` for this plugin. Root cause: SKILL.md \`name\` does not match the plugin manifest.

- \`.claude-plugin/marketplace.json\` entry: \`\"name\": \"c-level-skills\"\`
- \`c-level-advisor/.claude-plugin/plugin.json\`: \`\"name\": \"c-level-skills\"\`
- \`c-level-advisor/SKILL.md\`: \`name: \"c-level-advisor\"\` ← inconsistent

The plugin loader validates these three sources against each other and fails on the mismatch.

## Fix

One-line change in \`c-level-advisor/SKILL.md\`:

\`\`\`diff
-name: \"c-level-advisor\"
+name: \"c-level-skills\"
\`\`\`

No sub-skill folders renamed. The \`/em:*\` command namespace is unaffected (it's defined per-command in \`executive-mentor/\`). Only the plugin-level identity is normalised.

## Verification

Pulled the patched file into my local plugin cache, restarted Claude Code, and the error cleared for this plugin.