### PR TITLE
fix(marketing-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/marketing-skill/SKILL.md
+++ b/marketing-skill/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: "marketing-skills"
 description: "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only)."
-version: 2.0.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - marketing
-  - seo
-  - content
-  - copywriting
-  - cro
-  - analytics
-  - ai-seo
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 2.0.0
+  author: Alireza Rezvani
+  tags:
+    - marketing
+    - seo
+    - content
+    - copywriting
+    - cro
+    - analytics
+    - ai-seo
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Marketing Skills Division


### PR DESCRIPTION
## Problem

\`marketing-skill/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`agents\` in YAML frontmatter. Claude Code's SKILL.md schema flags these as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Moved them under a \`metadata:\` block, top level now only \`name\`, \`description\`, \`license\`.

Companion PRs cover the same pattern across 8 sibling plugins.

## Verification

Local restart cleared the error.