### PR TITLE
fix(integrations): update find depth in convert.sh for new repo structure

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -431,7 +431,7 @@ fi
 SKILLS_TMP="$(mktemp)"
 (
   cd "$REPO_ROOT"
-  find . -mindepth 3 -maxdepth 3 -type f -name 'SKILL.md' -not -path './.git/*' | sort
+  find . -mindepth 4 -maxdepth 6 -type f -name 'SKILL.md' -not -path './.git/*' -not -path './integrations/*' | sort
 ) > "$SKILLS_TMP"
 
 TOTAL_CANDIDATES="$(wc -l < "$SKILLS_TMP" | tr -d ' ')"


### PR DESCRIPTION
## Summary
- What: Fix `scripts/convert.sh` failing with "No skills found matching */*/SKILL.md" error
- Why: The repo directory layout moved from depth-3 (`category/skill/SKILL.md`) to depth-4+ (`team/skills/skill-name/SKILL.md`), but the `find` command still used `-mindepth 3 -maxdepth 3`

The fix updates the depth range to `-mindepth 4 -maxdepth 6` and adds `-not -path './integrations/*'` to avoid picking up already-converted output files.

## Checklist
- [x] Target branch is `dev` (not `main` — PRs to main will be auto-closed)
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback

## Type of Change
- [x] Bug fix

## Testing
- Ran `./scripts/convert.sh --tool cursor` after the fix — successfully found and converted 249 skills (previously 0 with the error)