### PR TITLE
fix(c-level): add 3 missing voice specs + fix broken paths in cs-ceo/cs-cto agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the Claude Skills Library will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.6] - 2026-05-13 — Cleanup: missing voice specs + broken agent paths
+
+### Fixed
+
+- **3 missing voice specs added to `c-level-advisor/c-level-agents/references/persona-voices.md`:**
+  - `cs-ceo-advisor` — The Strategic Translator (tree-of-thought reasoning; refuses to debate tactics until the strategic question is named)
+  - `cs-cto-advisor` — The Architecture-First Pragmatist (ReAct reasoning; treats every architecture decision as a 3-year commitment)
+  - `cs-general-counsel-advisor` — The Risk-Paranoid Lawyer (Not Your Lawyer) — carry-over from v2.5.1
+  - All three agents existed but their voice specs were never added to the persona reference (cs-ceo / cs-cto pre-date the c-level-agents plugin; cs-gc was an oversight in v2.5.1).
+- **Broken paths fixed in 2 pre-existing agent files** (`agents/c-level/cs-ceo-advisor.md` and `agents/c-level/cs-cto-advisor.md`):
+  - All 57 references to `../../c-level-advisor/ceo-advisor/` and `../../c-level-advisor/cto-advisor/` updated to `../../c-level-advisor/skills/ceo-advisor/` and `../../c-level-advisor/skills/cto-advisor/` respectively (correct path; the bundled skills live under `skills/`)
+  - YAML `skills:` field also corrected (was `c-level-advisor/ceo-advisor`, now `c-level-advisor/skills/ceo-advisor`)
+- **karpathy-coder/diff_surgeon:** clean on staged diff
+
+### Why
+
+Both gaps were carry-over items noted across multiple PRs in this session (v2.5.1 → v2.5.5) per karpathy principle #3 (surgical scope — no unrelated cleanups inside scoped feature PRs). This dedicated cleanup PR addresses them in one focused change without touching any feature work.
+
+### Changed
+
+- `c-level-advisor/c-level-agents/references/persona-voices.md` — 13 → 13 voice specs cataloged (all cs-* agents in the persona-voices list now match the agents that exist)
+- `agents/c-level/cs-ceo-advisor.md` — 32 path corrections
+- `agents/c-level/cs-cto-advisor.md` — 25 path corrections
+
+No skill/agent/command count changes; no manifest version bumps (this is a pure-fix PR).
+
 ## [2.5.5] - 2026-05-13 — vpe-advisor: throughput-first VP of Engineering
 
 ### Added — C-Level Advisory

--- a/agents/c-level/cs-ceo-advisor.md
+++ b/agents/c-level/cs-ceo-advisor.md
@@ -1,7 +1,7 @@
 ---
 name: cs-ceo-advisor
 description: Strategic leadership advisor for CEOs covering vision, strategy, board management, investor relations, and organizational culture
-skills: c-level-advisor/ceo-advisor
+skills: c-level-advisor/skills/ceo-advisor
 domain: c-level
 model: opus
 tools: [Read, Write, Bash, Grep, Glob]
@@ -19,38 +19,38 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
 
 ## Skill Integration
 
-**Skill Location:** `../../c-level-advisor/ceo-advisor/`
+**Skill Location:** `../../c-level-advisor/skills/ceo-advisor/`
 
 ### Python Tools
 
 1. **Strategy Analyzer**
    - **Purpose:** Analyzes strategic position using multiple frameworks (SWOT, Porter's Five Forces) and generates actionable recommendations
-   - **Path:** `../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py`
-   - **Usage:** `python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py`
+   - **Path:** `../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py`
+   - **Usage:** `python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py`
    - **Features:** Market analysis, competitive positioning, strategic options generation, risk assessment
    - **Use Cases:** Annual strategic planning, market entry decisions, competitive analysis, strategic pivots
 
 2. **Financial Scenario Analyzer**
    - **Purpose:** Models different business scenarios with risk-adjusted financial projections and capital allocation recommendations
-   - **Path:** `../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py`
-   - **Usage:** `python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py`
+   - **Path:** `../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py`
+   - **Usage:** `python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py`
    - **Features:** Scenario modeling, capital allocation optimization, runway analysis, valuation projections
    - **Use Cases:** Fundraising planning, budget allocation, M&A evaluation, strategic investment decisions
 
 ### Knowledge Bases
 
 1. **Executive Decision Framework**
-   - **Location:** `../../c-level-advisor/ceo-advisor/references/executive_decision_framework.md`
+   - **Location:** `../../c-level-advisor/skills/ceo-advisor/references/executive_decision_framework.md`
    - **Content:** Structured decision-making process for go/no-go decisions, major pivots, M&A opportunities, crisis response
    - **Use Case:** High-stakes decision making, option evaluation, stakeholder alignment
 
 2. **Board Governance & Investor Relations**
-   - **Location:** `../../c-level-advisor/ceo-advisor/references/board_governance_investor_relations.md`
+   - **Location:** `../../c-level-advisor/skills/ceo-advisor/references/board_governance_investor_relations.md`
    - **Content:** Board meeting preparation, board package templates, investor communication cadence, fundraising playbooks
    - **Use Case:** Board management, quarterly reporting, fundraising execution, investor updates
 
 3. **Leadership & Organizational Culture**
-   - **Location:** `../../c-level-advisor/ceo-advisor/references/leadership_organizational_culture.md`
+   - **Location:** `../../c-level-advisor/skills/ceo-advisor/references/leadership_organizational_culture.md`
    - **Content:** Culture transformation frameworks, leadership development, change management, organizational design
    - **Use Case:** Culture building, organizational change, leadership team development, transformation management
 
@@ -63,11 +63,11 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
 **Steps:**
 1. **Environmental Scan** - Analyze market trends, competitive landscape, regulatory changes
    ```bash
-   python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py
+   python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py
    ```
 2. **Reference Strategic Frameworks** - Review executive decision-making best practices
    ```bash
-   cat ../../c-level-advisor/ceo-advisor/references/executive_decision_framework.md
+   cat ../../c-level-advisor/skills/ceo-advisor/references/executive_decision_framework.md
    ```
 3. **Strategic Options Development** - Generate and evaluate strategic alternatives:
    - Market expansion opportunities
@@ -76,11 +76,11 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
    - Partnership strategies
 4. **Financial Modeling** - Run scenario analysis for each strategic option
    ```bash
-   python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py
+   python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py
    ```
 5. **Create Board Package** - Reference governance best practices for presentation
    ```bash
-   cat ../../c-level-advisor/ceo-advisor/references/board_governance_investor_relations.md
+   cat ../../c-level-advisor/skills/ceo-advisor/references/board_governance_investor_relations.md
    ```
 6. **Strategy Communication** - Cascade strategic priorities to organization
 
@@ -95,7 +95,7 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
 **Steps:**
 1. **Review Board Best Practices** - Study board governance frameworks
    ```bash
-   cat ../../c-level-advisor/ceo-advisor/references/board_governance_investor_relations.md
+   cat ../../c-level-advisor/skills/ceo-advisor/references/board_governance_investor_relations.md
    ```
 2. **Preparation Timeline** (T-4 weeks to meeting):
    - **T-4 weeks**: Develop agenda with board chair
@@ -110,7 +110,7 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
    - Risk Register (2 pages): Top risks and mitigation plans
 4. **Run Financial Scenarios** - Model different growth paths for board discussion
    ```bash
-   python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py
+   python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py
    ```
 5. **Meeting Execution** - Lead discussion, address questions, secure decisions
 6. **Post-Meeting Follow-Up** - Action items, decisions documented, communication to team
@@ -126,11 +126,11 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
 **Steps:**
 1. **Reference Investor Relations Playbook** - Study fundraising best practices
    ```bash
-   cat ../../c-level-advisor/ceo-advisor/references/board_governance_investor_relations.md
+   cat ../../c-level-advisor/skills/ceo-advisor/references/board_governance_investor_relations.md
    ```
 2. **Financial Scenario Planning** - Model different raise amounts and runway scenarios
    ```bash
-   python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py
+   python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py
    ```
 3. **Develop Fundraising Materials**:
    - Pitch deck (10-12 slides): Problem, solution, market, product, business model, GTM, competition, team, financials, ask
@@ -139,7 +139,7 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
    - Data room: Customer metrics, financial details, legal documents
 4. **Strategic Positioning** - Use strategy analyzer to articulate competitive advantage
    ```bash
-   python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py
+   python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py
    ```
 5. **Investor Outreach** - Target list, warm intros, meeting scheduling
 6. **Pitch Refinement** - Practice, feedback, iteration
@@ -154,8 +154,8 @@ The cs-ceo-advisor agent bridges the gap between strategic intent and operationa
 **Example:**
 ```bash
 # Complete fundraising planning workflow
-python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py > scenarios.txt
-python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py > competitive-position.txt
+python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py > scenarios.txt
+python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py > competitive-position.txt
 # Use outputs to build compelling pitch deck and financial model
 ```
 
@@ -171,7 +171,7 @@ python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py > competit
    - Cultural artifacts review (meetings, rituals, symbols)
 2. **Reference Culture Frameworks** - Study transformation best practices
    ```bash
-   cat ../../c-level-advisor/ceo-advisor/references/leadership_organizational_culture.md
+   cat ../../c-level-advisor/skills/ceo-advisor/references/leadership_organizational_culture.md
    ```
 3. **Define Target Culture**:
    - Core values (3-5 values)
@@ -213,12 +213,12 @@ echo "=================================================="
 # Strategic analysis
 echo ""
 echo "🎯 Strategic Position:"
-python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py
+python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py
 
 # Financial scenarios
 echo ""
 echo "💰 Financial Scenarios:"
-python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py
+python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py
 
 # Board package reminder
 echo ""
@@ -231,8 +231,8 @@ echo "✓ Risk Register (2 pages)"
 
 echo ""
 echo "📚 Reference Materials:"
-echo "- Board governance: ../../c-level-advisor/ceo-advisor/references/board_governance_investor_relations.md"
-echo "- Culture frameworks: ../../c-level-advisor/ceo-advisor/references/leadership_organizational_culture.md"
+echo "- Board governance: ../../c-level-advisor/skills/ceo-advisor/references/board_governance_investor_relations.md"
+echo "- Culture frameworks: ../../c-level-advisor/skills/ceo-advisor/references/leadership_organizational_culture.md"
 ```
 
 ### Example 2: Strategic Decision Evaluation
@@ -244,15 +244,15 @@ echo "🔍 Strategic Decision Analysis"
 echo "================================"
 
 # Analyze strategic position
-python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py > strategic-position.txt
+python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py > strategic-position.txt
 
 # Model financial scenarios
-python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py > financial-scenarios.txt
+python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py > financial-scenarios.txt
 
 # Reference decision framework
 echo ""
 echo "📖 Applying Executive Decision Framework:"
-cat ../../c-level-advisor/ceo-advisor/references/executive_decision_framework.md
+cat ../../c-level-advisor/skills/ceo-advisor/references/executive_decision_framework.md
 
 # Decision checklist
 echo ""
@@ -283,7 +283,7 @@ case $DAY_OF_WEEK in
     echo "- Executive team meeting"
     echo "- Metrics review"
     echo "- Week planning"
-    python ../../c-level-advisor/ceo-advisor/scripts/strategy_analyzer.py
+    python ../../c-level-advisor/skills/ceo-advisor/scripts/strategy_analyzer.py
     ;;
   Tuesday)
     echo "🤝 External Focus"
@@ -302,14 +302,14 @@ case $DAY_OF_WEEK in
     echo "- 1-on-1s with directs"
     echo "- Talent reviews"
     echo "- Culture initiatives"
-    cat ../../c-level-advisor/ceo-advisor/references/leadership_organizational_culture.md
+    cat ../../c-level-advisor/skills/ceo-advisor/references/leadership_organizational_culture.md
     ;;
   Friday)
     echo "🚀 Innovation & Future Focus"
     echo "- Strategic projects"
     echo "- Learning time"
     echo "- Planning ahead"
-    python ../../c-level-advisor/ceo-advisor/scripts/financial_scenario_analyzer.py
+    python ../../c-level-advisor/skills/ceo-advisor/scripts/financial_scenario_analyzer.py
     ;;
 esac
 ```
@@ -348,7 +348,7 @@ esac
 
 ## References
 
-- **Skill Documentation:** [../../c-level-advisor/ceo-advisor/SKILL.md](../../c-level-advisor/ceo-advisor/SKILL.md)
+- **Skill Documentation:** [../../c-level-advisor/skills/ceo-advisor/SKILL.md](../../c-level-advisor/skills/ceo-advisor/SKILL.md)
 - **C-Level Domain Guide:** [../../c-level-advisor/CLAUDE.md](../../c-level-advisor/CLAUDE.md)
 - **Agent Development Guide:** [../CLAUDE.md](../CLAUDE.md)
 

--- a/agents/c-level/cs-cto-advisor.md
+++ b/agents/c-level/cs-cto-advisor.md
@@ -1,7 +1,7 @@
 ---
 name: cs-cto-advisor
 description: Technical leadership advisor for CTOs covering technology strategy, team scaling, architecture decisions, and engineering excellence
-skills: c-level-advisor/cto-advisor
+skills: c-level-advisor/skills/cto-advisor
 domain: c-level
 model: opus
 tools: [Read, Write, Bash, Grep, Glob]
@@ -19,38 +19,38 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
 
 ## Skill Integration
 
-**Skill Location:** `../../c-level-advisor/cto-advisor/`
+**Skill Location:** `../../c-level-advisor/skills/cto-advisor/`
 
 ### Python Tools
 
 1. **Tech Debt Analyzer**
    - **Purpose:** Analyzes system architecture, identifies technical debt, and provides prioritized reduction plan
-   - **Path:** `../../c-level-advisor/cto-advisor/scripts/tech_debt_analyzer.py`
-   - **Usage:** `python ../../c-level-advisor/cto-advisor/scripts/tech_debt_analyzer.py`
+   - **Path:** `../../c-level-advisor/skills/cto-advisor/scripts/tech_debt_analyzer.py`
+   - **Usage:** `python ../../c-level-advisor/skills/cto-advisor/scripts/tech_debt_analyzer.py`
    - **Features:** Debt categorization (critical/high/medium/low), capacity allocation recommendations, remediation roadmap
    - **Use Cases:** Quarterly planning, architecture reviews, resource allocation, legacy system assessment
 
 2. **Team Scaling Calculator**
    - **Purpose:** Calculates optimal hiring plan and team structure based on growth projections and engineering ratios
-   - **Path:** `../../c-level-advisor/cto-advisor/scripts/team_scaling_calculator.py`
-   - **Usage:** `python ../../c-level-advisor/cto-advisor/scripts/team_scaling_calculator.py`
+   - **Path:** `../../c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py`
+   - **Usage:** `python ../../c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py`
    - **Features:** Team size modeling, ratio optimization (manager:engineer, senior:mid:junior), capacity planning
    - **Use Cases:** Annual planning, rapid growth scaling, team reorg, hiring roadmap development
 
 ### Knowledge Bases
 
 1. **Architecture Decision Records (ADR)**
-   - **Location:** `../../c-level-advisor/cto-advisor/references/architecture_decision_records.md`
+   - **Location:** `../../c-level-advisor/skills/cto-advisor/references/architecture_decision_records.md`
    - **Content:** ADR templates, examples, decision-making frameworks, architectural patterns
    - **Use Case:** Technology selection, architecture changes, documenting technical decisions, stakeholder alignment
 
 2. **Engineering Metrics**
-   - **Location:** `../../c-level-advisor/cto-advisor/references/engineering_metrics.md`
+   - **Location:** `../../c-level-advisor/skills/cto-advisor/references/engineering_metrics.md`
    - **Content:** DORA metrics implementation, quality metrics (test coverage, code review), team health indicators
    - **Use Case:** Performance measurement, continuous improvement, board reporting, benchmarking
 
 3. **Technology Evaluation Framework**
-   - **Location:** `../../c-level-advisor/cto-advisor/references/technology_evaluation_framework.md`
+   - **Location:** `../../c-level-advisor/skills/cto-advisor/references/technology_evaluation_framework.md`
    - **Content:** Vendor selection criteria, build vs buy analysis, technology assessment templates
    - **Use Case:** Technology stack decisions, vendor evaluation, platform selection, procurement
 
@@ -63,7 +63,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
 **Steps:**
 1. **Run Debt Analysis** - Identify and categorize technical debt across systems
    ```bash
-   python ../../c-level-advisor/cto-advisor/scripts/tech_debt_analyzer.py
+   python ../../c-level-advisor/skills/cto-advisor/scripts/tech_debt_analyzer.py
    ```
 2. **Categorize Debt** - Sort debt by severity:
    - **Critical**: System failure risk, blocking new features
@@ -78,7 +78,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
 4. **Create Remediation Roadmap** - Prioritize debt items by business impact
 5. **Reference Architecture Frameworks** - Document decisions using ADR template
    ```bash
-   cat ../../c-level-advisor/cto-advisor/references/architecture_decision_records.md
+   cat ../../c-level-advisor/skills/cto-advisor/references/architecture_decision_records.md
    ```
 6. **Communicate Plan** - Present to executive team and engineering org
 
@@ -98,7 +98,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
    - Key skill gaps
 2. **Run Scaling Calculator** - Model team growth scenarios
    ```bash
-   python ../../c-level-advisor/cto-advisor/scripts/team_scaling_calculator.py
+   python ../../c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
    ```
 3. **Optimize Ratios** - Maintain healthy team structure:
    - Manager:Engineer = 1:8 (avoid too many managers)
@@ -107,7 +107,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
    - QA:Engineering = 1.5:10 (quality coverage)
 4. **Reference Engineering Metrics** - Ensure team health indicators support scaling
    ```bash
-   cat ../../c-level-advisor/cto-advisor/references/engineering_metrics.md
+   cat ../../c-level-advisor/skills/cto-advisor/references/engineering_metrics.md
    ```
 5. **Create Hiring Roadmap**:
    - Q1-Q4 hiring targets by role
@@ -133,7 +133,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
    - Timeline considerations
 2. **Reference Evaluation Framework** - Use systematic assessment criteria
    ```bash
-   cat ../../c-level-advisor/cto-advisor/references/technology_evaluation_framework.md
+   cat ../../c-level-advisor/skills/cto-advisor/references/technology_evaluation_framework.md
    ```
 3. **Market Research** (Weeks 1-2):
    - Identify vendor options (3-5 candidates)
@@ -148,7 +148,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
    - Cost modeling (TCO over 3 years)
 5. **Document Decision** - Create ADR for transparency
    ```bash
-   cat ../../c-level-advisor/cto-advisor/references/architecture_decision_records.md
+   cat ../../c-level-advisor/skills/cto-advisor/references/architecture_decision_records.md
    # Use template to document:
    # - Context and problem statement
    # - Options considered (with pros/cons)
@@ -165,7 +165,7 @@ The cs-cto-advisor agent bridges the gap between technical vision and operationa
 **Example:**
 ```bash
 # Complete technology evaluation workflow
-cat ../../c-level-advisor/cto-advisor/references/technology_evaluation_framework.md > evaluation-criteria.txt
+cat ../../c-level-advisor/skills/cto-advisor/references/technology_evaluation_framework.md > evaluation-criteria.txt
 # Create comparison spreadsheet using criteria
 # Document final decision in ADR format
 ```
@@ -177,7 +177,7 @@ cat ../../c-level-advisor/cto-advisor/references/technology_evaluation_framework
 **Steps:**
 1. **Reference Metrics Framework** - Study industry standards
    ```bash
-   cat ../../c-level-advisor/cto-advisor/references/engineering_metrics.md
+   cat ../../c-level-advisor/skills/cto-advisor/references/engineering_metrics.md
    ```
 2. **Select Metrics Categories**:
    - **DORA Metrics** (industry standard for DevOps performance):
@@ -236,12 +236,12 @@ echo "=========================================================="
 # Technical debt assessment
 echo ""
 echo "⚠️ Technical Debt Status:"
-python ../../c-level-advisor/cto-advisor/scripts/tech_debt_analyzer.py
+python ../../c-level-advisor/skills/cto-advisor/scripts/tech_debt_analyzer.py
 
 # Team scaling status
 echo ""
 echo "👥 Team Scaling & Capacity:"
-python ../../c-level-advisor/cto-advisor/scripts/team_scaling_calculator.py
+python ../../c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
 
 # Engineering metrics
 echo ""
@@ -264,7 +264,7 @@ case $DAY_OF_WEEK in
     echo ""
     echo "🏗️ Tuesday: Architecture & Technical"
     echo "- Architecture review"
-    cat ../../c-level-advisor/cto-advisor/references/architecture_decision_records.md | grep -A 5 "Template"
+    cat ../../c-level-advisor/skills/cto-advisor/references/architecture_decision_records.md | grep -A 5 "Template"
     ;;
   Friday)
     echo ""
@@ -286,24 +286,24 @@ echo "================================================================"
 # Technical debt assessment
 echo ""
 echo "1. Technical Debt Assessment:"
-python ../../c-level-advisor/cto-advisor/scripts/tech_debt_analyzer.py > q$(date +%q)-debt-report.txt
+python ../../c-level-advisor/skills/cto-advisor/scripts/tech_debt_analyzer.py > q$(date +%q)-debt-report.txt
 cat q$(date +%q)-debt-report.txt
 
 # Team scaling analysis
 echo ""
 echo "2. Team Scaling & Organization:"
-python ../../c-level-advisor/cto-advisor/scripts/team_scaling_calculator.py > q$(date +%q)-team-scaling.txt
+python ../../c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py > q$(date +%q)-team-scaling.txt
 cat q$(date +%q)-team-scaling.txt
 
 # Engineering metrics review
 echo ""
 echo "3. Engineering Metrics Review:"
-cat ../../c-level-advisor/cto-advisor/references/engineering_metrics.md
+cat ../../c-level-advisor/skills/cto-advisor/references/engineering_metrics.md
 
 # Technology evaluation status
 echo ""
 echo "4. Technology Evaluation Framework:"
-cat ../../c-level-advisor/cto-advisor/references/technology_evaluation_framework.md
+cat ../../c-level-advisor/skills/cto-advisor/references/technology_evaluation_framework.md
 
 # Board package reminder
 echo ""
@@ -400,7 +400,7 @@ echo "- Process improvements identified"
 
 ## References
 
-- **Skill Documentation:** [../../c-level-advisor/cto-advisor/SKILL.md](../../c-level-advisor/cto-advisor/SKILL.md)
+- **Skill Documentation:** [../../c-level-advisor/skills/cto-advisor/SKILL.md](../../c-level-advisor/skills/cto-advisor/SKILL.md)
 - **C-Level Domain Guide:** [../../c-level-advisor/CLAUDE.md](../../c-level-advisor/CLAUDE.md)
 - **Agent Development Guide:** [../CLAUDE.md](../CLAUDE.md)
 

--- a/c-level-advisor/c-level-agents/references/persona-voices.md
+++ b/c-level-advisor/c-level-agents/references/persona-voices.md
@@ -16,6 +16,18 @@ Closing handoff (1 sentence) — character-stamped decision frame
 
 ## Per-Role Specs
 
+### cs-ceo-advisor — The Strategic Translator
+- **Opening:** "What's the strategic question we're actually answering?"
+- **Forcing questions:** "Where are we versus the 3-year vision? What does the board need to hear? What's the capital-allocation tradeoff?"
+- **Closing:** "The CEO's job is to answer hard questions clearly. Pick the call."
+- **Signature moves:** Tree-of-thought reasoning. Pushes for explicit strategic options (not just one path). Always asks about board narrative + investor framing. Refuses to debate tactics until the strategic question is named.
+
+### cs-cto-advisor — The Architecture-First Pragmatist
+- **Opening:** "What's the architecture decision driving this conversation?"
+- **Forcing questions:** "What's the scaling cliff? Is this a build or buy? What's the tech debt cost in 12 months?"
+- **Closing:** "CTOs are translators between business and technical. Pick the architecture that matches the business horizon, not the engineer's enthusiasm."
+- **Signature moves:** ReAct reasoning (observe → reason → act). Always names the scaling cliff explicitly. Treats every architecture decision as a 3-year commitment. Refuses to defer build-vs-buy to "we'll see."
+
 ### cs-cfo-advisor — The Numerate Skeptic
 - **Opening:** "Before anything else, let's see the math."
 - **Forcing questions:** "What's the burn multiple? If fundraising takes 6 months instead of 3, do you survive? Where's the unit economics line going?"
@@ -64,6 +76,12 @@ Closing handoff (1 sentence) — character-stamped decision frame
 - **Closing:** "Decision logged. Here's the next checkpoint."
 - **Signature moves:** Identifies cross-functional questions and triggers `/cs:boardroom`. Logs every decision to two-layer memory. Surfaces stale decisions for review.
 
+### cs-general-counsel-advisor — The Risk-Paranoid Lawyer (Not Your Lawyer)
+- **Opening:** "Before we sign, three things need to be settled in writing."
+- **Forcing questions:** "Who owns the IP? What's the liability cap? Is there a DPA?"
+- **Closing:** "Bring this to outside counsel — I've surfaced the questions, not the answers."
+- **Signature moves:** Distrusts handshakes and "we'll figure it out later." Surfaces the 3 clauses that quietly transfer 5% of equity. Never substitutes for licensed counsel — always escalates.
+
 ### cs-cdo-advisor — The Decision-Driven Data Realist
 - **Opening:** "What decision does this data drive?"
 - **Forcing questions:** "Who consumes this internally? What's the consent provenance? Can the model be retrained without it?"
@@ -94,5 +112,5 @@ Voice should feel like a **bookend**, not a costume. If the analysis itself star
 
 ---
 
-**Last Updated:** 2026-05-12
+**Last Updated:** 2026-05-13
 **Status:** Reference for agent authors


### PR DESCRIPTION
## Summary

Pure-cleanup PR addressing two carry-over items deferred across PRs #618-#626 per karpathy principle #3 (surgical scope — no unrelated cleanups inside scoped feature PRs):

1. **3 missing voice specs** in `c-level-advisor/c-level-agents/references/persona-voices.md`
2. **57 broken paths** in pre-existing `cs-ceo-advisor.md` and `cs-cto-advisor.md`

## Voice Specs Added

All three cs-* agents existed but were never added to the persona reference:

- **`cs-ceo-advisor` — The Strategic Translator** (tree-of-thought reasoning; refuses to debate tactics until the strategic question is named)
- **`cs-cto-advisor` — The Architecture-First Pragmatist** (ReAct reasoning; treats every architecture decision as a 3-year commitment)
- **`cs-general-counsel-advisor` — The Risk-Paranoid Lawyer (Not Your Lawyer)** — carry-over from v2.5.1

The voice catalog now matches the cs-* agent set 1:1.

## Path Fixes

Pre-existing agent files referenced the wrong skill path:

- `agents/c-level/cs-ceo-advisor.md`: **32 corrections** — `../../c-level-advisor/ceo-advisor/` → `../../c-level-advisor/skills/ceo-advisor/`
- `agents/c-level/cs-cto-advisor.md`: **25 corrections** — `../../c-level-advisor/cto-advisor/` → `../../c-level-advisor/skills/cto-advisor/`
- YAML `skills:` frontmatter field also corrected in both

The bundled skills live under `c-level-advisor/skills/<role>/`, not directly under `c-level-advisor/`. The agent paths now resolve correctly.

## Validation

- ✅ `karpathy-coder/diff_surgeon`: **0 findings** on staged diff
- ✅ Verified target folders exist (`c-level-advisor/skills/ceo-advisor/SKILL.md` + `c-level-advisor/skills/cto-advisor/SKILL.md`)
- ✅ Per-file path counts confirm 0 broken paths remaining

## Changed (4 files, +102 / -58)

| File | Change |
|---|---|
| `c-level-advisor/c-level-agents/references/persona-voices.md` | 13 voice specs (was 10; +3 cs-ceo / cs-cto / cs-gc) |
| `agents/c-level/cs-ceo-advisor.md` | 32 path corrections + YAML frontmatter |
| `agents/c-level/cs-cto-advisor.md` | 25 path corrections + YAML frontmatter |
| `CHANGELOG.md` | v2.5.6 entry |

## No version bumps

This is a pure-fix PR. No skill/agent/command count changes; no plugin.json or marketplace.json edits. CHANGELOG marked as v2.5.6 to record the cleanup.

## Test plan

- [x] `karpathy diff_surgeon`: 0 findings
- [x] Path verification: 32 fixes in cs-ceo, 25 fixes in cs-cto, 0 broken remaining
- [x] Voice specs match the agent files in `c-level-advisor/c-level-agents/agents/`
- [ ] CI: `Lint, Tests, Docs, Security` passes
- [ ] CI: `claude-review` passes

## Session arc complete

This closes the founder-mode lineup expansion:

| PR | Skill | Version |
|---|---|---|
| #618 | c-level-agents plugin | v2.5.0 |
| #619 | general-counsel-advisor | v2.5.1 |
| #620 | chief-data-officer-advisor | v2.5.2 |
| #621 | chief-ai-officer-advisor | v2.5.3 |
| #624 | dual-publish wrappers | — |
| #625 | chief-customer-officer-advisor | v2.5.4 |
| #626 | vpe-advisor | v2.5.5 |
| **this PR** | **voice + paths cleanup** | **v2.5.6** |

5 new C-roles, 13 cs-* persona agents, 21 /cs:* commands, 6 standalone marketplace plugins added, all built with karpathy-coder discipline (5 consecutive feature PRs with `complexity_checker` + `diff_surgeon` 0/0).

https://claude.ai/code/session_012WtZMm5NJHqkYoRqA9fHMN

---
_Generated by [Claude Code](https://claude.ai/code/session_012WtZMm5NJHqkYoRqA9fHMN)_