### PR TITLE
fix(llm-wiki): nest non-canonical frontmatter under metadata:

### DIFF
--- a/engineering/llm-wiki/SKILL.md
+++ b/engineering/llm-wiki/SKILL.md
@@ -2,11 +2,12 @@
 name: llm-wiki
 description: Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include "second brain", "Obsidian wiki", "personal knowledge management", "ingest this paper/article/book", "build a research wiki", "compound knowledge", "Memex", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.
 context: fork
-version: 1.0.0
-author: claude-code-skills
 license: MIT
-tags: [knowledge-management, obsidian, second-brain, pkm, rag-alternative, wiki, karpathy, memex]
-compatible_tools: [claude-code, codex-cli, cursor, antigravity, opencode, gemini-cli]
+metadata:
+  version: 1.0.0
+  author: claude-code-skills
+  tags: [knowledge-management, obsidian, second-brain, pkm, rag-alternative, wiki, karpathy, memex]
+  compatible_tools: [claude-code, codex-cli, cursor, antigravity, opencode, gemini-cli]
 ---
 
 # LLM Wiki — Second Brain for Claude Code + Obsidian


### PR DESCRIPTION
## Problem

\`engineering/llm-wiki/SKILL.md\` declares flat top-level \`version\`, \`author\`, \`tags\`, \`compatible_tools\`. Claude Code's SKILL.md schema flags these as \`✘ 1 error\` in the \`/plugin\` UI.

## Fix

Moved non-canonical fields under a \`metadata:\` block. **Kept \`context: fork\` at the top level** — recognised Claude Code schema key for v2.3.0 context-forking.

Companion PRs cover the same pattern across 8 sibling plugins.

## Verification

Local restart cleared the error.