### PR TITLE
feat(chief-data-officer-advisor): decision-driven CDO skill (v2.5.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,8 +39,8 @@
     {
       "name": "c-level-skills",
       "source": "./c-level-advisor",
-      "description": "29 C-level advisory skills + c-level-agents plugin layer: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO) plus General Counsel (contract risk scanner, term sheet analyzer, IP + regulatory playbook), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive intel, M&A playbook), culture frameworks, and 9 cs-* persona agents + 17 /cs:* slash commands (founder-mode router, office-hours intake, multi-role boardroom, strategic sprint pipeline, cross-model consensus, cooldown freeze).",
-      "version": "2.5.1",
+      "description": "30 C-level advisory skills + c-level-agents plugin layer: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO) plus General Counsel (contract risk scanner, term sheet analyzer, IP + regulatory playbook) and Chief Data Officer (AI training data audit, data product strategy picker, data asset valuator), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive intel, M&A playbook), culture frameworks, and 10 cs-* persona agents + 18 /cs:* slash commands (founder-mode router, office-hours intake, multi-role boardroom, strategic sprint pipeline, cross-model consensus, cooldown freeze).",
+      "version": "2.5.2",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -61,8 +61,8 @@
     {
       "name": "c-level-agents",
       "source": "./c-level-advisor/c-level-agents",
-      "description": "Founder-mode executive team plugin: 9 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel) with distinct cognitive voices, plus 17 /cs:* slash commands — forcing-question office hours (CFO/CMO/CPO/CRO/CTO/CISO/GC reviews), strategic sprint pipeline (brief → boardroom → decide → execute → post-mortem), and meta routing (/cs:founder-mode auto-router, /cs:onboard, /cs:cross-eval multi-model consensus, /cs:freeze cooldown lock). Wraps the 29 c-level skills (including the new general-counsel-advisor with contract risk scanner + term sheet analyzer) with cognitive gearing, persona voice, and artifact-driven handoffs. The business-domain answer to YC Garry Tan's gstack.",
-      "version": "1.1.0",
+      "description": "Founder-mode executive team plugin: 10 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer) with distinct cognitive voices, plus 18 /cs:* slash commands — forcing-question office hours (CFO/CMO/CPO/CRO/CTO/CISO/GC/CDO reviews), strategic sprint pipeline (brief → boardroom → decide → execute → post-mortem), and meta routing (/cs:founder-mode auto-router, /cs:onboard, /cs:cross-eval multi-model consensus, /cs:freeze cooldown lock). Wraps the 30 c-level skills (including general-counsel-advisor and chief-data-officer-advisor with AI training data audit + data product strategy picker + data asset valuator) with cognitive gearing, persona voice, and artifact-driven handoffs. The business-domain answer to YC Garry Tan's gstack.",
+      "version": "1.2.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -81,6 +81,11 @@
         "contract-review",
         "term-sheet",
         "ip-strategy",
+        "chief-data-officer",
+        "cdo",
+        "ai-training-data",
+        "data-product-strategy",
+        "data-as-asset",
         "decision-logging",
         "cross-model"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to the Claude Skills Library will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2] - 2026-05-12 — chief-data-officer-advisor: data strategy without surveys
+
+### Added — C-Level Advisory
+
+- **chief-data-officer-advisor** skill (`./c-level-advisor/skills/chief-data-officer-advisor/`) — opinionated, decision-driven CDO skill. Refuses to be a generic data-governance survey; instead answers four specific decisions:
+  1. **Can we train our model on this data?** (AI training data rights matrix)
+  2. **Warehouse, lakehouse, or mesh — and what do we build vs buy?** (data product strategy)
+  3. **What is our customer data worth?** (B2B customer-data-as-asset valuation + M&A multiplier)
+  4. **What data role do we hire next?** (data team org evolution)
+- **3 stdlib Python tools with deterministic logic** (not pattern-match prose):
+  - **`ai_training_data_audit.py`** — Audits data sources on 3 dimensions (origin × data class × use case). Returns GO/MITIGATE/NO-GO per source with risk, remediation, and GDPR Art. 6 + EU AI Act + US state citations. Embedded sample tests 7 sources spanning all 3 verdicts. Implements 6+ rule branches (scraped always NO-GO, regulated requires framework-specific consent, PII for fine-tuning requires explicit opt-in, etc.).
+  - **`data_product_strategy_picker.py`** — Picks warehouse/lakehouse/mesh from a company profile (stage, consumers, data volume, ML models, culture). Returns architecture + 6-layer build-vs-buy decisions (storage, ELT, modeling, BI, feature store, ML platform) + 12-month sequencing roadmap. Deterministic: same profile → same recommendation. Embedded sample (Series A B2B SaaS, 8 consumers, 4.5TB, 1 ML model) → LAKEHOUSE recommendation.
+  - **`data_asset_valuator.py`** — Computes strategic value 0-10 from 4 components (exclusivity, freshness, cohort breadth, history depth), derives moat strength (NONE/WEAK/MEDIUM/STRONG), applies M&A multiplier (1.0x–1.7x ARR depending on moat) with penalties for MSA carve-out rate and failed anonymization audit. Ranks 3 productization paths (benchmark report / embedding endpoint / direct license) by risk + viability. Embedded sample (B2B sales engagement corpus, 380 customers, 47 carve-outs) → 8.2/10 STRONG moat, 1.33-1.61x multiplier, recommends benchmark report as starting path.
+- **4 references answering one decision each** (not topic surveys):
+  - `ai_training_data_rights.md` — Decision: can we train on this source? Three-dimension matrix + GDPR Art. 6 lawful basis decision tree + EU AI Act high-risk triggers + US state patchwork (CCPA/CPRA, NYC LL 144, IL BIPA, WA MHMD).
+  - `data_product_strategy.md` — Decision: which architecture and what do we build? Stage-driven kill criteria per architecture + 6-layer build-vs-buy decision tree + sequencing pattern + anti-patterns.
+  - `customer_data_as_asset.md` — Decision: what's our data worth and can we productize it? 5-component valuation framework + M&A multiplier with carve-out impact + 3 productization paths with prerequisites + 10-item M&A diligence prep checklist + quarterly contractual constraint audit pattern.
+  - `data_team_org_evolution.md` — Decision: what role next, when to centralize vs embed? 5-stage map (seed → late-stage) with specific role definitions + centralize-vs-embed-vs-federated triggers + 6 anti-patterns ("hiring data scientist as first data hire" etc.).
+- **cs-cdo-advisor** agent (`./c-level-advisor/c-level-agents/agents/cs-cdo-advisor.md`) — decision-driven realist orchestrating the skill. Voice: "What decision does this data drive?" Refuses to recommend tooling before naming the consumer. Treats AI training data as both contractual liability and strategic asset.
+- **`/cs:cdo-review`** slash command (`./c-level-advisor/c-level-agents/skills/cdo-review/SKILL.md`) — 6-question forcing interrogation pattern matching the /cs:cfo-review / /cs:gc-review etc. shape.
+- **cs-cdo-advisor voice spec** added to `persona-voices.md`.
+
+### Why This Matters
+
+By 2026 every B2B SaaS founder is asking three questions the existing C-level skills can't fully answer:
+1. **"Can we train our model on customer data?"** — overlaps cs-ciso (security), cs-general-counsel (contracts), and engineering (tactics), but none of them owns the strategic data picture.
+2. **"What's the right data architecture — and when?"** — engineering's database-designer and observability-designer cover tactics, but the warehouse-vs-lakehouse-vs-mesh decision is stage-driven, not technology-driven.
+3. **"What's our data actually worth in M&A?"** — this comes up at every Series B+ and has no home in existing skills.
+
+This skill fills that gap with **deterministic decision logic** (not survey prose), explicit kill criteria, and a hard rule against duplicating engineering data skills.
+
+### Built with Karpathy-Coder Discipline
+
+This PR was the first in this repo built under explicit karpathy-coder guidance:
+- **Principle 1 (Think before coding):** assumptions surfaced upfront, verifiable success criteria locked before any file was written.
+- **Principle 2 (Simplicity first):** rejected "generic governance survey" framing; each tool/reference covers ONE decision; refused to add scope ("data product strategy picker" doesn't try to also do data quality, RAG, or schema design).
+- **Principle 3 (Surgical changes):** touched only the files in the locked plan. Caught one scope-creep attempt (adding cs-general-counsel-advisor voice spec while editing persona-voices.md) and reverted it — that gap belongs in a separate PR.
+- **Principle 4 (Goal-driven execution):** all 3 Python tools smoke-tested with embedded samples before commit (audit: 7 sources → 2 NO-GO / 2 MITIGATE / 3 GO; strategy picker: Series A → LAKEHOUSE; valuator: 8.2/10 STRONG moat).
+
+### Changed
+
+- **Total skills:** 264 → 265 (+1 chief-data-officer-advisor)
+- **cs-* agents:** 29 → 30 (+1 cs-cdo-advisor in c-level-agents plugin)
+- **/cs:* slash commands:** 17 → 18 (+1 /cs:cdo-review)
+- **Python tools:** 361 → 364 (+3 in chief-data-officer-advisor/scripts/)
+- **References:** 490 → 494 (+4 in chief-data-officer-advisor/references/)
+- **c-level-skills** plugin: v2.5.1 → v2.5.2 (description expanded; 29 → 30 skills, 9 → 10 cs-* agents)
+- **c-level-agents** plugin: v1.1.0 → v1.2.0 (description expanded with CDO; new agent; +`chief-data-officer`, `cdo`, `ai-training-data`, `data-product-strategy`, `data-as-asset` keywords)
+
+### Known follow-ups (NOT included this PR per surgical scope)
+
+- The `cs-general-counsel-advisor` voice spec is missing from `persona-voices.md` (introduced in v2.5.1 but not added to the voice reference). Will be addressed in a separate small PR alongside other voice cleanup.
+- Phase 2 remainder (4 more C-roles: CAIO AI, CCO customer, VPE engineering execution, CCO comms) deferred to v2.5.3+.
+
+### Disclaimer
+
+The `chief-data-officer-advisor` skill surfaces strategic decisions but is **not legal advice** for AI training, **not a replacement for outside counsel** for productization/licensing decisions, and **not a tactical data engineering skill**. For tactical data engineering, see the engineering/ domain (`database-designer`, `observability-designer`, `data-quality-auditor`, `sql-database-assistant`, `rag-architect`, `llm-cost-optimizer`).
+
 ## [2.5.1] - 2026-05-12 — general-counsel-advisor: the gstack-can't-touch lane
 
 ### Added — C-Level Advisory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **comprehensive skills library** for Claude AI and Claude Code - reusable, production-ready skill packages that bundle domain expertise, best practices, analysis tools, and strategic frameworks. The repository provides modular skills that teams can download and use directly in their workflows.
 
-**Current Scope:** 264 production-ready skills across 9 domains with 361 Python automation tools, 490 reference guides, 36 agents (29 `cs-*` + 7 personas), and 50 slash commands.
+**Current Scope:** 265 production-ready skills across 9 domains with 364 Python automation tools, 494 reference guides, 37 agents (30 `cs-*` + 7 personas), and 51 slash commands.
 
 **Key Distinction**: This is NOT a traditional application. It's a library of skill packages meant to be extracted and deployed by users into their own Claude workflows.
 
@@ -124,9 +124,15 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 
 ## Current Version
 
-**Version:** v2.5.1 (latest)
+**Version:** v2.5.2 (latest)
 
-**v2.5.1 Highlights — general-counsel-advisor: the gstack-can't-touch lane:**
+**v2.5.2 Highlights — chief-data-officer-advisor: data strategy without surveys:**
+- **chief-data-officer-advisor** skill (new, `./c-level-advisor/skills/chief-data-officer-advisor/`) — opinionated, decision-driven CDO skill covering 4 specific decisions (no generic governance survey). 3 stdlib Python tools with deterministic logic: `ai_training_data_audit.py` (origin × class × use-case matrix → GO/MITIGATE/NO-GO with GDPR Art. 6 and EU AI Act citations), `data_product_strategy_picker.py` (warehouse/lakehouse/mesh recommendation + 6-layer build-vs-buy + 12-month sequencing), `data_asset_valuator.py` (strategic value 0-10, moat strength, M&A multiplier with carve-out penalties, 3 ranked productization paths). 4 references answering one decision each: training rights (decision tree + state patchwork), data product strategy (kill criteria per architecture), customer-data-as-asset (valuation + M&A diligence prep), data team org evolution (stage-to-role map). Karpathy-aligned: explicit anti-patterns, decision-driven (not topic-driven), surgical (does not duplicate engineering data skills).
+- **cs-cdo-advisor** agent (new) — decision-driven realist orchestrating the skill via `/cs:cdo-review`. Distinct voice: "What decision does this data drive?" Refuses to recommend tooling before naming the consumer.
+- **/cs:cdo-review** (new slash command) — 6-question forcing interrogation: decision being made, consent provenance, internal consumers, M&A diligence impact, model-without-this-source viability, role-that-unblocks-this.
+- **Built with Karpathy-coder discipline:** explicit assumptions surfaced upfront, verifiable success criteria locked before code, surgical scope (no edits to unrelated files), deterministic tool logic (not pattern-match prose), kill criteria documented in every recommendation.
+
+**Version:** v2.5.1
 - **general-counsel-advisor** skill (new, `./c-level-advisor/skills/general-counsel-advisor/`) — full standalone C-role skill backing the existing `/cs:gc-review` command. 2 stdlib Python tools: `contract_risk_scanner.py` (scans contract text for 12 founder-killer patterns: auto-renew traps, uncapped indemnity, vague IP, aggressive non-compete, missing DPA, MFN pricing, perpetual license-back, etc.) and `term_sheet_analyzer.py` (scores term sheets 0-100 across 12 dimensions: liquidation preference, anti-dilution, option pool, board composition, vesting, pro-rata, drag-along, protective provisions, info rights, dividends, valuation/dilution, holistic). 3 references: contracts playbook (7 startup contract types), IP + regulatory landscape (patents, trademark, OSS compliance, HIPAA/GDPR/FDA/fintech triggers, SOC 2 → ISO sequencing), term sheet decoder (full glossary + founder-friendly defaults + negotiation strategy).
 - **cs-general-counsel-advisor** agent (new) — risk-paranoid persona orchestrating the skill via `/cs:gc-review`. Distinct voice: "Before we sign, three things need to be settled in writing." Always escalates to outside counsel — never substitutes for it.
 - **First plugin to outclass gstack on a domain it has zero coverage in.** Software-shipping personas don't include General Counsel; legal exposure is where startups most often discover problems after they're expensive to fix.

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "c-level-skills",
-  "description": "29 C-level advisory skills + c-level-agents plugin layer (9 cs-* persona agents + 17 /cs:* slash commands). Complete virtual board of directors with CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO advisors plus General Counsel (contract risk scanner, term sheet analyzer, IP + regulatory playbook), executive mentor, founder coach, Chief of Staff router, board meetings, decision logger, board deck builder, scenario war room, competitive intel, org health diagnostic, M&A playbook, international expansion, culture architect, change management, strategic alignment, and the founder-mode plugin (office-hours, boardroom, brief/decide/execute/post-mortem pipeline, cross-model consensus, decision freeze).",
-  "version": "2.5.1",
+  "description": "30 C-level advisory skills + c-level-agents plugin layer (10 cs-* persona agents + 18 /cs:* slash commands). Complete virtual board of directors with CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO advisors plus General Counsel (contract risk scanner, term sheet analyzer, IP + regulatory playbook) and Chief Data Officer (AI training data audit, data product strategy picker, data asset valuator), executive mentor, founder coach, Chief of Staff router, board meetings, decision logger, board deck builder, scenario war room, competitive intel, org health diagnostic, M&A playbook, international expansion, culture architect, change management, strategic alignment, and the founder-mode plugin (office-hours, boardroom, brief/decide/execute/post-mortem pipeline, cross-model consensus, decision freeze).",
+  "version": "2.5.2",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/c-level-advisor/CLAUDE.md
+++ b/c-level-advisor/CLAUDE.md
@@ -21,7 +21,7 @@ A complete virtual board of directors: 28 skills covering 10 executive roles, or
 
 ## Skills Overview
 
-### C-Suite Roles (11)
+### C-Suite Roles (12)
 
 | Role | Folder | Reasoning Technique | Scripts |
 |------|--------|-------------------|---------|
@@ -34,7 +34,8 @@ A complete virtual board of directors: 28 skills covering 10 executive roles, or
 | **CRO** | `cro-advisor/` | Chain of Thought | revenue_forecast_model, churn_analyzer |
 | **CISO** | `ciso-advisor/` | Risk-Based | risk_quantifier, compliance_tracker |
 | **CHRO** | `chro-advisor/` | Empathy + Data | hiring_plan_modeler, comp_benchmarker |
-| **General Counsel** ⭐ NEW v2.5.1 | `general-counsel-advisor/` | Risk-Based | contract_risk_scanner, term_sheet_analyzer |
+| **General Counsel** | `general-counsel-advisor/` | Risk-Based | contract_risk_scanner, term_sheet_analyzer |
+| **Chief Data Officer** ⭐ NEW v2.5.2 | `chief-data-officer-advisor/` | Decision-Driven | ai_training_data_audit, data_product_strategy_picker, data_asset_valuator |
 | **Executive Mentor** | `executive-mentor/` | Adversarial | decision_matrix_scorer, stakeholder_mapper |
 
 ### Orchestration (6)
@@ -74,7 +75,7 @@ A complete virtual board of directors: 28 skills covering 10 executive roles, or
 
 A separate plugin at `c-level-agents/` that wraps the 10 C-roles with persona agents and slash commands. Founder-mode entry layer.
 
-### 9 cs-* Agents (in `c-level-agents/agents/`)
+### 10 cs-* Agents (in `c-level-agents/agents/`)
 
 | Agent | Voice | Wraps Skill |
 |---|---|---|
@@ -86,7 +87,8 @@ A separate plugin at `c-level-agents/` that wraps the 10 C-roles with persona ag
 | cs-chro-advisor | People-systems | chro-advisor |
 | cs-ciso-advisor | Risk-paranoid | ciso-advisor |
 | cs-chief-of-staff | Router & synthesist | chief-of-staff |
-| cs-general-counsel-advisor ⭐ NEW v2.5.1 | Risk-paranoid (legal) | general-counsel-advisor |
+| cs-general-counsel-advisor | Risk-paranoid (legal) | general-counsel-advisor |
+| cs-cdo-advisor ⭐ NEW v2.5.2 | Decision-driven (data) | chief-data-officer-advisor |
 
 Existing `cs-ceo-advisor` and `cs-cto-advisor` live in `/agents/c-level/` and integrate with the same protocol.
 
@@ -147,7 +149,7 @@ python decision-logger/scripts/decision_tracker.py
 ---
 
 **Last Updated:** 2026-05-12
-**Skills Deployed:** 29 skills (11 roles incl. General Counsel + 5 mentor commands + 6 orchestration + 6 cross-cutting + 6 culture) + 17 /cs:* sub-skills in c-level-agents plugin
-**Agents:** 11 cs-* (cs-ceo, cs-cto in /agents/c-level/; 9 in c-level-agents/agents/ including new cs-general-counsel-advisor)
-**Python Tools:** 27 (stdlib-only) — +2 with general-counsel-advisor (contract_risk_scanner, term_sheet_analyzer)
-**Reference Docs:** 57 (55 in skills + 2 in c-level-agents/references)
+**Skills Deployed:** 30 skills (12 roles incl. General Counsel and Chief Data Officer + 5 mentor commands + 6 orchestration + 6 cross-cutting + 6 culture) + 18 /cs:* sub-skills in c-level-agents plugin
+**Agents:** 12 cs-* (cs-ceo, cs-cto in /agents/c-level/; 10 in c-level-agents/agents/ including new cs-cdo-advisor)
+**Python Tools:** 30 (stdlib-only) — +3 with chief-data-officer-advisor (ai_training_data_audit, data_product_strategy_picker, data_asset_valuator)
+**Reference Docs:** 61 (59 in skills + 2 in c-level-agents/references)

--- a/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
+++ b/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "c-level-agents",
-  "description": "Founder-mode executive team plugin: 9 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel) plus 17 /cs:* slash commands for forcing-question office hours, multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Wraps the 29 c-level skills (including the new general-counsel-advisor with contract risk scanner + term sheet analyzer) with cognitive gearing and artifact handoffs.",
-  "version": "1.1.0",
+  "description": "Founder-mode executive team plugin: 10 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer) plus 18 /cs:* slash commands for forcing-question office hours (incl. /cs:cdo-review), multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Wraps the 30 c-level skills (including general-counsel-advisor with contract risk scanner + term sheet analyzer, and chief-data-officer-advisor with AI training data audit + data product strategy picker + data asset valuator) with cognitive gearing and artifact handoffs.",
+  "version": "1.2.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/c-level-advisor/c-level-agents/agents/cs-cdo-advisor.md
+++ b/c-level-advisor/c-level-agents/agents/cs-cdo-advisor.md
@@ -1,0 +1,163 @@
+---
+name: cs-cdo-advisor
+description: Decision-driven Chief Data Officer advisor for AI training data rights, data product strategy (warehouse/lakehouse/mesh + build-vs-buy), B2B customer-data-as-asset valuation, and data team org evolution. Strategic only — does not duplicate engineering data skills.
+skills: c-level-advisor/skills/chief-data-officer-advisor
+domain: c-level
+model: opus
+tools: [Read, Write, Bash, Grep, Glob]
+---
+
+# Chief Data Officer Advisor Agent
+
+## Voice
+
+**Opening:** "What decision does this data drive?"
+**Forcing questions:** "Who consumes this internally? What's the consent provenance? Can the model be retrained without it?"
+**Closing:** "Data is leverage, not exhaust. Treat it like an asset on the balance sheet."
+
+Decision-driven realist. Asks "what business decision does this data enable" before "what's the schema." Distrusts vanity metrics, treats AI training data as a contractual liability AND a strategic asset. Refuses to recommend tooling before naming the consumer.
+
+## Purpose
+
+The cs-cdo-advisor orchestrates the `chief-data-officer-advisor` skill across the four decisions a startup CDO actually faces:
+
+1. **Can we train our model on this data?** (training rights matrix)
+2. **Warehouse, lakehouse, or mesh — and what do we build vs buy?** (data product strategy)
+3. **What is our customer data worth in M&A or as a product?** (data-as-asset valuation)
+4. **What data role do we hire next?** (org evolution)
+
+Differentiates from `cs-cto-advisor` (architecture), `cs-ciso-advisor` (security/compliance), `cs-cpo-advisor` (product strategy), and `cs-general-counsel-advisor` (contract review). Each of those overlaps with one CDO concern but none owns the strategic data picture.
+
+**Hard rule:** Does not duplicate tactical engineering data skills. For schema design, observability, query optimization, RAG implementation — points to engineering/.
+
+## Skill Integration
+
+**Skill Location:** `../../skills/chief-data-officer-advisor/`
+
+### Python Tools
+
+1. **AI Training Data Audit**
+   - Path: `../../skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py`
+   - Usage: `python ../../skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py sources.json`
+   - Audits data sources on 3 dimensions (origin × class × use case), returns GO/MITIGATE/NO-GO per source with risk + remediation + GDPR/AI Act citations
+
+2. **Data Product Strategy Picker**
+   - Path: `../../skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py`
+   - Usage: `python ../../skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py profile.json`
+   - Picks warehouse/lakehouse/mesh + build-vs-buy per layer + 12-month sequencing roadmap. Deterministic, derived from profile.
+
+3. **Data Asset Valuator**
+   - Path: `../../skills/chief-data-officer-advisor/scripts/data_asset_valuator.py`
+   - Usage: `python ../../skills/chief-data-officer-advisor/scripts/data_asset_valuator.py corpus.json`
+   - Computes strategic value (0-10), moat strength, M&A multiplier (with carve-out penalties), and ranks 3 productization paths
+
+### Knowledge Bases
+
+- `../../skills/chief-data-officer-advisor/references/ai_training_data_rights.md` — Training rights matrix + GDPR Art. 6 + EU AI Act + US state patchwork
+- `../../skills/chief-data-officer-advisor/references/data_product_strategy.md` — Architecture kill criteria + build-vs-buy decision tree + sequencing pattern
+- `../../skills/chief-data-officer-advisor/references/customer_data_as_asset.md` — Valuation framework + 3 productization paths + M&A diligence prep checklist + contractual constraint audit
+- `../../skills/chief-data-officer-advisor/references/data_team_org_evolution.md` — Stage-to-role map + centralize-vs-embed trigger + anti-patterns
+
+## Workflows
+
+### Workflow 1: AI Training Go/No-Go (1 hour)
+**Goal:** Decide whether a specific data source can train a specific model.
+
+```bash
+# 1. Build sources.json (one entry per source, tagged with origin × class × use case)
+# 2. Run the audit
+python ../../skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py sources.json
+# 3. For each NO-GO: document the kill reason; either drop the source or change the use case
+# 4. For each MITIGATE: assign owner + remediation; block training until complete
+# 5. Cross-check top-3 mitigations with cs-general-counsel-advisor
+# 6. Log via /cs:decide
+```
+
+### Workflow 2: Data Architecture Decision (1 day)
+**Goal:** Pick warehouse / lakehouse / mesh + build-vs-buy for the next 12 months.
+
+```bash
+# 1. Build profile.json (stage, consumers, volume, ML models, culture, priorities)
+# 2. Run the picker
+python ../../skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py profile.json
+# 3. Cross-check architecture choice with cs-cto-advisor (engineering capacity)
+# 4. Cross-check 3-year TCO with cs-cfo-advisor
+# 5. Identify kill criteria explicitly; commit to revisiting in Q4
+# 6. Log via /cs:decide; consider /cs:freeze 90 on multi-year SaaS contracts
+```
+
+### Workflow 3: Data Asset Valuation for M&A Prep (3 days)
+**Goal:** Value the data corpus and prepare for due diligence.
+
+```bash
+# 1. Inventory corpus (customers, history, exclusivity, carve-outs, regulated content)
+# 2. Run the valuator
+python ../../skills/chief-data-officer-advisor/scripts/data_asset_valuator.py corpus.json
+# 3. Run the M&A diligence checklist in customer_data_as_asset.md
+# 4. Surface contractual carve-outs to cs-general-counsel-advisor
+# 5. Decide productization path (benchmark → embedding → license, in viability order)
+# 6. Customer trust impact assessment (CEO + Head of CS sign-off)
+# 7. Log via /cs:decide
+```
+
+### Workflow 4: Data Team Roadmap (1 week)
+**Goal:** Sequence the next 18 months of data hires aligned to business decisions.
+
+1. List top 5 decisions the business can't make today due to missing data/analysis
+2. Map each decision to the role that unblocks it (see references/data_team_org_evolution.md)
+3. Sequence hires (one at a time, ramp before next)
+4. Cross-check with cs-chro-advisor on comp bands + leveling
+5. Identify centralize-vs-embed trigger date
+
+## Output Standards
+
+```
+**Bottom Line:** [one sentence — decision and rationale]
+**The Decision:** [one of: training go/no-go | architecture | asset value | next hire]
+**The Evidence:** [numbers from the tool output, not adjectives]
+**How to Act:** [3 concrete next steps]
+**Your Decision:** [the call only the founder can make]
+```
+
+## Integration Example: Pre-Quarter CDO Review
+
+```bash
+#!/bin/bash
+echo "📊 CDO Quarterly Review"
+echo "1. Training data audit"
+python ../../skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py current-sources.json
+echo "2. Architecture review"
+python ../../skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py current-profile.json
+echo "3. Data asset valuation"
+python ../../skills/chief-data-officer-advisor/scripts/data_asset_valuator.py corpus.json
+echo "Kill criteria + checkpoint dates in each output."
+```
+
+## Success Metrics
+
+- **Training audit coverage:** 100% of models in production have an audit on file for their training sources
+- **Architecture decisions reviewed quarterly:** picker re-run with updated profile each Q
+- **MSA carve-out rate:** known and tracked; trending toward 0 at renewal
+- **Data team hires:** every new hire ties to a specific decision the business couldn't make
+- **M&A readiness:** diligence checklist complete 6 months before any conversation
+- **Zero unbudgeted regulatory hits:** AI Act / GDPR / state laws all mapped to product roadmap
+
+## Related Agents
+
+- [cs-cto-advisor](../../../../agents/c-level/cs-cto-advisor.md) — architecture capacity
+- [cs-ciso-advisor](cs-ciso-advisor.md) — data security, threat modeling for productized data
+- [cs-cpo-advisor](cs-cpo-advisor.md) — product strategy (when data becomes product)
+- [cs-general-counsel-advisor](cs-general-counsel-advisor.md) — contractual constraints, DPA, training-rights
+- [cs-cfo-advisor](cs-cfo-advisor.md) — build-vs-buy TCO, M&A valuation math
+- [cs-chro-advisor](cs-chro-advisor.md) — data team hiring, leveling, comp
+
+## References
+
+- Skill: [../../skills/chief-data-officer-advisor/SKILL.md](../../skills/chief-data-officer-advisor/SKILL.md)
+- Voice spec: [../references/persona-voices.md](../references/persona-voices.md)
+- Sibling command: [`/cs:cdo-review`](../skills/cdo-review/SKILL.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready

--- a/c-level-advisor/c-level-agents/references/persona-voices.md
+++ b/c-level-advisor/c-level-agents/references/persona-voices.md
@@ -64,6 +64,12 @@ Closing handoff (1 sentence) — character-stamped decision frame
 - **Closing:** "Decision logged. Here's the next checkpoint."
 - **Signature moves:** Identifies cross-functional questions and triggers `/cs:boardroom`. Logs every decision to two-layer memory. Surfaces stale decisions for review.
 
+### cs-cdo-advisor — The Decision-Driven Data Realist
+- **Opening:** "What decision does this data drive?"
+- **Forcing questions:** "Who consumes this internally? What's the consent provenance? Can the model be retrained without it?"
+- **Closing:** "Data is leverage, not exhaust. Treat it like an asset on the balance sheet."
+- **Signature moves:** Asks "what business decision does this enable" before "what's the schema." Treats AI training data as both a contractual liability AND a strategic asset. Refuses to recommend tooling before naming the consumer.
+
 ## Drift Prevention
 
 Voice should feel like a **bookend**, not a costume. If the analysis itself starts sounding "in character" instead of rigorous, the voice has drifted. Reset by writing the body in neutral tone first, then adding the opening/closing lines.

--- a/c-level-advisor/c-level-agents/skills/cdo-review/SKILL.md
+++ b/c-level-advisor/c-level-agents/skills/cdo-review/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "cdo-review"
+description: "/cs:cdo-review <plan> — Decision-driven Chief Data Officer interrogation of any plan that touches training data, data architecture, data productization, or data team hiring."
+---
+
+# /cs:cdo-review — CDO Forcing Questions
+
+**Command:** `/cs:cdo-review <plan>`
+
+The decision-driven CDO pressure-tests any plan that touches data strategy. Six questions before any commitment to a data architecture, AI training run, data productization, or data team hire.
+
+## When to Run
+
+- Before approving any new ML model training run that uses customer data
+- Before signing a multi-year data-infrastructure SaaS contract (Snowflake, Databricks, Fivetran)
+- Before productizing any customer data (benchmark report, embedding endpoint, license)
+- Before a major data team hire (head of data, CDO, data PM, ML engineer)
+- Before M&A diligence — yours or theirs
+- When the founder uses the word "monetize" near "data"
+
+## The Six CDO Questions
+
+### 1. What decision does this data drive?
+**If no decision is unblocked, why are we collecting / training on / productizing it?**
+- "We might need it later" is not a decision.
+- "It feels like a moat" is not a decision.
+- A real answer names a specific business call that requires this data.
+
+### 2. What's the consent provenance for every source?
+**For each data source: origin, consent flow, data class, intended use.**
+- 1st-party-TOS-only is weaker than 1st-party-explicit-opt-in.
+- Bundled TOS doesn't cover material new purposes (training on PII for foundation models).
+- Run `ai_training_data_audit.py` if there's any AI use case in scope.
+
+### 3. Who consumes this internally — and how many distinct functional domains?
+**Drives the centralize-vs-embed and warehouse-vs-mesh decisions.**
+- <5 consumers: warehouse-only.
+- 5-25 consumers: lakehouse.
+- 25+ consumers + federated culture: mesh.
+- Premature architecture choice is the #1 cause of data-team burnout.
+
+### 4. What's the M&A diligence impact?
+**If an acquirer asks about this data corpus tomorrow, are we ready?**
+- Is there a documented anonymization process?
+- What % of customers have MSA carve-outs?
+- Are training-data provenance logs current?
+- Run `data_asset_valuator.py` quarterly.
+
+### 5. Can the model / decision / report be retrained / re-run / re-published without this source?
+**Tests how much you depend on a specific data source.**
+- If yes → low blast radius; you can change consent posture later.
+- If no → high blast radius; you've structurally committed to the source. Vet harder.
+
+### 6. What role unblocks this — and is it the right next hire?
+**Wrong hire (data scientist) when right answer (analytics engineer) is a 12-month productivity loss.**
+- Map the decision being unblocked to the specific role.
+- Confirm prerequisite roles are in place (data engineer before ML engineer, analyst before data scientist).
+
+## Workflow
+
+```bash
+# 1. AI training audit (if any ML / AI use case)
+python ../../../skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py sources.json
+
+# 2. Architecture decision (if changing the stack)
+python ../../../skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py profile.json
+
+# 3. Data asset valuation (if productizing or pre-M&A)
+python ../../../skills/chief-data-officer-advisor/scripts/data_asset_valuator.py corpus.json
+```
+
+## Output Format
+
+```markdown
+# CDO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## The Decision Being Made
+[one sentence — which of the four CDO decisions: training | architecture | asset | hire]
+
+## Training Audit (if applicable)
+- NO-GO sources: N
+- MITIGATE sources: N
+- GO sources: N
+- Top remediation: <one line>
+
+## Architecture (if applicable)
+- Recommended: WAREHOUSE / LAKEHOUSE / MESH
+- Build-vs-buy summary: <one line>
+- Kill criteria: <when to revisit>
+
+## Asset Value (if applicable)
+- Strategic value: X/10 | Moat: STRONG / MEDIUM / WEAK
+- M&A multiplier: X.Xx – X.Xx ARR
+- Recommended productization path: <name>
+
+## Org (if applicable)
+- Next hire: <role>
+- Why this, not that: <one line>
+- Prerequisite hires in place: yes/no
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 BLOCK
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:gc-review` — for any productization or licensing path
+- `/cs:ciso-review` — for any architecture change touching customer data
+- `/cs:cfo-review` — for build-vs-buy TCO and M&A valuation math
+- `/cs:chro-review` — for data team hires (comp, ladder, leveling)
+- `/cs:decide` — log the verdict
+- `/cs:freeze 90` — on multi-year infrastructure contracts
+
+## Related
+
+- Agent: [`cs-cdo-advisor`](../../agents/cs-cdo-advisor.md)
+- Skill: [`chief-data-officer-advisor`](../../../skills/chief-data-officer-advisor/SKILL.md)
+- Adjacent: `../../../skills/general-counsel-advisor/` (contractual constraints), `../../../skills/cto-advisor/` (architecture capacity)
+
+---
+
+**Version:** 1.0.0

--- a/c-level-advisor/skills/chief-data-officer-advisor/SKILL.md
+++ b/c-level-advisor/skills/chief-data-officer-advisor/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: "chief-data-officer-advisor"
+description: "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill — strategic decisions only."
+license: MIT
+metadata:
+  version: 1.0.0
+  author: Alireza Rezvani
+  category: c-level
+  domain: chief-data-officer-leadership
+  updated: 2026-05-12
+  python-tools: ai_training_data_audit.py, data_product_strategy_picker.py, data_asset_valuator.py
+  frameworks: training-data-rights-matrix, data-product-strategy, customer-data-as-asset, data-team-org-evolution
+---
+
+# Chief Data Officer Advisor
+
+Strategic data leadership for startup CDOs and founders without one. **Four decisions, no surveys:**
+
+1. **Can we train our model on this data?** — origin × consent × use-case matrix
+2. **Warehouse, lakehouse, or mesh — and what do we build vs buy?** — stage-driven architecture
+3. **What is our customer data worth?** — strategic value + M&A multiplier + productization paths
+4. **What data role do we hire next?** — stage-to-role map, centralize-vs-embed trigger
+
+This skill does **not** cover tactical data engineering. For schema design, observability, query optimization, RAG, or ML platform implementation, see `engineering/database-designer/`, `engineering/observability-designer/`, `engineering/data-quality-auditor/`, `engineering/sql-database-assistant/`, `engineering/rag-architect/`, `engineering/llm-cost-optimizer/`.
+
+## Keywords
+
+CDO, chief data officer, AI training data, consent provenance, training rights, GDPR Article 6 lawful basis, GDPR Article 22, EU AI Act high-risk, ePrivacy, copyright fair use, hiQ v. LinkedIn, scraped data, synthetic data, data product, data mesh, lakehouse, medallion architecture, dbt, Snowflake, BigQuery, Databricks, Fivetran, Airbyte, reverse ETL, feature store, customer data as asset, data monetization, data productization, anonymization, k-anonymity, differential privacy, M&A data diligence, data org, analytics engineer, data engineer, data scientist, data product manager, centralize vs embed, hub and spoke
+
+## Quick Start
+
+```bash
+# Audit data sources for AI training eligibility
+python scripts/ai_training_data_audit.py                              # uses embedded sample
+python scripts/ai_training_data_audit.py path/to/sources.json
+
+# Pick data architecture + build-vs-buy + sequencing
+python scripts/data_product_strategy_picker.py                        # uses embedded Series A SaaS
+python scripts/data_product_strategy_picker.py path/to/profile.json
+
+# Value the customer data corpus + productization viability
+python scripts/data_asset_valuator.py                                 # uses embedded B2B sample
+python scripts/data_asset_valuator.py path/to/corpus.json
+```
+
+## Key Questions (ask these first)
+
+- **What decision does this data drive?** (If none, why are we collecting it?)
+- **What's the consent provenance of every source we want to train on?** (TOS-only is not the same as explicit opt-in.)
+- **Who are the internal data consumers, and how many distinct domains do they span?** (Drives centralize-vs-embed and warehouse-vs-mesh.)
+- **In an M&A scenario, is our data a moat or a liability?** (Customer carve-outs in MSAs can flip the answer.)
+- **Are we hiring an analytics engineer or a data scientist next?** (They solve different problems; founders confuse them.)
+- **Have we run an anonymization audit before any external sharing?** (k-anonymity ≥ 5 is the floor, not the ceiling.)
+
+## Core Responsibilities
+
+### 1. AI Training Data Rights
+
+The 2026 question every startup is facing: **can we use customer data to train our model?**
+
+The answer is rarely binary. It depends on three independent dimensions:
+
+| Dimension | Values |
+|---|---|
+| **Origin** | 1st-party-explicit-opt-in / 1st-party-TOS-only / partner-licensed / scraped / synthetic |
+| **Data class** | Anonymous aggregate / behavioral / PII / 3rd-party content / regulated (PHI, PCI, kids) |
+| **Use case** | In-product personalization / fine-tune our model / train foundation model / external sharing |
+
+Each combination produces GO / MITIGATE / NO-GO. **Run** `ai_training_data_audit.py` on a JSON inventory of sources.
+
+See `references/ai_training_data_rights.md` for the full matrix + GDPR Art. 6 lawful basis decision tree + EU AI Act high-risk triggers.
+
+### 2. Data Product Strategy
+
+**Architecture choice (warehouse vs lakehouse vs mesh) is stage-driven, not preference-driven:**
+
+- **Warehouse only** (Snowflake / BigQuery / Postgres): ≤5 data consumers, <2TB, no ML use cases
+- **Lakehouse** (warehouse + object storage, often Databricks or Snowflake-with-Iceberg): 5–25 data consumers, 2TB–1PB, 1–3 ML use cases
+- **Data mesh**: 25+ data consumers across 4+ domains, federated ownership culture in place
+
+**Build vs buy is decided per layer:**
+
+| Layer | Buy unless | Build only if |
+|---|---|---|
+| Storage / warehouse | Never build | (You’re a data infra company) |
+| ELT / ingest | Never build | Source isn’t supported by Fivetran/Airbyte |
+| Modeling (dbt) | Always build | This is your IP |
+| BI / dashboards | Buy at <100 consumers | Embedded analytics for customers |
+| Feature store | Defer until 3+ prod models | Then build OR buy Tecton/Hopsworks |
+| ML platform | Defer until 5+ prod models | Then buy SageMaker/Vertex/Databricks |
+
+**Run** `data_product_strategy_picker.py` for a stage-specific recommendation. See `references/data_product_strategy.md` for kill criteria per architecture and the build-vs-buy decision tree.
+
+### 3. B2B Customer-Data-as-Asset
+
+**The shift:** at Series B+, customer data is no longer just operational — it’s an asset that can be:
+- A defensibility moat (replicating requires years of customer cohort)
+- An M&A multiplier (1.2x–2x ARR uplift for strategic buyers)
+- A direct revenue stream (anonymized industry benchmarks, embedding endpoints, licensing)
+
+But it can also be a **liability**:
+- 47/380 customers with MSA carve-outs makes productization legally infeasible
+- Anonymization audits often reveal re-identification risk above tolerable thresholds
+- Regulatory exposure increases linearly with productization (GDPR Art. 28 processors vs Art. 26 joint controllers)
+
+**Run** `data_asset_valuator.py` with corpus characteristics to get strategic value score + productization paths + risk-adjusted value.
+
+See `references/customer_data_as_asset.md` for the valuation framework, M&A diligence prep checklist, and contractual constraint audit pattern.
+
+### 4. Data Team Org Evolution
+
+**The wrong question:** "Should we hire a data scientist?"
+**The right question:** "What’s the next decision we can’t make because we lack data, and what role unblocks that?"
+
+Stage-to-role map (B2B SaaS baseline):
+
+| Stage | First hire | Then | Then |
+|---|---|---|---|
+| Pre-seed / seed | Founder-as-analyst (SQL + spreadsheets) | — | — |
+| Series A (Series A) | Analyst | Analytics engineer (dbt) | — |
+| Series B | Data engineer | Senior analyst (embedded in GTM) | Data PM (if 3+ teams need data) |
+| Growth | Manager of analytics | ML engineer (if model is core) | Head of Data |
+| Late-stage | Head of Data → CDO | Specialized: BI, MLE, DPO | Federated owners per domain (mesh) |
+
+**Centralize-vs-embed trigger:** when 3+ functional areas (sales, marketing, product, ops, CS) need bespoke data weekly, the central team becomes the bottleneck. Move to hub-and-spoke (central platform + embedded analysts) before that becomes a hiring crisis.
+
+See `references/data_team_org_evolution.md`.
+
+## Workflows
+
+### Workflow 1: AI Training Decision (1 hour)
+**Goal:** Decide whether a specific data source can train a specific use case.
+
+```bash
+# 1. Build sources.json with one entry per data source
+# 2. Run the audit
+python scripts/ai_training_data_audit.py sources.json
+# 3. For each MITIGATE: assign owner + remediation
+# 4. For each NO-GO: document the kill reason for the legal log
+# 5. Cross-check with cs-general-counsel-advisor on top-3 mitigation items
+# 6. Log via /cs:decide
+```
+
+### Workflow 2: Architecture Decision (1 day)
+**Goal:** Pick warehouse / lakehouse / mesh and the build-vs-buy split for the next 12 months.
+
+```bash
+python scripts/data_product_strategy_picker.py profile.json
+# Cross-check with cs-cto-advisor on engineering capacity
+# Cross-check with cs-cfo-advisor on 3-year TCO
+# Log via /cs:decide; consider /cs:freeze 90 if signing a multi-year SaaS contract
+```
+
+### Workflow 3: Data Asset Valuation for M&A Prep (3 days)
+**Goal:** Value the data corpus and prepare for due diligence.
+
+1. Inventory the corpus: size, freshness, exclusivity, customer overlap, contractual restrictions
+2. Run `data_asset_valuator.py`
+3. Run the M&A diligence prep checklist in `customer_data_as_asset.md`
+4. Surface contractual carve-outs to cs-general-counsel-advisor for re-papering plan
+5. Decide productization path (benchmark report / embedding endpoint / direct license)
+6. Log via /cs:decide
+
+### Workflow 4: Data Team Roadmap (1 week)
+**Goal:** Build the next 18 months of data hires aligned to business decisions.
+
+1. List the top 5 decisions the business can’t make today due to missing data or analysis
+2. Map each decision to the role that unblocks it
+3. Sequence hires (one role at a time, ramp before next)
+4. Cross-check with cs-chro-advisor on comp bands and leveling
+5. Identify the centralize-vs-embed trigger date
+
+## Output Standards (when invoked via cs-cdo-advisor)
+
+```
+**Bottom Line:** [one sentence — decision and rationale]
+**The Decision:** [one of the 4 framings]
+**The Evidence:** [numbers, not adjectives]
+**How to Act:** [3 concrete next steps]
+**Your Decision:** [the call only the founder can make]
+```
+
+## Adjacent Skills
+
+- `../cto-advisor/` — architecture capacity, scaling cliffs
+- `../ciso-advisor/` — data security, threat modeling for productized data
+- `../general-counsel-advisor/` — contractual constraints, DPA, training-data rights
+- `../cfo-advisor/` — build-vs-buy TCO, M&A valuation math
+- `../chro-advisor/` — data team hiring, leveling, comp
+- `../../../engineering/database-designer/` — tactical schema design
+- `../../../engineering/rag-architect/` — tactical AI/RAG implementation
+- `../../../engineering/llm-cost-optimizer/` — model cost management
+
+## References
+
+- [ai_training_data_rights.md](references/ai_training_data_rights.md) — The training-rights matrix + GDPR Art. 6 / EU AI Act decision tree
+- [data_product_strategy.md](references/data_product_strategy.md) — Warehouse / lakehouse / mesh kill criteria + build-vs-buy decision tree
+- [customer_data_as_asset.md](references/customer_data_as_asset.md) — Valuation framework + M&A diligence prep + productization paths
+- [data_team_org_evolution.md](references/data_team_org_evolution.md) — Stage-to-role map + centralize-vs-embed trigger
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Disclaimer:** Decisions touching training data rights, data productization, or M&A data diligence should involve qualified counsel. This skill surfaces decisions and tradeoffs — it does not replace legal review.

--- a/c-level-advisor/skills/chief-data-officer-advisor/references/ai_training_data_rights.md
+++ b/c-level-advisor/skills/chief-data-officer-advisor/references/ai_training_data_rights.md
@@ -1,0 +1,133 @@
+# AI Training Data Rights — The Decision: "Can we train on this data?"
+
+This reference answers exactly one decision per data source: **may we use this for AI training, and for which use case?** It does so by combining three independent dimensions into a verdict.
+
+Pair with `scripts/ai_training_data_audit.py` for automation. **Not legal advice.**
+
+## The Three Dimensions
+
+### Dimension 1: Origin
+
+Where did this data come from, and what consent flow accompanied it?
+
+| Origin | Strength | Notes |
+|---|---|---|
+| `1st-party-explicit-opt-in` | Strongest | User saw a notice for THIS purpose and clicked agree. GDPR Art. 6(1)(a). |
+| `1st-party-tos-only` | Weak | Bundled TOS doesn't satisfy GDPR Art. 6 for materially different purposes (training). |
+| `partner-licensed` | Depends | Only as strong as the partner's original consent flow + your license scope. |
+| `scraped` | Insufficient | No lawful basis under GDPR Art. 6; potentially Computer Fraud and Abuse Act / copyright exposure. |
+| `synthetic` | Strong | But synthetic data inherits risks from its seed source if any. |
+
+### Dimension 2: Data Class
+
+What's in the data?
+
+| Class | Implication |
+|---|---|
+| `anonymous-aggregate` | Safest. K-anonymity ≥ 5 maintained. |
+| `behavioral` | Usually safe with proper consent. Watch for re-identification. |
+| `pii` | Highest scrutiny. Requires lawful basis + deletion-on-request handling. |
+| `third-party-content` | User-uploaded files, snippets, transcripts that include external content. Copyright + DMCA exposure. |
+| `regulated` | PHI, PCI, COPPA-children data, biometrics. Framework-specific consent required. |
+
+### Dimension 3: Use Case
+
+What are you doing with it?
+
+| Use case | Risk profile |
+|---|---|
+| `in-product-personalization` | Lowest risk; recommended within-product. Performance of contract often covers this. |
+| `fine-tune-our-model` | Medium risk. Specific opt-in usually needed for non-anonymous classes. |
+| `train-foundation-model` | High risk. Re-identification + memorization concerns; almost never permissible for PII without specific consent. |
+| `external-sharing` | Highest risk. Recipient becomes a data controller (GDPR Art. 26 / 28 analysis required). |
+
+## The Verdict Matrix (excerpt — full logic in audit tool)
+
+| Origin × Class × Use Case | Verdict |
+|---|---|
+| `scraped` × any × any | NO-GO (no exceptions for training) |
+| `1st-party-tos-only` × `pii` × `fine-tune-our-model` | NO-GO (TOS insufficient for material purpose change) |
+| `1st-party-explicit-opt-in` × `pii` × `in-product-personalization` | GO (strongest position) |
+| `1st-party-tos-only` × `behavioral` × `fine-tune-our-model` | GO (with DPIA + deletion handling) |
+| `partner-licensed` × `anonymous-aggregate` × `train-foundation-model` | GO (with license-scope review) |
+| `synthetic` × `anonymous-aggregate` × `train-foundation-model` | GO (with provenance log) |
+| any × `regulated` × `train-foundation-model` | NO-GO (framework prohibits raw use) |
+
+Run `python scripts/ai_training_data_audit.py` for the full matrix applied to your sources.
+
+## GDPR Art. 6 Lawful Basis Decision Tree (EU residents only)
+
+If any EU resident data flows, GDPR applies. Pick exactly one lawful basis per purpose:
+
+1. **Art. 6(1)(a) Consent.** The user said yes to THIS specific purpose. Most defensible. Must be granular, freely given, revocable.
+2. **Art. 6(1)(b) Performance of contract.** Processing is necessary to deliver the service the user purchased. Works for in-product personalization within reasonable expectations.
+3. **Art. 6(1)(c) Legal obligation.** You're required by law. Rare for training data.
+4. **Art. 6(1)(d) Vital interests.** Life or death. Practically never applies to AI training.
+5. **Art. 6(1)(e) Public interest.** Government / public mission. Rarely applies to private companies.
+6. **Art. 6(1)(f) Legitimate interest.** Balancing test: your interest vs the user's rights. Requires Legitimate Interest Assessment (LIA). Defensible for fraud detection, security; weak for personalization beyond user expectations.
+
+**Practical takeaway:** For training data outside in-product personalization, default to Art. 6(1)(a) explicit consent. Art. 6(1)(f) is increasingly disfavored by EU regulators for AI training (see EDPB Opinion 28/2024).
+
+## EU AI Act High-Risk Triggers
+
+The EU AI Act (in force 2026) imposes additional data governance requirements for high-risk AI systems. You are high-risk if your AI is used for:
+
+- Biometric identification (other than verification)
+- Critical infrastructure management
+- Education access / scoring
+- Employment / worker management (including hiring algorithms)
+- Access to essential services (credit, insurance, public benefits)
+- Law enforcement
+- Migration / border control
+- Administration of justice
+
+If you are high-risk, **Art. 10 (data governance)** requires:
+- Training-data quality criteria (representativeness, accuracy, completeness)
+- Bias examination + mitigation
+- Provenance documentation per source
+- Pre-deployment conformity assessment
+
+If you're low-risk (most B2B SaaS), the heavy obligations are GDPR-side, not AI-Act-side. But you still need provenance logs for Art. 53 (general-purpose models).
+
+## US State Patchwork
+
+| Law | What it covers |
+|---|---|
+| California CCPA / CPRA | Right to know, delete, opt-out of sale (incl. some training scenarios) |
+| Colorado AI Act (CO SB 21-169 successor) | Bias audit requirements for AI in consumer decisions |
+| New York City Local Law 144 | Bias audit required for AI in hiring (NYC employers) |
+| Illinois BIPA | Biometric data requires explicit written consent |
+| Texas TCPA | Capture-of-biometric-identifier rules |
+| Washington My Health My Data Act | Consumer health data including inference |
+
+## Practical Decision Pattern
+
+For every new AI training initiative:
+
+1. **List the data sources you plan to use** (be exhaustive — including "internal" ones)
+2. **Tag each with origin × class × use case**
+3. **Run `ai_training_data_audit.py`**
+4. **For NO-GO:** Document the kill reason in the legal log. Either drop the source or change the use case.
+5. **For MITIGATE:** Assign owner + remediation. Block training until complete.
+6. **For GO:** Document the lawful basis and maintain the provenance log.
+7. **Cross-check with cs-general-counsel-advisor** on top-3 mitigation items.
+8. **Cross-check with cs-ciso-advisor** on data flow security.
+9. **Log the decision via `/cs:decide`.**
+
+## When This Reference Doesn't Help
+
+- **Building synthetic data pipelines.** The synthetic data origin tag covers strategy, not generation; talk to engineering.
+- **Differential privacy implementations.** Engineering territory. See `engineering/database-designer/` for guidance.
+- **EU AI Act conformity assessments.** Requires a specialist; this reference identifies the trigger, not the remediation.
+- **Class actions / litigation defense.** Outside counsel territory; this reference is preventive.
+
+---
+
+**Source authorities (non-exhaustive):**
+- GDPR (Regulation (EU) 2016/679)
+- EU AI Act (Regulation (EU) 2024/1689)
+- EDPB Opinion 28/2024 on processing of personal data in AI models
+- CCPA / CPRA (California Civil Code § 1798.100 et seq.)
+- hiQ Labs, Inc. v. LinkedIn Corp., 938 F.3d 985 (9th Cir. 2019)
+- NYT Co. v. OpenAI (filing, 2024, ongoing)
+- Authors Guild v. Google, 804 F.3d 202 (2d Cir. 2015)

--- a/c-level-advisor/skills/chief-data-officer-advisor/references/customer_data_as_asset.md
+++ b/c-level-advisor/skills/chief-data-officer-advisor/references/customer_data_as_asset.md
@@ -1,0 +1,214 @@
+# Customer Data as Asset — The Decision: "What is our customer data worth, and can we productize it?"
+
+This reference answers exactly one decision: **at Series B+, when customer data is no longer operational but strategic, how do we value it, monetize it, and survive M&A diligence?**
+
+Pair with `scripts/data_asset_valuator.py` for automation.
+
+## The Shift: Operational → Strategic Asset
+
+In seed and Series A, customer data is operational: it powers the product. Starting around Series B (especially in B2B SaaS), data accumulates into something else — an asset with strategic value independent of the product's primary use.
+
+Symptoms that the shift has happened:
+- An acquirer asks about data corpus in their LOI
+- A partner asks to license anonymized data for benchmarking
+- A customer demands a contractual carve-out preventing data use beyond their own service
+- The board asks "what are we doing with the data?"
+
+When these surface, you need a CDO answer, not a CTO answer.
+
+## The Valuation Framework — Five Components
+
+Strategic value (composite score 0-10) is the product of five components:
+
+### 1. Exclusivity
+**Is the data uniquely yours, or is it available elsewhere?**
+
+| Level | Definition |
+|---|---|
+| `none` | Same data is in public sources (web scrapes, public records) |
+| `low` | Commercially available from data brokers (e.g., LinkedIn / ZoomInfo data) |
+| `medium` | Available only via specific platforms (e.g., Stripe transaction data, Slack messages) |
+| `high` | No public or commercial equivalent (e.g., your unique customer cohort's workflow behavior) |
+
+**Default for B2B SaaS:** medium-to-high. The combination of customer cohort + your specific product usage is usually exclusive.
+
+### 2. Freshness
+**How current is the data?**
+
+Real-time > near-real-time > daily batch > weekly batch. Predictive value decays roughly exponentially with staleness.
+
+### 3. Cohort Breadth
+**How many customers does the corpus span?**
+
+Below 50 customers: insufficient cohort for benchmarks. 50–200: marginally productizable. 200–500: solid. 500+: strong.
+
+**Cohort breadth is highly correlated with industry-specific value:** a 500-customer B2B SaaS in vertical X often has more strategic value than a 5000-customer horizontal SaaS, because the verticalized cohort is harder to replicate.
+
+### 4. History Depth
+**How many years of time-series do you have?**
+
+1 year is anecdotal. 2–3 years shows trend. 5+ years enables cycle analysis and is increasingly rare (most startups don't survive that long).
+
+History depth is THE thing acquirers value most — and the thing you can't manufacture later.
+
+### 5. Real-Time Behavioral Signal
+**Does the data capture intent + behavior, or just outcomes?**
+
+Outcome data ("customer churned") is low signal. Intent + behavior data ("customer reduced usage by 40% in week 8, then opened pricing page 3 times") is high signal.
+
+This component is implicit in the freshness + exclusivity scores in the tool.
+
+## Moat Strength
+
+The composite score maps to moat strength:
+
+| Score | Moat | Defense |
+|---|---|---|
+| 8+ | STRONG | Replicating requires 2+ years of customer cohort acquisition |
+| 5-7 | MEDIUM | Well-funded competitor with 18-24 months can match |
+| 2-4 | WEAK | Some unique signal but largely replicable |
+| 0-1 | NONE | Same data is freely available |
+
+## M&A Multiplier
+
+Acquirers (especially strategic ones, not financial) pay a multiplier on data-as-asset deals.
+
+| Moat | Multiplier (ARR uplift) |
+|---|---|
+| STRONG | 1.4x – 1.7x |
+| MEDIUM | 1.15x – 1.35x |
+| WEAK | 1.0x – 1.1x |
+| NONE | 1.0x |
+
+**These multipliers compound with normal SaaS multiples.** A $10M ARR B2B SaaS valued at 8x ARR ($80M) with a STRONG data moat might fetch $112M-$136M in a strategic acquisition where the buyer values the cohort.
+
+**Discounts:**
+- High MSA carve-out rate (>25% of customers): -15%
+- Moderate carve-out rate (10-25%): -5%
+- Failed anonymization audit (re-identification risk): -10%
+- Regulated data without specific consent framework: -20%
+
+## The Three Productization Paths
+
+### Path 1: Industry Benchmark Report (lowest risk)
+
+**What it is:** Quarterly or semi-annual report of anonymized aggregates ("80% of B2B sales teams have >5 stalled deals in their pipeline at any time").
+
+**Revenue potential:** Low ($50K-$500K/yr). Often given away to drive credibility / leads rather than sold.
+
+**Why start here:**
+- Lowest legal risk (anonymous aggregates, no individual data leaves)
+- Highest credibility lift (your brand becomes the "definitive source" for the category)
+- Tests appetite without committing to product
+- Lowest customer-trust cost (customers like seeing aggregate insights)
+
+**Prerequisites:**
+- Anonymization audit confirming k-anonymity ≥ 5 in all published cells
+- Opt-out flow for customers who don't want their (anonymized) data included
+- Quarterly review cadence
+
+### Path 2: Anonymized Embedding Endpoint (medium risk)
+
+**What it is:** API that returns anonymized embeddings of your data corpus, usable by your customers (or by you) for AI features.
+
+**Revenue potential:** Medium ($500K-$3M/yr) as a platform feature or paid add-on.
+
+**Why medium risk:**
+- Embeddings can leak training data via inversion attacks (mitigated by differential privacy)
+- 47/380 customer carve-outs would block the endpoint from including their data
+- Re-identification of a single customer in the corpus risks contractual + reputational damage
+
+**Prerequisites:**
+- Anonymization + memorization testing
+- DPA addendum covering training-data flow
+- Differential privacy on the embedding pipeline (epsilon ≤ 1.0 recommended)
+- Pilot with 3 design-partner customers under explicit opt-in before broad release
+
+### Path 3: Direct Data Licensing (highest risk)
+
+**What it is:** Selling access to the data corpus (or derivatives) to AI labs, data brokers, or industry players.
+
+**Revenue potential:** High ($2M-$20M/yr at scale).
+
+**Why high risk:**
+- Customer trust impact: even with proper anonymization, customers often perceive this as "selling our data"
+- Requires re-papering or excluding any MSA carve-out customers
+- Requires GDPR Art. 26 joint-controller analysis if EU customers are present
+- Regulator scrutiny increases (e.g., FTC has signaled interest in B2B-to-AI-lab data flows in 2024-2025)
+
+**Prerequisites (in order):**
+1. Customer-trust impact assessment (CEO + Head of CS sign-off)
+2. Re-paper carve-out customers OR build carve-out-excluded dataset
+3. Engage data broker counsel (specialist)
+4. Customer communications plan (proactive, not reactive)
+5. Differential privacy on the licensed product
+6. Audit clauses in the licensing contract
+
+## M&A Diligence Prep Checklist
+
+Acquirers will dig deep on data assets. Be ready before the LOI.
+
+**6 months before any M&A discussion, complete:**
+
+- [ ] Inventory of all customer data with: origin, consent flow, contractual restrictions, retention policy
+- [ ] MSA carve-out audit: which customers have which restrictions; reconciliation list
+- [ ] Anonymization audit: k-anonymity, re-identification risk assessment
+- [ ] DPA inventory: which customers have DPAs, which subprocessors are listed, gaps
+- [ ] Training-data provenance log: every model in production has documented source data
+- [ ] Right-to-erasure handling: documented process for honoring GDPR Art. 17 / state law equivalents
+- [ ] Cross-border data flow inventory: which EU residents' data is processed, which US states, which countries
+- [ ] Vendor / subprocessor list current and reconciled with customer-facing list
+- [ ] Data breach history: documented, even minor incidents
+- [ ] Litigation / regulatory inquiries: documented
+
+**Common findings that tank deals:**
+- "We've been training on X without a clear lawful basis" → acquirer requires indemnity carve-out or retrains
+- "We don't have a documented anonymization process" → 10-20% multiplier discount
+- "30% of customers have carve-outs we can't easily reconcile" → productization-as-thesis collapses
+- "Our DPA list and our customer-facing DPA list don't match" → governance red flag
+
+## Contractual Constraint Audit (run quarterly)
+
+Many startups don't realize their MSA template has been updated 3 times in 5 years, and earlier customers signed earlier versions. The carve-out rate often exceeds expectations.
+
+**Quarterly audit:**
+
+1. Pull every executed customer MSA from CLM (or DocuSign / Ironclad)
+2. Search for: "data use", "training", "AI", "machine learning", "aggregate", "anonymized", "license back"
+3. Categorize each customer:
+   - `clear` — no carve-out, standard rights
+   - `carve-out-aggregate-only` — can use only as anonymized aggregates
+   - `carve-out-no-training` — can use operationally but not for AI training
+   - `carve-out-blocked` — cannot use beyond own service
+4. Compute carve-out rates
+5. For each carve-out type, decide: re-paper at renewal? Live with the constraint? Build carve-out-excluded dataset?
+
+## Customer Trust Considerations
+
+The legal feasibility of productization is necessary but not sufficient. Customer trust impact is often the binding constraint.
+
+**Signs the trust cost will exceed the revenue:**
+- Customer NPS is below 30
+- Recent press cycle on "Big Tech data abuses" in your category
+- A vocal customer or two raised data concerns publicly
+- Your sales team uses "we don't share your data" as a competitive differentiator
+
+**If any of these are true:** delay productization 12-18 months and address trust first.
+
+## When This Reference Doesn't Help
+
+- **Tactical anonymization implementation.** See engineering / privacy-engineering resources.
+- **Specific DPA template language.** See `c-level-advisor/skills/general-counsel-advisor/`.
+- **M&A negotiation strategy.** See `c-level-advisor/skills/ma-playbook/`.
+- **GDPR compliance program.** See `ra-qm-team/`.
+
+This reference is about strategic valuation and productization decisions. Tactical execution lives elsewhere.
+
+---
+
+**Source authorities (non-exhaustive):**
+- GDPR Articles 26 (joint controllers), 28 (processors), 35 (DPIA), 17 (right to erasure)
+- EDPB Guidelines on data subject rights
+- US state data broker registration laws (CA, VT, OR)
+- FTC enforcement actions on data licensing (e.g., FTC v. Avast, 2024)
+- Dwork, Cynthia — "Differential Privacy" (2006)

--- a/c-level-advisor/skills/chief-data-officer-advisor/references/data_product_strategy.md
+++ b/c-level-advisor/skills/chief-data-officer-advisor/references/data_product_strategy.md
@@ -1,0 +1,159 @@
+# Data Product Strategy — The Decision: "Warehouse, lakehouse, or mesh — and what do we build vs buy?"
+
+This reference answers exactly one decision: **what is the right data platform for our stage, and which components do we build ourselves?** It is stage-driven, not technology-trend-driven.
+
+Pair with `scripts/data_product_strategy_picker.py` for automation.
+
+## The Three Architectures
+
+### Warehouse Only
+
+**What it is:** A single SQL-accessible data store (Snowflake / BigQuery / Redshift / Postgres + dbt). All transformations happen in-warehouse.
+
+**Use when:**
+- ≤5 distinct data consumers (people/teams who query data weekly)
+- <2TB of data
+- No ML/AI use cases in production
+- Reporting + dashboards are 90%+ of use cases
+
+**Kill criteria (stop using warehouse-only when):**
+- A data consumer needs unstructured data (logs, images, audio) → can't ingest cleanly
+- ML model in production needs feature pipelines → warehouse-only is rigid
+- 5+ consumers means hub-and-spoke ownership becomes the bottleneck
+
+**Failure mode:** Treating it as forever. Many companies sit on warehouse-only for 2 years past viability because migration feels expensive.
+
+### Lakehouse
+
+**What it is:** Warehouse + object storage (S3/GCS/Azure Blob) with a table format like Apache Iceberg, Delta Lake, or Hudi. Single substrate for SQL analytics, ML training data, and unstructured ingestion.
+
+Implementations: Databricks (Delta), Snowflake with Iceberg, AWS Redshift with Spectrum, BigQuery with BigLake.
+
+**Use when:**
+- 5–25 distinct data consumers
+- 2TB–1PB data
+- 1–3 ML models in production OR planning to be in 12 months
+- Mixed structured + unstructured data
+- Team has engineering capacity to maintain ingestion + transformation pipelines
+
+**Kill criteria:**
+- 25+ consumers AND federated ownership culture → time to consider mesh
+- ML workloads disappear AND data shrinks below 2TB → simplify back to warehouse
+- Vendor lock-in becomes intolerable → table formats (Iceberg) mitigate this; lakehouse vendor swaps remain expensive
+
+**Failure mode:** Adopting before needed. Lakehouse architecture has 2–3x the operational complexity of pure warehouse. If you have 4 consumers and no ML, it's premature.
+
+### Data Mesh
+
+**What it is:** Federated data product ownership. Domain teams own their data products end-to-end (ingest → modeling → serving → SLAs). Central platform team provides the infrastructure substrate but does not produce data products.
+
+Coined by Zhamak Dehghani (Thoughtworks); productionized at Netflix, Zalando, JP Morgan.
+
+**Use when:**
+- 25+ distinct data consumers across 4+ domains
+- Federated ownership culture **already exists** in the org (you can't bolt it on)
+- Central data team is a bottleneck for 50%+ of work
+- Stage: growth or late-stage (Series C+)
+
+**Kill criteria (mesh failure modes):**
+- After 6 months: producing teams haven't adopted ownership → revert to hub-and-spoke
+- Platform team still doing 50%+ of data product work → platform isn't truly self-serve
+- Domain teams complain about onboarding → too much friction for "do it yourself"
+- Cross-domain analytics has degraded vs warehouse era → integration layer missing
+
+**Failure mode:** Mesh-without-culture. Companies adopt the architecture before the operating model. Result: distributed warehouses with no governance, worse than starting point.
+
+## The Build-vs-Buy Decision Tree
+
+For each platform layer, the question isn't "can we build it?" — it's "is it our IP, and does building it create a moat?"
+
+### Storage / Warehouse
+
+**Always BUY.** Snowflake, BigQuery, Databricks, Redshift, Postgres-with-Citus. Storage is commodity. Building distributed storage is a 50-engineer-year investment with zero business return unless you ARE a data infra company.
+
+**Only build if:** You're a database company.
+
+### ELT / Ingest
+
+**Almost always BUY.** Fivetran, Airbyte, Stitch, Meltano. The connector maintenance burden (200+ source APIs, all changing constantly) is unjustifiable for any non-data-infra company.
+
+**Only build if:** Source isn't supported by any vendor AND is business-critical AND you'll contribute the connector upstream so you're not maintaining a fork forever.
+
+### Modeling / Transformations
+
+**Always BUILD.** dbt is the de facto standard (open source). Your domain logic encoded in dbt models IS your data IP. No vendor can supply your domain understanding.
+
+**Variants to evaluate:**
+- dbt Core (open source) → free, self-hosted, requires orchestration (Airflow/Dagster/Prefect)
+- dbt Cloud → managed, expensive at scale, simpler ops
+- SQLMesh → newer, claims better state management
+- Coalesce → visual SQL, expensive
+
+### BI / Dashboards
+
+**Almost always BUY.** Metabase (cheap, OSS option), Looker (enterprise, semantic layer), Mode (analyst-friendly + SQL), Hex (notebooks + dashboards), Tableau (legacy strong), Sigma (spreadsheet UX).
+
+**Build only if:** You're shipping embedded analytics as a customer-facing feature (then evaluate Cube.dev, Embeddable, or build on Apache Superset).
+
+**Embedded analytics is a real build-vs-buy:** for B2B SaaS shipping dashboards to customers, the choice between embedding a vendor (Cube + custom UI) vs full custom (Superset + heavy frontend) is significant. Buy-with-customization usually wins until 100K+ customer-tenants.
+
+### Feature Store
+
+**DEFER until you have 3+ ML models in production.**
+
+**Then:** Tecton (managed, expensive, mature) or Hopsworks (alternative) for BUY; Feast (open source, lighter) for BUILD-on-OSS.
+
+**Why defer:** Feature stores solve feature reuse + governance. With 1 model, you have 0 features-to-reuse. The operational overhead of a feature store exceeds the value below ~3 models sharing features.
+
+### ML Platform
+
+**DEFER until you have 5+ ML models in production.**
+
+**Then:** Databricks ML, Vertex AI (Google), SageMaker (AWS), or Azure ML.
+
+**Why defer:** ML platforms wrap experiment tracking, model registry, deployment, monitoring. Below 5 models with active retraining, scheduled training jobs + MLflow / W&B + simple K8s deployment is sufficient.
+
+## Operational Maturity Layers (independent of architecture)
+
+These apply regardless of warehouse / lakehouse / mesh choice:
+
+1. **Data quality monitoring.** dbt tests, Great Expectations, Monte Carlo. Start at any scale.
+2. **Lineage tracking.** dbt auto-generates lineage; OpenLineage / DataHub / Atlan for cross-tool. Start at 50+ models.
+3. **Catalog + discovery.** DataHub, Atlan, Castor, Selectstar. Start at 100+ tables consumed by 10+ people.
+4. **Access control + governance.** Snowflake/BigQuery native RBAC; Immuta / Privacera for policy abstraction. Start when you have regulated data or > 50 consumers.
+
+## Sequencing Pattern (12-month plan)
+
+A typical Series A → Series B sequencing:
+
+| Quarter | Focus | Deliverable |
+|---|---|---|
+| Q1 | Foundation | Centralized ELT (buy); dbt for top-5 marts (build); 5 data quality tests |
+| Q2 | Self-serve BI | Roll out BI tool; semantic layer in dbt or LookML; train 3 functional teams |
+| Q3 | First ML use case OR embedded analysts | Either feature store for top-1 ML model OR embed 1 analyst per major function |
+| Q4 | Evaluate and decide | Re-run picker; decide on Q1-next-year architecture changes |
+
+## Anti-Patterns
+
+- **Adopting a vendor before knowing the use case.** "We bought Snowflake but we're 80% on Postgres still." → vendor first, problem second.
+- **Building "platform" before having customers (consumers).** Internal data platform team with no users is shelfware.
+- **Treating data mesh as an architecture choice.** It's an operating model choice; the architecture is a consequence.
+- **Splitting warehouse spend across 3 vendors.** Multi-cloud data is a 3x cost increase with no benefit until you're at Series D+.
+- **Hiring data scientists before analysts.** Data scientists need clean data + clear questions. Build the analyst + analytics-engineer layer first.
+
+## When This Reference Doesn't Help
+
+- **Schema design.** See `engineering/database-designer/`.
+- **Query optimization.** See `engineering/sql-database-assistant/`.
+- **Observability for data pipelines.** See `engineering/observability-designer/`.
+- **RAG architecture.** See `engineering/rag-architect/`.
+
+This reference picks the architecture and the build-vs-buy. Tactical implementation is a separate skill family.
+
+---
+
+**Source authorities:**
+- Dehghani, Zhamak — "Data Mesh: Delivering Data-Driven Value at Scale" (O'Reilly, 2022)
+- Databricks Lakehouse paper, 2021
+- Apache Iceberg, Delta Lake, Apache Hudi specifications
+- dbt Labs Analytics Engineering Guide

--- a/c-level-advisor/skills/chief-data-officer-advisor/references/data_team_org_evolution.md
+++ b/c-level-advisor/skills/chief-data-officer-advisor/references/data_team_org_evolution.md
@@ -1,0 +1,198 @@
+# Data Team Org Evolution — The Decision: "What data role do we hire next, and when do we centralize vs embed?"
+
+This reference answers exactly one decision: **for our stage and business decisions we can't currently make, what is the next role to add — and at what point do we centralize vs embed?**
+
+## The Wrong Question
+
+> "Should we hire a data scientist?"
+
+This is the wrong question. Most data scientists hired by Series A startups are unable to deliver value because:
+- The data isn't clean enough for modeling
+- There's no infrastructure to deploy a model
+- The "model" the founder imagines is actually a SQL query
+
+## The Right Question
+
+> "What's the next decision we can't make because we lack data, and what role unblocks that?"
+
+This shifts hiring from role-taxonomy to decision-unblocking. The data org grows in response to specific decision gaps.
+
+## The Five Stages
+
+### Stage 1: Pre-seed / Seed
+**Team size:** 1-15 people. **Data team:** 0.
+
+**Reality:** Founder is the analyst. SQL + spreadsheets are sufficient.
+
+**Don't hire:** Data engineer, data scientist, head of data. They will have nothing to do because the questions aren't crisp enough yet.
+
+**Tooling:** Postgres / production DB direct read access. Metabase Free or Looker Studio. Google Sheets.
+
+**When to move to stage 2:** Founder is spending >20% of their week on data work AND it's preventing them from doing CEO work.
+
+### Stage 2: Series A
+**Team size:** 15-50 people. **Data team:** 1-3.
+
+**First hire: Analyst (NOT data engineer, NOT data scientist).**
+
+Why: at this stage, 80% of the value is in clean reports, dashboards, and quick ad-hoc analyses. An analyst delivers all of this. A data engineer wants to build infrastructure that's premature; a data scientist wants to build models that don't have ROI yet.
+
+Profile: 2-4 years experience, strong SQL, BI tool fluency, comfortable with ambiguity, can talk to non-data people.
+
+**Second hire: Analytics engineer (dbt practitioner).**
+
+Why: after the first analyst, the most acute pain is "dashboards are out of sync because everyone defines 'active customer' differently." Analytics engineer brings discipline (dbt models, semantic layer) and turns the analyst's work into reusable infrastructure.
+
+Profile: SQL fluency + software engineering practices (PRs, tests, version control), dbt experience preferred but not required.
+
+**Don't hire yet:** Data engineer, data scientist, head of data, data PM.
+
+**When to move to stage 3:** 3+ functional teams are requesting bespoke analyses weekly, AND your first ML use case has a clear ROI.
+
+### Stage 3: Series B
+**Team size:** 50-200. **Data team:** 4-8.
+
+**Third hire: Data engineer.**
+
+Why: ingest pipelines are now business-critical. Salesforce → warehouse, Stripe → warehouse, product events → warehouse. Reliability matters. The analytics engineer cannot maintain this AND ship dbt models.
+
+Profile: Python + SQL + understanding of streaming vs batch tradeoffs, experience with Fivetran/Airbyte or similar.
+
+**Fourth hire: Senior analyst (embedded in GTM, often Sales/Marketing).**
+
+Why: GTM is where data ROI is most measurable. An analyst embedded in the sales org (or reporting dotted-line to CRO) closes the gap between data team and revenue org.
+
+**Fifth hire (conditional): Data PM.**
+
+When: 3+ functional teams need data and the data team has ≥4 people. The data PM owns the roadmap, intake, and SLA negotiations. Without this, the team flips into reactive mode and never builds platform.
+
+**Conditional: Data scientist / ML engineer.**
+
+Hire only when:
+- You have at least 1 model in production OR a strong hypothesis with ROI math
+- Data engineer is in place (so data scientist isn't blocked on infrastructure)
+- Eng leadership signs on for productionizing models (not just notebooks)
+
+**When to move to stage 4:** Central data team is the bottleneck for >50% of GTM data requests, OR you're hiring data people every quarter and they all report to one manager.
+
+### Stage 4: Growth (Series C / pre-IPO)
+**Team size:** 200-1000. **Data team:** 8-30.
+
+**Sixth hire: Manager of Analytics (people manager).**
+
+Why: at 5-8 reports, the original analytics lead can no longer code AND manage. Split into managers + senior ICs.
+
+**Seventh hire: ML engineer (production-grade).**
+
+When: 1+ model in production, 2-3 more planned. ML engineer owns deployment, monitoring, retraining infrastructure. Different person from data scientist (who owns model invention).
+
+**Eighth hire: Head of Data.**
+
+Triggers:
+- Data team is 10+ people
+- Data team has its own strategy independent of company strategy (problematic if no one owns the reconciliation)
+- Founder/CTO is no longer the right escalation for data decisions
+- Compliance / governance becomes board-level concern
+
+The Head of Data owns data strategy, hires/fires, and is the cross-functional executive for all data + AI.
+
+**Centralize vs Embed decision:**
+
+By Series C, the centralize-vs-embed tension is acute. Two patterns work:
+
+**Hub-and-spoke (most common, recommended):**
+- Central data platform team owns infrastructure, governance, semantic layer
+- Embedded analysts in 3-5 major functional teams (Sales, Marketing, Product, CS, Finance)
+- Embedded analysts have solid-line to function leader, dotted-line to Head of Data
+- Tools, standards, dbt models are central; questions and SLAs are local
+
+**Federated (data mesh — only if culture supports):**
+- Each domain team owns their data products end-to-end
+- Central platform team provides infrastructure substrate, not data products
+- Requires high data culture maturity; failure mode is mesh-without-culture
+
+Hub-and-spoke handles 95% of Series C companies. Mesh fits when you're 1000+ people with strong domain ownership culture (Netflix, Zalando, JP Morgan scale).
+
+**When to move to stage 5:** Series D / late-stage growth, 50+ data team members, multiple domains with their own data leadership.
+
+### Stage 5: Late-stage (Series D+, post-IPO)
+**Team size:** 1000+. **Data team:** 30-200+.
+
+**CDO promotion / hire.**
+
+Triggers:
+- Data is in the company's strategic narrative (board deck, investor calls)
+- Data has its own P&L (productized data, monetization)
+- Multiple regulatory regimes apply (GDPR + CCPA + HIPAA + EU AI Act)
+- Head of Data is escalating data-strategy questions to CTO and it's not landing right
+
+Profile:
+- Has run a data org at $100M+ ARR scale
+- Comfortable with board reporting
+- Strategic, not just technical
+- Strong on data governance + AI policy (post-2024 AI Act and similar requirements)
+
+**Federated CDO model (late-stage):**
+
+At thousands-of-people scale, the CDO often runs:
+- Central platform team (engineering)
+- Central governance team (privacy, compliance, AI policy)
+- Federated data leaders embedded per business unit
+- Data product leaders for any productized data
+
+## Specific Roles Defined
+
+Because founders confuse these:
+
+| Role | Owns | Does NOT own |
+|---|---|---|
+| Analyst | Ad-hoc analyses, dashboards, business questions | Pipeline reliability, model deployment |
+| Analytics engineer | dbt models, semantic layer, data quality tests | Ingest pipelines, ML, infrastructure |
+| Data engineer | Ingest pipelines (Fivetran/Airbyte/custom), warehouse infra, streaming | Modeling logic, dashboards, ML models |
+| Data scientist | Model invention, experimentation, statistical analysis | Production deployment, monitoring |
+| ML engineer | Production model deployment, monitoring, retraining infra | Model invention |
+| Data PM | Data team roadmap, intake, prioritization, stakeholder mgmt | IC delivery work |
+| Data PM (productized data) | Data products sold to customers | Internal-only data work |
+| Head of Data | Data strategy, hiring, budget, exec representation | Day-to-day IC work |
+| CDO | Data + AI strategy at board level, governance, P&L (where applicable) | Day-to-day execution |
+
+## The Centralize-vs-Embed Trigger
+
+The decision is not "centralize or embed" — it's "when do you transition from one to the other?"
+
+**Centralized (everyone reports to one data leader):** works up to ~5 data people serving ≤5 functional teams.
+
+**Hub-and-spoke (central platform + embedded analysts):** works from 5-30 data people serving 5-15 functional teams.
+
+**Federated (each domain owns):** works at 30+ data people across 15+ functional teams WITH strong data culture.
+
+**The trigger to move from centralized to hub-and-spoke:** when 3+ functional teams complain that the central team doesn't understand their domain, AND when the central team's intake queue exceeds 4 weeks of lead time.
+
+**The trigger to move from hub-and-spoke to federated (data mesh):** when domain teams have data leaders, are already running their own data SLAs, and would rather not depend on central platform for product launches. This is rare and usually arrives at thousands-of-people scale.
+
+## Anti-Patterns
+
+- **Hiring a data scientist as first data hire.** They will spend 6 months unable to deliver because data isn't clean.
+- **Hiring a "head of data" at Series A.** Nothing for them to manage.
+- **Hiring multiple analysts before adding analytics engineer.** Dashboards multiply; consistency vanishes.
+- **Building a data platform with no users.** Internal platform team with no customers is shelfware.
+- **Hiring an ML engineer before a data engineer.** ML engineer cannot deploy models if data pipelines are broken.
+- **Promoting an analyst to "Head of Data" without people-management experience.** Most analysts are great ICs; people management is a different skill.
+
+## When This Reference Doesn't Help
+
+- **Comp benchmarking.** See `c-level-advisor/skills/chro-advisor/scripts/comp_benchmarker.py`.
+- **Leveling ladders.** See `c-level-advisor/skills/chro-advisor/references/leveling_ladders.md`.
+- **Specific JD templates.** Not covered here; many open-source examples exist.
+- **Performance management.** Standard people management; not data-specific.
+
+This reference is about the data team's evolution as a function of company-stage decisions, not about HR mechanics.
+
+---
+
+**Source observations (non-exhaustive):**
+- Tristan Handy (dbt Labs) — "The Modern Data Stack: Past, Present, Future"
+- Maxime Beauchemin — "The Rise of the Data Engineer" (2017), "The Downfall of the Data Engineer" (2017)
+- Erik Bernhardsson — "The Modern Data Experience" (2022)
+- Lauren Balik — "Modern Data Stack writings"
+- Direct observations from 50+ B2B SaaS data org evolutions, 2020-2026

--- a/c-level-advisor/skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py
+++ b/c-level-advisor/skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""ai_training_data_audit.py — Audit data sources for AI training eligibility.
+
+Stdlib-only. Audits each data source on 3 dimensions:
+  - Origin (1st-party-explicit-opt-in / 1st-party-tos-only / partner-licensed / scraped / synthetic)
+  - Data class (anonymous-aggregate / behavioral / pii / third-party-content / regulated)
+  - Use case (in-product-personalization / fine-tune-our-model / train-foundation-model / external-sharing)
+
+Returns GO / MITIGATE / NO-GO per source with the specific risk and remediation.
+
+NOT legal advice — surfaces decisions for qualified counsel.
+
+Input schema (JSON):
+{
+  "sources": [
+    {
+      "name": "Product telemetry events",
+      "origin": "1st-party-tos-only",
+      "data_class": "behavioral",
+      "use_case": "in-product-personalization"
+    },
+    ...
+  ]
+}
+
+Usage:
+    python ai_training_data_audit.py                       # uses embedded sample
+    python ai_training_data_audit.py path/to/sources.json
+    python ai_training_data_audit.py sources.json --output json
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional, Tuple
+
+
+SAMPLE: Dict[str, Any] = {
+    "sources": [
+        {
+            "name": "Anonymous product telemetry (event aggregates)",
+            "origin": "1st-party-tos-only",
+            "data_class": "anonymous-aggregate",
+            "use_case": "in-product-personalization",
+        },
+        {
+            "name": "Customer support transcripts",
+            "origin": "1st-party-tos-only",
+            "data_class": "pii",
+            "use_case": "fine-tune-our-model",
+        },
+        {
+            "name": "Scraped LinkedIn profiles",
+            "origin": "scraped",
+            "data_class": "pii",
+            "use_case": "fine-tune-our-model",
+        },
+        {
+            "name": "Synthetic conversational data (LLM-generated)",
+            "origin": "synthetic",
+            "data_class": "third-party-content",
+            "use_case": "train-foundation-model",
+        },
+        {
+            "name": "User opt-in survey responses",
+            "origin": "1st-party-explicit-opt-in",
+            "data_class": "behavioral",
+            "use_case": "external-sharing",
+        },
+        {
+            "name": "Partner-licensed industry dataset",
+            "origin": "partner-licensed",
+            "data_class": "anonymous-aggregate",
+            "use_case": "train-foundation-model",
+        },
+        {
+            "name": "Anonymized health screening responses",
+            "origin": "1st-party-explicit-opt-in",
+            "data_class": "regulated",
+            "use_case": "fine-tune-our-model",
+        },
+    ]
+}
+
+
+VALID_ORIGINS = {
+    "1st-party-explicit-opt-in",
+    "1st-party-tos-only",
+    "partner-licensed",
+    "scraped",
+    "synthetic",
+}
+VALID_CLASSES = {
+    "anonymous-aggregate",
+    "behavioral",
+    "pii",
+    "third-party-content",
+    "regulated",
+}
+VALID_USE_CASES = {
+    "in-product-personalization",
+    "fine-tune-our-model",
+    "train-foundation-model",
+    "external-sharing",
+}
+
+
+@dataclass
+class AuditResult:
+    name: str
+    origin: str
+    data_class: str
+    use_case: str
+    verdict: str           # GO | MITIGATE | NO-GO
+    risk: str
+    remediation: str
+    citations: List[str]
+
+
+# Verdict matrix: (origin, data_class, use_case) -> (verdict, risk, remediation, citations)
+# Built by applying these rules in order; first match wins.
+def _decide(origin: str, data_class: str, use_case: str) -> Tuple[str, str, str, List[str]]:
+
+    # Rule 1: Scraped data is always NO-GO for training (hiQ v. LinkedIn, copyright, GDPR Art. 6).
+    if origin == "scraped":
+        return (
+            "NO-GO",
+            "Scraped data lacks lawful basis under GDPR Art. 6 (no consent, no legitimate interest "
+            "balancing test); high copyright risk; hiQ v. LinkedIn left exposure for ToS-violation claims; "
+            "many AI Act high-risk use cases require demonstrable provenance.",
+            "Remove from training set. Either (a) procure licensed alternative from data broker, "
+            "(b) replace with synthetic data, or (c) build 1st-party explicit opt-in pipeline.",
+            ["GDPR Art. 6", "hiQ Labs v. LinkedIn", "EU AI Act Art. 10 (data governance)"],
+        )
+
+    # Rule 2: Regulated data (PHI, PCI, kids) requires explicit opt-in + specific compliance
+    # framework; never train foundation model with raw regulated data.
+    if data_class == "regulated":
+        if origin == "1st-party-explicit-opt-in" and use_case in {"in-product-personalization", "fine-tune-our-model"}:
+            return (
+                "MITIGATE",
+                "Regulated data (PHI / PCI / children) may be processed under explicit opt-in IF the "
+                "framework permits (HIPAA Limited Data Set, COPPA verifiable parental consent). "
+                "Fine-tuning increases re-identification risk vs in-product use.",
+                "Required: (1) framework-specific consent flow, (2) DPIA/PIA on file, (3) k-anonymity "
+                "≥ 5 audit before any training, (4) model output filters for regulated-content leakage, "
+                "(5) DPA with any vendor in the pipeline.",
+                ["HIPAA", "HITECH §13402", "COPPA", "GDPR Art. 9", "EU AI Act Annex III"],
+            )
+        return (
+            "NO-GO",
+            "Regulated data (PHI / PCI / children) cannot be used for foundation training or external "
+            "sharing without specific framework authorization, and not at all without explicit opt-in.",
+            "Either (a) restrict to in-product use under existing framework consent, (b) train on "
+            "synthetic data modeled on the corpus, or (c) obtain new explicit opt-in covering the "
+            "specific training purpose.",
+            ["HIPAA", "GDPR Art. 9", "COPPA"],
+        )
+
+    # Rule 3: PII at any use case beyond in-product-personalization requires explicit opt-in,
+    # specific lawful basis, AND anonymization/pseudonymization.
+    if data_class == "pii":
+        if use_case == "in-product-personalization":
+            if origin == "1st-party-tos-only":
+                return (
+                    "MITIGATE",
+                    "PII processing for in-product personalization can rest on GDPR Art. 6(1)(b) "
+                    "(performance of contract) or 6(1)(f) (legitimate interest) IF the personalization "
+                    "is reasonably expected. Train-once derived models retain risk.",
+                    "Required: (1) Art. 6 lawful basis documented, (2) data minimization audit, "
+                    "(3) deletion request honored for the source data even after model training "
+                    "(implementation: filter-on-output OR retrain on deletion), (4) DPIA if scale > 5000 users.",
+                    ["GDPR Art. 6", "GDPR Art. 17 (right to erasure)", "EDPB Guidelines on Art. 22"],
+                )
+            if origin == "1st-party-explicit-opt-in":
+                return (
+                    "GO",
+                    "PII with explicit opt-in for in-product personalization is the strongest position. "
+                    "Standard residual risks: opt-in revocation, deletion requests.",
+                    "Maintain: (1) opt-in audit trail per user, (2) machinery to honor revocation/erasure "
+                    "(filter-on-output or retrain), (3) clear notice on what model is trained.",
+                    ["GDPR Art. 6(1)(a)", "GDPR Art. 17"],
+                )
+
+        # Fine-tune-our-model, train-foundation-model, external-sharing with PII
+        if origin == "1st-party-explicit-opt-in":
+            return (
+                "MITIGATE",
+                "PII for fine-tuning or beyond requires explicit opt-in covering THIS specific "
+                "training purpose (not generic TOS). Risk: training-data extraction attacks, "
+                "memorization, model-output leakage.",
+                "Required: (1) purpose-specific opt-in (not bundled TOS), (2) differential privacy "
+                "or k-anonymity audit, (3) memorization tests on the trained model, (4) DPIA, "
+                "(5) DPA with infra/training vendor, (6) EU AI Act conformity assessment if "
+                "high-risk use case.",
+                ["GDPR Art. 6(1)(a)", "GDPR Art. 35 (DPIA)", "EU AI Act Art. 10"],
+            )
+        return (
+            "NO-GO",
+            "PII for fine-tuning or foundation training without explicit opt-in fails GDPR Art. 6. "
+            "TOS-only consent is insufficient for materially different purpose.",
+            "Either (a) restrict use case to in-product personalization under existing basis, "
+            "(b) build explicit opt-in pipeline before training, or (c) anonymize/pseudonymize "
+            "to k-anonymity ≥ 5 and re-classify as anonymous-aggregate.",
+            ["GDPR Art. 6", "EDPB Opinion 28/2024"],
+        )
+
+    # Rule 4: 3rd-party content (e.g., user-uploaded files, customer support transcripts
+    # quoting other systems, scraped public documents within user submissions).
+    if data_class == "third-party-content":
+        if origin in {"synthetic", "partner-licensed"}:
+            return (
+                "MITIGATE",
+                "Synthetic or licensed 3rd-party-content carries content-license risk: even with a "
+                "license, training a model may exceed the license scope (e.g., 'view' license vs "
+                "'derivative work creation').",
+                "Required: (1) license review by counsel for training-specific clauses, (2) carve-out "
+                "for AI training in licensing agreement, (3) provenance log per source for AI Act compliance, "
+                "(4) opt-out mechanism if license permits revocation.",
+                ["NYT v. OpenAI (2024)", "EU AI Act Art. 53 (general-purpose models)"],
+            )
+        if origin == "1st-party-tos-only":
+            return (
+                "MITIGATE",
+                "User-uploaded content under TOS-only license has uncertain training rights post-2024 "
+                "lawsuits. Risk: copyright infringement if model output is substantially similar to "
+                "training data.",
+                "Required: (1) TOS explicitly grants training rights for the specific model class, "
+                "(2) output similarity monitoring (de-duping / fuzzy match against training corpus), "
+                "(3) opt-out mechanism in TOS update.",
+                ["Authors Guild v. Google", "Andersen v. Stability AI", "NYT v. OpenAI"],
+            )
+        if origin == "1st-party-explicit-opt-in":
+            return (
+                "GO",
+                "Explicit opt-in for training on user-uploaded content is the strongest position. "
+                "Maintain output-similarity guardrails to catch unexpected memorization.",
+                "Required: (1) opt-in audit trail, (2) revocation flow, (3) output similarity testing.",
+                ["GDPR Art. 6(1)(a)"],
+            )
+
+    # Rule 5: Behavioral data — generally safer than PII, but external sharing still requires consent.
+    if data_class == "behavioral":
+        if use_case == "external-sharing":
+            if origin == "1st-party-explicit-opt-in":
+                return (
+                    "GO",
+                    "Behavioral data with explicit opt-in for external sharing — clean.",
+                    "Maintain: (1) revocation flow, (2) anonymization audit before each external "
+                    "share (k-anonymity ≥ 5), (3) recipient DPA.",
+                    ["GDPR Art. 6(1)(a)"],
+                )
+            return (
+                "MITIGATE",
+                "Behavioral data without explicit opt-in for external sharing is borderline. TOS-only "
+                "is weak basis; partner-licensed depends on partner's original consent flow.",
+                "Required: (1) anonymization to k-anonymity ≥ 5, (2) recipient DPA with no-reidentification "
+                "clause, (3) audit upstream consent if partner-licensed, (4) consider opt-in pipeline.",
+                ["GDPR Art. 6", "Art. 22 (automated decision-making)"],
+            )
+        # Behavioral + training use cases
+        if origin in {"1st-party-explicit-opt-in", "1st-party-tos-only", "partner-licensed"}:
+            return (
+                "GO",
+                "Behavioral data from controlled origin for internal training is generally safe. "
+                "Residual risk: model leakage if behavioral patterns are individually identifying.",
+                "Maintain: (1) deletion handling on user request, (2) periodic memorization tests, "
+                "(3) DPIA if scale > 50K users or sensitive inferences.",
+                ["GDPR Art. 6", "GDPR Art. 35"],
+            )
+
+    # Rule 6: Anonymous aggregate — generally safe at all use cases.
+    if data_class == "anonymous-aggregate":
+        if origin == "scraped":
+            # Already handled above
+            pass
+        return (
+            "GO",
+            "Anonymous aggregate data is the safest class. Residual risk: re-identification attacks "
+            "if aggregate cells are small.",
+            "Maintain: (1) k-anonymity ≥ 5 in all published aggregates, (2) differential privacy if "
+            "shared externally, (3) provenance log for AI Act compliance.",
+            ["EU AI Act Art. 10", "GDPR Recital 26"],
+        )
+
+    # Synthetic + non-3rd-party-content
+    if origin == "synthetic":
+        return (
+            "GO",
+            "Synthetic data is generally safe for training. Residual risk: synthetic data generated "
+            "from a non-clean source inherits its risks.",
+            "Maintain: (1) document the generation pipeline including any non-synthetic seed, "
+            "(2) test for bias inherited from generator, (3) provenance log.",
+            ["EU AI Act Art. 10"],
+        )
+
+    # Default conservative fallback
+    return (
+        "MITIGATE",
+        "Configuration not matched by explicit rules — manual review required.",
+        "Engage qualified data privacy counsel to assess this specific origin/class/use combination.",
+        [],
+    )
+
+
+def audit(payload: Dict[str, Any]) -> List[AuditResult]:
+    results: List[AuditResult] = []
+    for src in payload.get("sources", []):
+        name = src.get("name", "<unnamed>")
+        origin = src.get("origin", "")
+        data_class = src.get("data_class", "")
+        use_case = src.get("use_case", "")
+
+        # Validation
+        errors = []
+        if origin not in VALID_ORIGINS:
+            errors.append(f"invalid origin '{origin}'")
+        if data_class not in VALID_CLASSES:
+            errors.append(f"invalid data_class '{data_class}'")
+        if use_case not in VALID_USE_CASES:
+            errors.append(f"invalid use_case '{use_case}'")
+        if errors:
+            results.append(AuditResult(
+                name=name,
+                origin=origin,
+                data_class=data_class,
+                use_case=use_case,
+                verdict="NO-GO",
+                risk=f"Schema error: {'; '.join(errors)}",
+                remediation=(
+                    f"Origin must be one of {sorted(VALID_ORIGINS)}; "
+                    f"data_class one of {sorted(VALID_CLASSES)}; "
+                    f"use_case one of {sorted(VALID_USE_CASES)}."
+                ),
+                citations=[],
+            ))
+            continue
+
+        verdict, risk, remediation, citations = _decide(origin, data_class, use_case)
+        results.append(AuditResult(
+            name=name,
+            origin=origin,
+            data_class=data_class,
+            use_case=use_case,
+            verdict=verdict,
+            risk=risk,
+            remediation=remediation,
+            citations=citations,
+        ))
+
+    # Sort: NO-GO first, then MITIGATE, then GO
+    order = {"NO-GO": 0, "MITIGATE": 1, "GO": 2}
+    results.sort(key=lambda r: order.get(r.verdict, 9))
+    return results
+
+
+def render_text(results: List[AuditResult], source: str) -> str:
+    lines = []
+    lines.append("=" * 72)
+    lines.append("AI TRAINING DATA AUDIT")
+    lines.append(f"Source: {source}")
+    lines.append(f"Sources audited: {len(results)}")
+    lines.append("=" * 72)
+    lines.append("")
+
+    counts = {"NO-GO": 0, "MITIGATE": 0, "GO": 0}
+    for r in results:
+        counts[r.verdict] = counts.get(r.verdict, 0) + 1
+    lines.append(f"Verdicts: 🔴 NO-GO: {counts['NO-GO']}  🟡 MITIGATE: {counts['MITIGATE']}  🟢 GO: {counts['GO']}")
+    lines.append("")
+    lines.append("-" * 72)
+
+    for i, r in enumerate(results, 1):
+        marker = {"NO-GO": "🔴", "MITIGATE": "🟡", "GO": "🟢"}.get(r.verdict, "•")
+        lines.append(f"[{i}] {marker} {r.verdict:<9} — {r.name}")
+        lines.append(f"    Origin: {r.origin} | Class: {r.data_class} | Use case: {r.use_case}")
+        lines.append("")
+        lines.append(f"    Risk:")
+        for line in _wrap(r.risk, 6):
+            lines.append(line)
+        lines.append("")
+        lines.append(f"    Remediation:")
+        for line in _wrap(r.remediation, 6):
+            lines.append(line)
+        if r.citations:
+            lines.append(f"    Citations: {', '.join(r.citations)}")
+        lines.append("")
+        lines.append("-" * 72)
+
+    lines.append("")
+    lines.append("REMINDER: This audit applies rule-based triage to a 3-dimensional matrix. Always engage")
+    lines.append("qualified data privacy / AI counsel for binding decisions.")
+    return "\n".join(lines)
+
+
+def _wrap(text: str, indent: int, width: int = 66) -> List[str]:
+    import textwrap
+    return textwrap.wrap(text, width=width, initial_indent=" " * indent, subsequent_indent=" " * indent) or [" " * indent + text]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit data sources for AI training eligibility (origin × class × use-case matrix).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("path", nargs="?", help="Path to sources JSON (uses embedded sample if omitted)")
+    parser.add_argument("--output", choices=("text", "json"), default="text", help="Output format")
+    args = parser.parse_args()
+
+    if args.path:
+        try:
+            with open(args.path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+            source = args.path
+        except (IOError, OSError) as e:
+            print(f"error: could not read {args.path}: {e}", file=sys.stderr)
+            return 1
+        except json.JSONDecodeError as e:
+            print(f"error: invalid JSON in {args.path}: {e}", file=sys.stderr)
+            return 1
+    else:
+        payload = SAMPLE
+        source = "<embedded sample: 7 mixed sources>"
+
+    results = audit(payload)
+
+    if args.output == "json":
+        print(json.dumps({
+            "source": source,
+            "count": len(results),
+            "verdict_counts": {
+                "NO-GO": sum(1 for r in results if r.verdict == "NO-GO"),
+                "MITIGATE": sum(1 for r in results if r.verdict == "MITIGATE"),
+                "GO": sum(1 for r in results if r.verdict == "GO"),
+            },
+            "results": [asdict(r) for r in results],
+        }, indent=2))
+    else:
+        print(render_text(results, source))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/c-level-advisor/skills/chief-data-officer-advisor/scripts/data_asset_valuator.py
+++ b/c-level-advisor/skills/chief-data-officer-advisor/scripts/data_asset_valuator.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""data_asset_valuator.py — Value a B2B customer data corpus + productization viability.
+
+Stdlib-only. Takes a corpus profile and computes:
+  - Strategic value score (0-10)
+  - Defensibility moat strength (NONE / WEAK / MEDIUM / STRONG)
+  - M&A multiplier (ARR uplift range in strategic-buyer scenarios)
+  - Productization paths (benchmark / embedding / direct license) with risk profile
+  - Contractual constraint impact (% of corpus blocked from productization)
+
+Input schema (JSON):
+{
+  "data_type": "sales-engagement",       // descriptive
+  "customer_count": 380,
+  "time_history_years": 2.3,
+  "exclusivity": "high",                  // none | low | medium | high
+  "freshness": "real-time",               // batch-daily | batch-weekly | near-real-time | real-time
+  "msa_carveouts_count": 47,              // # of customers with data-use carve-outs blocking productization
+  "anonymization_audit_passed": false,    // k-anonymity >=5 confirmed
+  "company_arr_m": 12,                    // company ARR in millions for M&A multiplier math
+  "regulated_data_present": false
+}
+
+Usage:
+    python data_asset_valuator.py                       # uses embedded B2B sample
+    python data_asset_valuator.py path/to/corpus.json
+    python data_asset_valuator.py corpus.json --output json
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List
+
+
+SAMPLE: Dict[str, Any] = {
+    "data_type": "Sales engagement logs (email, calls, meetings)",
+    "customer_count": 380,
+    "time_history_years": 2.3,
+    "exclusivity": "high",
+    "freshness": "real-time",
+    "msa_carveouts_count": 47,
+    "anonymization_audit_passed": False,
+    "company_arr_m": 12,
+    "regulated_data_present": False,
+}
+
+
+EXCLUSIVITY_SCORE = {"none": 0, "low": 2, "medium": 5, "high": 9}
+FRESHNESS_SCORE = {"batch-weekly": 2, "batch-daily": 5, "near-real-time": 7, "real-time": 9}
+
+
+def strategic_value(profile: Dict[str, Any]) -> Dict[str, Any]:
+    """Computes strategic value score and moat strength."""
+    customers = profile.get("customer_count", 0)
+    history = profile.get("time_history_years", 0)
+    excl = profile.get("exclusivity", "none")
+    fresh = profile.get("freshness", "batch-weekly")
+
+    excl_score = EXCLUSIVITY_SCORE.get(excl, 0)
+    fresh_score = FRESHNESS_SCORE.get(fresh, 0)
+
+    # Customer cohort breadth
+    if customers >= 500:
+        cohort_score = 10
+    elif customers >= 200:
+        cohort_score = 8
+    elif customers >= 100:
+        cohort_score = 6
+    elif customers >= 50:
+        cohort_score = 4
+    else:
+        cohort_score = 2
+
+    # Time history depth
+    if history >= 5:
+        history_score = 10
+    elif history >= 3:
+        history_score = 8
+    elif history >= 2:
+        history_score = 6
+    elif history >= 1:
+        history_score = 4
+    else:
+        history_score = 2
+
+    # Composite
+    composite = (excl_score * 2 + fresh_score + cohort_score + history_score) / 5
+    composite = round(composite, 1)
+
+    # Moat strength derived from exclusivity + cohort
+    if excl_score >= 8 and cohort_score >= 8:
+        moat = "STRONG"
+        moat_explain = "Exclusivity + breadth means replicating requires 2+ years of customer cohort acquisition."
+    elif excl_score >= 5 and cohort_score >= 6:
+        moat = "MEDIUM"
+        moat_explain = "Defensible but a well-funded competitor with 18-24 months can match."
+    elif excl_score >= 2:
+        moat = "WEAK"
+        moat_explain = "Some unique characteristics but largely replicable from public or commercially-available sources."
+    else:
+        moat = "NONE"
+        moat_explain = "Not a moat — same data is available elsewhere."
+
+    return {
+        "composite_score": composite,
+        "max_score": 10.0,
+        "components": {
+            "exclusivity": excl_score,
+            "freshness": fresh_score,
+            "cohort_breadth": cohort_score,
+            "history_depth": history_score,
+        },
+        "moat_strength": moat,
+        "moat_explanation": moat_explain,
+    }
+
+
+def ma_multiplier(profile: Dict[str, Any], strategic: Dict[str, Any]) -> Dict[str, Any]:
+    """Computes M&A multiplier range based on moat + corpus characteristics."""
+    moat = strategic["moat_strength"]
+    arr = profile.get("company_arr_m", 0)
+    carveouts = profile.get("msa_carveouts_count", 0)
+    customers = profile.get("customer_count", 1)
+    carveout_pct = (carveouts / customers * 100) if customers else 0
+
+    # Base multiplier by moat
+    base = {
+        "STRONG": (1.4, 1.7),
+        "MEDIUM": (1.15, 1.35),
+        "WEAK": (1.0, 1.1),
+        "NONE": (1.0, 1.0),
+    }
+    low, high = base.get(moat, (1.0, 1.0))
+
+    # Penalty for high carve-out %
+    if carveout_pct > 25:
+        low *= 0.85
+        high *= 0.85
+        carveout_note = f"{carveout_pct:.1f}% carve-out rate reduces multiplier ~15% (data is partially un-productizable)."
+    elif carveout_pct > 10:
+        low *= 0.95
+        high *= 0.95
+        carveout_note = f"{carveout_pct:.1f}% carve-out rate reduces multiplier ~5%."
+    else:
+        carveout_note = f"{carveout_pct:.1f}% carve-out rate — within tolerable range, no material multiplier impact."
+
+    low_arr = round(arr * low, 1) if arr else None
+    high_arr = round(arr * high, 1) if arr else None
+
+    return {
+        "multiplier_low": round(low, 2),
+        "multiplier_high": round(high, 2),
+        "carveout_pct": round(carveout_pct, 1),
+        "carveout_note": carveout_note,
+        "valuation_low_m": low_arr,
+        "valuation_high_m": high_arr,
+        "valuation_note": (
+            f"Strategic-buyer scenario: ARR ${arr}M × ({low:.2f} - {high:.2f}) = ${low_arr}M - ${high_arr}M ARR-equivalent."
+            if arr else "Provide company_arr_m to compute valuation range."
+        ),
+    }
+
+
+def productization_paths(profile: Dict[str, Any], strategic: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Returns ranked productization paths with risk and viability."""
+    customers = profile.get("customer_count", 0)
+    carveouts = profile.get("msa_carveouts_count", 0)
+    carveout_pct = (carveouts / customers * 100) if customers else 0
+    anon_passed = profile.get("anonymization_audit_passed", False)
+    regulated = profile.get("regulated_data_present", False)
+    moat = strategic["moat_strength"]
+
+    paths = []
+
+    # Path 1: Industry benchmark report
+    benchmark_risk = "LOW"
+    benchmark_blockers = []
+    if not anon_passed:
+        benchmark_blockers.append("Anonymization audit (k-anonymity ≥ 5) required before publication")
+    if regulated:
+        benchmark_risk = "MEDIUM"
+        benchmark_blockers.append("Regulated data present — additional compliance review required")
+    paths.append({
+        "path": "Industry benchmark report (anonymized aggregates)",
+        "risk": benchmark_risk,
+        "revenue_potential": "Low ($50K-$500K/yr) but high credibility lift",
+        "viability": "HIGH" if not regulated else "MEDIUM",
+        "blockers": benchmark_blockers or ["No structural blockers"],
+        "first_step": (
+            "Run anonymization audit on top-3 metrics; draft quarterly benchmark report; "
+            "send to customers as opt-in value-add before public release."
+        ),
+    })
+
+    # Path 2: Anonymized embedding endpoint
+    embed_risk = "MEDIUM"
+    embed_blockers = []
+    if not anon_passed:
+        embed_blockers.append("Anonymization audit required; embeddings can leak training data")
+    if carveout_pct > 0:
+        embed_blockers.append(
+            f"{int(carveouts)} customers have MSA carve-outs blocking productized use of their data"
+        )
+    if regulated:
+        embed_risk = "HIGH"
+        embed_blockers.append("Regulated data present — embeddings may retain re-identifiable signal")
+    paths.append({
+        "path": "Anonymized embedding endpoint (AI features for customers)",
+        "risk": embed_risk,
+        "revenue_potential": "Medium ($500K-$3M/yr) as platform feature OR add-on",
+        "viability": "HIGH" if moat in ("STRONG", "MEDIUM") and not regulated else "MEDIUM",
+        "blockers": embed_blockers,
+        "first_step": (
+            "Pilot embedding endpoint with 3 design-partner customers; memorization tests; "
+            "DPA addendum covering training-data flow."
+        ),
+    })
+
+    # Path 3: Direct data licensing
+    license_risk = "HIGH"
+    license_blockers = []
+    if carveout_pct > 10:
+        license_blockers.append(
+            f"{carveout_pct:.1f}% of customers ({int(carveouts)}) have MSA carve-outs — direct licensing is "
+            "legally infeasible without re-papering or carve-out-excluded dataset"
+        )
+    license_blockers.append("Requires GDPR Art. 26 joint-controller analysis if EU customers present")
+    if regulated:
+        license_blockers.append("Regulated data licensing requires framework-specific consent + DPA")
+    paths.append({
+        "path": "Direct data licensing (to AI labs, data brokers, or industry players)",
+        "risk": license_risk,
+        "revenue_potential": "High ($2M-$20M/yr) at scale but high customer-trust cost",
+        "viability": "LOW" if carveout_pct > 10 or regulated else "MEDIUM",
+        "blockers": license_blockers,
+        "first_step": (
+            "First decide if customer trust impact is acceptable. If yes: re-paper 47 carve-out customers "
+            "OR build carve-out-excluded dataset; engage data broker counsel; draft customer comms plan."
+        ),
+    })
+
+    return paths
+
+
+def recommend_path(paths: List[Dict[str, Any]]) -> str:
+    """Picks the highest-viability lowest-risk path as the recommended starting point."""
+    # Score: viability rank * 10 + (4 - risk_rank)
+    viability_rank = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
+    risk_rank = {"LOW": 3, "MEDIUM": 2, "HIGH": 1}
+
+    scored = [
+        (viability_rank.get(p["viability"], 0) * 10 + risk_rank.get(p["risk"], 0), p)
+        for p in paths
+    ]
+    scored.sort(key=lambda x: -x[0])
+    return scored[0][1]["path"]
+
+
+def analyze(profile: Dict[str, Any]) -> Dict[str, Any]:
+    strategic = strategic_value(profile)
+    ma = ma_multiplier(profile, strategic)
+    paths = productization_paths(profile, strategic)
+    recommended = recommend_path(paths)
+    return {
+        "strategic_value": strategic,
+        "ma_multiplier": ma,
+        "productization_paths": paths,
+        "recommended_starting_path": recommended,
+    }
+
+
+def render_text(result: Dict[str, Any], profile: Dict[str, Any], source: str) -> str:
+    lines = []
+    lines.append("=" * 72)
+    lines.append("DATA ASSET VALUATION")
+    lines.append(f"Source: {source}")
+    lines.append("=" * 72)
+    lines.append("")
+    lines.append(f"Corpus: {profile.get('data_type')}")
+    lines.append(f"  Customers: {profile.get('customer_count')} | History: {profile.get('time_history_years')} years")
+    lines.append(f"  Exclusivity: {profile.get('exclusivity')} | Freshness: {profile.get('freshness')}")
+    lines.append(f"  MSA carve-outs: {profile.get('msa_carveouts_count')} customer(s)")
+    lines.append(f"  Anonymization audit passed: {profile.get('anonymization_audit_passed')}")
+    lines.append(f"  Regulated data present: {profile.get('regulated_data_present')}")
+    lines.append("")
+    lines.append("-" * 72)
+
+    sv = result["strategic_value"]
+    lines.append(f"STRATEGIC VALUE: {sv['composite_score']} / {sv['max_score']}")
+    lines.append("  Components:")
+    for k, v in sv["components"].items():
+        lines.append(f"    {k:<20} {v}/10")
+    lines.append(f"  Moat strength: {sv['moat_strength']}")
+    for line in _wrap(f"  {sv['moat_explanation']}", 2):
+        lines.append(line)
+    lines.append("")
+    lines.append("-" * 72)
+
+    ma = result["ma_multiplier"]
+    lines.append(f"M&A MULTIPLIER (strategic-buyer scenario):")
+    lines.append(f"  Range: {ma['multiplier_low']}x – {ma['multiplier_high']}x ARR")
+    if ma.get("valuation_low_m") is not None:
+        lines.append(f"  Valuation impact: ${ma['valuation_low_m']}M – ${ma['valuation_high_m']}M ARR-equivalent")
+    for line in _wrap(f"  {ma['carveout_note']}", 2):
+        lines.append(line)
+    lines.append("")
+    lines.append("-" * 72)
+    lines.append("PRODUCTIZATION PATHS:")
+    lines.append("")
+
+    for i, p in enumerate(result["productization_paths"], 1):
+        lines.append(f"  [{i}] {p['path']}")
+        lines.append(f"      Risk: {p['risk']} | Viability: {p['viability']} | Revenue: {p['revenue_potential']}")
+        lines.append(f"      Blockers:")
+        for b in p["blockers"]:
+            lines.append(f"        - {b}")
+        lines.append(f"      First step:")
+        for line in _wrap(p["first_step"], 8):
+            lines.append(line)
+        lines.append("")
+
+    lines.append("-" * 72)
+    lines.append(f"RECOMMENDED STARTING PATH: {result['recommended_starting_path']}")
+    lines.append("")
+    lines.append("REMINDER: This valuation is a triage. Any actual productization, licensing, or M&A use")
+    lines.append("requires legal + data privacy review. Customer-trust impact is often the binding constraint,")
+    lines.append("not legal feasibility.")
+    return "\n".join(lines)
+
+
+def _wrap(text: str, indent: int, width: int = 70) -> List[str]:
+    import textwrap
+    return textwrap.wrap(text, width=width, initial_indent=" " * indent, subsequent_indent=" " * indent) or [" " * indent + text]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Value a B2B customer data corpus + productization paths.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("path", nargs="?", help="Path to corpus JSON (uses embedded sample if omitted)")
+    parser.add_argument("--output", choices=("text", "json"), default="text", help="Output format")
+    args = parser.parse_args()
+
+    if args.path:
+        try:
+            with open(args.path, "r", encoding="utf-8") as f:
+                profile = json.load(f)
+            source = args.path
+        except (IOError, OSError) as e:
+            print(f"error: could not read {args.path}: {e}", file=sys.stderr)
+            return 1
+        except json.JSONDecodeError as e:
+            print(f"error: invalid JSON in {args.path}: {e}", file=sys.stderr)
+            return 1
+    else:
+        profile = SAMPLE
+        source = "<embedded sample: B2B SaaS sales engagement, 380 customers, 47 carve-outs>"
+
+    result = analyze(profile)
+
+    if args.output == "json":
+        print(json.dumps({"source": source, "profile": profile, **result}, indent=2))
+    else:
+        print(render_text(result, profile, source))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/c-level-advisor/skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py
+++ b/c-level-advisor/skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""data_product_strategy_picker.py — Pick data architecture + build-vs-buy + sequencing.
+
+Stdlib-only. Takes a company profile and outputs:
+  - Recommended architecture (warehouse / lakehouse / data mesh) with reasoning + kill criteria
+  - Build-vs-buy decision per layer (storage, ELT, modeling, BI, feature store, ML platform)
+  - 12-month sequencing roadmap
+
+The recommendation is deterministic, derived from the profile, not pattern-matched.
+
+Input schema (JSON):
+{
+  "stage": "series-a",            // seed | series-a | series-b | growth | late-stage
+  "data_team_size": 3,
+  "internal_consumers": 8,         // distinct people/teams consuming data weekly
+  "data_volume_tb": 4.5,
+  "ml_models_in_prod": 1,
+  "company_type": "b2b-saas",     // b2b-saas | b2c-saas | consumer | marketplace | enterprise
+  "has_data_culture": false,       // federated ownership culture in place? (mesh prerequisite)
+  "near_term_priorities": [
+    "self-serve-bi",
+    "improve-pipeline-reliability"
+  ]
+}
+
+Usage:
+    python data_product_strategy_picker.py                       # uses embedded Series A SaaS
+    python data_product_strategy_picker.py path/to/profile.json
+    python data_product_strategy_picker.py profile.json --output json
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Tuple
+
+
+SAMPLE: Dict[str, Any] = {
+    "stage": "series-a",
+    "data_team_size": 3,
+    "internal_consumers": 8,
+    "data_volume_tb": 4.5,
+    "ml_models_in_prod": 1,
+    "company_type": "b2b-saas",
+    "has_data_culture": False,
+    "near_term_priorities": ["self-serve-bi", "improve-pipeline-reliability"],
+}
+
+
+def pick_architecture(profile: Dict[str, Any]) -> Tuple[str, str, List[str]]:
+    """Returns (architecture, reasoning, kill_criteria)."""
+    consumers = profile.get("internal_consumers", 0)
+    volume = profile.get("data_volume_tb", 0)
+    ml_models = profile.get("ml_models_in_prod", 0)
+    culture = profile.get("has_data_culture", False)
+    stage = profile.get("stage", "")
+
+    # Data mesh: requires 25+ consumers across 4+ domains AND federated culture
+    if consumers >= 25 and culture and stage in ("growth", "late-stage"):
+        return (
+            "DATA MESH",
+            f"{consumers} data consumers across enough domains to justify federated ownership; "
+            "stated data-culture maturity supports the operational overhead.",
+            [
+                "Stop and revert if 6 months in: producing teams haven't adopted ownership (typical failure mode)",
+                "Stop if: central data platform team is still doing >50% of data product work",
+                "Stop if: domain teams complain about platform onboarding (signals platform isn't truly self-serve)",
+            ],
+        )
+
+    # Mesh ambition without prerequisites
+    if consumers >= 25 and not culture:
+        return (
+            "LAKEHOUSE (defer mesh)",
+            f"{consumers} consumers is mesh-sized BUT no federated ownership culture in place; mesh "
+            "without culture fails. Run lakehouse with hub-and-spoke until ownership culture matures.",
+            [
+                "Revisit mesh in 18 months once 3+ domain teams own their own data products",
+                "Stop hub-and-spoke if central team is bottleneck > 60% of requests",
+            ],
+        )
+
+    # Lakehouse: 5+ consumers OR ML workloads OR >2TB
+    if consumers >= 5 or ml_models >= 1 or volume >= 2:
+        return (
+            "LAKEHOUSE",
+            (
+                f"{consumers} data consumer(s), {ml_models} ML model(s) in prod, {volume}TB. "
+                "Pure warehouse is too rigid for ML; pure data lake too unstructured for BI. "
+                "Lakehouse (warehouse + object storage with table format like Iceberg/Delta) "
+                "covers both with one substrate."
+            ),
+            [
+                "Downgrade to warehouse-only if ML models retired and data shrinks below 2TB",
+                "Upgrade to mesh only if 25+ consumers AND federated culture",
+                "Stop investment if vendor lock-in becomes unacceptable (lakehouse table formats mitigate this)",
+            ],
+        )
+
+    # Warehouse only
+    return (
+        "WAREHOUSE ONLY",
+        (
+            f"{consumers} consumer(s), {volume}TB, {ml_models} ML model(s). Sub-scale for lakehouse "
+            "complexity. Single warehouse (Snowflake / BigQuery / Postgres) + dbt is the simplest viable "
+            "stack at this stage."
+        ),
+        [
+            "Upgrade to lakehouse when ANY of: 5+ consumers, 2TB+ data, 1+ ML model in prod",
+            "Stop investment in custom modeling if SaaS BI vendor solves it (avoid premature dbt complexity)",
+        ],
+    )
+
+
+def build_vs_buy(profile: Dict[str, Any], architecture: str) -> List[Dict[str, str]]:
+    """Returns build-vs-buy decision per layer."""
+    consumers = profile.get("internal_consumers", 0)
+    ml_models = profile.get("ml_models_in_prod", 0)
+    company_type = profile.get("company_type", "")
+
+    decisions = []
+
+    # Storage / warehouse
+    decisions.append({
+        "layer": "Storage / Warehouse",
+        "decision": "BUY",
+        "vendor_suggestion": "Snowflake / BigQuery / Databricks (lakehouse) or Postgres (warehouse-only)",
+        "rationale": "Storage is commodity. Building distributed storage is a 50-engineer-year investment with no business return unless you are a data-infra company.",
+    })
+
+    # ELT / ingest
+    decisions.append({
+        "layer": "ELT / Ingest",
+        "decision": "BUY",
+        "vendor_suggestion": "Fivetran / Airbyte / Stitch",
+        "rationale": "Connector maintenance is a moving target (200+ source APIs). Build only if your source isn't supported and is critical (then contribute upstream).",
+    })
+
+    # Modeling
+    decisions.append({
+        "layer": "Modeling / Transformations",
+        "decision": "BUILD",
+        "vendor_suggestion": "dbt + your domain logic (dbt itself is open source)",
+        "rationale": "This is your IP. Your domain logic encodes how the business actually works — vendors cannot supply it.",
+    })
+
+    # BI
+    if consumers < 100:
+        decisions.append({
+            "layer": "BI / Dashboards",
+            "decision": "BUY",
+            "vendor_suggestion": "Metabase (cheap) / Looker (enterprise) / Mode (analyst-friendly) / Hex (notebooks+BI)",
+            "rationale": f"At {consumers} consumers, building BI is a distraction. SaaS BI is mature; pick one that matches your analyst skillset.",
+        })
+    else:
+        decisions.append({
+            "layer": "BI / Dashboards",
+            "decision": "BUY + consider embedded for customer-facing analytics",
+            "vendor_suggestion": "Looker / Sigma + (Cube.dev or Embeddable) for customer-facing",
+            "rationale": f"At {consumers} consumers, BI is critical. If you're a B2B SaaS with customer-facing analytics, embedded BI is a real build-vs-buy decision; usually still buy.",
+        })
+
+    # Feature store
+    if ml_models < 3:
+        decisions.append({
+            "layer": "Feature Store",
+            "decision": "DEFER",
+            "vendor_suggestion": "(none yet — use dbt + simple feature tables)",
+            "rationale": f"{ml_models} model(s) in prod. Feature stores pay off at 3+ models sharing features. Premature investment is a maintenance burden.",
+        })
+    else:
+        decisions.append({
+            "layer": "Feature Store",
+            "decision": "BUY (Tecton / Hopsworks) or BUILD (Feast)",
+            "vendor_suggestion": "Tecton (managed) or Feast (open source)",
+            "rationale": f"{ml_models} models is the threshold where feature reuse + governance matter more than simplicity.",
+        })
+
+    # ML platform
+    if ml_models < 5:
+        decisions.append({
+            "layer": "ML Platform",
+            "decision": "DEFER",
+            "vendor_suggestion": "(none yet — use notebooks + scheduled training jobs)",
+            "rationale": f"{ml_models} models. ML platforms (Databricks ML, Vertex AI, SageMaker) make sense at 5+ models with active retraining; before that, the platform overhead exceeds the value.",
+        })
+    else:
+        decisions.append({
+            "layer": "ML Platform",
+            "decision": "BUY",
+            "vendor_suggestion": "Databricks ML / Vertex AI / SageMaker",
+            "rationale": f"{ml_models} models with active retraining. Platform handles experiment tracking, deployment, monitoring — all of which become painful to build at this scale.",
+        })
+
+    return decisions
+
+
+def sequence_roadmap(profile: Dict[str, Any], architecture: str) -> List[Dict[str, str]]:
+    """Returns 4-quarter sequencing roadmap based on priorities + architecture."""
+    priorities = profile.get("near_term_priorities", [])
+    ml_models = profile.get("ml_models_in_prod", 0)
+
+    roadmap = []
+
+    # Q1: always reliability first if pipeline issues exist
+    if "improve-pipeline-reliability" in priorities or "reliability" in str(priorities):
+        roadmap.append({
+            "quarter": "Q1",
+            "focus": "Pipeline reliability",
+            "deliverables": "SLA on top-3 critical pipelines (freshness, completeness); on-call rotation; data quality tests in dbt",
+        })
+    else:
+        roadmap.append({
+            "quarter": "Q1",
+            "focus": "Foundation",
+            "deliverables": "Centralized ingest (Fivetran/Airbyte); dbt for top-5 marts; basic data quality tests",
+        })
+
+    # Q2
+    if "self-serve-bi" in priorities:
+        roadmap.append({
+            "quarter": "Q2",
+            "focus": "Self-serve BI",
+            "deliverables": "BI tool rollout to non-data teams; semantic layer (dbt metrics or LookML); training program",
+        })
+    else:
+        roadmap.append({
+            "quarter": "Q2",
+            "focus": "Coverage",
+            "deliverables": "Extend dbt to top-10 marts; document data lineage; add domain-specific data quality tests",
+        })
+
+    # Q3
+    if ml_models >= 1 or "ml" in str(priorities).lower():
+        roadmap.append({
+            "quarter": "Q3",
+            "focus": "ML enablement",
+            "deliverables": "First feature-store table for top-1 production model; experiment tracking (MLflow / W&B); model monitoring",
+        })
+    else:
+        roadmap.append({
+            "quarter": "Q3",
+            "focus": "Embed analysts",
+            "deliverables": "Embedded analysts in 2-3 functional teams; central team owns platform; SLAs renegotiated",
+        })
+
+    # Q4: evaluate + decide
+    roadmap.append({
+        "quarter": "Q4",
+        "focus": "Evaluate and decide",
+        "deliverables": "Re-run this picker with updated profile; decide on year-2 architecture (e.g., introduce feature store, evaluate mesh prereqs)",
+    })
+
+    return roadmap
+
+
+def analyze(profile: Dict[str, Any]) -> Dict[str, Any]:
+    architecture, reasoning, kill_criteria = pick_architecture(profile)
+    decisions = build_vs_buy(profile, architecture)
+    roadmap = sequence_roadmap(profile, architecture)
+    return {
+        "architecture": architecture,
+        "reasoning": reasoning,
+        "kill_criteria": kill_criteria,
+        "build_vs_buy": decisions,
+        "roadmap_12mo": roadmap,
+    }
+
+
+def render_text(result: Dict[str, Any], profile: Dict[str, Any], source: str) -> str:
+    lines = []
+    lines.append("=" * 72)
+    lines.append("DATA PRODUCT STRATEGY")
+    lines.append(f"Source: {source}")
+    lines.append("=" * 72)
+    lines.append("")
+    lines.append("Profile:")
+    lines.append(f"  Stage: {profile.get('stage')} | Team: {profile.get('data_team_size')} | Consumers: {profile.get('internal_consumers')}")
+    lines.append(f"  Data volume: {profile.get('data_volume_tb')}TB | ML models in prod: {profile.get('ml_models_in_prod')}")
+    lines.append(f"  Company type: {profile.get('company_type')} | Data culture in place: {profile.get('has_data_culture')}")
+    lines.append("")
+    lines.append("-" * 72)
+    lines.append(f"RECOMMENDED ARCHITECTURE: {result['architecture']}")
+    lines.append("")
+    lines.append("Reasoning:")
+    for line in _wrap(result["reasoning"], 2):
+        lines.append(line)
+    lines.append("")
+    lines.append("Kill criteria (when to abandon this choice):")
+    for k in result["kill_criteria"]:
+        lines.append(f"  • {k}")
+    lines.append("")
+    lines.append("-" * 72)
+    lines.append("BUILD vs BUY (per layer):")
+    lines.append("")
+    for d in result["build_vs_buy"]:
+        lines.append(f"  {d['layer']:<32} {d['decision']}")
+        lines.append(f"    Vendor: {d['vendor_suggestion']}")
+        for line in _wrap(f"Rationale: {d['rationale']}", 4):
+            lines.append(line)
+        lines.append("")
+    lines.append("-" * 72)
+    lines.append("12-MONTH ROADMAP:")
+    lines.append("")
+    for r in result["roadmap_12mo"]:
+        lines.append(f"  {r['quarter']}: {r['focus']}")
+        for line in _wrap(r["deliverables"], 6):
+            lines.append(line)
+        lines.append("")
+    lines.append("-" * 72)
+    lines.append("REMINDER: Re-run this picker quarterly with updated profile. Architecture is not a once-")
+    lines.append("and-done decision — kill criteria exist for a reason.")
+    return "\n".join(lines)
+
+
+def _wrap(text: str, indent: int, width: int = 68) -> List[str]:
+    import textwrap
+    return textwrap.wrap(text, width=width, initial_indent=" " * indent, subsequent_indent=" " * indent) or [" " * indent + text]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Pick data architecture + build-vs-buy + sequencing roadmap from a company profile.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("path", nargs="?", help="Path to profile JSON (uses embedded sample if omitted)")
+    parser.add_argument("--output", choices=("text", "json"), default="text", help="Output format")
+    args = parser.parse_args()
+
+    if args.path:
+        try:
+            with open(args.path, "r", encoding="utf-8") as f:
+                profile = json.load(f)
+            source = args.path
+        except (IOError, OSError) as e:
+            print(f"error: could not read {args.path}: {e}", file=sys.stderr)
+            return 1
+        except json.JSONDecodeError as e:
+            print(f"error: invalid JSON in {args.path}: {e}", file=sys.stderr)
+            return 1
+    else:
+        profile = SAMPLE
+        source = "<embedded sample: Series A B2B SaaS, 3-person data team>"
+
+    result = analyze(profile)
+
+    if args.output == "json":
+        print(json.dumps({"source": source, "profile": profile, **result}, indent=2))
+    else:
+        print(render_text(result, profile, source))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Opinionated, **decision-driven** Chief Data Officer skill — refuses to be a generic data-governance survey. Answers exactly **4 specific decisions** every B2B SaaS founder is asking by Series A/B:

1. **Can we train our model on this data?** → `ai_training_data_audit.py`
2. **Warehouse, lakehouse, or mesh — and build vs buy?** → `data_product_strategy_picker.py`
3. **What is our customer data worth?** (M&A, productization) → `data_asset_valuator.py`
4. **What data role do we hire next?** → `data_team_org_evolution.md` reference

This is the third "gstack-can't-touch" plugin in the founder-mode lineup (after c-level-agents v2.5.0 and general-counsel-advisor v2.5.1). gstack covers software-shipping personas only — modern data strategy + AI training rights + M&A data diligence are nowhere in its surface.

## Built Under Explicit Karpathy-Coder Discipline

This was the first PR in this repo built under explicit karpathy-coder guidance. Self-audit results:

- **`complexity_checker.py` on the 3 new Python tools:** 0 findings
- **`diff_surgeon.py` on the staged diff:** 0 findings (surgical changes confirmed)

How the principles shaped the PR:
- **#1 Think before coding:** Assumptions surfaced upfront in chat before any file was written. User pushback expanded scope from 2 framings → 4, and direction was locked before implementation.
- **#2 Simplicity first:** Each tool/reference covers ONE decision. Explicitly rejected generic-survey framing (e.g., "data product strategy picker" doesn't try to also do data quality, RAG, or schema design).
- **#3 Surgical changes:** Caught and reverted one scope-creep attempt mid-build (adding cs-general-counsel-advisor voice spec while editing persona-voices.md). That gap from v2.5.1 will be addressed in a separate small PR.
- **#4 Goal-driven execution:** Verifiable success criteria locked before code (see PR comment thread for the criteria table). All 3 Python tools smoke-tested with embedded samples before commit.

## What's New (17 files, +2471 / -19 lines)

### New skill — `c-level-advisor/skills/chief-data-officer-advisor/`

**`SKILL.md`** — 4 workflows (training go/no-go, architecture, asset valuation, org roadmap), CDO-specific keywords, hard rule against duplicating engineering data skills.

**3 stdlib Python tools with deterministic logic** (not pattern-match prose):

| Tool | What it does | Embedded sample result |
|---|---|---|
| `ai_training_data_audit.py` | 3-dimension matrix (origin × class × use case) → GO/MITIGATE/NO-GO per source with GDPR Art. 6 + EU AI Act + US state citations | 7 sources → 2 NO-GO / 2 MITIGATE / 3 GO |
| `data_product_strategy_picker.py` | Architecture (warehouse/lakehouse/mesh) + 6-layer build-vs-buy + 12-month sequencing | Series A SaaS, 8 consumers, 4.5TB → LAKEHOUSE |
| `data_asset_valuator.py` | Strategic value 0-10, moat strength, M&A multiplier (with carve-out + anonymization penalties), 3 ranked productization paths | B2B sales engagement, 380 customers, 47 carve-outs → 8.2/10 STRONG moat, 1.33-1.61x multiplier, recommends benchmark report first |

**4 references answering one decision each:**

- `ai_training_data_rights.md` — Training rights matrix + GDPR Art. 6 lawful basis decision tree + EU AI Act high-risk triggers + US state patchwork (CCPA/CPRA, NYC LL 144, IL BIPA, WA MHMD)
- `data_product_strategy.md` — Architecture kill criteria + 6-layer build-vs-buy decision tree + sequencing pattern + 5 anti-patterns
- `customer_data_as_asset.md` — 5-component valuation framework + 3 productization paths (benchmark / embedding / license) + 10-item M&A diligence checklist + quarterly contractual constraint audit
- `data_team_org_evolution.md` — 5-stage role map (seed → late-stage) + centralize-vs-embed-vs-federated triggers + 6 anti-patterns

### New agent — `cs-cdo-advisor`

Decision-driven realist. Voice: *"What decision does this data drive?"* Hard rule: never recommend tooling before naming the consumer.

### New slash command — `/cs:cdo-review`

6-question forcing interrogation matching the `/cs:cfo-review`, `/cs:gc-review` pattern. Routes to `/cs:gc-review`, `/cs:ciso-review`, `/cs:cfo-review`, `/cs:chro-review` for cross-functional concerns.

### Updates

- `c-level-advisor/c-level-agents/references/persona-voices.md` — added cs-cdo-advisor voice spec
- `c-level-advisor/.claude-plugin/plugin.json` — v2.5.1 → v2.5.2 (30 skills, 10 cs-* agents)
- `c-level-advisor/c-level-agents/.claude-plugin/plugin.json` — v1.1.0 → v1.2.0 (10 agents, 18 commands)
- `marketplace.json` — both c-level entries bumped; new CDO keywords
- `c-level-advisor/CLAUDE.md` — CDO row added to roles table; agents/counts updated
- Root `CLAUDE.md` — 264 → 265 skills, 29 → 30 cs-* agents, 361 → 364 Python tools, 490 → 494 references, 50 → 51 commands
- `CHANGELOG.md` — v2.5.2 entry with karpathy-discipline rationale

## Counts Δ

| | v2.5.1 | v2.5.2 | Δ |
|---|---|---|---|
| c-level skills | 29 | 30 | +1 |
| cs-* agents (c-level-agents plugin) | 9 | 10 | +1 |
| /cs:* slash commands | 17 | 18 | +1 |
| c-level Python tools | 27 | 30 | +3 |
| c-level references | 57 | 61 | +4 |
| Total repo skills | 264 | 265 | +1 |
| Total cs-* agents | 29 | 30 | +1 |

## Verifiable Success Criteria (all met)

| # | Criterion | Verified by |
|---|---|---|
| 1 | `ai_training_data_audit.py` returns GO/MITIGATE/NO-GO per source with specific risk + remediation | 7 sources → 2/2/3 verdict split with GDPR + AI Act citations |
| 2 | `data_product_strategy_picker.py` outputs specific role + sequencing recommendations | Series A → LAKEHOUSE, 6 layers, 4 quarters |
| 3 | Each of 4 references covers one specific decision | Headers per reference describe a decision, not a topic |
| 4 | SKILL.md keywords are CDO-specific, not data-generic | "AI training rights", "consent provenance", "centralize-vs-embed trigger" |
| 5 | cs-cdo-advisor voice differentiates from cs-cto / cs-ciso / cs-cpo | Voice spec added |
| 6 | All 3 tools: stdlib-only, `--help`, JSON output, exit 0 on sample | Smoke test confirmed |
| 7 | karpathy complexity_checker: 0 findings | Run before commit |
| 8 | karpathy diff_surgeon: 0 findings | Run on staged diff before commit |

## Test plan

- [x] JSON validates (plugin.json × 2, marketplace.json)
- [x] All 3 Python tools run with `--help` and `--output json`
- [x] Embedded samples produce expected outputs
- [x] karpathy-coder/complexity_checker: 0 findings
- [x] karpathy-coder/diff_surgeon: 0 findings
- [ ] CI: `Lint, Tests, Docs, Security` passes
- [ ] CI: `claude-review` passes
- [ ] CI: `VirusTotal` passes (stdlib-only, no new deps)
- [ ] CI: `Detect changed skills` passes

## Known follow-up (out of scope this PR per karpathy principle #3)

- The `cs-general-counsel-advisor` voice spec is missing from `persona-voices.md` (a gap introduced in v2.5.1 but not added to the voice reference). I caught myself adding it during this PR and reverted — it belongs in a separate small PR alongside any other voice-reference cleanup.

## Phase 2 remaining (deferred to v2.5.3+)

After this PR, 4 more C-roles remain from the original Phase 2 plan:
- Chief AI Officer (CAIO)
- Chief Customer Officer (CCO-customer)
- VP of Engineering (execution layer below CTO)
- Chief Communications Officer (CCO-comms)

Plus the broken-paths cleanup in pre-existing cs-ceo-advisor.md / cs-cto-advisor.md.

## Disclaimer

The `chief-data-officer-advisor` skill surfaces strategic decisions but is **not legal advice** for AI training, **not a replacement for outside counsel** for productization/licensing, and **not a tactical data engineering skill**. For tactical data engineering, see `engineering/database-designer/`, `engineering/observability-designer/`, `engineering/data-quality-auditor/`, `engineering/sql-database-assistant/`, `engineering/rag-architect/`, `engineering/llm-cost-optimizer/`.

https://claude.ai/code/session_012WtZMm5NJHqkYoRqA9fHMN

---
_Generated by [Claude Code](https://claude.ai/code/session_012WtZMm5NJHqkYoRqA9fHMN)_