### PR TITLE
fix(ra-qm-skills): nest non-canonical frontmatter under metadata:

### DIFF
--- a/ra-qm-team/SKILL.md
+++ b/ra-qm-team/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: "ra-qm-skills"
 description: "12 regulatory & QM agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, ISO 27001 ISMS, GDPR/DSGVO, risk management (ISO 14971), CAPA, document control, auditing. Python tools (stdlib-only)."
-version: 1.0.0
-author: Alireza Rezvani
 license: MIT
-tags:
-  - regulatory
-  - quality-management
-  - iso-13485
-  - mdr
-  - fda
-  - iso-27001
-  - gdpr
-agents:
-  - claude-code
-  - codex-cli
-  - openclaw
+metadata:
+  version: 1.0.0
+  author: Alireza Rezvani
+  tags:
+    - regulatory
+    - quality-management
+    - iso-13485
+    - mdr
+    - fda
+    - iso-27001
+    - gdpr
+  compatible_agents:
+    - claude-code
+    - codex-cli
+    - openclaw
 ---
 
 # Regulatory Affairs & Quality Management Skills


### PR DESCRIPTION
## Problem

\`ra-qm-team/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`agents\`. Claude Code's SKILL.md schema flags these as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Nested under a \`metadata:\` block.

Companion PRs cover the same pattern across 8 sibling plugins.

## Verification

Local restart cleared the error.