### PR TITLE
fix(plugin.json): remove skills field to fix path-escape rejection

### DIFF
--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "license": "MIT",
-  "skills": "./"
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Claude Code plugin loader (v2.1.114+) rejects `"skills": "./"` in plugin manifests with the error:

```
Path escapes plugin directory: ./ (skills)
```

This blocks all 9 plugins shipped from this repo from registering their skills, even when properly enabled in `enabledPlugins`. Users see them in `/doctor` as plugin errors and the SKILL.md files never appear in the skill listing.

## Root cause

`"skills": "./"` resolves to the plugin root itself, which fails Claude Code's path-traversal safety check (the loader treats `./` as escaping the plugin directory rather than referring to it).

## Fix

Remove the `"skills"` field entirely from all 9 manifests. With the field absent (or `null`), the loader falls back to auto-discovery of `SKILL.md` files in sub-directories — the same pattern used by working plugins like `obra/superpowers` and `disler/fullstack-dev-skills`. Existing per-skill `SKILL.md` files under sub-directories continue to work without any structural changes to the repo.

## Affected manifests (9 files)

- `c-level-advisor/.claude-plugin/plugin.json` (c-level-skills)
- `business-growth/.claude-plugin/plugin.json` (business-growth-skills)
- `engineering/.claude-plugin/plugin.json` (engineering-advanced-skills)
- `engineering-team/.claude-plugin/plugin.json` (engineering-skills)
- `finance/.claude-plugin/plugin.json` (finance-skills)
- `marketing-skill/.claude-plugin/plugin.json` (marketing-skills)
- `product-team/.claude-plugin/plugin.json` (product-skills)
- `project-management/.claude-plugin/plugin.json` (pm-skills)
- `ra-qm-team/.claude-plugin/plugin.json` (ra-qm-skills)

## Reproducer

```
$ claude /doctor
Plugin errors
  8 plugin error(s) detected:
   finance-skills@claude-code-skills [finance-skills]: Path escapes plugin directory: ./ (skills)
   marketing-skills@claude-code-skills [marketing-skills]: Path escapes plugin directory: ./ (skills)
   ra-qm-skills@claude-code-skills [ra-qm-skills]: Path escapes plugin directory: ./ (skills)
   engineering-advanced-skills@claude-code-skills [engineering-advanced-skills]: Path escapes plugin directory: ./ (skills)
   pm-skills@claude-code-skills [pm-skills]: Path escapes plugin directory: ./ (skills)
   product-skills@claude-code-skills [product-skills]: Path escapes plugin directory: ./ (skills)
   business-growth-skills@claude-code-skills [business-growth-skills]: Path escapes plugin directory: ./ (skills)
   c-level-skills@claude-code-skills [c-level-skills]: Path escapes plugin directory: ./ (skills)
```

Tested against Claude Code 2.1.114.

## Diff

9 files changed, 18 insertions(+), 27 deletions(-) — minimal change, single field removal per manifest.
