### PR TITLE
fix(engineering-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/engineering-team/SKILL.md
+++ b/engineering-team/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: "engineering-skills"
 description: "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only)."
-version: 1.1.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - engineering
-  - frontend
-  - backend
-  - devops
-  - security
-  - ai-ml
-  - data-engineering
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.1.0
+  author: Alireza Rezvani
+  tags:
+    - engineering
+    - frontend
+    - backend
+    - devops
+    - security
+    - ai-ml
+    - data-engineering
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Engineering Team Skills


### PR DESCRIPTION
## Problem

\`engineering-team/SKILL.md\` uses flat top-level \`version\`, \`author\`, \`tags\`, \`agents\` in its YAML frontmatter. Claude Code's SKILL.md schema rejects non-canonical top-level fields and surfaces \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Moved \`version\`, \`author\`, \`tags\`, and compatible-agent list under a \`metadata:\` block. Top level now keeps only \`name\`, \`description\`, \`license\`. Same structure as \`c-level-advisor\` and \`agenthub\`. \`agents:\` renamed to \`compatible_agents:\` to avoid confusion with \`agents/\` subdirs.

Companion PRs address the same pattern in:
- business-growth-skills, engineering-advanced-skills, marketing-skills, pm-skills, product-skills, ra-qm-skills, karpathy-coder, llm-wiki

## Verification

Local restart of Claude Code cleared the error for this plugin.