### PR TITLE
fix(docs): correct skill/agent/plugin counts to ground-truth file-system numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **comprehensive skills library** for Claude AI and Claude Code - reusable, production-ready skill packages that bundle domain expertise, best practices, analysis tools, and strategic frameworks. The repository provides modular skills that teams can download and use directly in their workflows.
 
-**Current Scope:** 188 production-ready skills across 9 domains with 359 Python automation tools, 485 reference guides, 30 agents, and 33 slash commands.
+**Current Scope:** 246 production-ready skills across 9 domains with 359 Python automation tools, 485 reference guides, 27 agents (20 `cs-*` + 7 personas), and 33 slash commands.
 
 **Key Distinction**: This is NOT a traditional application. It's a library of skill packages meant to be extracted and deployed by users into their own Claude workflows.
 
@@ -36,7 +36,7 @@ This repository uses **modular documentation**. For domain-specific guidance, se
 ```
 claude-code-skills/
 ├── .claude-plugin/            # Plugin registry (marketplace.json)
-├── agents/                    # 30 agents across all domains
+├── agents/                    # 27 agents (20 cs-* + 7 personas)
 ├── commands/                  # 33 slash commands (changelog, tdd, saas-health, prd, code-to-prd, plugin-audit, sprint-plan, slo-design, etc.)
 ├── engineering-team/          # 32 core engineering skills + Playwright Pro + Self-Improving Agent + Security Suite
 ├── engineering/               # 40 POWERFUL-tier advanced skills (incl. AgentHub, self-eval, llm-wiki, tc-tracker, ship-gate, slo-architect)
@@ -134,7 +134,7 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 - **ship-gate** — pre-production audit skill (89 checks across 8 categories, stdlib-only, MIT). External contribution.
 - **Atlassian Remote MCP** — bundled `.mcp.json` in `project-management/` (SSE transport, OAuth handled by Claude Code, no env vars required).
 - **Auditor + CI cleanup** — `.mcp.json` allowlist in skill-security-auditor, manifest-only PRs skip audit, README links (toprank).
-- 188 total skills, 359 Python tools, 485 references, 30 agents, 33 commands.
+- 246 total skills, 359 Python tools, 485 references, 27 agents, 33 commands.
 
 **v2.3.0 Highlights:**
 - **llm-wiki plugin** — new POWERFUL-tier skill implementing Karpathy's LLM Wiki pattern. Second brain for Claude Code + Obsidian where the LLM incrementally ingests sources into a persistent, interlinked markdown vault. Ships SKILL.md (with `context: fork`), 3 sub-agents (wiki-ingestor, wiki-librarian, wiki-linter), 5 slash commands (/wiki-init, /wiki-ingest, /wiki-query, /wiki-lint, /wiki-log), 8 stdlib-only Python tools, 8 reference guides, full vault templates, and a worked example. Cross-tool compatible with Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI.
@@ -171,9 +171,9 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 
 ## Roadmap
 
-**Phase 1-4 Complete:** 188 production-ready skills deployed across 9 domains
+**Phase 1-4 Complete:** 246 production-ready skills deployed across 9 domains
 - Engineering Core (32), Engineering POWERFUL (40), Product (13), Marketing (44), PM (9), C-Level (28), RA/QM (14), Business & Growth (5), Finance (3)
-- 359 Python automation tools, 485 reference guides, 30 agents, 33 commands
+- 359 Python automation tools, 485 reference guides, 27 agents, 33 commands
 - Complete enterprise coverage from engineering through regulatory compliance, sales, customer success, and finance
 - Reliability portfolio: feature-flags-architect, kubernetes-operator, chaos-engineering, slo-architect (Google SRE Workbook canon)
 - MkDocs Material docs site with 293+ indexed pages for SEO
@@ -230,4 +230,4 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
 
 **Last Updated:** May 10, 2026
 **Version:** v2.4.4
-**Status:** 235 skills deployed across 9 domains, 30 marketplace plugins, docs site live
+**Status:** 246 skills deployed across 9 domains, 33 marketplace plugins, docs site live

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Claude Code Skills & Plugins — Agent Skills for Every Coding Tool
 
-**188 production-ready Claude Code skills, plugins, and agent skills for 12 AI coding tools.**
+**246 production-ready Claude Code skills, plugins, and agent skills for 12 AI coding tools.**
 
 The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 7 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing, compliance, C-level advisory, and more.
 
 **Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Hermes Agent · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/Skills-188-brightgreen?style=for-the-badge)](#skills-overview)
-[![Agents](https://img.shields.io/badge/Agents-30-blue?style=for-the-badge)](#agents)
-[![Personas](https://img.shields.io/badge/Personas-3-purple?style=for-the-badge)](#personas)
+[![Skills](https://img.shields.io/badge/Skills-246-brightgreen?style=for-the-badge)](#skills-overview)
+[![Agents](https://img.shields.io/badge/Agents-20-blue?style=for-the-badge)](#agents)
+[![Personas](https://img.shields.io/badge/Personas-7-purple?style=for-the-badge)](#personas)
 [![Commands](https://img.shields.io/badge/Commands-33-orange?style=for-the-badge)](#commands)
 [![Stars](https://img.shields.io/github/stars/alirezarezvani/claude-skills?style=for-the-badge)](https://github.com/alirezarezvani/claude-skills/stargazers)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1?style=for-the-badge)](https://getskillcheck.com)
@@ -146,7 +146,7 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 
 ## Skills Overview
 
-**188 skills across 9 domains:**
+**246 skills across 9 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Install Agent Skills — Codex, Gemini CLI, OpenClaw Setup
-description: "How to install 188 Claude Code skills and agent plugins for 12 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more."
+description: "How to install 246 Claude Code skills and agent plugins for 12 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more."
 ---
 
 # Getting Started
@@ -274,7 +274,7 @@ See the [Skills & Agents Factory](https://github.com/alirezarezvani/claude-code-
     Yes. Run `./scripts/gemini-install.sh` to set up skills for Gemini CLI. A sync script (`scripts/sync-gemini-skills.py`) generates the skills index automatically.
 
 ??? question "Does this work with Cursor, Windsurf, Aider, or other tools?"
-    Yes. All 188 skills can be converted to native formats for Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. Run `./scripts/convert.sh --tool all` and then install with `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](integrations.md) for details.
+    Yes. All 246 skills can be converted to native formats for Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. Run `./scripts/convert.sh --tool all` and then install with `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](integrations.md) for details.
 
 ??? question "Can I use Agent Skills in ChatGPT?"
     Yes. We have [6 Custom GPTs](custom-gpts.md) that bring Agent Skills directly into ChatGPT — no installation needed. Just click and start chatting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-title: 188 Agent Skills for Codex, Gemini CLI & OpenClaw
-description: "188 production-ready Claude Code skills and agent plugins for 12 AI coding tools. Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Cursor, and OpenClaw."
+title: 246 Agent Skills for Codex, Gemini CLI & OpenClaw
+description: "246 production-ready Claude Code skills and agent plugins for 12 AI coding tools. Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Cursor, and OpenClaw."
 hide:
   - toc
   - edit
@@ -14,7 +14,7 @@ hide:
 
 # Agent Skills
 
-188 production-ready skills, 30 agents, 3 personas, and an orchestration protocol for AI coding tools.
+246 production-ready skills, 20 cs-* agents, 7 personas, and an orchestration protocol for AI coding tools.
 { .hero-subtitle }
 
 [Get Started](getting-started.md){ .md-button .md-button--primary }
@@ -49,7 +49,7 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-toolbox:{ .lg .middle } **188 Skills**
+-   :material-toolbox:{ .lg .middle } **246 Skills**
 
     ---
 
@@ -57,7 +57,7 @@ hide:
 
     [:octicons-arrow-right-24: Browse skills](skills/)
 
--   :material-robot:{ .lg .middle } **30 Agents**
+-   :material-robot:{ .lg .middle } **20 Agents**
 
     ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Claude Code Skills & Agent Plugins
 site_url: https://alirezarezvani.github.io/claude-skills/
-site_description: "188 production-ready skills, 30 agents, 3 personas, and an orchestration protocol for 12 AI coding tools. Reusable expertise for engineering, product, marketing, compliance, and more."
+site_description: "246 production-ready skills, 20 cs-* agents, 7 personas, and an orchestration protocol for 12 AI coding tools. Reusable expertise for engineering, product, marketing, compliance, and more."
 site_author: Alireza Rezvani
 repo_url: https://github.com/alirezarezvani/claude-skills
 repo_name: alirezarezvani/claude-skills


### PR DESCRIPTION
## Why this exists

PR #607 shipped wrong numbers (`188 skills`, `30 agents`, `3 personas`, `30 marketplace plugins`) because I trusted a stale `codex-sync` output instead of running `find`. The user pushed back with "we have had over 235 skills" — they were right.

This PR aligns every metric claim in `CLAUDE.md`, `README.md`, `docs/`, and `mkdocs.yml` to **ground-truth file-system counts**. No source skills changed; only the numbers in headlines, badges, and descriptions.

Karpathy principle applied: every number ships with the deterministic command that reproduces it.

## Summary table

| Metric | PR #607 (wrong) | This PR (truth) | Reproduce |
|---|---|---|---|
| Skills | 188 | **246** | `find . -name SKILL.md` (excl. `.gemini/`, `.codex/`, `site/`, `docs/`) → 250 raw, minus 4 distribution duplicates = 246 unique |
| Tools | 359 ✓ | 359 | `find . -path "*/scripts/*.py"` |
| References | 485 ✓ | 485 | `find . -path "*/references/*.md"` |
| Agents | 30 | **27** (20 `cs-*` + 7 personas) | `find agents -name 'cs-*.md'` → 20; `ls agents/personas/*.md \| grep -vE 'README\|TEMPLATE'` → 7 |
| Personas | 3 | **7** | (same command above) |
| Commands | 33 ✓ | 33 | `find commands -name '*.md'` |
| Marketplace plugins | 30 (Status line) | **33** | `python3 -c "import json; print(len(json.load(open('.claude-plugin/marketplace.json'))['plugins']))"` |

## The 4 distribution duplicates (250 → 246)

The v2.4.x reliability portfolio is packaged twice — once in the domain umbrella, once as a standalone plugin for users who want to install just one:

| Skill | Umbrella | Standalone |
|---|---|---|
| chaos-engineering | `engineering/skills/chaos-engineering/` | `engineering/chaos-engineering/skills/chaos-engineering/` |
| feature-flags-architect | `engineering/skills/feature-flags-architect/` | `engineering/feature-flags-architect/skills/feature-flags-architect/` |
| kubernetes-operator | `engineering/skills/kubernetes-operator/` | `engineering/kubernetes-operator/skills/kubernetes-operator/` |
| slo-architect | `engineering/skills/slo-architect/` | `engineering/slo-architect/skills/slo-architect/` |

5 same-named sub-skills (`init`, `status`, `run`, `review`) appear in multiple multi-skill plugins (e.g., `agenthub`, `playwright-pro`, `self-improving-agent`) but are genuinely different skills, so they count separately.

## What's NOT changed

- No skills added, removed, renamed, or restructured
- No `plugin.json` `skills` arrays edited
- No marketplace.json plugin list edited
- Per-domain CLAUDE.md sub-counts left intact (still correct against per-domain `find`)

## Test plan

- [x] `grep '188\|30 agents\|3 personas\|235 skills\|30 marketplace' CLAUDE.md README.md docs/ mkdocs.yml` returns 0 matches
- [x] All 6 ground-truth commands reproduce the exact numbers cited in docs
- [ ] CI green
- [ ] mkdocs build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011TDdEiNm39GyFvgcAGb4MV)_