### PR TITLE
fix(skill-security-auditor): allowlist .mcp.json in FS-HIDDEN check

### DIFF
--- a/engineering/skill-security-auditor/scripts/skill_security_auditor.py
+++ b/engineering/skill-security-auditor/scripts/skill_security_auditor.py
@@ -15,7 +15,6 @@ Exit codes:
 
 import argparse
 import json
-import os
 import re
 import stat
 import subprocess
@@ -764,9 +763,17 @@ def scan_filesystem(skill_path: Path, report: AuditReport):
 
         # Hidden files (except common ones)
         if item.name.startswith(".") and item.name not in (
-            ".gitignore", ".gitkeep", ".editorconfig", ".prettierrc",
-            ".eslintrc", ".pylintrc", ".flake8",
-            ".claude-plugin", ".codex", ".gemini",
+            ".gitignore",
+            ".gitkeep",
+            ".editorconfig",
+            ".prettierrc",
+            ".eslintrc",
+            ".pylintrc",
+            ".flake8",
+            ".claude-plugin",
+            ".codex",
+            ".gemini",
+            ".mcp.json",
         ):
             severity = Severity.CRITICAL if item.name == ".env" else Severity.HIGH
             report.findings.append(
@@ -783,8 +790,17 @@ def scan_filesystem(skill_path: Path, report: AuditReport):
 
         # Binary files
         if item.is_file() and item.suffix.lower() in (
-            ".exe", ".dll", ".so", ".dylib", ".bin", ".elf",
-            ".com", ".msi", ".deb", ".rpm", ".apk",
+            ".exe",
+            ".dll",
+            ".so",
+            ".dylib",
+            ".bin",
+            ".elf",
+            ".com",
+            ".msi",
+            ".deb",
+            ".rpm",
+            ".apk",
         ):
             report.findings.append(
                 Finding(


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` to the FS-HIDDEN allowlist in `skill_security_auditor.py`
- Eliminates a false-positive HIGH finding that fires on every plugin-bundled MCP server config

## Why

`.mcp.json` is the canonical filename Claude Code expects for plugin-bundled MCP server configuration. The auditor's hidden-file rule was flagging it as a HIGH-severity finding because it starts with a `.`, which blocks the `--strict` quality gate documented in `CLAUDE.md`.

This was already producing a real false-positive in the repo: `engineering-team/playwright-pro/.mcp.json` is flagged identically. After this change, playwright-pro's HIGH count drops from 60 → 59.

## Side effects

The local ruff format-on-save hook fired during the edit and applied two adjacent cleanups:
- Removed unused `import os` (F401)
- Reformatted the hidden-files and binary-extensions tuples to one-per-line form

No behavioral change beyond the allowlist addition.

## Test plan

- [x] Re-run `python engineering/skill-security-auditor/scripts/skill_security_auditor.py project-management/ --strict` — passes (0 CRITICAL, 0 HIGH)
- [x] Sanity-check on `engineering-team/playwright-pro/` — HIGH count drops 60 → 59 (exactly the `.mcp.json` finding)
- [x] Auditor still parses cleanly
- [ ] CI passes on PR

## Context

Unblocks a follow-up PR that adds `project-management/.mcp.json` (Atlassian Remote MCP integration). Without this allowlist fix, that follow-up fails the `--strict` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)