### PR TITLE
fix(pm-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/project-management/SKILL.md
+++ b/project-management/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: "pm-skills"
 description: "6 project management agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Senior PM, scrum master, Jira expert (JQL), Confluence expert, Atlassian admin, template creator. MCP integration for live Jira/Confluence automation."
-version: 1.0.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - project-management
-  - jira
-  - confluence
-  - atlassian
-  - scrum
-  - agile
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.0.0
+  author: Alireza Rezvani
+  tags:
+    - project-management
+    - jira
+    - confluence
+    - atlassian
+    - scrum
+    - agile
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Project Management Skills


### PR DESCRIPTION
## Problem

\`project-management/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`agents\` in YAML frontmatter. Claude Code's SKILL.md schema flags non-canonical top-level fields as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Nested under a \`metadata:\` block.

Companion PRs cover the same pattern across 8 sibling plugins.

## Verification

Local restart cleared the error.