### PR TITLE
docs(readme): add 3 audit-first skills to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,9 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
 | [**toprank**](https://github.com/nowork-studio/toprank) | 9 SEO and Google Ads skills for Claude Code — connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag, schema markup, and keyword bid fixes to source or CMS. MIT, 107 stars |
+| [**hormozi-offer-audit**](https://github.com/johnericforte/claude-skill-hormozi-offer-audit) | Audit sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from $100M Offers and $100M Leads. Scores Value Equation + Grand Slam checklist. Returns Top 3 Fixes with before/after. MIT |
+| [**cialdini-influence-audit**](https://github.com/johnericforte/claude-skill-cialdini-influence-audit) | Audit persuasive copy (landing pages, emails, sales sequences) for missing influence principles using Robert Cialdini's seven principles + Pre-Suasion. Scores each principle PRESENT/WEAK/MISSING with anti-overstacking check. MIT |
+| [**claude-blog-assistant**](https://github.com/johnericforte/claude-skill-blog-assistant) | Dual-mode blog publishing assistant. Ship new posts via 8-step lifecycle OR retroactively audit existing posts and return prioritized retrofit list. Wraps AgriciDaniel/claude-blog. MIT |
 
 ---
 


### PR DESCRIPTION
Adds 3 audit-first Claude Code plugins to the **Related Projects** table in README:

- **hormozi-offer-audit** — scored audit of sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from \$100M Offers and \$100M Leads. Returns Top 3 Fixes with before/after.
- **cialdini-influence-audit** — per-principle audit of persuasive copy using Robert Cialdini's seven principles + Pre-Suasion. Anti-overstacking check.
- **claude-blog-assistant** — dual-mode blog publishing assistant wrapping AgriciDaniel/claude-blog. Ship via 8-step lifecycle OR audit existing posts for retrofit.

All three:
- MIT licensed
- Audit-first (not generators)
- Plugin format (.claude-plugin manifest + skills/<name>/SKILL.md)
- Frameworks cited descriptively under nominative fair use
- Include DISCLAIMER.md for IP transparency

Repos live with branch protection (PR-required for non-admin merges):
- https://github.com/johnericforte/claude-skill-hormozi-offer-audit
- https://github.com/johnericforte/claude-skill-cialdini-influence-audit
- https://github.com/johnericforte/claude-skill-blog-assistant

Author: Eric Forte (https://www.ericforte.com)

---

PR targets `dev` branch per CONTRIBUTING.md.