### PR TITLE
fix(product-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/product-team/SKILL.md
+++ b/product-team/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: "product-skills"
 description: "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only)."
-version: 1.1.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - product
-  - product-management
-  - ux
-  - ui
-  - saas
-  - agile
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.1.0
+  author: Alireza Rezvani
+  tags:
+    - product
+    - product-management
+    - ux
+    - ui
+    - saas
+    - agile
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Product Team Skills


### PR DESCRIPTION
## Problem

\`product-team/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`agents\`. Claude Code's SKILL.md schema flags these as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Nested under a \`metadata:\` block.

Companion PRs cover the same pattern across 8 sibling plugins.

## Verification

Local restart cleared the error.