### PR TITLE
fix(skill-security-auditor): add missing .claude-plugin/plugin.json

### DIFF
--- a/engineering/skill-security-auditor/.claude-plugin/plugin.json
+++ b/engineering/skill-security-auditor/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "skill-security-auditor",
+  "description": "Security audit and vulnerability scanner for AI agent skills. Scans for malicious patterns, prompt injection, data exfiltration, and unsafe file operations.",
+  "version": "2.2.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/skill-security-auditor",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": "./"
+}


### PR DESCRIPTION
## Problem

The marketplace registers this plugin:

\`\`\`json
// .claude-plugin/marketplace.json
{
  \"name\": \"skill-security-auditor\",
  \"source\": \"./engineering/skill-security-auditor\",
  \"description\": \"Security audit and vulnerability scanner for AI agent skills...\",
  \"version\": \"2.2.0\"
}
\`\`\`

But the plugin source directory \`engineering/skill-security-auditor/\` is missing its \`.claude-plugin/plugin.json\` manifest entirely — the directory contains only \`SKILL.md\`, \`references/\`, and \`scripts/\`.

Without \`plugin.json\` Claude Code cannot register the plugin and the \`/plugin\` UI shows \`✘ 1 error\`.

## Fix

Added a minimal \`plugin.json\` matching sibling single-skill plugins in \`engineering/\` (e.g. \`data-quality-auditor\`, \`statistical-analyst\`):

\`\`\`json
{
  \"name\": \"skill-security-auditor\",
  \"description\": \"Security audit and vulnerability scanner for AI agent skills. Scans for malicious patterns, prompt injection, data exfiltration, and unsafe file operations.\",
  \"version\": \"2.2.0\",
  \"author\": { \"name\": \"Alireza Rezvani\", \"url\": \"https://alirezarezvani.com\" },
  \"homepage\": \"https://github.com/alirezarezvani/claude-skills/tree/main/engineering/skill-security-auditor\",
  \"repository\": \"https://github.com/alirezarezvani/claude-skills\",
  \"license\": \"MIT\",
  \"skills\": \"./\"
}
\`\`\`

Name, description, and version are copied from the existing marketplace entry; the other fields follow this repo's standard manifest shape. No other files changed.

## Verification

Local restart of Claude Code cleared the error for this plugin.