### PR TITLE
ci(skill-security-audit): skip on manifest-only changes

### DIFF
--- a/.github/workflows/skill-security-audit.yml
+++ b/.github/workflows/skill-security-audit.yml
@@ -17,8 +17,6 @@ name: Skill Security Audit
       - 'ra-qm-team/**'
       - 'agents/**'
       - 'templates/**'
-    paths-ignore:
-      - '**/.claude-plugin/**'
 
 concurrency:
   group: security-audit-${{ github.event.pull_request.number }}
@@ -60,6 +58,7 @@ jobs:
             # Skip non-skill paths
             case "$dir" in
               .github/*|.claude/*|.codex/*|.gemini/*|docs/*|scripts/*|commands/*|standards/*|eval-workspace/*) continue ;;
+              */.claude-plugin) continue ;;
             esac
             # Check if this directory has a SKILL.md (is a skill)
             skill_root=$(echo "$file" | cut -d'/' -f1)

--- a/.github/workflows/skill-security-audit.yml
+++ b/.github/workflows/skill-security-audit.yml
@@ -17,6 +17,8 @@ name: Skill Security Audit
       - 'ra-qm-team/**'
       - 'agents/**'
       - 'templates/**'
+    paths-ignore:
+      - '**/.claude-plugin/**'
 
 concurrency:
   group: security-audit-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Why

Manifest-only PRs (e.g. updating `plugin.json` fields) cannot introduce auditable code patterns, but the current workflow still triggers and scans entire skill root directories — causing pre-existing findings inside untouched files to surface as fresh CRITICAL/HIGH on the PR.

Concrete example: PR #579 modifies only 9 `.claude-plugin/plugin.json` files (+18/-27, JSON only). The audit nevertheless reports findings from `engineering-team/senior-secops/scripts/security_scanner.py`, `senior-data-engineer/scripts/pipeline_orchestrator.py`, etc. that exist on `dev` independent of the diff.

## What

Adds `paths-ignore: ['**/.claude-plugin/**']` to the existing workflow `on.pull_request` trigger. Other paths continue to run audit as before.

## Effect

- Manifest-only PRs no longer trigger this workflow
- PR #579 (and any future plugin.json-only fix) becomes mergeable
- No change to actual security coverage — `.claude-plugin/plugin.json` does not contain executable patterns the auditor checks for

## Verify

1. After merging, the workflow file shows the new `paths-ignore` block
2. Reopen any plugin.json-only PR — `Skill Security Audit` will not appear in checks