### PR TITLE
feat(pm-skills): bundle Atlassian Remote MCP server

### DIFF
--- a/engineering/skill-security-auditor/scripts/skill_security_auditor.py
+++ b/engineering/skill-security-auditor/scripts/skill_security_auditor.py
@@ -15,7 +15,6 @@ Exit codes:
 
 import argparse
 import json
-import os
 import re
 import stat
 import subprocess
@@ -764,9 +763,17 @@ def scan_filesystem(skill_path: Path, report: AuditReport):
 
         # Hidden files (except common ones)
         if item.name.startswith(".") and item.name not in (
-            ".gitignore", ".gitkeep", ".editorconfig", ".prettierrc",
-            ".eslintrc", ".pylintrc", ".flake8",
-            ".claude-plugin", ".codex", ".gemini",
+            ".gitignore",
+            ".gitkeep",
+            ".editorconfig",
+            ".prettierrc",
+            ".eslintrc",
+            ".pylintrc",
+            ".flake8",
+            ".claude-plugin",
+            ".codex",
+            ".gemini",
+            ".mcp.json",
         ):
             severity = Severity.CRITICAL if item.name == ".env" else Severity.HIGH
             report.findings.append(
@@ -783,8 +790,17 @@ def scan_filesystem(skill_path: Path, report: AuditReport):
 
         # Binary files
         if item.is_file() and item.suffix.lower() in (
-            ".exe", ".dll", ".so", ".dylib", ".bin", ".elf",
-            ".com", ".msi", ".deb", ".rpm", ".apk",
+            ".exe",
+            ".dll",
+            ".so",
+            ".dylib",
+            ".bin",
+            ".elf",
+            ".com",
+            ".msi",
+            ".deb",
+            ".rpm",
+            ".apk",
         ):
             report.findings.append(
                 Finding(

--- a/project-management/.mcp.json
+++ b/project-management/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    }
+  }
+}

--- a/project-management/README.md
+++ b/project-management/README.md
@@ -258,12 +258,21 @@ This project management skills collection provides world-class Atlassian experti
 
 ### Setup
 
-Configure Atlassian MCP server in your Claude Code settings with:
-- Jira/Confluence instance URL
-- API token or OAuth credentials
-- Project/space access permissions
+The plugin bundles a pre-configured `.mcp.json` pointing at Atlassian's official Remote MCP server (`https://mcp.atlassian.com/v1/sse`). When you enable the plugin:
+
+1. Claude Code reads `.mcp.json` and registers the `atlassian` SSE server automatically.
+2. On first tool call, you're redirected to Atlassian in your browser to authenticate (OAuth) and select which Cloud sites to grant access to.
+3. Tokens are managed by Claude Code — no API keys in environment variables, no credentials in the repo.
+
+**Prerequisites:**
+- An Atlassian Cloud account (free tier is sufficient — Jira Free or Confluence Free both work)
+- Access to at least one Jira project or Confluence space
+
+**No environment variables required** — the SSE transport handles OAuth automatically.
 
 ### Example Operations
+
+> **Note:** Tool names below are shown in simplified form for readability. The actual Claude Code prefix for plugin-bundled MCP tools is `mcp__plugin_pm-skills_atlassian__<tool>` — e.g. `mcp__plugin_pm-skills_atlassian__create_issue`. Both the simplified and fully-qualified forms refer to the same tool.
 
 ```bash
 # Create Jira issue


### PR DESCRIPTION
## Summary

- Adds `project-management/.mcp.json` registering Atlassian's official Remote MCP server (`https://mcp.atlassian.com/v1/sse`) as a plugin-bundled SSE MCP
- Updates `project-management/README.md` Setup section to reflect bundled-MCP reality (previous text described user-scope setup, which is no longer accurate)
- Closes the doc/code drift between the existing claim in `project-management/CLAUDE.md` ("Atlassian MCP integration") and the absence of any `.mcp.json` file

## Why

The README and `CLAUDE.md` for `project-management/` extensively documented an Atlassian MCP integration (capabilities, examples, tool names) — but no `.mcp.json` actually existed. This PR delivers what the docs describe.

## Implementation

- **Server type: SSE** — Atlassian hosts the MCP server publicly. OAuth is handled automatically by Claude Code on first tool call. No environment variables, no API tokens in the repo.
- **No new code, no dependencies** — three lines of JSON pointing at the published endpoint.
- **Tool naming clarification** — added a note explaining that Claude Code prefixes plugin-bundled MCP tools as `mcp__plugin_pm-skills_atlassian__<tool>`, while the README examples use the simplified `mcp__atlassian__<tool>` form for readability.

## Dependency

⚠️ **Depends on #596** (skill-security-auditor allowlist for `.mcp.json`). Without that fix, this PR fails the `--strict` security audit gate documented in the root `CLAUDE.md`.

The diff currently shows 2 commits because this PR is stacked on #596. After #596 merges to `dev`, I'll rebase this PR onto the updated `dev` and force-push, leaving only the `feat(pm-skills)` commit visible.

## Test plan

- [x] `python engineering/skill-security-auditor/scripts/skill_security_auditor.py project-management/ --strict` — passes (0 CRITICAL, 0 HIGH, 0 INFO) on the stacked branch
- [x] `.mcp.json` is valid JSON parsable
- [x] README Setup section reads correctly post-edit
- [ ] CI passes once #596 is in
- [ ] Manual smoke: enable plugin, run `/mcp`, expect `atlassian` server to register and OAuth flow to trigger on first tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)