### PR TITLE
fix(docs): pass-2 count corrections — marketplace registry + integrations page

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,11 +4,11 @@
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
   },
-  "description": "188 production-ready skill packages for Claude AI across 9 domains: marketing (44), engineering (40 advanced + 32 core), C-level advisory (28), regulatory/QMS (14), product (13), project management (9), business growth (5), and finance (3). Includes 359 Python tools, 485 reference documents, 30 agents, and 33 slash commands.",
+  "description": "246 production-ready skill packages for Claude AI across 9 domains: engineering advanced (67 unique), engineering core (51), marketing (45), c-level advisory (34), product (17), regulatory/QMS (14), project management (9), business growth (5), and finance (4). Includes 359 Python tools, 485 reference documents, 27 agents (20 cs-* + 7 personas), and 33 slash commands.",
   "homepage": "https://github.com/alirezarezvani/claude-skills",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "metadata": {
-    "description": "188 production-ready skill packages across 9 domains with 359 Python tools, 485 reference documents, 30 agents, and 33 slash commands. Compatible with Claude Code, Codex CLI, Hermes Agent, Cursor, Antigravity, OpenCode, Gemini CLI, and OpenClaw.",
+    "description": "246 production-ready skill packages across 9 domains with 359 Python tools, 485 reference documents, 27 agents (20 cs-* + 7 personas), and 33 slash commands. Compatible with Claude Code, Codex CLI, Hermes Agent, Cursor, Antigravity, OpenCode, Gemini CLI, and OpenClaw.",
     "version": "2.4.4"
   },
   "plugins": [

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -5,7 +5,7 @@ description: "Install Claude Code skills and agent plugins in Hermes Agent, Curs
 
 # Multi-Tool Integrations
 
-All 235 skills in this repository work natively with **8 AI coding tools** beyond Claude Code, Codex, Gemini CLI, and OpenClaw. Hermes Agent uses the same agentskills.io SKILL.md standard — no conversion needed. For the other 7 tools, a conversion script adapts the format each tool expects while preserving skill instructions, workflows, and supporting files.
+All 246 skills in this repository work natively with **8 AI coding tools** beyond Claude Code, Codex, Gemini CLI, and OpenClaw. Hermes Agent uses the same agentskills.io SKILL.md standard — no conversion needed. For the other 7 tools, a conversion script adapts the format each tool expects while preserving skill instructions, workflows, and supporting files.
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
## Why this exists

Followup to #608. The user asked "anything else to modify on this task?" — and yes, I had missed 3 spots on the first pass. Honest sweep with `grep -rln '188\|235 skill\|30 agents'` revealed:

| Location | Issue | Action |
|---|---|---|
| `docs/integrations.md:8` | "All **235** skills in this repository" — current-state claim | Fixed → **246** |
| `.claude-plugin/marketplace.json:7,11` | "**188** skills... **30** agents" + stale per-domain breakdown | Fixed → **246** + per-domain rewrite |
| `CLAUDE.md:143` | "**235** total skills..." | **Intentionally left alone** — v2.3.0 historical highlights, not current state |

## Marketplace registry — per-domain rewrite

The marketplace.json description includes a per-domain breakdown that summed to the old 188. With 246 as the new total, per-domain numbers had to be re-derived from `find SKILL.md`:

| Domain | Old | New | Δ |
|---|---|---|---|
| engineering (advanced) | 40 | **67 unique** (71 raw − 4 dist dupes) | +27 |
| engineering-team (core) | 32 | **51** | +19 |
| marketing-skill | 44 | **45** | +1 |
| c-level-advisor | 28 | **34** | +6 |
| product-team | 13 | **17** | +4 |
| ra-qm-team | 14 | 14 | — |
| project-management | 9 | 9 | — |
| business-growth | 5 | 5 | — |
| finance | 3 | **4** | +1 |
| **Total** | **188** | **246** | **+58** |

Per-domain sum reconciles: 67+51+45+34+17+14+9+5+4 = **246**.

## Verification

```bash
# Per-domain counts
for d in marketing-skill engineering engineering-team c-level-advisor \
         ra-qm-team product-team project-management business-growth finance; do
  printf '%-22s %3d\n' "$d" "$(find "$d" -name SKILL.md | wc -l)"
done

# JSON validity + plugin count
python3 -c "import json; m=json.load(open('.claude-plugin/marketplace.json')); print(len(m['plugins']))"
# → 33

# Stale-number sweep
grep -rln '188 skill\|Skills-188\|Personas-3\|30 agents\|Agents-30\|235 skill' \
  --include='*.md' --include='*.yml' --include='*.json' \
  --exclude-dir=.git --exclude-dir=site .
# → (empty)
```

## What's NOT changed

- `CLAUDE.md:143` — 235 stays. It's inside `**v2.3.0 Highlights:**` block (historical release snapshot, not current claim). Rewriting it would falsify history.
- Per-domain sub-CLAUDE.md files (their own counts were already correct against per-domain `find`).
- No skills, plugins, or marketplace entries added/removed/renamed.

## Test plan

- [x] `python3 -m json.tool .claude-plugin/marketplace.json` valid
- [x] Per-domain numbers in description reproduce from `find SKILL.md`
- [x] Per-domain sum reconciles to headline (246)
- [x] Stale-number grep sweep returns 0 hits
- [ ] CI green
- [ ] mkdocs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011TDdEiNm39GyFvgcAGb4MV)_