### PR TITLE
chore(release): v2.4.5 — close out unreleased work + count reconciliation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "metadata": {
     "description": "246 production-ready skill packages across 9 domains with 359 Python tools, 485 reference documents, 27 agents (20 cs-* + 7 personas), and 33 slash commands. Compatible with Claude Code, Codex CLI, Hermes Agent, Cursor, Antigravity, OpenCode, Gemini CLI, and OpenClaw.",
-    "version": "2.4.4"
+    "version": "2.4.5"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Claude Skills Library will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — Skill Expansion Phase 1+2+3+4 (+ ship-gate)
+## [2.4.5] - 2026-05-11 — Reliability Portfolio + Count-Truth Reconciliation
 
 ### Added — Engineering POWERFUL
 
@@ -22,16 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Total skills:** 235 → 238 (+3 new engineering POWERFUL skills)
-- **Python tools:** 314 → 325
-- **References:** 435 → 447
-- **Slash commands:** 27 → 30
+- **Total skills:** 235 (v2.3.0 claim) → 246 (file-system truth via `find . -name SKILL.md` minus 4 distribution duplicates). +5 new skills this cycle (slo-architect, ship-gate, feature-flags-architect, kubernetes-operator, chaos-engineering); +6 discovered during #608/#609 reconciliation.
+- **Python tools:** 314 → 359 (`find . -path '*/scripts/*.py' | wc -l`)
+- **References:** 435 → 485 (`find . -path '*/references/*.md' | wc -l`)
+- **Agents:** 28 → 27 (file-system truth: 20 `cs-*` + 7 personas. Previous "30" miscounted README/TEMPLATE as agents)
+- **Slash commands:** 27 → 33 (`find commands -name '*.md' | wc -l`)
+- **Marketplace plugins:** 30 → 33 (registered in `.claude-plugin/marketplace.json`)
 - **engineering-advanced-skills** plugin: v2.3.3 → v2.4.2
 - **marketplace.json**: `feature-flags-architect`, `kubernetes-operator`, and `chaos-engineering` registered as standalone plugins
 
 ### Fixed
 
 - `tests/test_skill_integrity.py::TestScriptDirectories::test_scripts_dirs_have_python_files` — was rejecting valid skills shipping `.mjs`/`.js`/`.ts`/`.sh` scripts (e.g., `full-page-screenshot`). Now accepts any executable script extension while keeping the "scripts/ dir is non-empty" intent.
+- **#608, #609 — Count claims aligned to ground-truth.** Every metric in `CLAUDE.md`, `README.md`, `docs/`, `mkdocs.yml`, and `.claude-plugin/marketplace.json` now reproduces from a deterministic `find` or `python3 -c "import json"` command. Stale claims of "188 skills", "30 agents", "3 personas", "235 skills" (current-state) were replaced with file-system truth. Per-domain marketplace breakdown also reconciled: engineering-advanced 40→67 unique, engineering-core 32→51, marketing 44→45, c-level 28→34, product 13→17, finance 3→4. Domains ra-qm-team (14), project-management (9), business-growth (5) unchanged.
+- **skill-security-auditor** — self-skip false positives via `noqa` directive (the auditor was flagging its own scanner code).
 
 ## [2.2.0] - 2026-03-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 
 ## Current Version
 
-**Version:** v2.4.4 (latest)
+**Version:** v2.4.5 (latest)
 
 **v2.4.x Highlights — Reliability Portfolio (Phase 1–4):**
 - **slo-architect** (Phase 4 — keystone) — SLO/SLI/error-budget discipline per Google SRE Workbook. 3 stdlib Python tools (`slo_designer`, `error_budget_calculator` with multi-window burn-rate alerts, `slo_review`), 4 reference docs, asset templates, `/slo-design` slash command. Engineering-advanced bundle 49 → 50.
@@ -228,6 +228,6 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
 
 ---
 
-**Last Updated:** May 10, 2026
-**Version:** v2.4.4
+**Last Updated:** May 11, 2026
+**Version:** v2.4.5
 **Status:** 246 skills deployed across 9 domains, 33 marketplace plugins, docs site live


### PR DESCRIPTION
## Why this exists

Step 1 of the dev → main promotion sequence. We have 11 commits sitting on `dev` since v2.4.4, including:
- Phase 1-4 reliability portfolio (slo-architect, ship-gate, feature-flags-architect, kubernetes-operator, chaos-engineering)
- Count-truth reconciliation (#608, #609)
- Skill-security-auditor self-skip fix
- Docs site regen + scripts/generate-docs.py fixes

Promoting silently would ship docs claims about "246 skills" under the v2.4.4 label, which is dishonest. This PR closes out the `[Unreleased]` CHANGELOG block as **v2.4.5** so the dev → main promotion has matching release notes.

## What changed

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[2.4.5] - 2026-05-11`. Totals corrected to file-system truth (235→246, not the original 235→238). Added bullets for #608/#609 + skill-security-auditor fix. |
| `.claude-plugin/marketplace.json` | `metadata.version`: `2.4.4` → `2.4.5` (root only) |
| `CLAUDE.md` | `**Version:** v2.4.4 (latest)` → `v2.4.5` (×2 places); `Last Updated: May 10` → `May 11` |

## Per-skill version stamps deliberately NOT bumped

- `marketplace.json` line 643 — `slo-architect` plugin's own version stays `2.4.4` (it's the skill's release stamp, not the repo's)
- `engineering/skills/slo-architect/SKILL.md` and `engineering/slo-architect/skills/slo-architect/SKILL.md` frontmatter `version: 2.4.4` stays — same reason
- `engineering/.claude-plugin/plugin.json` and `engineering/slo-architect/.claude-plugin/plugin.json` `version: 2.4.4` stays — same reason

## CHANGELOG totals corrected

The original `[Unreleased]` totals were drafted mid-cycle and never reconciled. Compared to file-system truth:

| Metric | Was claimed | File-system truth | Source |
|---|---|---|---|
| Skills | 235 → 238 | 235 → **246** | `find . -name SKILL.md` − 4 dist dupes |
| Python tools | 314 → 325 | 314 → **359** | `find . -path '*/scripts/*.py' \| wc -l` |
| References | 435 → 447 | 435 → **485** | `find . -path '*/references/*.md' \| wc -l` |
| Agents | missing | 28 → **27** | 20 `cs-*` + 7 personas |
| Slash commands | 27 → 30 | 27 → **33** | `find commands -name '*.md' \| wc -l` |
| Marketplace plugins | missing | 30 → **33** | `python3 -c "import json; print(len(json.load(open('.claude-plugin/marketplace.json'))['plugins']))"` |

## What's next

After this merges to `dev`, the second PR (`dev` → `main`) will be opened as draft to release v2.4.5.

## Test plan

- [x] `python3 -m json.tool .claude-plugin/marketplace.json` valid
- [x] `metadata.version` is `2.4.5`; `slo-architect` plugin version stays `2.4.4`
- [x] 33 plugins still in marketplace
- [x] CHANGELOG totals all reproducible from one-line shell commands
- [ ] CI green
- [ ] mkdocs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011TDdEiNm39GyFvgcAGb4MV)_