### PR TITLE
fix(ci): update test paths and sync script for new ./skills/ layout

### DIFF
--- a/scripts/sync-codex-skills.py
+++ b/scripts/sync-codex-skills.py
@@ -73,29 +73,40 @@ def find_skills(repo_root: Path) -> List[Dict]:
         if not domain_path.exists():
             continue
 
-        # Find all subdirectories with SKILL.md
-        for skill_path in domain_path.iterdir():
-            if not skill_path.is_dir():
-                continue
+        # Skills now live under <domain>/skills/<name>/SKILL.md after the
+        # plugin restructure (see PR #593). Fall back to scanning <domain>/
+        # directly so the script keeps working for domains that weren't
+        # restructured.
+        scan_roots = []
+        skills_subdir = domain_path / "skills"
+        if skills_subdir.is_dir():
+            scan_roots.append(("skills/", skills_subdir))
+        scan_roots.append(("", domain_path))
 
-            skill_md = skill_path / "SKILL.md"
-            if not skill_md.exists():
-                continue
+        for prefix, scan_root in scan_roots:
+            for skill_path in scan_root.iterdir():
+                if not skill_path.is_dir():
+                    continue
+                # Skip subfolders that are themselves nested plugins or special dirs
+                if skill_path.name in {"skills", ".claude-plugin", ".codex-plugin"}:
+                    continue
 
-            # Extract skill name and description from SKILL.md
-            skill_name = skill_path.name
-            description = extract_skill_description(skill_md)
+                skill_md = skill_path / "SKILL.md"
+                if not skill_md.exists():
+                    continue
 
-            # Calculate relative path from .codex/skills/ to skill folder
-            relative_path = f"../../{domain_dir}/{skill_name}"
+                skill_name = skill_path.name
+                description = extract_skill_description(skill_md)
 
-            skills.append({
-                "name": skill_name,
-                "source": relative_path,
-                "source_absolute": str(skill_path.relative_to(repo_root)),
-                "category": domain_info["category"],
-                "description": description or f"Skill from {domain_dir}"
-            })
+                relative_path = f"../../{domain_dir}/{prefix}{skill_name}"
+
+                skills.append({
+                    "name": skill_name,
+                    "source": relative_path,
+                    "source_absolute": str(skill_path.relative_to(repo_root)),
+                    "category": domain_info["category"],
+                    "description": description or f"Skill from {domain_dir}"
+                })
 
     # Sort by category then name for consistent output
     skills.sort(key=lambda s: (s["category"], s["name"]))

--- a/tests/test_campaign_roi.py
+++ b/tests/test_campaign_roi.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "marketing-skill", "campaign-analytics", "scripts"
+    os.path.dirname(__file__), "..", "marketing-skill", "skills", "campaign-analytics", "scripts"
 ))
 from campaign_roi_calculator import (
     safe_divide,

--- a/tests/test_commit_linter.py
+++ b/tests/test_commit_linter.py
@@ -7,7 +7,7 @@ import tempfile
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "engineering", "changelog-generator", "scripts"
+    os.path.dirname(__file__), "..", "engineering", "skills", "changelog-generator", "scripts"
 ))
 from commit_linter import lint, CONVENTIONAL_RE, lines_from_file, CLIError
 

--- a/tests/test_dcf_valuation.py
+++ b/tests/test_dcf_valuation.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "finance", "financial-analyst", "scripts"
+    os.path.dirname(__file__), "..", "finance", "skills", "financial-analyst", "scripts"
 ))
 from dcf_valuation import DCFModel, safe_divide
 

--- a/tests/test_funnel_analyzer.py
+++ b/tests/test_funnel_analyzer.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "marketing-skill", "campaign-analytics", "scripts"
+    os.path.dirname(__file__), "..", "marketing-skill", "skills", "campaign-analytics", "scripts"
 ))
 from funnel_analyzer import analyze_funnel, compare_segments, safe_divide
 

--- a/tests/test_gdpr_compliance.py
+++ b/tests/test_gdpr_compliance.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "ra-qm-team", "gdpr-dsgvo-expert", "scripts"
+    os.path.dirname(__file__), "..", "ra-qm-team", "skills", "gdpr-dsgvo-expert", "scripts"
 ))
 from gdpr_compliance_checker import (
     PERSONAL_DATA_PATTERNS,

--- a/tests/test_okr_tracker.py
+++ b/tests/test_okr_tracker.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "c-level-advisor", "coo-advisor", "scripts"
+    os.path.dirname(__file__), "..", "c-level-advisor", "skills", "coo-advisor", "scripts"
 ))
 from okr_tracker import calculate_kr_score, get_kr_status
 

--- a/tests/test_ratio_calculator.py
+++ b/tests/test_ratio_calculator.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "finance", "financial-analyst", "scripts"
+    os.path.dirname(__file__), "..", "finance", "skills", "financial-analyst", "scripts"
 ))
 from ratio_calculator import FinancialRatioCalculator, safe_divide
 

--- a/tests/test_rice_prioritizer.py
+++ b/tests/test_rice_prioritizer.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "product-team", "product-manager-toolkit", "scripts"
+    os.path.dirname(__file__), "..", "product-team", "skills", "product-manager-toolkit", "scripts"
 ))
 from rice_prioritizer import RICECalculator
 

--- a/tests/test_seo_checker.py
+++ b/tests/test_seo_checker.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.join(
-    os.path.dirname(__file__), "..", "marketing-skill", "seo-audit", "scripts"
+    os.path.dirname(__file__), "..", "marketing-skill", "skills", "seo-audit", "scripts"
 ))
 from seo_checker import SEOParser, analyze_html, compute_overall_score
 


### PR DESCRIPTION
## Summary

Fixes the two CI failures on PR #594 (\`dev → main\`) caused by the multi-skill restructure in #593.

PR #593 moved every skill from \`<plugin>/<name>/\` to \`<plugin>/skills/<name>/\` to satisfy Claude Code's runtime loader. That broke two CI jobs that hardcoded the old paths.

## What changed

**1. Test imports (9 files)**

Each test had:
```python
sys.path.insert(0, os.path.join(__file__, \"..\", \"<domain>\", \"<skill>\", \"scripts\"))
```

After restructure that points at a non-existent dir → `ModuleNotFoundError`. Inserted `\"skills\"` between domain and skill so imports resolve again. Affected:
- test_campaign_roi, test_funnel_analyzer, test_seo_checker (marketing-skill)
- test_commit_linter (engineering)
- test_dcf_valuation, test_ratio_calculator (finance)
- test_gdpr_compliance (ra-qm-team)
- test_okr_tracker (c-level-advisor)
- test_rice_prioritizer (product-team)

**2. \`scripts/sync-codex-skills.py\`**

`find_skills()` scanned `<domain>/<skill>/SKILL.md` directly → returned \"No skills found\" after restructure. Updated to prefer `<domain>/skills/<name>/` and fall back to `<domain>/<name>/` so it handles both layouts.

## Test plan

- [x] `python3 scripts/sync-codex-skills.py --dry-run` finds 178 skills
- [x] `pytest tests/` collects all modules; 3216 tests pass
- [ ] CI green on this PR
- [ ] After this lands on dev: re-run CI on #594, then merge dev → main → marketplace fix reaches users

## Out of scope

4 pre-existing failures remain (unrelated to my restructure):
- 3 argparse duplicate-flag bugs in `integrations/.../document_version_control.py`
- 1 strict \"must have .py\" check on a JS-only skill (`engineering/skills/full-page-screenshot/`)

Refs #539 #593 #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)