### PR TITLE
fix(engineering-advanced-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/engineering/SKILL.md
+++ b/engineering/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: "engineering-advanced-skills"
 description: "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops."
-version: 1.1.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - engineering
-  - architecture
-  - agents
-  - rag
-  - mcp
-  - ci-cd
-  - observability
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.1.0
+  author: Alireza Rezvani
+  tags:
+    - engineering
+    - architecture
+    - agents
+    - rag
+    - mcp
+    - ci-cd
+    - observability
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Engineering Advanced Skills (POWERFUL Tier)


### PR DESCRIPTION
## Problem

\`engineering/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`agents\` in its YAML frontmatter. Claude Code's SKILL.md schema flags non-canonical top-level fields as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Moved them under a \`metadata:\` block. Top level now keeps only \`name\`, \`description\`, \`license\`.

Same-shape PRs: business-growth-skills, engineering-skills, marketing-skills, pm-skills, product-skills, ra-qm-skills, karpathy-coder, llm-wiki.

## Verification

Local restart cleared the error for this plugin.