### PR TITLE
fix(self-improving-agent): align plugin.json name + add agent frontmatter

### DIFF
--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "si",
+  "name": "self-improving-agent",
   "version": "2.3.0",
   "description": "Self-Improving Agent: curate auto-memory, promote learnings to CLAUDE.md and rules, extract proven patterns into reusable skills. Provides /si:review, /si:promote, /si:extract, /si:status, and /si:remember slash commands.",
   "author": {

--- a/engineering-team/self-improving-agent/agents/memory-analyst.md
+++ b/engineering-team/self-improving-agent/agents/memory-analyst.md
@@ -1,3 +1,8 @@
+---
+name: memory-analyst
+description: Analyzes Claude Code's auto-memory directory to surface health issues, promotion candidates, and stale or duplicative entries. Spawned by /si:review to scan MEMORY.md and related topic files, classify findings, and produce actionable recommendations.
+---
+
 # Memory Analyst Agent
 
 You are a memory analyst for Claude Code projects. Your job is to analyze the auto-memory directory and produce actionable insights.

--- a/engineering-team/self-improving-agent/agents/skill-extractor.md
+++ b/engineering-team/self-improving-agent/agents/skill-extractor.md
@@ -1,3 +1,8 @@
+---
+name: skill-extractor
+description: Transforms proven patterns, debugging solutions, or recurring workflows captured in auto-memory into standalone, portable Claude Code skills. Spawned by /si:extract to scaffold SKILL.md plus supporting scripts and references from an identified pattern.
+---
+
 # Skill Extractor Agent
 
 You are a skill extraction specialist. Your job is to transform proven patterns and debugging solutions into standalone, portable skills.


### PR DESCRIPTION
## Problem

Claude Code's \`/plugin\` UI reports \`✘ 1 error\` for this plugin. Two underlying issues:

### 1. plugin.json name mismatch

\`engineering-team/self-improving-agent/.claude-plugin/plugin.json\` currently declares:

\`\`\`json
{
  \"name\": \"si\"
}
\`\`\`

But every other identity source in the repo calls this plugin \`self-improving-agent\`:

- \`.claude-plugin/marketplace.json\` entry → \`\"name\": \"self-improving-agent\"\`
- \`engineering-team/self-improving-agent/settings.json\` → \`\"name\": \"self-improving-agent\"\`
- \`engineering-team/self-improving-agent/SKILL.md\` → \`name: self-improving-agent\`

\`si\` looks like a leftover from the \`/si:*\` command namespace, but the namespace is defined per-command inside \`skills/extract/\`, \`skills/promote/\`, etc. — not by plugin.json — so renaming plugin.json \`name\` is safe.

### 2. Agents missing YAML frontmatter

Both files under \`engineering-team/self-improving-agent/agents/\` start with a plain markdown heading:

- \`memory-analyst.md\`
- \`skill-extractor.md\`

Claude Code's agent loader requires \`name\` and \`description\` in YAML frontmatter. Without it the agents are skipped and the plugin surfaces an error.

## Fix

- \`plugin.json\` → \`\"name\": \"self-improving-agent\"\`
- Prepended minimal \`name\` + \`description\` frontmatter to both agent files

No prose changes, no command-namespace changes.

## Verification

Local restart of Claude Code cleared the error for this plugin.