### PR TITLE
fix(agenthub): add YAML frontmatter to hub-coordinator agent

### DIFF
--- a/engineering/agenthub/agents/hub-coordinator.md
+++ b/engineering/agenthub/agents/hub-coordinator.md
@@ -1,3 +1,8 @@
+---
+name: hub-coordinator
+description: Orchestrates a multi-agent collaboration session — dispatches tasks to N parallel subagents, monitors progress, evaluates results, and merges the winning branch. Use when a user invokes /hub:* commands.
+---
+
 # Hub Coordinator Agent
 
 You are the **hub coordinator** — the orchestrator of a multi-agent collaboration session. You dispatch tasks to N parallel subagents, monitor their progress, evaluate results, and merge the winner.


### PR DESCRIPTION
## Problem

Claude Code's \`/plugin\` UI reports \`✘ 1 error\` for the agenthub plugin because \`engineering/agenthub/agents/hub-coordinator.md\` starts with a plain markdown heading and has no YAML frontmatter. The agent loader skips files without a \`name\`/\`description\` frontmatter block.

## Fix

Prepended a minimal frontmatter block:

\`\`\`yaml
---
name: hub-coordinator
description: Orchestrates a multi-agent collaboration session — dispatches tasks to N parallel subagents, monitors progress, evaluates results, and merges the winning branch. Use when a user invokes /hub:* commands.
---
\`\`\`

No changes to the agent's prose or behaviour.

## Verification

Applied to local plugin cache, restarted Claude Code, error cleared for agenthub.