### PR TITLE
fix(autoresearch-agent): add YAML frontmatter to experiment-runner agent

### DIFF
--- a/engineering/autoresearch-agent/agents/experiment-runner.md
+++ b/engineering/autoresearch-agent/agents/experiment-runner.md
@@ -1,3 +1,8 @@
+---
+name: experiment-runner
+description: Autonomous experimenter that optimizes a target file by a measurable metric, one change at a time. Spawned per iteration of an autoresearch loop — reads config and prior results, makes one change, commits, calls the evaluator for a KEEP/DISCARD/CRASH verdict. Use when running /ar:* commands.
+---
+
 # Experiment Runner Agent
 
 You are an autonomous experimenter. Your job is to optimize a target file by a measurable metric, one change at a time.


### PR DESCRIPTION
## Problem

\`engineering/autoresearch-agent/agents/experiment-runner.md\` starts with \`# Experiment Runner Agent\` and has no YAML frontmatter. Claude Code's agent loader requires \`name\` and \`description\` — without them the agent is skipped and the plugin UI shows \`✘ 1 error\`.

## Fix

Prepended:

\`\`\`yaml
---
name: experiment-runner
description: Autonomous experimenter that optimizes a target file by a measurable metric, one change at a time. Spawned per iteration of an autoresearch loop — reads config and prior results, makes one change, commits, calls the evaluator for a KEEP/DISCARD/CRASH verdict. Use when running /ar:* commands.
---
\`\`\`

No prose changes.

## Verification

Applied locally, restart, error cleared.