### PR TITLE
fix(business-growth-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/business-growth/SKILL.md
+++ b/business-growth/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: "business-growth-skills"
 description: "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only)."
-version: 1.1.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - business
-  - customer-success
-  - sales
-  - revenue-operations
-  - growth
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.1.0
+  author: Alireza Rezvani
+  tags:
+    - business
+    - customer-success
+    - sales
+    - revenue-operations
+    - growth
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Business & Growth Skills


### PR DESCRIPTION
## Problem

\`business-growth/SKILL.md\` declares \`version\`, \`author\`, \`tags\`, and \`agents\` at the top level of its YAML frontmatter. Claude Code's SKILL.md schema validates the top level strictly — only \`name\`, \`description\`, \`license\`, \`allowed-tools\`, and \`context\` are recognised. Arrays at the top level (\`tags\`, \`agents\`) surface as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Nest the author-provided metadata under a \`metadata:\` block — the same pattern already used by working plugins in this repo (\`c-level-advisor\`, \`data-quality-auditor\`, \`agenthub\` etc.):

\`\`\`diff
 ---
 name: \"business-growth-skills\"
 description: \"...\"
-version: 1.1.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - business
-  - customer-success
-  - sales
-  - revenue-operations
-  - growth
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.1.0
+  author: Alireza Rezvani
+  tags:
+    - business
+    - customer-success
+    - sales
+    - revenue-operations
+    - growth
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
\`\`\`

I renamed the \`agents:\` array to \`compatible_agents:\` so it isn't confused with the \`agents/\` directory convention elsewhere in the repo. No semantic change to what's declared; just moved under the correct schema location.

## Verification

Same pattern applied locally across 10 plugins with this bug. Restarted Claude Code; \`/plugin\` error cleared for business-growth-skills.