### PR TITLE
fix(karpathy-coder): nest non-canonical frontmatter under metadata:

### DIFF
--- a/engineering/karpathy-coder/SKILL.md
+++ b/engineering/karpathy-coder/SKILL.md
@@ -2,11 +2,12 @@
 name: karpathy-coder
 description: Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on "review my diff", "check complexity", "am I overcomplicating this", "karpathy check", "before I commit", or any code quality concern where the LLM might be overcoding.
 context: fork
-version: 2.3.0
-author: claude-code-skills
 license: MIT
-tags: [code-quality, discipline, karpathy, simplicity, surgical-changes, anti-patterns, review]
-compatible_tools: [claude-code, codex-cli, cursor, antigravity, opencode, gemini-cli]
+metadata:
+  version: 2.3.0
+  author: claude-code-skills
+  tags: [code-quality, discipline, karpathy, simplicity, surgical-changes, anti-patterns, review]
+  compatible_tools: [claude-code, codex-cli, cursor, antigravity, opencode, gemini-cli]
 ---
 
 # Karpathy Coder — Active Coding Discipline


### PR DESCRIPTION
## Problem

\`engineering/karpathy-coder/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`compatible_tools\` in YAML frontmatter. Claude Code's SKILL.md schema only recognises a small set of top-level keys (\`name\`, \`description\`, \`license\`, \`context\`, \`allowed-tools\`); everything else surfaces as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Moved the non-canonical fields under a \`metadata:\` block. **Kept \`context: fork\` at the top level** — it's a recognised Claude Code schema key for the v2.3.0 context-forking behaviour and must remain top-level.

Companion PRs cover the same pattern across 8 sibling plugins.

## Verification

Local restart cleared the error for this plugin.