### PR TITLE
fix(plugins): bump versions to deliver #587 path fix to installed users

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
       "name": "marketing-skills",
       "source": "./marketing-skill",
       "description": "44 marketing skills across 7 pods: Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -40,7 +40,7 @@
       "name": "c-level-skills",
       "source": "./c-level-advisor",
       "description": "28 C-level advisory skills: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive intel, M&A playbook), and culture frameworks.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -60,7 +60,7 @@
       "name": "engineering-advanced-skills",
       "source": "./engineering",
       "description": "44 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, self-eval, llm-cost-optimizer, prompt-governance, behuman, code-tour, demo-video, data-quality-auditor, statistical-analyst, llm-wiki (second brain for Obsidian + Claude Code, Karpathy pattern), and more.",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -83,7 +83,7 @@
       "name": "engineering-skills",
       "source": "./engineering-team",
       "description": "36 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit (WCAG 2.2), Azure cloud architect, GCP cloud architect, security pen testing, Snowflake development, adversarial-reviewer, ai-security, cloud-security, incident-response, red-team, threat-detection.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -110,7 +110,7 @@
       "name": "ra-qm-skills",
       "source": "./ra-qm-team",
       "description": "13 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation, SOC 2 compliance.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -130,7 +130,7 @@
       "name": "product-skills",
       "source": "./product-team",
       "description": "15 product skills with 17 Python tools: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer, apple-hig-expert.",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -157,7 +157,7 @@
       "name": "pm-skills",
       "source": "./project-management",
       "description": "6 project management skills with 12 Python tools: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -175,7 +175,7 @@
       "name": "business-growth-skills",
       "source": "./business-growth",
       "description": "4 business & growth skills: customer success manager, sales engineer, revenue operations, contract & proposal writer.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -192,7 +192,7 @@
       "name": "finance-skills",
       "source": "./finance",
       "description": "3 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, projections), and business investment advisor. 7 Python automation tools.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -216,7 +216,7 @@
       "name": "pw",
       "source": "./engineering-team/playwright-pro",
       "description": "Production-grade Playwright testing toolkit. 9 skills, 3 agents, 55 templates, TestRail + BrowserStack MCP integrations. Generate tests, fix flaky failures, migrate from Cypress/Selenium.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -251,7 +251,7 @@
       "name": "autoresearch-agent",
       "source": "./engineering/autoresearch-agent",
       "description": "Autonomous experiment loop — optimize any file by a measurable metric. 5 slash commands (/ar:setup, /ar:run, /ar:loop, /ar:status, /ar:resume), 8 built-in evaluators, configurable loop intervals (10min to monthly).",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -381,7 +381,7 @@
       "name": "google-workspace-cli",
       "source": "./engineering-team/google-workspace-cli",
       "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. 5 Python tools, 3 reference guides, 43 built-in recipes, 10 persona bundles.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -400,7 +400,7 @@
       "name": "code-to-prd",
       "source": "./product-team/code-to-prd",
       "description": "Reverse-engineer any codebase into a complete PRD. Frontend (React, Vue, Angular, Next.js), backend (NestJS, Django, Express, FastAPI), and fullstack. 2 Python scripts (codebase_analyzer, prd_scaffolder), 2 reference guides, /code-to-prd slash command.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -427,7 +427,7 @@
       "name": "agenthub",
       "source": "./engineering/agenthub",
       "description": "Multi-agent collaboration — spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any task that benefits from diverse solutions. 7 slash commands (/hub:init, /hub:spawn, /hub:status, /hub:eval, /hub:merge, /hub:board, /hub:run), agent templates, DAG-based orchestration, LLM judge mode, message board coordination.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -449,7 +449,7 @@
       "name": "a11y-audit",
       "source": "./engineering-team/a11y-audit",
       "description": "WCAG 2.2 accessibility audit and fix for React, Next.js, Vue, Angular, Svelte, and HTML. Static scanner detecting 20+ violation types, contrast checker with suggest mode, framework-specific fix patterns, /a11y-audit slash command.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -468,7 +468,7 @@
       "name": "executive-mentor",
       "source": "./c-level-advisor/executive-mentor",
       "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for board meetings, navigates hard calls, runs postmortems. 5 sub-skills with slash commands.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -486,7 +486,7 @@
       "name": "docker-development",
       "source": "./engineering/docker-development",
       "description": "Docker and container development — Dockerfile optimization, docker-compose orchestration, multi-stage builds, security hardening, and CI/CD container pipelines.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -503,7 +503,7 @@
       "name": "helm-chart-builder",
       "source": "./engineering/helm-chart-builder",
       "description": "Helm chart development — chart scaffolding, values design, template patterns, dependency management, and Kubernetes deployment strategies.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -520,7 +520,7 @@
       "name": "terraform-patterns",
       "source": "./engineering/terraform-patterns",
       "description": "Terraform infrastructure-as-code — module design patterns, state management, provider configuration, CI/CD integration, and multi-environment strategies.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -537,7 +537,7 @@
       "name": "research-summarizer",
       "source": "./product-team/research-summarizer",
       "description": "Structured research summarization — summarize academic papers, market research, user interviews, and competitive analysis into actionable insights.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -554,7 +554,7 @@
       "name": "code-tour",
       "source": "./engineering/code-tour",
       "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. 10 developer personas, all CodeTour step types, SMIG description formula.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -571,7 +571,7 @@
       "name": "demo-video",
       "source": "./engineering/demo-video",
       "description": "Create polished demo videos from screenshots and scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts with story structure, scene design system, and narration guidance.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -589,7 +589,7 @@
       "name": "data-quality-auditor",
       "source": "./engineering/data-quality-auditor",
       "description": "Audit datasets for completeness, consistency, accuracy, and validity. 3 stdlib-only Python tools: data profiler with DQS scoring, missing value analyzer with MCAR/MAR/MNAR classification, and multi-method outlier detector.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -606,7 +606,7 @@
       "name": "statistical-analyst",
       "source": "./engineering/statistical-analyst",
       "description": "Hypothesis testing, A/B experiment analysis, sample size calculation, and confidence intervals. 3 stdlib-only Python tools: Z-test/t-test/chi-square with effect sizes, sample size calculator with power tradeoffs, and Wilson score confidence intervals.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -623,7 +623,7 @@
       "name": "apple-hig-expert",
       "source": "./product-team/apple-hig-expert",
       "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets and contrast.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -643,7 +643,7 @@
       "name": "llm-wiki",
       "source": "./engineering/llm-wiki",
       "description": "A second brain for Claude Code + Obsidian inspired by Karpathy's LLM Wiki gist. Turn any LLM CLI into a disciplined wiki maintainer: incrementally ingest sources into a persistent, interlinked markdown vault; update entity/concept/source pages; flag contradictions; maintain index and append-only log. Knowledge compounds instead of being re-derived by RAG on every query. Ships 3 sub-agents (wiki-ingestor, wiki-librarian, wiki-linter), 5 slash commands (/wiki-init, /wiki-ingest, /wiki-query, /wiki-lint, /wiki-log), 8 Python tools (stdlib only: init_vault, ingest_source, update_index, append_log, wiki_search BM25, lint_wiki, graph_analyzer, export_marp), 8 reference docs, full vault templates (CLAUDE.md, AGENTS.md, cursorrules, 5 page templates), and a worked example vault. Cross-tool compatible with Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, and Gemini CLI.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -665,7 +665,7 @@
       "name": "karpathy-coder",
       "source": "./engineering/karpathy-coder",
       "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, simplify, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check command, and pre-commit hook. All stdlib-only.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -685,7 +685,7 @@
       "name": "agile-product-owner",
       "source": "./product-team/agile-product-owner",
       "description": "Agile product ownership for backlog management and sprint execution. INVEST-compliant user story generation, acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool and 2 reference guides.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "Alireza Rezvani"
       },

--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-growth-skills",
   "description": "4 business & growth skills: customer success manager, sales engineer, revenue operations, and contract & proposal writer. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "c-level-skills",
   "description": "28 C-level advisory skills: complete virtual board of directors with CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO advisors, executive mentor, founder coach, Chief of Staff router, board meetings, decision logger, board deck builder, scenario war room, competitive intel, org health diagnostic, M&A playbook, international expansion, culture architect, change management, strategic alignment, and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
+++ b/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "executive-mentor",
   "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for board meetings, navigates hard decisions, and forces honest post-mortems.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engineering-skills",
   "description": "36 production-ready engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, security suite (adversarial-reviewer, ai-security, cloud-security, incident-response, red-team, threat-detection), Stripe integration, TDD guide, Google Workspace CLI, a11y audit, Snowflake development, and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering-team/a11y-audit/.claude-plugin/plugin.json
+++ b/engineering-team/a11y-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "a11y-audit",
   "description": "WCAG 2.2 accessibility audit and fix skill for React, Next.js, Vue, Angular, Svelte, and HTML. Static scanner detecting 20+ violation types, contrast checker with suggest mode, framework-specific fix patterns, CI-friendly exit codes.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
+++ b/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "google-workspace-cli",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. 5 Python tools, 3 reference guides, 43 built-in recipes, 10 persona bundles.",
   "author": {
     "name": "Alireza Rezvani",

--- a/engineering-team/playwright-pro/.claude-plugin/plugin.json
+++ b/engineering-team/playwright-pro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pw",
   "description": "Production-grade Playwright testing toolkit. Generate tests from specs, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55+ ready-to-use templates, 3 specialized agents, smart reporting that plugs into your existing workflow.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "si",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Self-Improving Agent: curate auto-memory, promote learnings to CLAUDE.md and rules, extract proven patterns into reusable skills. Provides /si:review, /si:promote, /si:extract, /si:status, and /si:remember slash commands.",
   "author": {
     "name": "Alireza Rezvani",

--- a/engineering-team/snowflake-development/.claude-plugin/plugin.json
+++ b/engineering-team/snowflake-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "snowflake-development",
   "description": "Snowflake SQL, data pipelines (Dynamic Tables, Streams+Tasks), Cortex AI functions, Snowpark Python, and dbt integration. Includes query helper script, 3 reference guides, and troubleshooting.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engineering-advanced-skills",
   "description": "45 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, self-eval, llm-cost-optimizer, prompt-governance, llm-wiki (second brain for Obsidian + Claude Code, Karpathy pattern), tc-tracker (task context tracker with lifecycle and handoff format), and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/agenthub/.claude-plugin/plugin.json
+++ b/engineering/agenthub/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agenthub",
   "description": "Multi-agent collaboration plugin for Claude Code. Spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any problem that benefits from diverse solutions. Evaluate by metric or LLM judge, merge the winner. 7 slash commands, agent templates, git DAG orchestration, message board coordination.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/autoresearch-agent/.claude-plugin/plugin.json
+++ b/engineering/autoresearch-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch-agent",
   "description": "Autonomous experiment loop that optimizes any file by a measurable metric. 5 slash commands, 8 evaluators, configurable loop intervals (10min to monthly).",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/behuman/.claude-plugin/plugin.json
+++ b/engineering/behuman/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "behuman",
   "description": "Self-Mirror consciousness loop for human-like AI responses. Adds inner dialogue (Self → Mirror → Conscious Response) to make AI output feel authentic, not robotic. Zero dependencies — pure prompt technique.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/code-tour/.claude-plugin/plugin.json
+++ b/engineering/code-tour/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-tour",
   "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Supports 10 developer personas (vibecoder, new joiner, architect, security reviewer, etc.), all CodeTour step types, and SMIG description formula.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/data-quality-auditor/.claude-plugin/plugin.json
+++ b/engineering/data-quality-auditor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "data-quality-auditor",
   "description": "Audit datasets for completeness, consistency, accuracy, and validity. 3 stdlib-only Python tools: data profiler with DQS scoring, missing value analyzer with MCAR/MAR/MNAR classification, and multi-method outlier detector.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/demo-video/.claude-plugin/plugin.json
+++ b/engineering/demo-video/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "demo-video",
   "description": "Create polished demo videos from screenshots and scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts to produce product walkthroughs, feature showcases, and marketing teasers with story structure, scene design system, and narration guidance.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/docker-development/.claude-plugin/plugin.json
+++ b/engineering/docker-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docker-development",
   "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Covers build performance, layer caching, and production-ready container patterns.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/helm-chart-builder/.claude-plugin/plugin.json
+++ b/engineering/helm-chart-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "helm-chart-builder",
   "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/karpathy-coder/.claude-plugin/plugin.json
+++ b/engineering/karpathy-coder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "karpathy-coder",
   "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, keep it simple, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check slash command, and a pre-commit hook. All tools stdlib-only.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
+++ b/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-cost-optimizer",
   "description": "Use when you need to reduce LLM API spend, control token usage, route between models by cost/quality, implement prompt caching, or build cost observability for AI features. Triggers: 'my AI costs are ",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/llm-wiki/.claude-plugin/plugin.json
+++ b/engineering/llm-wiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-wiki",
   "description": "Turn Claude Code + Obsidian into a second brain. The LLM incrementally ingests sources into a persistent, interlinked markdown wiki — building entity/concept/source pages, flagging contradictions, maintaining an index and log. Knowledge compounds instead of being re-derived by RAG on every query. Inspired by Karpathy's LLM Wiki gist. Ships SKILL, 3 sub-agents, 5 slash commands, 8 Python tools (stdlib only), full vault templates, and cross-tool compatibility (Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI).",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/prompt-governance/.claude-plugin/plugin.json
+++ b/engineering/prompt-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-governance",
   "description": "Use when managing prompts in production at scale: versioning prompts, running A/B tests on prompts, building prompt registries, preventing prompt regressions, or creating eval pipelines for production",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/statistical-analyst/.claude-plugin/plugin.json
+++ b/engineering/statistical-analyst/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "statistical-analyst",
   "description": "Hypothesis testing, A/B experiment analysis, sample size calculation, and confidence intervals. 3 stdlib-only Python tools with Z-test, t-test, chi-square, effect sizes, power analysis, and Wilson score intervals.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/terraform-patterns/.claude-plugin/plugin.json
+++ b/engineering/terraform-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "terraform-patterns",
   "description": "Terraform infrastructure-as-code agent skill and plugin for module design patterns, state management strategies, provider configuration, security hardening, and CI/CD plan/apply workflows. Covers mono-repo vs multi-repo, workspaces, policy-as-code, and drift detection.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "finance-skills",
   "description": "3 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, 12-month projections), and business investment advisor. 7 Python automation tools. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/finance/business-investment-advisor/.claude-plugin/plugin.json
+++ b/finance/business-investment-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-investment-advisor",
   "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use f",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "44 production-ready marketing skills across 7 pods: Content (copywriting, content strategy, content production), SEO (audits, schema markup, programmatic SEO, site architecture), CRO (A/B testing, forms, popups, signup flows, pricing, onboarding), Channels (email sequences, social media, paid ads, cold email, X/Twitter growth), Growth (launch strategy, referral programs, free tools), Intelligence (competitor analysis, marketing psychology, analytics tracking), and Sales enablement. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
+++ b/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "video-content-strategist",
   "description": "Use when planning video content strategy, writing video scripts, optimizing YouTube channels, building short-form video pipelines (Reels, TikTok, Shorts), or repurposing long-form content into video. ",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "product-skills",
   "description": "16 production-ready product skills: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer, apple-hig-expert (Apple Human Interface Guidelines), spec-to-repo. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/product-team/agile-product-owner/.claude-plugin/plugin.json
+++ b/product-team/agile-product-owner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agile-product-owner",
   "description": "Agile product ownership for backlog management and sprint execution. User story generation (INVEST-compliant), acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/product-team/apple-hig-expert/.claude-plugin/plugin.json
+++ b/product-team/apple-hig-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-hig-expert",
   "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets, contrast, and accessibility validation. Reference docs cover visual design, platform specifics (iOS/macOS/visionOS), and accessibility best practices.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/product-team/code-to-prd/.claude-plugin/plugin.json
+++ b/product-team/code-to-prd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-to-prd",
   "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, models, APIs, and interactions for frontend (React, Vue, Angular, Next.js), backend (NestJS, Django, Express, FastAPI), and fullstack applications.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/product-team/research-summarizer/.claude-plugin/plugin.json
+++ b/product-team/research-summarizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-summarizer",
   "description": "Structured research summarization agent skill and plugin for Claude Code, Codex, and Gemini CLI. Summarize academic papers, compare web articles, extract citations, and produce actionable research briefs.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-skills",
   "description": "6 project management skills: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, and template creator for Atlassian users. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ra-qm-skills",
   "description": "12 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation, and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"


### PR DESCRIPTION
## Summary

Critical follow-up to #587. Users still see \"✘ 1 error\" on every plugin in this marketplace because their installed plugin cache (`~/.claude/plugins/cache/claude-code-skills/<name>/<version>/`) holds the old `plugin.json` with `"skills": "./"`.

The marketplace cache refresh works correctly — but Claude Code uses **version as the cache key**. Same version string = `/plugin update` is a no-op and the broken cached copy stays in place. From the [version-management docs](https://code.claude.com/docs/en/plugins-reference#version-management):

> If you set `version` in `plugin.json`, you must bump it every time you want users to receive changes. Pushing new commits alone is not enough.

## What changed

- Bumped every `plugin.json` version by one patch (`2.1.2 → 2.2.1`, `2.3.0 → 2.3.1`, etc.) using `max(plugin_version, marketplace_version)` as the base so no version moves backward.
- Synced the new versions back into `.claude-plugin/marketplace.json` so the marketplace entry matches.

## How users recover

After this lands on `main`:

```
/plugin marketplace update claude-code-skills
/plugin update --all
```

Each plugin re-installs from the new version directory with the fixed `skills` path.

## Test plan

- [x] All 35 manifests still pass `claude plugin validate`
- [x] `marketplace.json` parses as valid JSON
- [x] No version moves backward (verified by `max(plugin, marketplace)` base)
- [ ] After merge: confirm `/plugin update --all` clears the \"1 error\" markers in `/plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)