### PR TITLE
release: v2.5.7 hotfix 2 — recover 79 dropped sub-skill pages

### DIFF
--- a/docs/skills/c-level-advisor/c-level-agents-boardroom.md
+++ b/docs/skills/c-level-advisor/c-level-agents-boardroom.md
@@ -1,0 +1,145 @@
+---
+title: "/cs:boardroom — Multi-Role Boardroom Deliberation — Agent Skill for Executives"
+description: "/cs:boardroom <brief> — 6-phase multi-role deliberation across the C-suite with Phase 2 isolation, critic pre-screen, and synthesis. Outputs a board. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:boardroom — Multi-Role Boardroom Deliberation
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `boardroom`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/boardroom/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:boardroom <brief-path>`
+
+Runs the `board-meeting` skill protocol across the C-suite for a single strategy brief. This is the **heart of the plugin** — the multi-role deliberation that gstack's review chain only approximates.
+
+## Pipeline Position
+
+```
+/cs:office-hours  →  /cs:brief  →  /cs:boardroom  →  /cs:decide  →  /cs:execute  →  /cs:post-mortem
+                                     ↑ you are here
+```
+
+## The 6 Phases (from board-meeting skill)
+
+### Phase 1 — Briefing
+- Chief of Staff distributes the brief to all advisors marked in **Affected Roles**.
+- Each advisor reads company-context.md + the brief.
+- No discussion yet.
+
+### Phase 2 — Independent Thinking (ISOLATION)
+- **Critical:** each advisor produces their position **independently**, without seeing others' positions.
+- This prevents groupthink and surfaces dissent.
+- Each writes: their voice's opening, recommendation, top 3 concerns, top 3 supports.
+
+### Phase 3 — Cross-Examination
+- Positions revealed simultaneously.
+- Each advisor critiques the others' positions on the dimensions they own:
+  - cs-cfo-advisor critiques the math
+  - cs-ciso-advisor critiques the risk
+  - cs-cpo-advisor critiques the JTBD
+  - cs-cmo-advisor critiques the positioning
+  - cs-cro-advisor critiques the revenue math
+  - etc.
+
+### Phase 4 — Devil's Advocate Pass
+- `executive-mentor/devils-advocate` agent runs `/em:challenge` on the leading option.
+- Surfaces three concerns with severity ratings.
+
+### Phase 5 — Synthesis
+- Chief of Staff synthesizes: which option commands majority, what are unresolved dissents.
+- Produces the **board memo** with recommendation + dissent.
+
+### Phase 6 — Decision Hand-off
+- Memo is presented to the founder.
+- Founder accepts, modifies, or rejects.
+- Approved memo routes to `/cs:decide` for logging.
+
+## Output: Board Memo
+
+Saved to `~/.claude/boardroom/YYYY-MM-DD-<slug>.md`:
+
+```markdown
+# Board Memo: <topic>
+**Date:** YYYY-MM-DD
+**Brief:** <link to /cs:brief file>
+**Status:** AWAITING FOUNDER DECISION | APPROVED | REJECTED
+
+## Question
+[One sentence from the brief]
+
+## Recommended Option
+**<Option name>** — chosen because <synthesis reasoning>
+
+## Vote Tally
+| Advisor | Vote | One-Sentence Reason |
+|---|---|---|
+| cs-ceo-advisor | A | <reason> |
+| cs-cfo-advisor | A | <reason> |
+| cs-cto-advisor | B | <reason> |
+| ... | | |
+
+## Dissent
+- **<dissenter>:** <unresolved concern>
+
+## Devil's Advocate Concerns
+1. **CRITICAL** — <concern> — Mitigation: <plan>
+2. **HIGH** — <concern> — Mitigation: <plan>
+3. **MEDIUM** — <concern> — Mitigation: <plan>
+
+## Success & Kill Criteria
+[Copied from brief, refined by the panel]
+
+## Recommended Decision Path
+- `/cs:decide` → log the decision
+- `/cs:execute` → 90-day plan
+- `/cs:cross-eval` → multi-model sanity check (optional, high-stakes)
+- `/cs:freeze N` → cooldown lock (optional, irreversible)
+```
+
+## Why Phase 2 Isolation Matters
+
+If advisors see each other's positions before forming their own, they anchor. Phase 2 isolation is the single highest-leverage practice in the board-meeting protocol — it surfaces the dissents that sycophancy would have suppressed.
+
+## Why This Beats gstack's Review Chain
+
+| | gstack `/autoplan` | `/cs:boardroom` |
+|---|---|---|
+| Roles | CEO → design → eng (3) | Up to 10 C-roles |
+| Order | Sequential | Phase 2 isolation, then simultaneous |
+| Dissent capture | Implicit | Explicit dissent column |
+| Adversarial pass | No | Phase 4 devil's advocate |
+| Output | Reviewed plan | Voted memo with dissent + kill criteria |
+
+## Workflow
+
+1. Read brief from `~/.claude/briefs/<file>`
+2. Identify affected roles
+3. Invoke each cs-* advisor independently (Phase 2)
+4. Collect positions
+5. Run cross-examination round (Phase 3)
+6. Run `/em:challenge` on leading option (Phase 4)
+7. Synthesize memo (Phase 5)
+8. Hand off to founder (Phase 6)
+
+## Routing
+
+- `/cs:decide` — log approved memo
+- `/cs:cross-eval` — high-stakes second opinion
+- `/cs:freeze` — cooldown lock
+
+## Related
+
+- Agent: [`cs-chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-chief-of-staff.md)
+- Skills: [`board-meeting`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/board-meeting/SKILL.md), [`executive-mentor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-brief.md
+++ b/docs/skills/c-level-advisor/c-level-agents-brief.md
@@ -1,0 +1,124 @@
+---
+title: "/cs:brief — One-Page Strategy Brief — Agent Skill for Executives"
+description: "/cs:brief <topic> — Generate a one-page strategy brief from an office-hours intake. First step in the strategic sprint pipeline. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:brief — One-Page Strategy Brief
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `brief`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/brief/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:brief <topic>` or `/cs:brief <office-hours-output>`
+
+Turns intake (raw question or office-hours output) into a one-page strategy brief that the boardroom can deliberate on. This is **Step 1** of the strategic sprint pipeline.
+
+## Pipeline Position
+
+```
+/cs:office-hours  →  /cs:brief  →  /cs:boardroom  →  /cs:decide  →  /cs:execute  →  /cs:post-mortem
+                       ↑ you are here
+```
+
+## Inputs
+
+- A topic string, **or**
+- An office-hours brief (preferred — more rigor)
+- `~/.claude/company-context.md` (loaded automatically)
+
+## Output
+
+A single Markdown file under `~/.claude/briefs/YYYY-MM-DD-<slug>.md` with this structure:
+
+```markdown
+# Strategy Brief: <topic>
+**Date:** YYYY-MM-DD
+**Author:** cs-chief-of-staff
+**Status:** DRAFT | UNDER REVIEW | APPROVED | RETIRED
+
+## Context
+[1-2 paragraphs: where the company sits today on this topic — pulled from company-context.md]
+
+## Question
+[The one sentence question the boardroom must answer]
+
+## Options
+1. **Option A:** <name> — <one-sentence summary>
+2. **Option B:** <name> — <one-sentence summary>
+3. **Option C:** <name> — <one-sentence summary>
+
+(Minimum 2 options. "Do nothing" is always an option.)
+
+## Assumptions
+- <assumption 1 — explicit>
+- <assumption 2>
+- <assumption 3>
+
+## Constraints
+- Time: <by when must this decide>
+- Money: <budget envelope>
+- People: <who can / can't be reallocated>
+- Reversibility: <one-way door | two-way door>
+
+## Affected Roles
+[Which cs-* advisors should weigh in. Used to route to /cs:boardroom panel composition.]
+
+- [ ] cs-ceo-advisor
+- [ ] cs-cfo-advisor
+- [ ] cs-cto-advisor
+- [ ] cs-cmo-advisor
+- [ ] cs-cro-advisor
+- [ ] cs-cpo-advisor
+- [ ] cs-coo-advisor
+- [ ] cs-chro-advisor
+- [ ] cs-ciso-advisor
+- [ ] cs-chief-of-staff
+
+## Success Criteria
+[Measurable outcomes that define success — set BEFORE the decision]
+- <metric 1, threshold, timeframe>
+- <metric 2, threshold, timeframe>
+
+## Kill Criteria
+[What signal would tell you in 90 days that this was the wrong call]
+- <metric, threshold, action if missed>
+```
+
+## Workflow
+
+1. Load company-context.md via context-engine
+2. If input is office-hours output, parse the 6 answers
+3. If input is a raw topic, prompt the founder for the missing pieces
+4. Draft 2-3 options (never just one — every brief needs a counterfactual)
+5. Make assumptions and constraints explicit
+6. Identify affected roles → drives panel composition for `/cs:boardroom`
+7. Write success + kill criteria BEFORE the decision (this is the rigor moment)
+8. Save to `~/.claude/briefs/`
+
+## Why This Step Exists
+
+The biggest decision-making failure is debating implementation before agreeing on the question. The brief locks the question, options, and success criteria so the boardroom can deliberate without scope creep.
+
+This is also the **artifact handoff** — the next command consumes this file, not your memory.
+
+## Routing
+
+- `/cs:boardroom <brief>` — multi-role deliberation
+- `/cs:cross-eval <brief>` — multi-model sanity check before boardroom (for high-stakes)
+- `/cs:freeze <brief>` — cooldown lock for irreversible decisions
+
+## Related
+
+- Agent: [`cs-chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-chief-of-staff.md)
+- Skills: [`context-engine`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/context-engine/SKILL.md), [`board-meeting`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/board-meeting/SKILL.md)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-caio-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-caio-review.md
@@ -1,0 +1,151 @@
+---
+title: "/cs:caio-review — CAIO Forcing Questions — Agent Skill for Executives"
+description: "/cs:caio-review <plan> — Eval-demanding Chief AI Officer interrogation of any plan that involves AI: model selection, risk classification, cost. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:caio-review — CAIO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `caio-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/caio-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:caio-review <plan>`
+
+The eval-demanding CAIO pressure-tests any plan that involves AI. Six questions before any AI feature ships, any multi-year vendor commitment, or any AI team expansion.
+
+## When to Run
+
+- Before shipping any new AI-powered feature
+- Before signing a multi-year AI vendor contract (API or self-hosted infra)
+- Before EU launch of any AI feature
+- Before a major AI team hire (especially ML engineer or research scientist)
+- Before a fine-tuning project commitment
+- Before adopting AI in a regulated domain (employment, credit, healthcare, education, etc.)
+- When the founder uses the word "AI" near "competitive advantage" or "moat"
+
+## The Six CAIO Questions
+
+### 1. What does this AI need to be good at, and how would you measure it?
+**No eval set = no ship.** Before any AI feature deploys, define the eval criteria.
+- 50-100 representative inputs minimum
+- Expected outputs OR rubric for grading
+- Edge cases: ambiguous, adversarial, format-edge
+- If you can't write down what "good" looks like, you don't have a feature; you have a vibe.
+
+### 2. What's the SLO on hallucination / error rate, and what's the fallback?
+**Every AI feature has a failure mode. Plan for it.**
+- Quantified SLO: "<5% hallucination on factual queries"
+- Detection mechanism: monitoring, sampling, customer feedback loop
+- Fallback: human-in-loop review, lower-risk default response, refuse-to-answer
+- Blast radius if SLO breached: how many users affected, what is the cost?
+
+### 3. What's the risk tier under EU AI Act, and is conformity assessment required?
+**Run `ai_risk_classifier.py` if any EU residents are affected OR domain is regulated.**
+- PROHIBITED → cannot launch in EU; re-scope
+- HIGH → conformity assessment + EU DB registration + 10 Articles of obligations (3-12 months, $50-200K)
+- LIMITED → transparency obligations (chatbot disclosure, AI-generated content marking)
+- MINIMAL → no specific obligations; NIST AI RMF voluntary
+
+### 4. API, fine-tune, or build?
+**Run `model_buildvsbuy_calculator.py` for the specific use case.**
+- 80% of B2B SaaS use cases: API
+- 15%: fine-tune (when domain-specific behavior + labeled data + ML team + high volume)
+- <1%: build from scratch
+- Decision must consider economic breakeven AND practical feasibility (data, team, compliance)
+
+### 5. What's the 12-month cost trajectory at expected scale?
+**Run `ai_cost_economics.py` for the workload.**
+- API: variable, scales linearly
+- Self-hosted: mostly fixed, breakeven typically 1-10B tokens/month for 70B-class
+- Hidden costs of self-hosted: ops, monitoring, model updates, capacity, failover, security
+- Hidden costs of API: vendor lock-in, capability drift, rate limits, data residency
+- Prompt caching is the most underrated lever; check provider support
+
+### 6. What role unblocks this — and have we hired prerequisites first?
+**Map AI capability to specific role. Founders confuse AI engineer / ML engineer / research scientist.**
+- AI engineer: applied + full-stack + prompts + evals + deployment (most startups need this)
+- ML engineer: fine-tuning + retraining infra (only after platform engineer + labeled data)
+- Research scientist: model invention (only if model IS the product)
+- Don't hire research scientist as first AI hire — they need infrastructure to be productive
+
+## Workflow
+
+```bash
+# 1. Model selection check
+python ../../../skills/chief-ai-officer-advisor/scripts/model_buildvsbuy_calculator.py use_case.json
+
+# 2. Regulatory classification
+python ../../../skills/chief-ai-officer-advisor/scripts/ai_risk_classifier.py use_case.json
+
+# 3. Cost projection
+python ../../../skills/chief-ai-officer-advisor/scripts/ai_cost_economics.py workload.json
+```
+
+## Output Format
+
+```markdown
+# CAIO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## The Decision Being Made
+[one sentence — which CAIO decision: model selection | risk classification | economics | next hire]
+
+## Eval Discipline
+- Eval set committed: yes/no
+- SLO defined: <metric> < <threshold>
+- Fallback behavior: <one line>
+
+## Model Selection (if applicable)
+- Recommended: API / FINE_TUNE / BUILD
+- 3-year TCO: $X (chosen path) vs $Y (alternatives)
+- Breakeven: <volume>
+
+## Risk Classification (if applicable)
+- EU AI Act tier: PROHIBITED / HIGH / LIMITED / MINIMAL
+- Conformity assessment required: yes/no
+- US state triggers: [list]
+- Required controls open: N
+
+## Cost Economics (if applicable)
+- Monthly cost at current volume: $X
+- Breakeven for self-hosted migration: <volume>
+- Migration cost if applicable: $X (3-6 months)
+
+## Org (if applicable)
+- Next hire: <role>
+- Why this, not the alternative: <one line>
+- Prerequisite hires in place: yes/no
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 BLOCK
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:cdo-review` — for any training-data implications
+- `/cs:gc-review` — for AI vendor contracts, output liability, training-data licensing
+- `/cs:ciso-review` — for prompt injection / jailbreak / training-data poisoning threat model
+- `/cs:cfo-review` — for multi-year vendor or GPU commitment TCO
+- `/cs:chro-review` — for AI team hires (comp, ladder, leveling)
+- `/cs:decide` — log the verdict
+- `/cs:freeze 60` — on multi-year AI commitments
+
+## Related
+
+- Agent: [`cs-caio-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-caio-advisor.md)
+- Skill: [`chief-ai-officer-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/chief-ai-officer-advisor/SKILL.md)
+- Adjacent: [`skills/chief-data-officer-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/chief-data-officer-advisor) (training data rights, data strategy)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cco-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cco-review.md
@@ -1,0 +1,141 @@
+---
+title: "/cs:cco-review — CCO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cco-review <plan> — Retention-obsessed Chief Customer Officer interrogation of any plan that touches customer retention, segmentation, CS team. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cco-review — CCO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cco-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cco-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cco-review <plan>`
+
+The retention-obsessed CCO pressure-tests any plan that touches customer experience. Six questions before any retention claim, segmentation change, CS team expansion, or major CS hire.
+
+## When to Run
+
+- Before any board narrative that includes a retention number
+- Before approving a CS team headcount expansion
+- Before re-segmenting the customer base or changing tier definitions
+- Before launching a customer marketing or advocacy program
+- Before a major CS hire (CSM, AM, Implementation, Customer Marketing)
+- When NRR is "great" but churn complaints from CSMs are increasing
+- Before deciding whether to add an AM role separate from CSM
+
+## The Six CCO Questions
+
+### 1. What's the GROSS retention rate?
+**Not NRR. Gross.** NRR can hide a leaky bucket behind expansion.
+- GRR healthy ≥ 90% at growth stage, ≥ 95% at scale
+- If GRR < 85% but NRR > 100%, the product is failing for 15%+ of customers; expansion is masking the failure
+- Run `retention_decomposition_analyzer.py`
+
+### 2. What's the #1 reason customers leave?
+**If you can't name it, you don't understand churn.**
+- 7-category taxonomy: product_fit / competitor_loss / no_value_realized / pricing / champion_left / company_event / tactical_failure
+- Preventable churn = product_fit + no_value_realized + tactical_failure
+- If preventable > 50%, CS has clear leverage; if < 30%, churn is structural (ICP, market, competition)
+
+### 3. What's the median time-to-value (TTV) by segment?
+**Long TTV signals different problems by segment.**
+- Long TTV in low tier = ICP misfit; downgrade or kill
+- Long TTV in high tier = onboarding broken; fix the Implementation Manager handoff
+- TTV is a leading indicator of GRR
+
+### 4. Which customer would you fire today?
+**If "none" — your segmentation is broken.**
+- Some accounts cost more than they earn (support cost > 50% of ARR + low ICP fit)
+- Run `customer_segmentation_designer.py` to surface kill list
+- The 3 paths for kill candidates: non-renewal / downgrade-to-tech-touch / raise-price-to-cost-recover
+
+### 5. What's the ARR-per-CSM ratio, and is the model pooled or named?
+**Wrong model wastes capacity.**
+- Strategic: named + exec sponsor, $300K-$1M ARR/CSM
+- Enterprise: named, $500K-$2M
+- Mid-market: pooled, $2M-$5M
+- SMB: tech-touch, $5M+
+- Run `cs_coverage_calculator.py` to size the team
+
+### 6. Is CS in your comp plan, and how is it different from Sales comp?
+**Misalignment is the leading indicator of CS failure.**
+- CS comp: 70/30 base/variable typical
+- Variable: 50% gross retention + 30% net retention + 20% activity
+- Anti-pattern: comp CSMs on NPS — they game it
+- Anti-pattern: comp CSMs same as Sales — they sell instead of serve
+
+## Workflow
+
+```bash
+# 1. Retention decomposition (always start here)
+python ../../../skills/chief-customer-officer-advisor/scripts/retention_decomposition_analyzer.py cohorts.json
+
+# 2. Segmentation audit
+python ../../../skills/chief-customer-officer-advisor/scripts/customer_segmentation_designer.py customers.json
+
+# 3. Coverage sizing (if making CS team changes)
+python ../../../skills/chief-customer-officer-advisor/scripts/cs_coverage_calculator.py book.json
+```
+
+## Output Format
+
+```markdown
+# CCO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## The Decision Being Made
+[one sentence — retention | segmentation | coverage | next hire]
+
+## Retention (if applicable)
+- GRR: X% (vs vanity NRR of Y%)
+- Top churn driver: <category> at X% of churn
+- Preventable churn: X% (CS-controllable)
+- Leaky-bucket pattern? yes/no
+
+## Segmentation (if applicable)
+- Tier distribution: Strategic X / Enterprise X / Mid-market X / SMB X
+- Kill list size: N customers (X% of customers, Y% of ARR)
+- Upgrade candidates: N
+
+## Coverage (if applicable)
+- Current CSMs: N | Required now: M | Required 12mo: P
+- Annual cost (12mo): $X
+- Manager trigger fired: yes/no
+
+## Org (if applicable)
+- Next hire: <CSM | Support | AM | IM | CS Ops | Customer Marketing>
+- Why this, not the alternative: <one line>
+- Customer outcome unblocked: <specific>
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 BLOCK
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:cpo-review` — if churn root cause is product_fit or no_value_realized
+- `/cs:cro-review` — if expansion math or comp alignment is in question
+- `/cs:cfo-review` — for CS cost commitments and retention-impact-on-revenue
+- `/cs:chro-review` — for CS hires, comp, ladder
+- `/cs:decide` — log the verdict
+- `/cs:freeze 30` — on multi-year CS comp plan changes
+
+## Related
+
+- Agent: [`cs-cco-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-cco-advisor.md)
+- Skill: [`chief-customer-officer-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/chief-customer-officer-advisor/SKILL.md)
+- Adjacent: [`business-growth`](https://github.com/alirezarezvani/claude-skills/tree/main/business-growth) (tactical CS execution)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cdo-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cdo-review.md
@@ -1,0 +1,137 @@
+---
+title: "/cs:cdo-review — CDO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cdo-review <plan> — Decision-driven Chief Data Officer interrogation of any plan that touches training data, data architecture, data. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cdo-review — CDO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cdo-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cdo-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cdo-review <plan>`
+
+The decision-driven CDO pressure-tests any plan that touches data strategy. Six questions before any commitment to a data architecture, AI training run, data productization, or data team hire.
+
+## When to Run
+
+- Before approving any new ML model training run that uses customer data
+- Before signing a multi-year data-infrastructure SaaS contract (Snowflake, Databricks, Fivetran)
+- Before productizing any customer data (benchmark report, embedding endpoint, license)
+- Before a major data team hire (head of data, CDO, data PM, ML engineer)
+- Before M&A diligence — yours or theirs
+- When the founder uses the word "monetize" near "data"
+
+## The Six CDO Questions
+
+### 1. What decision does this data drive?
+**If no decision is unblocked, why are we collecting / training on / productizing it?**
+- "We might need it later" is not a decision.
+- "It feels like a moat" is not a decision.
+- A real answer names a specific business call that requires this data.
+
+### 2. What's the consent provenance for every source?
+**For each data source: origin, consent flow, data class, intended use.**
+- 1st-party-TOS-only is weaker than 1st-party-explicit-opt-in.
+- Bundled TOS doesn't cover material new purposes (training on PII for foundation models).
+- Run `ai_training_data_audit.py` if there's any AI use case in scope.
+
+### 3. Who consumes this internally — and how many distinct functional domains?
+**Drives the centralize-vs-embed and warehouse-vs-mesh decisions.**
+- <5 consumers: warehouse-only.
+- 5-25 consumers: lakehouse.
+- 25+ consumers + federated culture: mesh.
+- Premature architecture choice is the #1 cause of data-team burnout.
+
+### 4. What's the M&A diligence impact?
+**If an acquirer asks about this data corpus tomorrow, are we ready?**
+- Is there a documented anonymization process?
+- What % of customers have MSA carve-outs?
+- Are training-data provenance logs current?
+- Run `data_asset_valuator.py` quarterly.
+
+### 5. Can the model / decision / report be retrained / re-run / re-published without this source?
+**Tests how much you depend on a specific data source.**
+- If yes → low blast radius; you can change consent posture later.
+- If no → high blast radius; you've structurally committed to the source. Vet harder.
+
+### 6. What role unblocks this — and is it the right next hire?
+**Wrong hire (data scientist) when right answer (analytics engineer) is a 12-month productivity loss.**
+- Map the decision being unblocked to the specific role.
+- Confirm prerequisite roles are in place (data engineer before ML engineer, analyst before data scientist).
+
+## Workflow
+
+```bash
+# 1. AI training audit (if any ML / AI use case)
+python ../../../skills/chief-data-officer-advisor/scripts/ai_training_data_audit.py sources.json
+
+# 2. Architecture decision (if changing the stack)
+python ../../../skills/chief-data-officer-advisor/scripts/data_product_strategy_picker.py profile.json
+
+# 3. Data asset valuation (if productizing or pre-M&A)
+python ../../../skills/chief-data-officer-advisor/scripts/data_asset_valuator.py corpus.json
+```
+
+## Output Format
+
+```markdown
+# CDO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## The Decision Being Made
+[one sentence — which of the four CDO decisions: training | architecture | asset | hire]
+
+## Training Audit (if applicable)
+- NO-GO sources: N
+- MITIGATE sources: N
+- GO sources: N
+- Top remediation: <one line>
+
+## Architecture (if applicable)
+- Recommended: WAREHOUSE / LAKEHOUSE / MESH
+- Build-vs-buy summary: <one line>
+- Kill criteria: <when to revisit>
+
+## Asset Value (if applicable)
+- Strategic value: X/10 | Moat: STRONG / MEDIUM / WEAK
+- M&A multiplier: X.Xx – X.Xx ARR
+- Recommended productization path: <name>
+
+## Org (if applicable)
+- Next hire: <role>
+- Why this, not that: <one line>
+- Prerequisite hires in place: yes/no
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 BLOCK
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:gc-review` — for any productization or licensing path
+- `/cs:ciso-review` — for any architecture change touching customer data
+- `/cs:cfo-review` — for build-vs-buy TCO and M&A valuation math
+- `/cs:chro-review` — for data team hires (comp, ladder, leveling)
+- `/cs:decide` — log the verdict
+- `/cs:freeze 90` — on multi-year infrastructure contracts
+
+## Related
+
+- Agent: [`cs-cdo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-cdo-advisor.md)
+- Skill: [`chief-data-officer-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/chief-data-officer-advisor/SKILL.md)
+- Adjacent: [`skills/general-counsel-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/general-counsel-advisor) (contractual constraints), [`skills/cto-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cto-advisor) (architecture capacity)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cfo-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cfo-review.md
@@ -1,0 +1,116 @@
+---
+title: "/cs:cfo-review — CFO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cfo-review <plan> — Numerate-skeptic interrogation of any plan that touches money. Unit economics, runway, dilution, capital allocation. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cfo-review — CFO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cfo-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cfo-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cfo-review <plan>`
+
+The numerate skeptic stress-tests anything that touches money. Six questions before any spend or fundraise.
+
+## When to Run
+
+- Before approving any spend > 1% of revenue
+- Before opening a new hiring requisition
+- Before any fundraise conversation
+- Before changing pricing or unit economics
+- Before signing a multi-year contract
+
+## The Six CFO Questions
+
+### 1. Burn & Runway
+**What's the burn multiple and how many months of cash remain at base / bull / bear?**
+- Burn multiple = Net burn ÷ Net new ARR. Above 2x is a problem.
+- If bear case < 12 months, you're already in fundraising mode.
+
+### 2. Unit Economics
+**What is LTV / CAC per channel, and what's the payback period on the top-2 channels?**
+- LTV / CAC > 3x is healthy. Payback < 12 months is healthy.
+- If either is broken, do not scale that channel.
+
+### 3. Dilution Path
+**If this plan requires a raise, what's the dilution at base and bear valuations?**
+- Founder dilution per round.
+- Cumulative dilution to next 2 rounds.
+
+### 4. Capital Allocation Alternative
+**If this dollar wasn't spent here, where else could it go and what's the expected return?**
+- Three alternatives: hiring, product, marketing.
+- Make the opportunity cost explicit.
+
+### 5. Revenue Quality
+**What's the gross margin, and how does it trend at scale?**
+- If margin compresses with scale, the model is broken.
+- Cost-of-revenue should grow slower than revenue.
+
+### 6. Bear Case Survival
+**If revenue is 50% of plan, does the company survive 18 months?**
+- Default-alive is non-negotiable.
+- If not, identify the cut triggers in advance.
+
+## Workflow
+
+1. **Run the numbers:**
+   ```bash
+   python ../../../skills/cfo-advisor/scripts/burn_rate_calculator.py
+   python ../../../skills/cfo-advisor/scripts/unit_economics_analyzer.py
+   python ../../../skills/cfo-advisor/scripts/fundraising_model.py
+   ```
+2. **Answer all six questions** with numbers, not adjectives.
+3. **Apply the verdict:**
+   - 🟢 GREEN — fund it
+   - 🟡 YELLOW — fund with cut triggers
+   - 🔴 RED — kill or revise
+
+## Output Format
+
+```markdown
+# CFO Review: <plan>
+**Date:** YYYY-MM-DD
+**Reviewer:** cs-cfo-advisor
+
+## Numbers
+- Burn multiple: X.Xx
+- Runway (base/bull/bear): X / X / X months
+- LTV/CAC top channel: X.Xx, payback Y months
+- Gross margin: X% (trend: Y)
+- Dilution this round: X%
+- Bear-case survival: PASS / FAIL
+
+## Verdict
+🟢 GREEN | 🟡 YELLOW | 🔴 RED
+
+## Conditions (if YELLOW)
+- Cut trigger: <metric> < <threshold> → <action>
+- Review checkpoint: <date>
+
+## Recommendation
+[3 concrete next steps]
+```
+
+## Routing
+
+- `/cs:decide` — log the verdict
+- `/cs:execute` — build 90-day plan if GREEN
+- `/cs:boardroom` — escalate if multi-role implications
+
+## Related
+
+- Agent: [`cs-cfo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-cfo-advisor.md)
+- Skill: [`cfo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cfo-advisor/SKILL.md)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-ciso-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-ciso-review.md
@@ -1,0 +1,124 @@
+---
+title: "/cs:ciso-review — CISO Forcing Questions — Agent Skill for Executives"
+description: "/cs:ciso-review <plan> — Risk-paranoid interrogation of any plan that touches data, compliance, or production access. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:ciso-review — CISO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `ciso-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/ciso-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:ciso-review <plan>`
+
+The risk-paranoid threat-modeler. Six questions before any production change that touches customer data or compliance scope.
+
+## When to Run
+
+- Before deploying any system that touches PII / PHI / cardholder data
+- Before signing a new vendor with data access
+- Before a compliance audit (SOC 2, ISO 27001, HIPAA, GDPR)
+- Before any architecture decision crossing trust boundaries
+- After any near-miss incident
+
+## The Six CISO Questions
+
+### 1. Threat Model
+**What's the STRIDE threat model for this system, and which threat is most likely?**
+- Spoofing, Tampering, Repudiation, Info Disclosure, DoS, Elevation of Privilege.
+- Pick the top 3 by likelihood × impact.
+
+### 2. Blast Radius
+**If this is fully compromised, what data is exposed and how many users are affected?**
+- Worst case in plain English.
+- Quantify in dollars via FAIR-based ALE.
+
+### 3. Detection
+**What signals indicate compromise, and how long until they're triggered (MTTD)?**
+- Logs alone are not detection.
+- Define the detection rule, the alert, and the on-call.
+
+### 4. Response
+**Is there an IR runbook for this scenario, and has it been tabletop-tested?**
+- If no runbook: build one before ship.
+- If untested: tabletop before ship.
+
+### 5. Regulatory Window
+**What's the regulator notification window if this scenario occurs?**
+- GDPR: 72h. HIPAA: 60d. State breach laws vary.
+- Pre-write the customer comms template.
+
+### 6. Vendor & Supply Chain
+**Which third-party vendors are in scope, and what's their security posture?**
+- Subprocessor list current?
+- DPAs in place?
+- Last security review per vendor?
+
+## Workflow
+
+```bash
+python ../../../skills/ciso-advisor/scripts/risk_quantifier.py
+python ../../../skills/ciso-advisor/scripts/compliance_tracker.py
+```
+
+## Output Format
+
+```markdown
+# CISO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## Threat Model
+- Top threat: <STRIDE category> — <description>
+- Likelihood: H/M/L | Impact: H/M/L
+- ALE: $X / year
+
+## Blast Radius
+- Data exposed (worst case): <description>
+- Users affected: N
+- Estimated cost: $X
+
+## Detection
+- MTTD target: X hours
+- Current MTTD: X hours
+- Detection rule: <name>
+
+## Response
+- IR runbook: ✅ / ❌
+- Last tabletop: <date>
+
+## Regulatory
+- Frameworks in scope: SOC 2 / ISO 27001 / HIPAA / GDPR
+- Notification window: X hours/days
+
+## Vendors
+- New vendors added: N
+- DPAs signed: N / N
+- Security reviews complete: N / N
+
+## Verdict
+🟢 SHIP | 🟡 MITIGATE THEN SHIP | 🔴 BLOCK
+```
+
+## Routing
+
+- `/cs:cto-review` — architecture alignment
+- `/cs:gc-review` — DPA, regulatory implications
+- `/cs:decide` — log risk acceptance
+- `/cs:boardroom` — for CRITICAL risks
+
+## Related
+
+- Agent: [`cs-ciso-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-ciso-advisor.md)
+- Skill: [`ciso-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/ciso-advisor/SKILL.md)
+- Compliance: [`ra-qm-team`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cmo-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cmo-review.md
@@ -1,0 +1,112 @@
+---
+title: "/cs:cmo-review — CMO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cmo-review <plan> — Narrative-first interrogation of positioning, ICP, message house, and channel mix. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cmo-review — CMO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cmo-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cmo-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cmo-review <plan>`
+
+The narrative-first strategist pressure-tests positioning before debating tactics.
+
+## When to Run
+
+- Before launching any new campaign
+- Before changing positioning, tagline, or category
+- Before allocating > 10% of marketing budget to a new channel
+- Before a major PR moment (funding announcement, product launch)
+- When pipeline contribution is declining
+
+## The Six CMO Questions
+
+### 1. ICP (One Real Person)
+**Name one real person in your ICP. Company, title, what they do daily, what they hate.**
+- Persona ≠ ICP. ICP is real.
+- If you can't name one, the ICP isn't sharp enough.
+
+### 2. JTBD
+**What job is the customer hiring this product to do, and what's the alternative they use today?**
+- One sentence the customer would say out loud.
+- "We use spreadsheets" is a valid alternative. So is "we don't."
+
+### 3. Positioning Statement
+**One sentence: For [ICP], who needs [job], we are [category] that [differentiator] unlike [alternative].**
+- This is the headline. Everything cascades.
+- If it doesn't fit in one sentence, it's not positioning yet.
+
+### 4. Distribution Channel
+**Where does the customer first hear your name — and is it inbound or outbound at this stage?**
+- Name the channel, intent, and the path to first contact.
+- PLG, sales-led, content-led, partnership-led — pick a primary.
+
+### 5. CAC Payback
+**Per channel: what's CAC, what's payback in months, and is it improving?**
+- If a channel's payback is > 18 months, it isn't a channel — it's a hobby.
+
+### 6. Defensibility of Brand
+**If a well-funded competitor copies your messaging tomorrow, what's still yours?**
+- Category position, founder-market fit, customer love, distribution lock — name one.
+
+## Workflow
+
+1. **Run the models:**
+   ```bash
+   python ../../../skills/cmo-advisor/scripts/marketing_budget_modeler.py
+   python ../../../skills/cmo-advisor/scripts/growth_model_simulator.py
+   ```
+2. **Answer the six questions** in writing.
+3. **Apply the verdict:**
+   - 🟢 GREEN — story is sharp, channel mix sound
+   - 🟡 YELLOW — sharpen positioning before scaling
+   - 🔴 RED — positioning broken; do not spend
+
+## Output Format
+
+```markdown
+# CMO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## Positioning
+One-sentence statement: <here>
+
+## ICP
+- Named persona: <name, title, company>
+- JTBD: <one sentence in their words>
+
+## Channel Mix
+- Primary: <channel> | CAC $X | Payback Ym
+- Secondary: <channel> | CAC $X | Payback Ym
+
+## Verdict
+🟢 / 🟡 / 🔴
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:cro-review` — pipeline contribution check
+- `/cs:cpo-review` — product ↔ positioning alignment
+- `/cs:decide` — log the verdict
+
+## Related
+
+- Agent: [`cs-cmo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-cmo-advisor.md)
+- Skill: [`cmo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cmo-advisor/SKILL.md)
+- Execution domain: [`marketing-skill`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cpo-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cpo-review.md
@@ -1,0 +1,121 @@
+---
+title: "/cs:cpo-review — CPO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cpo-review <plan> — JTBD-driven interrogation of product roadmap, PMF signal, and portfolio focus. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cpo-review — CPO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cpo-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cpo-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cpo-review <plan>`
+
+The JTBD-driven builder cuts the roadmap in half. Six questions to surface what to ship and what to kill.
+
+## When to Run
+
+- Before quarterly roadmap commitment
+- Before launching a new product line
+- Before adding > 3 features to a release
+- When retention is flat or declining
+- When the team is debating "should we build X?"
+
+## The Six CPO Questions
+
+### 1. JTBD
+**What job is this feature hired to do, in the user's words?**
+- Not "improve onboarding." "Help a new ops manager get their first deal closed within 7 days."
+- Job ≠ feature. Hire ≠ try.
+
+### 2. North Star Metric
+**What user behavior does this move, and how does that ladder to the North Star?**
+- The metric must be leading, behavior-based, and value-correlated.
+- If you can't trace the feature to the North Star, don't build it.
+
+### 3. PMF Signal
+**What's the retention curve for users who hire this job — is it flat, decaying, or smiling?**
+- Flat or smiling = PMF signal. Decaying = no PMF.
+- "Users like it in surveys" is not a signal.
+
+### 4. RICE Score
+**Reach, Impact, Confidence, Effort — what's the score and where does this rank in the queue?**
+```bash
+python ../../../../product-team/product-manager-toolkit/scripts/rice_prioritizer.py
+```
+
+### 5. Opportunity Cost
+**What gets cut if this ships? Name the specific initiative or feature.**
+- Headcount and time are zero-sum. The cut list is the focus list.
+
+### 6. Kill Criteria
+**What signal would tell you in 90 days that this was the wrong bet?**
+- Define the metric and threshold in writing, before launch.
+- If you can't define a kill criterion, you can't ship responsibly.
+
+## Workflow
+
+1. **Run the analyses:**
+   ```bash
+   python ../../../skills/cpo-advisor/scripts/pmf_scorer.py
+   python ../../../skills/cpo-advisor/scripts/portfolio_analyzer.py
+   ```
+2. **Answer the six questions.**
+3. **Apply the verdict.**
+
+## Output Format
+
+```markdown
+# CPO Review: <feature/plan>
+**Date:** YYYY-MM-DD
+
+## JTBD
+> <one sentence in user voice>
+
+## North Star Link
+- Metric moved: <name>
+- Expected delta: <%>
+
+## PMF Signal
+- Retention curve shape: flat / smiling / decaying
+- Cohort sample size: N
+
+## Score
+- RICE: <number>
+- Rank in queue: #N of M
+
+## Cut List
+- Cut: <initiative>
+- Reason: <why this matters more>
+
+## Kill Criteria (90 days)
+- Metric: <name>
+- Threshold: <value>
+- Action if missed: <kill | iterate>
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 KILL
+```
+
+## Routing
+
+- `/cs:cmo-review` — does the positioning support this feature?
+- `/cs:execute` — build the 90-day plan
+- `/cs:post-mortem` — if kill criteria triggered
+
+## Related
+
+- Agent: [`cs-cpo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-cpo-advisor.md)
+- Skill: [`cpo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cpo-advisor/SKILL.md)
+- Execution: [`product-team/product-manager-toolkit`](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/product-manager-toolkit)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cro-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cro-review.md
@@ -1,0 +1,121 @@
+---
+title: "/cs:cro-review — CRO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cro-review <plan> — Pipeline-paranoid interrogation of revenue, win rate, NRR, and ramp time. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cro-review — CRO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cro-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cro-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cro-review <plan>`
+
+The pipeline-paranoid operator pressure-tests revenue assumptions. Six questions that surface next-quarter pain this quarter.
+
+## When to Run
+
+- Before committing to a quarterly revenue target
+- Before changing sales motion (PLG ↔ sales-led, mid-market ↔ enterprise)
+- Before hiring a batch of reps
+- When pipeline coverage drops below 3x
+- When NRR is trending down
+
+## The Six CRO Questions
+
+### 1. Pipeline Coverage
+**What is pipeline coverage for the current quarter, by stage?**
+- Inbound-heavy: 3x. Outbound-heavy: 4x. Below either threshold = act now.
+- Stage-weighted, not just total.
+
+### 2. Win Rate Trajectory
+**What's win rate this quarter vs the last 4 — and what's the leak point?**
+- Stage-by-stage conversion.
+- If a single stage softens, identify why before forecasting.
+
+### 3. NRR Decomposition
+**What's gross retention, contraction, and expansion separately?**
+- NRR alone hides churn.
+- A 110% NRR with 95% gross retention is different from 110% with 80%.
+
+### 4. Ramp Time
+**For the last 4 hires, how many days to first deal and to quota?**
+- If ramp > 90 days at growth stage, hiring profile or enablement is broken.
+- Forecasted hires must build in ramp.
+
+### 5. Discount Discipline
+**What's the median discount this quarter vs last 4? Where is it creeping?**
+- Discount creep is the leading indicator of pricing or positioning weakness.
+- Cap discounts by approver tier.
+
+### 6. Pipeline Source Mix
+**What % of pipeline is marketing-sourced, sales-sourced, partner-sourced?**
+- If one source dominates > 80%, you have concentration risk.
+- Cross-check with cs-cmo-advisor.
+
+## Workflow
+
+```bash
+python ../../../skills/cro-advisor/scripts/revenue_forecast_model.py
+python ../../../skills/cro-advisor/scripts/churn_analyzer.py
+```
+
+## Output Format
+
+```markdown
+# CRO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## Pipeline
+- Coverage: X.Xx (target 3x+)
+- Win rate: X% (4Q trend: ↑ / → / ↓)
+- Top leaking stage: <name>
+
+## Retention
+- Gross retention: X%
+- NRR: X%
+- Expansion: X%
+- Contraction: X%
+
+## Ramp
+- New hires last quarter: N
+- Median days to first deal: X
+- Median days to quota: X
+
+## Discount
+- Median discount this quarter: X%
+- Trend vs 4Q ago: <delta>
+
+## Source Mix
+- Marketing: X% | Sales: X% | Partner: X%
+
+## Verdict
+🟢 ON PLAN | 🟡 GAP | 🔴 PIPELINE CRISIS
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:cfo-review` — does this hit the cash plan?
+- `/cs:cmo-review` — is pipeline source-mix healthy?
+- `/cs:execute` — quarterly plan if GREEN
+- `/cs:boardroom` — if RED
+
+## Related
+
+- Agent: [`cs-cro-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-cro-advisor.md)
+- Skill: [`cro-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cro-advisor/SKILL.md)
+- Execution: [`business-growth`](https://github.com/alirezarezvani/claude-skills/tree/main/business-growth)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cross-eval.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cross-eval.md
@@ -1,0 +1,126 @@
+---
+title: "/cs:cross-eval — Multi-Model Consensus — Agent Skill for Executives"
+description: "/cs:cross-eval <memo> — Multi-model consensus on a board memo or strategy brief. Claude + Codex + Gemini cross-review with graceful degradation."
+---
+
+# /cs:cross-eval — Multi-Model Consensus
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cross-eval`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cross-eval/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cross-eval <memo-or-brief>`
+
+Runs the same memo through multiple model providers and reconciles divergences. Use for **high-stakes, irreversible decisions** where single-model bias is too costly: M&A, major fundraises, layoffs, strategic pivots, regulatory commitments.
+
+Adapted from gstack's `/codex` cross-review pattern, generalized to **business memos** instead of code PRs.
+
+## When to Run
+
+- Before signing a term sheet
+- Before announcing a layoff
+- Before committing to a regulated market
+- Before any decision where reversing costs > 6 months of company time
+- When the boardroom vote was split or had a CRITICAL dissent
+
+## Models Used (graceful degradation)
+
+The command tries to invoke each available model in order:
+
+1. **Claude** (primary, always available) — the boardroom's native voice
+2. **Codex / OpenAI** (if `OPENAI_API_KEY` or `codex` CLI available)
+3. **Gemini** (if `GEMINI_API_KEY` or `gemini` CLI available)
+
+If only Claude is available, the command runs **Claude-only with adversarial mode** — same model, different prompt seeds — and clearly labels the output as single-model.
+
+## Workflow
+
+1. Read the memo / brief
+2. Probe environment for available model CLIs / API keys
+3. For each available model:
+   - Send the memo with this prompt prefix:
+     > "You are an independent C-suite reviewer. The following is a board memo from another company's boardroom. Identify the top 3 concerns, the top 3 supports, and your vote (APPROVE / REJECT / DEFER). Do not deferentially agree — assume the memo's reasoning is flawed until proven otherwise."
+4. Collect three independent reviews
+5. Reconcile: where do they agree? Where do they diverge?
+6. Surface the divergences as questions for the founder
+
+## Output Format
+
+Saved to `~/.claude/cross-eval/YYYY-MM-DD-<slug>.md`:
+
+```markdown
+# Cross-Eval: <memo title>
+**Date:** YYYY-MM-DD
+**Memo reviewed:** <link>
+**Models invoked:** Claude / Codex / Gemini (or noted fallbacks)
+
+## Vote Tally
+| Model | Vote | Confidence |
+|---|---|---|
+| Claude | APPROVE | High |
+| Codex | DEFER | Med |
+| Gemini | APPROVE | Low |
+
+## Consensus Concerns (≥2 models flagged)
+1. <concern> — flagged by Claude + Codex
+2. <concern> — flagged by all 3
+
+## Divergent Concerns (1 model flagged)
+- <Codex only:> <concern> — worth a second look
+- <Gemini only:> <concern> — likely noise, but check
+
+## Consensus Supports (≥2 models endorsed)
+1. <support>
+2. <support>
+
+## Recommendation
+- 🟢 GO if 2+ models APPROVE and no CRITICAL concerns from any model
+- 🟡 PAUSE if any model is DEFER or any concern is CRITICAL
+- 🔴 STOP if 2+ models REJECT
+
+## Open Questions for Founder
+1. <question raised by divergence>
+2. <question raised by divergence>
+```
+
+## Why This Matters
+
+Single-model recommendations have systematic biases. Claude trends helpful and may under-weight risk. Codex (OpenAI) trends more cautious on emerging-market and regulatory topics. Gemini trends more cautious on technical scale claims. Disagreement is signal, not noise.
+
+This is the **safety net before irreversibility** — not a replacement for outside counsel or a real board.
+
+## Graceful Degradation
+
+If only Claude is available:
+
+```markdown
+**Models available:** Claude only
+**Mode:** ADVERSARIAL — running 3 independent Claude passes with different system prompts:
+  1. Standard reviewer
+  2. Devil's advocate (must find 3 critical concerns)
+  3. Steelman (must find 3 strongest reasons to approve)
+
+This is weaker than true multi-model. Treat the result as suggestive, not conclusive.
+```
+
+## Routing
+
+- `/cs:decide` — if consensus is GO
+- `/cs:freeze` — if consensus is PAUSE
+- `/cs:boardroom` (re-run) — if consensus is STOP
+
+## Related
+
+- Skills: [`board-meeting`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/board-meeting/SKILL.md), [`executive-mentor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor)
+- Inspiration: gstack's `/codex` cross-review pattern (adapted to business memos)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-cto-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-cto-review.md
@@ -1,0 +1,128 @@
+---
+title: "/cs:cto-review — CTO Forcing Questions — Agent Skill for Executives"
+description: "/cs:cto-review <plan> — Architecture and scaling interrogation. Tech debt, scaling cliffs, team scaling, build-vs-buy. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:cto-review — CTO Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `cto-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/cto-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:cto-review <plan>`
+
+Pressure-tests architecture and engineering scaling decisions. Six questions to surface the next scaling cliff before you hit it.
+
+## When to Run
+
+- Before approving a major architecture change
+- Before doubling the engineering team
+- Before a build-vs-buy decision > $100K/year
+- When a system is showing reliability stress (SLOs missed)
+- Before committing to a new platform / language / DB
+
+## The Six CTO Questions
+
+### 1. Scaling Cliff
+**Where does the current architecture break, in terms of users / requests / data volume?**
+- Be specific. "It breaks at 10× current load because the primary DB writes saturate."
+- If you don't know, run a load test before deciding.
+
+### 2. Tech Debt Inventory
+**What's the top tech debt item, what's it costing per week, and when does it become blocking?**
+```bash
+python ../../../skills/cto-advisor/scripts/tech_debt_analyzer.py
+```
+
+### 3. Team Scaling
+**For each open req, what's the ramp time and contribution model?**
+```bash
+python ../../../skills/cto-advisor/scripts/team_scaling_calculator.py
+```
+
+### 4. Build vs Buy
+**Why are we building this instead of buying it — and what's the 3-year TCO of each?**
+- If "we want control" or "it's not that hard" — push back.
+- If the answer is "this is our core moat," build.
+
+### 5. SLO / Reliability
+**What are the SLOs for this system and what's the current error budget burn?**
+- Without an SLO, you can't reason about reliability tradeoffs.
+- See `engineering/slo-architect` for SLO design.
+
+### 6. Security & Compliance Surface
+**What does this expose, and has cs-ciso-advisor signed off?**
+- Architecture decisions are compliance decisions.
+- Loop in cs-ciso-advisor before commit.
+
+## Workflow
+
+1. Run the tech debt analyzer + team scaling calculator
+2. Define the scaling-cliff hypothesis explicitly
+3. Cross-check with cs-ciso-advisor for security implications
+4. Apply the verdict
+
+## Output Format
+
+```markdown
+# CTO Review: <plan>
+**Date:** YYYY-MM-DD
+
+## Scaling Cliff
+- Current capacity: <metric>
+- Break point: <metric>
+- Headroom: X months at current growth
+
+## Tech Debt
+- Top item: <description>
+- Cost per week: $X or N eng-hours
+- Blocking date estimate: <date>
+
+## Team
+- Open reqs: N
+- Median ramp: X months
+- Contribution model: <pairing / squad / area>
+
+## Build vs Buy
+- 3-year build TCO: $X
+- 3-year buy TCO: $X
+- Strategic fit: <core / context>
+- Decision: BUILD | BUY
+
+## Reliability
+- SLO defined: yes / no
+- Error budget burn: X% (target < Y%)
+
+## Security
+- cs-ciso sign-off: ✅ / ❌
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 BLOCK
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:ciso-review` — mandatory if data surface changes
+- `/cs:cfo-review` — for build-vs-buy > $100K
+- `/cs:execute` — quarterly plan
+- `/cs:boardroom` — for architecture pivots
+
+## Related
+
+- Agent: [`cs-cto-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/agents/c-level/cs-cto-advisor.md)
+- Skill: [`cto-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cto-advisor/SKILL.md)
+- SLO: [`engineering/slo-architect`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-decide.md
+++ b/docs/skills/c-level-advisor/c-level-agents-decide.md
@@ -1,0 +1,115 @@
+---
+title: "/cs:decide — Log the Decision — Agent Skill for Executives"
+description: "/cs:decide <memo> — Log a decision to two-layer memory via decision-logger. Approved memo becomes durable; raw transcripts kept for reference. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:decide — Log the Decision
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `decide`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/decide/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:decide <memo-path>`
+
+Logs the founder's decision via the `decision-logger` skill. This is the gate where in-session deliberation becomes durable company memory.
+
+## Pipeline Position
+
+```
+/cs:office-hours  →  /cs:brief  →  /cs:boardroom  →  /cs:decide  →  /cs:execute  →  /cs:post-mortem
+                                                       ↑ you are here
+```
+
+## Two-Layer Memory Model
+
+The `decision-logger` skill maintains two layers:
+
+1. **Raw transcripts** — every boardroom session, every advisor's Phase 2 position, every dissent. Stored under `~/.claude/decisions/raw/`. Reference only, never feeds back automatically.
+2. **Approved decisions** — only the founder-signed memos. Stored under `~/.claude/decisions/approved/`. Feeds into future `/cs:office-hours` and `/cs:founder-mode` calls.
+
+This split prevents the system from "remembering" unresolved debates as if they were decisions.
+
+## Input
+
+A board memo file (output of `/cs:boardroom`).
+
+## Workflow
+
+1. Read the memo path
+2. Verify it has founder approval (status: APPROVED)
+3. Extract structured decision record:
+   - Decision title
+   - Date decided
+   - Option chosen
+   - Success + kill criteria
+   - Dissent (preserved)
+   - Review checkpoint date
+4. Append to `~/.claude/decisions/approved/<YYYY-MM-DD>-<slug>.md`
+5. Update the raw transcript pointer
+6. If llm-wiki bridge configured, write to vault (`~/company-vault/10-decisions/`)
+7. Schedule auto-revisit (90 days)
+
+## Output Record Format
+
+```markdown
+# Decision: <title>
+**Decided:** YYYY-MM-DD
+**By:** <founder name>
+**Memo:** <link to boardroom memo>
+**Brief:** <link to original brief>
+**Review checkpoint:** YYYY-MM-DD (90d default)
+
+## Decision
+**Chose:** <option>
+**Rejected:** <other options + one-line why>
+
+## Success Criteria (binding)
+- <metric, threshold, timeframe>
+
+## Kill Criteria (binding)
+- <metric, threshold, action>
+
+## Preserved Dissent
+- **<dissenter>:** <unresolved concern>
+- (preserved verbatim; dissent never erased)
+
+## Next Action
+- `/cs:execute` → 90-day plan due <date>
+
+## Status History
+- YYYY-MM-DD: APPROVED
+```
+
+## Why Preserved Dissent
+
+The biggest risk in approved decisions is forgetting why someone disagreed. When the kill criteria trigger, the dissent often turns out to have been correct. Preserving it verbatim — not summarized — keeps the company honest at post-mortem time.
+
+## Routing
+
+- `/cs:execute <decision>` — build the 90-day plan
+- `/cs:freeze <decision> <days>` — lock if irreversible
+- (Auto-scheduled) `/cs:post-mortem <decision>` — at 90-day checkpoint
+
+## Stale-Decision Audit
+
+`cs-chief-of-staff` runs a weekly stale audit:
+- Decisions > 90 days without revisit → flag for `/cs:post-mortem`
+- Decisions with kill criteria triggered → flag immediately
+- Decisions whose company-context.md basis has changed → flag for re-examination
+
+## Related
+
+- Skill: [`decision-logger`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/decision-logger/SKILL.md)
+- Agent: [`cs-chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-chief-of-staff.md)
+- Bridge: [[`references/llm-wiki-bridge.md`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-execute.md
+++ b/docs/skills/c-level-advisor/c-level-agents-execute.md
@@ -1,0 +1,110 @@
+---
+title: "/cs:execute — 90-Day Execution Plan — Agent Skill for Executives"
+description: "/cs:execute <decision> — Generate a 90-day execution plan with weekly milestones, DRIs, and check-in cadence from an approved decision. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:execute — 90-Day Execution Plan
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `execute`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/execute/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:execute <decision-path>`
+
+Turns an approved decision into a 90-day plan with weekly milestones, named DRIs, and a check-in cadence. Where most decisions die: between "we decided" and "what's next Monday?"
+
+## Pipeline Position
+
+```
+/cs:office-hours  →  /cs:brief  →  /cs:boardroom  →  /cs:decide  →  /cs:execute  →  /cs:post-mortem
+                                                                       ↑ you are here
+```
+
+## Input
+
+An approved decision record (output of `/cs:decide`).
+
+## Output Plan Format
+
+Saved to `~/.claude/execution/YYYY-MM-DD-<slug>.md`:
+
+```markdown
+# Execution Plan: <decision title>
+**Decision:** <link to /cs:decide record>
+**Owner (Sponsor):** <founder or exec>
+**Start:** YYYY-MM-DD
+**Checkpoint:** YYYY-MM-DD (90d)
+
+## Outcome (binding)
+[Copied from decision: success + kill criteria]
+
+## Workstreams
+| Workstream | DRI | Success Metric | Status |
+|---|---|---|---|
+| <e.g., Pricing rollout> | <name> | <metric, threshold> | Not started |
+| <e.g., Comms> | <name> | <metric> | Not started |
+| <e.g., Eng changes> | <name> | <metric> | Not started |
+
+## Weekly Milestones
+| Week | Milestone | DRI | Definition of Done |
+|---|---|---|---|
+| 1 | <e.g., positioning locked> | <name> | <observable outcome> |
+| 2 | <e.g., draft launched> | <name> | <observable> |
+| 3 | ... | | |
+| 12 | <e.g., checkpoint review> | <name> | <observable> |
+
+## Cadence
+- **Weekly:** Owner reviews status (15 min)
+- **Bi-weekly:** Cross-functional sync (30 min)
+- **Day 30 / 60 / 90:** Checkpoint with cs-chief-of-staff
+
+## Dependencies
+- Internal: <list>
+- External: <vendors, regulators, customers>
+
+## Risk Register
+| Risk | Likelihood | Impact | Owner | Mitigation |
+|---|---|---|---|---|
+| <e.g., delayed legal review> | M | H | <name> | <plan> |
+
+## Kill Criteria Watch
+[Copied from decision; reviewed at every checkpoint]
+- <metric, threshold, action>
+```
+
+## Workflow
+
+1. Read the decision record
+2. Decompose the chosen option into 3-6 workstreams
+3. Name a DRI for each workstream
+4. Reverse-engineer 12 weekly milestones from the checkpoint date
+5. Set the cadence (weekly + bi-weekly + 30/60/90 checkpoints)
+6. Build the risk register (cross-reference original Phase 4 devil's-advocate concerns)
+7. Save and notify DRIs
+
+## Why 90 Days
+
+- Long enough to show real signal (not just activity)
+- Short enough to course-correct before damage compounds
+- Matches quarterly OKR cycle, fundraise sprints, and most board cadences
+
+## Routing
+
+- `/cs:post-mortem <decision>` — at day 90 (or earlier if kill criteria trigger)
+- `/cs:boardroom` — if a checkpoint reveals a need to re-decide
+
+## Related
+
+- Skills: [`coo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/coo-advisor/SKILL.md), [`strategic-alignment`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/strategic-alignment/SKILL.md), [`change-management`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/change-management/SKILL.md)
+- Agent: [`cs-coo-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-coo-advisor.md)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-founder-mode.md
+++ b/docs/skills/c-level-advisor/c-level-agents-founder-mode.md
@@ -1,0 +1,112 @@
+---
+title: "/cs:founder-mode — The Auto-Router — Agent Skill for Executives"
+description: "/cs:founder-mode <question> — Auto-routes any founder question to the right C-role advisor or to /cs:boardroom for multi-role topics. The. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:founder-mode — The Auto-Router
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `founder-mode`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/founder-mode/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:founder-mode <question>`
+
+The single command a founder needs to remember. Routes the question to the right C-role automatically, or triggers `/cs:boardroom` if multi-role.
+
+This is the **killer command** — the answer to "I don't know which slash command to use." Type the question; the system figures out the room.
+
+## Routing Logic
+
+The router (via `cs-chief-of-staff`) does keyword + intent matching:
+
+| Signal in question | Route |
+|---|---|
+| burn, runway, fundraise, dilution, model, LTV, CAC | `cs-cfo-advisor` |
+| pipeline, win rate, forecast, NRR, churn, ramp | `cs-cro-advisor` |
+| positioning, ICP, message, brand, channel, campaign | `cs-cmo-advisor` |
+| roadmap, PMF, JTBD, North Star, RICE, kill | `cs-cpo-advisor` |
+| cadence, OKR, scorecard, DRI, operating system, rhythm | `cs-coo-advisor` |
+| hiring, comp, ladder, level, attrition, eNPS, equity | `cs-chro-advisor` |
+| security, threat, breach, compliance, audit, SOC 2 | `cs-ciso-advisor` |
+| architecture, scaling, tech debt, SLO, latency | `cs-cto-advisor` |
+| contract, IP, term sheet, regulator, license | `/cs:gc-review` |
+| strategy, vision, board, M&A, raise, exit | `cs-ceo-advisor` |
+| **2+ signals from different roles** | `/cs:boardroom` |
+| **ambiguous** | `/cs:office-hours` first, then route |
+
+## Workflow
+
+1. Parse the question for role signals
+2. If exactly one role: invoke that cs-* agent directly
+3. If 2+ roles: build a brief via `/cs:brief` and trigger `/cs:boardroom`
+4. If ambiguous / no signal match: trigger `/cs:office-hours` to force the founder to sharpen
+5. Log the routing decision (raw layer) via `decision-logger`
+
+## Output
+
+The router emits one of three responses:
+
+### Single-role route
+```
+**Routing:** cs-cfo-advisor
+**Why:** Question hits burn rate and unit economics.
+**Next:** Invoking cs-cfo-advisor with company-context loaded.
+
+[Advisor's response follows]
+```
+
+### Multi-role route
+```
+**Routing:** /cs:boardroom
+**Why:** Question touches CFO + CMO + CPO (pricing change has finance, positioning, and product implications).
+**Next:** Building brief via /cs:brief, then running boardroom.
+
+Brief saved: ~/.claude/briefs/2026-05-12-pricing-v3.md
+Run: /cs:boardroom ~/.claude/briefs/2026-05-12-pricing-v3.md
+```
+
+### Ambiguous → office hours
+```
+**Routing:** /cs:office-hours
+**Why:** Question is too broad ("should we grow faster?"). Need framing before any advisor can help.
+**Next:** Six-question intake.
+
+[Office hours questions follow]
+```
+
+## Why This Is the Killer Command
+
+gstack requires the founder to know all 23 slash commands and pick the right one. That's a cognitive tax. `/cs:founder-mode` collapses that to one — the system picks. This is also where persistent memory pays off: with company-context.md + decision-logger, the router knows what's already been decided and won't re-litigate.
+
+## Examples
+
+```
+/cs:founder-mode "should we raise a Series B now or wait 6 months?"
+   → boardroom (CFO + CEO + CRO touched)
+
+/cs:founder-mode "the win rate dropped 20% this month"
+   → cs-cro-advisor
+
+/cs:founder-mode "let's hire a VP Marketing"
+   → boardroom (CHRO + CMO + CFO touched)
+
+/cs:founder-mode "should we be growing faster?"
+   → /cs:office-hours (too ambiguous)
+```
+
+## Related
+
+- Agent: [`cs-chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-chief-of-staff.md) — does the routing
+- Skill: [`chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/chief-of-staff/SKILL.md) — routing logic
+- Skill: [`context-engine`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/context-engine/SKILL.md) — loads context
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-freeze.md
+++ b/docs/skills/c-level-advisor/c-level-agents-freeze.md
@@ -1,0 +1,112 @@
+---
+title: "/cs:freeze — Cooldown Lock on a Decision — Agent Skill for Executives"
+description: "/cs:freeze <decision> <days> — Lock a strategic decision for a cooldown period to prevent impulse reversal. Mirrors gstack's safety primitives for. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:freeze — Cooldown Lock on a Decision
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `freeze`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/freeze/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:freeze <decision-path> <days>`
+
+Locks a decision for a defined cooldown period. During the freeze, the chief-of-staff router refuses to re-litigate the decision unless a kill criterion explicitly triggers.
+
+Inspired by gstack's `/freeze` and `/guard` safety primitives — adapted from code-scoping to strategic-scoping.
+
+## When to Use
+
+Founders are pattern-matchers; pattern-matching after a tough decision often produces a reversal that's actually just decision fatigue. The freeze enforces a discipline:
+
+- After any **irreversible** or **high-cost-to-reverse** decision (fundraise, layoff, market entry)
+- After a **split-vote boardroom** (preserve the call against second-guessing)
+- After a **founder gut-feel** override of unanimous advisor consensus (let it run)
+- During a **personnel transition** (lock the strategy so the new exec can execute, not redebate)
+
+## Default Freeze Periods
+
+| Decision type | Default freeze |
+|---|---|
+| Fundraise round size / lead choice | 30 days |
+| Pricing change | 60 days |
+| Market entry / exit | 90 days |
+| Layoff / RIF | 30 days |
+| Strategic pivot | 90 days |
+| Personnel (exec hire / fire) | 60 days |
+| M&A LOI | 30 days |
+| Custom | specify in command |
+
+## Workflow
+
+1. Read the decision record
+2. Validate it has APPROVED status
+3. Apply freeze: write `freeze_until: YYYY-MM-DD` to the decision record
+4. Add to active-freezes index at `~/.claude/freezes/active.md`
+5. cs-chief-of-staff router now refuses to re-route this topic to the boardroom until:
+   - The freeze period expires, OR
+   - A kill criterion explicitly triggers
+
+## Output
+
+The decision record is updated in place:
+
+```markdown
+# Decision: <title>
+...
+**Status:** FROZEN
+**Frozen until:** YYYY-MM-DD
+**Reason for freeze:** <text>
+**Override condition:** Kill criterion <name> triggers OR founder issues `/cs:unfreeze` with stated reason
+```
+
+The active-freezes index is updated:
+
+```markdown
+# Active Freezes
+**Updated:** YYYY-MM-DD
+
+| Decision | Frozen until | Override condition |
+|---|---|---|
+| <decision title> | YYYY-MM-DD | <kill criterion or /cs:unfreeze> |
+```
+
+## Override
+
+To unfreeze before the period ends, the founder runs:
+
+```
+/cs:unfreeze <decision> <reason>
+```
+
+The unfreeze is logged in the decision history (preserved permanently). Forced overrides create a paper trail that surfaces at post-mortem.
+
+## Auto-Override
+
+If a kill criterion in the decision triggers, the freeze auto-releases and the chief-of-staff routes immediately to `/cs:post-mortem`. The freeze does not protect against reality; it protects against impulse.
+
+## Why This Beats "Just Don't Re-Decide"
+
+Founders have authority. Without an explicit lock + log, every wobble produces a "let's discuss this again" — which is exhausting for advisors and erodes the value of the boardroom. The freeze is **a process**, not a rule; it logs every override so the post-mortem can audit founder discipline.
+
+## Routing
+
+- `/cs:unfreeze` — explicit early release
+- `/cs:post-mortem` — auto-triggered if kill criterion fires
+- `/cs:boardroom` — blocked until unfreeze or expiry
+
+## Related
+
+- Skill: [`decision-logger`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/decision-logger/SKILL.md)
+- Agent: [`cs-chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-chief-of-staff.md) — enforces freezes in routing
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-gc-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-gc-review.md
@@ -1,0 +1,143 @@
+---
+title: "/cs:gc-review — General Counsel Forcing Questions — Agent Skill for Executives"
+description: "/cs:gc-review <plan> — General Counsel interrogation of contracts, IP, regulatory, term sheets, and employment-law surface. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:gc-review — General Counsel Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `gc-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/gc-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:gc-review <plan>`
+
+The General Counsel lens. Six questions before any contract, term sheet, IP move, or regulatory commitment. This is a lane gstack has zero of — and one where a single missed clause costs more than a year of engineering.
+
+> ⚠️ **Not legal advice.** This command surfaces the right questions to ask before talking to outside counsel. Always engage qualified counsel for binding decisions.
+
+## When to Run
+
+- Before signing any contract > $100K or > 1 year
+- Before issuing equity (employee grants, advisor grants)
+- Before a term sheet response
+- Before entering a regulated market (healthcare, fintech, defense)
+- Before any open-source license decision in core IP
+- Before an M&A LOI
+
+## The Six GC Questions
+
+### 1. IP Ownership
+**Who owns the IP being created or shared in this transaction?**
+- Work-for-hire vs license vs joint.
+- For employees and contractors: written IP assignment in place?
+- For OSS: license compatibility checked?
+
+### 2. Liability & Indemnity
+**What's the liability cap, and what's carved out from it?**
+- Standard cap: 12 months of fees.
+- Carve-outs: IP infringement, data breach, willful misconduct.
+- Mutual indemnity desirable.
+
+### 3. Data Processing
+**What personal data is involved, and is a DPA in place?**
+- GDPR / CCPA scope?
+- Subprocessor flow-down?
+- Data residency requirements?
+
+### 4. Termination & Renewal
+**What's the termination right, what's the notice period, and what's auto-renew?**
+- Termination for convenience vs cause.
+- Notice period (30 / 60 / 90 days).
+- Auto-renewal trap?
+
+### 5. Regulatory Surface
+**Does this expose the company to a new regulatory regime?**
+- Healthcare → HIPAA.
+- Fintech → BSA/AML, state money-transmitter.
+- Medical device → FDA, MDR, ISO 13485.
+- Data → GDPR, CCPA, state breach laws.
+
+### 6. Employment / Equity
+**If this is a hire or contractor: jurisdiction, classification, equity grant, IP assignment?**
+- Misclassification risk?
+- Equity vesting standard (4-year, 1-year cliff)?
+- Acceleration triggers?
+- 409A current?
+
+## Workflow
+
+1. Read the contract / term sheet end to end
+2. Run the six questions
+3. Identify the top-3 issues that need outside counsel review
+4. Apply the verdict
+
+## Output Format
+
+```markdown
+# GC Review: <plan>
+**Date:** YYYY-MM-DD
+
+## Document
+- Type: <contract / term sheet / grant / DPA>
+- Counterparty: <name>
+- $ value or scope: <amount>
+
+## Issues
+| # | Issue | Risk | Recommendation |
+|---|---|---|---|
+| 1 | <e.g., uncapped IP indemnity> | HIGH | Cap at fees paid, mutual |
+| 2 | <e.g., 5-year auto-renew> | MED | 1-year max, 60-day notice |
+| 3 | <e.g., no DPA, EU data> | HIGH | Require DPA before sign |
+
+## Regulatory Trigger
+- New regime triggered? <yes/no>
+- Specific frameworks: <HIPAA / GDPR / etc.>
+
+## Outside Counsel Action Items
+- [ ] <specific item 1>
+- [ ] <specific item 2>
+- [ ] <specific item 3>
+
+## Verdict
+🟢 SIGN AS-IS (rare)
+🟡 NEGOTIATE — counter on top-3 issues
+🔴 DO NOT SIGN — material risk
+```
+
+## Routing
+
+- `/cs:ciso-review` — for any data-touching contract
+- `/cs:cfo-review` — for any commitment > 1 year or > 1% of revenue
+- `/cs:decide` — log the verdict after outside counsel review
+
+## Workflow Integration with `general-counsel-advisor` skill
+
+Since v2.5.1, this command is backed by a full skill at [`skills/general-counsel-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/general-counsel-advisor) with two Python tools:
+
+```bash
+# Automated contract scan (12 founder-killer patterns)
+python ../../../skills/general-counsel-advisor/scripts/contract_risk_scanner.py path/to/contract.txt
+
+# Term sheet scoring (0-100 founder-friendliness)
+python ../../../skills/general-counsel-advisor/scripts/term_sheet_analyzer.py path/to/term_sheet.json
+```
+
+The `cs-general-counsel-advisor` agent orchestrates both tools plus 3 references (contracts playbook, IP + regulatory, term sheet decoder).
+
+## Related
+
+- Skill: [`general-counsel-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/general-counsel-advisor/SKILL.md) — full skill with Python tools + references
+- Agent: [`cs-general-counsel-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-general-counsel-advisor.md)
+- Compliance execution: [`ra-qm-team`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team)
+- Adjacent: [`skills/ma-playbook`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/ma-playbook)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-office-hours.md
+++ b/docs/skills/c-level-advisor/c-level-agents-office-hours.md
@@ -1,0 +1,125 @@
+---
+title: "/cs:office-hours — Six-Question Founder Interrogation — Agent Skill for Executives"
+description: "/cs:office-hours <topic> — YC-style 6-question founder interrogation before any advice. Forces clarity on problem, customer, distribution. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:office-hours — Six-Question Founder Interrogation
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `office-hours`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/office-hours/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:office-hours <topic>`
+
+Before any advice, the founder must answer six questions. Modeled on YC office hours: no analysis until the founder has done the thinking. This is the cognitive forcing function that prevents drift into solutionism.
+
+## When to Run
+
+- Before starting any major initiative
+- Before fundraising
+- Before a strategic pivot
+- When the founder is excited (excitement is a tell — pressure-test)
+- When the answer is "obvious" (the obvious answer is usually wrong)
+
+## The Six Questions
+
+The founder must answer **all six** in writing before any C-role weighs in.
+
+### 1. Problem
+**Whose problem is this, and how do they describe it in their own words?**
+- Not your framing. Their words.
+- If you can't quote a customer, you don't have a problem worth solving.
+
+### 2. Customer
+**Who is the ICP? Name one real person who would buy this today.**
+- Real human. Real company. Real seat.
+- If you can't name one, the ICP isn't ready.
+
+### 3. Distribution
+**How does the customer first hear your name?**
+- Channel, intent, search query, friend, conference — name it.
+- If the answer is "we'll figure out marketing later," the answer is no.
+
+### 4. Defensibility
+**If this works, what stops a competitor from copying it in 6 months?**
+- Network effects, switching costs, data moat, regulatory moat, brand — pick one.
+- "We'll execute better" is not a defense.
+
+### 5. Capital
+**What does this cost, when does it pay back, and what's the alternative use of the money?**
+- Total spend, payback months, opportunity cost.
+- If you don't know, don't approve it.
+
+### 6. Founder Fit
+**Why are you the right person to do this — and why does this matter enough to spend the next 3 years on it?**
+- Founder-market fit is the strongest predictor of survival.
+- If the answer is mercenary, the company will be too.
+
+## Output Format
+
+After the founder answers all six, this command produces a one-page brief:
+
+```markdown
+# Office Hours Brief: <topic>
+**Date:** YYYY-MM-DD
+**Founder:** <name>
+
+## 1. Problem
+> [founder's verbatim answer]
+
+## 2. Customer
+> [founder's verbatim answer]
+
+## 3. Distribution
+> [founder's verbatim answer]
+
+## 4. Defensibility
+> [founder's verbatim answer]
+
+## 5. Capital
+> [founder's verbatim answer]
+
+## 6. Founder Fit
+> [founder's verbatim answer]
+
+---
+
+**Assessment** (one of):
+- 🟢 GREEN — ship the brief to /cs:boardroom
+- 🟡 YELLOW — sharpen Q[N] before proceeding
+- 🔴 RED — kill or redefine; do not proceed
+```
+
+## Routing
+
+After the brief is GREEN, route to:
+- Single-role question → corresponding `/cs:{role}-review`
+- Multi-role question → `/cs:brief` then `/cs:boardroom`
+
+## Why This Works
+
+Most bad decisions don't fail at execution — they fail at framing. Forcing six concrete answers surfaces the framing weaknesses before anyone burns time on analysis. The founder either fills the gaps or recognizes the question wasn't ready.
+
+This is the YC `office hours` pattern adapted for Claude Code: the interrogation is the value.
+
+## Related Commands
+
+- `/cs:brief` — turn the answers into a one-page strategy brief
+- `/cs:boardroom` — multi-role deliberation
+- `/cs:founder-mode` — let the system pick the next step
+
+## Related Agents
+
+- All cs-* advisors consume the brief output
+- `cs-chief-of-staff` triggers `/cs:office-hours` when intake is unclear
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-onboard.md
+++ b/docs/skills/c-level-advisor/c-level-agents-onboard.md
@@ -1,0 +1,135 @@
+---
+title: "/cs:onboard — Founder Interview — Agent Skill for Executives"
+description: "/cs:onboard — Founder interview that populates ~/.claude/company-context.md. The first command to run when starting with c-level-agents. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:onboard — Founder Interview
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `onboard`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/onboard/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:onboard`
+
+The first command to run when adopting c-level-agents. A structured founder interview that produces `~/.claude/company-context.md` — the file every cs-* advisor reads before responding. Without this, the advisors are guessing.
+
+## What This Produces
+
+`~/.claude/company-context.md` — a single file with the durable facts about the company. Read by:
+- `cs-chief-of-staff` (routing decisions)
+- Every cs-* advisor (context for any question)
+- `/cs:brief` (assumptions in any new decision)
+
+## The Interview (12 Questions)
+
+### Company Basics
+1. **Company name and one-sentence pitch.**
+2. **Stage:** pre-seed / seed / Series A / Series B / Series C+ / public
+3. **Headcount:** total, by function (eng / product / GTM / ops / G&A)
+4. **Geographic distribution:** HQ + remote split, key countries
+
+### Business Model
+5. **Revenue model:** SaaS subscription / usage / transaction / marketplace / hardware / services
+6. **ICP:** name one real customer and describe what they have in common with others
+7. **ACV:** median and range; deal count last 12 months
+8. **Growth rate:** ARR YoY; if pre-revenue, leading metric (users, MAU, etc.)
+
+### Financial Posture
+9. **Runway:** months of cash at current burn; bear-case months
+10. **Last raise:** amount, valuation, lead investor, date
+
+### Strategic Context
+11. **Top 3 priorities for the current quarter** (in plain language)
+12. **Top 3 risks the founder loses sleep over** (be specific)
+
+## Output Format
+
+Saved to `~/.claude/company-context.md`:
+
+```markdown
+# Company Context
+**Generated:** YYYY-MM-DD
+**Last updated:** YYYY-MM-DD
+
+## Identity
+- **Company:** <name>
+- **Pitch:** <one sentence>
+- **Stage:** <stage>
+- **HQ + remote:** <distribution>
+
+## Business
+- **Model:** <type>
+- **ICP:** <description + named customer>
+- **ACV:** $<median> (range $<low> - $<high>)
+- **Deal count (LTM):** N
+- **ARR growth (YoY):** X%
+
+## Financial
+- **Cash on hand:** $<amount>
+- **Net burn (monthly):** $<amount>
+- **Runway base:** N months
+- **Runway bear:** N months
+- **Last raise:** $<amount> at $<post> in <month YYYY>, led by <investor>
+
+## Team
+- **Total headcount:** N
+- **Eng:** N | Product: N | GTM: N | Ops: N | G&A: N
+
+## Quarter
+- **Top priorities (Q<X> YYYY):**
+  1. <priority>
+  2. <priority>
+  3. <priority>
+
+- **Top risks:**
+  1. <risk>
+  2. <risk>
+  3. <risk>
+
+## Routing Hints
+[Optional: any role the founder wants to use sparingly or rely on heavily]
+```
+
+## Workflow
+
+1. Walk the founder through all 12 questions
+2. Quote founder's own words wherever possible (don't paraphrase the ICP)
+3. Save to `~/.claude/company-context.md`
+4. (Optional) If llm-wiki bridge is configured: symlink to vault
+   ```bash
+   ln -sf ~/company-vault/00-meta/company-context.md ~/.claude/company-context.md
+   ```
+5. Confirm with founder: read the file back, ask "anything missing?"
+
+## When to Re-Run
+
+- After a fundraise (numbers change)
+- After a major pivot or product launch
+- After 6+ months (most facts have drifted)
+- After a major hire (team distribution changes)
+- Always before a `/cs:boardroom` for a high-stakes decision
+
+## Persistence
+
+By default, `~/.claude/company-context.md` is local to the founder's machine. To make it persistent across machines / shareable:
+
+- **Markdown vault (recommended):** see [[`references/llm-wiki-bridge.md`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)
+- **Encrypted dotfile sync:** age + git
+- **Shared team:** keep in a private repo, symlink from `~/.claude/`
+
+## Related
+
+- Skill: [`cs-onboard`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/cs-onboard/SKILL.md) — the underlying interview protocol
+- Skill: [`context-engine`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/context-engine/SKILL.md) — reads this file
+- Reference: [[`references/llm-wiki-bridge.md`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-post-mortem.md
+++ b/docs/skills/c-level-advisor/c-level-agents-post-mortem.md
@@ -1,0 +1,126 @@
+---
+title: "/cs:post-mortem — Honest Retrospective — Agent Skill for Executives"
+description: "/cs:post-mortem <decision> — Honest retrospective on an executed decision, scored against original assumptions and dissent. Closes the strategic. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:post-mortem — Honest Retrospective
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `post-mortem`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/post-mortem/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:post-mortem <decision-path>`
+
+Closes the strategic sprint loop. Scores a decision against the success and kill criteria written **before** the decision (not retro-fitted) and revisits the preserved dissent. This is the rigor that compounds over time.
+
+## Pipeline Position
+
+```
+/cs:office-hours  →  /cs:brief  →  /cs:boardroom  →  /cs:decide  →  /cs:execute  →  /cs:post-mortem
+                                                                                       ↑ you are here
+```
+
+## When to Run
+
+- At the 90-day checkpoint (auto-scheduled by `/cs:decide`)
+- When a kill criterion triggers
+- After a major decision is reversed
+- Quarterly on all decisions of the past quarter
+
+## Inputs
+
+- The decision record (output of `/cs:decide`)
+- The execution plan (output of `/cs:execute`)
+- Actual outcomes (metrics, events, customer signals)
+
+## Output: Post-Mortem Record
+
+Saved to `~/.claude/postmortems/YYYY-MM-DD-<slug>.md`:
+
+```markdown
+# Post-Mortem: <decision title>
+**Decision date:** YYYY-MM-DD
+**Post-mortem date:** YYYY-MM-DD
+**Status:** WIN / PARTIAL / LOSS / MIXED
+
+## Outcome Scoring (against pre-committed criteria)
+
+| Success Criterion | Threshold | Actual | Met? |
+|---|---|---|---|
+| <metric 1> | <threshold> | <actual> | ✅ / ❌ |
+| <metric 2> | <threshold> | <actual> | ✅ / ❌ |
+
+| Kill Criterion | Threshold | Actual | Triggered? |
+|---|---|---|---|
+| <metric> | <threshold> | <actual> | ✅ / ❌ |
+
+**Overall:** WIN / PARTIAL / LOSS / MIXED
+
+## What We Got Right
+- <factor 1>
+- <factor 2>
+
+## What We Got Wrong
+- <factor 1>
+- <factor 2>
+
+## Preserved Dissent — Revisited
+[Original dissent from the boardroom memo, scored:]
+
+- **<dissenter>:** <original concern>
+  - **Did it materialize?** YES / NO / PARTIAL
+  - **Cost if YES:** <quantified impact>
+  - **Lesson:** <one sentence>
+
+## Assumption Audit
+[Original brief's assumptions, scored:]
+
+- **Assumption 1:** <text>
+  - **Held?** YES / NO / PARTIAL
+  - **Why:** <explanation>
+
+## Process Lessons
+- **Phase 2 isolation worked?** YES / NO
+- **Devil's advocate concerns played out?** YES / NO / PARTIAL
+- **Cadence was right?** YES / TOO LOOSE / TOO TIGHT
+
+## Forward Actions
+- [ ] <change to operating system or routing logic>
+- [ ] <new decision to make based on this learning>
+- [ ] <update company-context.md>
+
+## Status
+- WIN → archive, log lesson
+- LOSS → schedule follow-up boardroom: `/cs:brief` for the next call
+```
+
+## Why Pre-Committed Criteria Matter
+
+The biggest temptation in post-mortems is retroactive justification: "we always knew X, that's why we did Y." Pre-committed criteria, signed at `/cs:decide` time, eliminate that move. The numbers either matched or they didn't.
+
+## Why Revisit Dissent
+
+The dissent column from `/cs:boardroom` is the single most useful piece of organizational memory. Most of the time, the dissenter was directionally right. Revisiting and scoring it builds calibration over years.
+
+## Routing
+
+- `/cs:brief` — if the post-mortem surfaces a new decision
+- `/cs:freeze` — if the post-mortem reveals a process gap that needs cooldown enforcement
+- Updates to company-context.md via `cs-onboard`
+
+## Related
+
+- Skill: [`decision-logger`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/decision-logger/SKILL.md)
+- Agent: [`cs-chief-of-staff`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-chief-of-staff.md)
+- Sibling: [`/em:postmortem`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor/skills/postmortem/SKILL.md) — adversarial single-decision post-mortem
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents-vpe-review.md
+++ b/docs/skills/c-level-advisor/c-level-agents-vpe-review.md
@@ -1,0 +1,140 @@
+---
+title: "/cs:vpe-review — VPE Forcing Questions — Agent Skill for Executives"
+description: "/cs:vpe-review <plan> — Throughput-first VP of Engineering interrogation of any plan that touches delivery, eng hiring, team structure, or production. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# /cs:vpe-review — VPE Forcing Questions
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `vpe-review`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/vpe-review/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+**Command:** `/cs:vpe-review <plan>`
+
+The throughput-first VPE pressure-tests any plan touching eng operations. Six questions before any delivery commitment, eng hiring expansion, team restructure, or production-discipline change.
+
+## When to Run
+
+- Before quarterly delivery commitment (sprint planning, OKR review)
+- Before approving an eng hiring plan
+- Before restructuring eng teams (splitting/merging squads, adding tribes)
+- Before deciding whether to hire a VPE separately from CTO (or merge them)
+- When production incidents are increasing
+- When sprint velocity is dropping but everyone says "we're working hard"
+
+## The Six VPE Questions
+
+### 1. What's the cycle time, and where does work wait?
+**No DORA, no diagnosis.**
+- Lead Time for Changes is the single best health metric
+- If you can't decompose cycle time into stages, you can't fix the bottleneck
+- Run `delivery_throughput_analyzer.py`
+
+### 2. What's the DORA performance level on all 4 metrics?
+**One Elite metric and three Lows = bad. Four Highs = healthy.**
+- Deployment Frequency, Lead Time, MTTR, Change Failure Rate
+- The worst metric defines overall level
+- Fix lead time first; everything else follows
+
+### 3. Where is the hiring funnel leaking?
+**"Can't find good engineers" is wrong.**
+- Specific stage is over-filtering OR top-of-funnel volume is too low OR offer-to-accept is broken
+- Run `eng_hiring_funnel_calculator.py`
+- If offer-to-accept < 70%, comp is below market or close discipline is weak
+
+### 4. Is the team structure healthy for the headcount?
+**5-9 ICs per squad; 5-8 ICs per EM; 4-6 EMs per director.**
+- Run `eng_team_structure_designer.py`
+- Manager-trigger fires when 5+ ICs have no dedicated EM
+- Director-trigger fires when 3+ EMs report directly to VPE/CTO
+
+### 5. What's the production discipline maturity?
+**Level 1-5; aim for Level 3 at growth stage.**
+- On-call rotation ≥ 6 people
+- Severity-defined incident response with blameless postmortems
+- SLOs on customer-facing services (pair with `engineering/slo-architect/`)
+- Continuous deployment OR scheduled — not "usually one, sometimes the other"
+
+### 6. Are we adding a VPE separately, or is CTO doing both?
+**If CTO is spending > 50% on management vs strategy, VPE is needed.**
+- Or: VPE complement when CTO is co-founder more comfortable with strategy
+- VPE owns operating model; CTO owns architecture
+- At small scale (< 20 eng), one person can do both
+
+## Workflow
+
+```bash
+# 1. Delivery throughput
+python ../../../skills/vpe-advisor/scripts/delivery_throughput_analyzer.py sprint_metrics.json
+
+# 2. Hiring funnel
+python ../../../skills/vpe-advisor/scripts/eng_hiring_funnel_calculator.py funnel.json
+
+# 3. Team structure
+python ../../../skills/vpe-advisor/scripts/eng_team_structure_designer.py team.json
+```
+
+## Output Format
+
+```markdown
+# VPE Review: <plan>
+**Date:** YYYY-MM-DD
+
+## The Decision Being Made
+[throughput | hiring | structure | production | VPE-vs-CTO]
+
+## Delivery Throughput (if applicable)
+- DORA overall: Elite / High / Medium / Low
+- Worst metric: <DF | LT | MTTR | FR>
+- Bottleneck: <stage> (X% of cycle time)
+- Top fix: <action + owner>
+
+## Hiring Funnel (if applicable)
+- End-to-end conversion: X%
+- Weakest stage: <stage>
+- Pipeline gap: +N candidates needed
+- Top fix: <specific action>
+
+## Team Structure (if applicable)
+- Recommended: <informal pods / squads / tribes>
+- Manager trigger fired: yes/no
+- Director trigger fired: yes/no
+- Action: <hire EM | hire director | split squad>
+
+## Production Discipline (if applicable)
+- Current maturity level: 1-5
+- Next practice to add: <specific>
+- SLO coverage: X / Y services
+
+## Verdict
+🟢 SHIP | 🟡 SHARPEN | 🔴 BLOCK
+
+## Next Steps
+[3 concrete actions]
+```
+
+## Routing
+
+- `/cs:cto-review` — for architectural causes of throughput problems
+- `/cs:chro-review` — for hiring funnel comp/leveling issues
+- `/cs:cfo-review` — for cost-per-hire envelope and eng budget
+- `/cs:ciso-review` — for production discipline + compliance overlap
+- `/cs:decide` — log the verdict
+- `/cs:freeze 30` — on multi-year hiring commitments
+
+## Related
+
+- Agent: [`cs-vpe-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/agents/cs-vpe-advisor.md)
+- Skill: [`vpe-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/skills/vpe-advisor/SKILL.md)
+- Adjacent: [`engineering/slo-architect`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect), [`engineering/feature-flags-architect`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/feature-flags-architect), [`engineering/chaos-engineering`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/chaos-engineering)
+
+---
+
+**Version:** 1.0.0

--- a/docs/skills/c-level-advisor/c-level-agents.md
+++ b/docs/skills/c-level-advisor/c-level-agents.md
@@ -1,0 +1,117 @@
+---
+title: "c-level-agents — Founder-Mode Executive Team — Agent Skill for Executives"
+description: "Founder-mode executive team. 8 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff) and 17 /cs:* slash commands for. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# c-level-agents — Founder-Mode Executive Team
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-account-tie: C-Level Advisory</span>
+<span class="meta-badge">:material-identifier: `c-level-agents`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/c-level-agents/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install c-level-skills</code>
+</div>
+
+
+A virtual C-suite delivered through slash commands and persona agents.
+
+## Keywords
+
+founder mode, virtual c-suite, executive team, boardroom, office hours, cfo review, cmo review, strategic sprint, decision logging, cross-model consensus, persona agents, chief of staff, forcing questions
+
+## What This Plugin Provides
+
+### 8 cs-* Agents (in `agents/`)
+
+Each agent wraps an existing c-level skill and adds:
+- A distinct cognitive voice (numerate skeptic, narrative-first, etc.)
+- Forcing questions specific to the role
+- Workflow orchestration tied to skill Python tools
+- Output template: Bottom Line → What → Why → How to Act → Your Decision
+
+See [`references/persona-voices.md`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/references/persona-voices.md) for voice specs.
+
+### 17 /cs:* Slash Commands (in `skills/`)
+
+**Forcing-question office hours (8):**
+- `/cs:office-hours` — YC-style 6-question intake
+- `/cs:cfo-review` — unit economics, runway, dilution
+- `/cs:cmo-review` — ICP, CAC payback, positioning
+- `/cs:cpo-review` — RICE, JTBD, North Star, PMF
+- `/cs:cro-review` — pipeline coverage, win rate, NRR
+- `/cs:cto-review` — architecture risk, scaling cliff
+- `/cs:ciso-review` — threat model, blast radius, compliance
+- `/cs:gc-review` — contracts, IP, regulatory, term sheets
+
+**Strategic sprint pipeline (5):**
+- `/cs:brief` → `/cs:boardroom` → `/cs:decide` → `/cs:execute` → `/cs:post-mortem`
+
+**Meta + safety (4):**
+- `/cs:founder-mode` — auto-routes to the right C-role
+- `/cs:onboard` — founder interview → `company-context.md`
+- `/cs:cross-eval` — multi-model consensus
+- `/cs:freeze` — cooldown lock on a decision
+
+## Quick Start
+
+```
+/cs:onboard                          # populate company context first
+/cs:office-hours "should we hire a VP Sales?"
+/cs:founder-mode "runway pressure"   # auto-routes to CFO
+/cs:boardroom briefs/pricing-v3.md   # full panel
+```
+
+## Architecture
+
+```
+User question
+   │
+   ├─ Single-role? → cs-{role}-advisor agent
+   │                     ↓
+   │                  /cs:{role}-review command (forcing Qs)
+   │                     ↓
+   │                  Skill tools + references
+   │                     ↓
+   │                  Bottom Line + Memo
+   │
+   └─ Multi-role?  → /cs:boardroom
+                        ↓
+                     6-phase deliberation (Phase 2 isolation)
+                        ↓
+                     /cs:decide → decision-logger (two-layer memory)
+                        ↓
+                     /cs:execute → 90-day plan
+```
+
+## Integration Points
+
+- **Existing 28 c-level skills** — wrapped, not replaced
+- **decision-logger** — every `/cs:decide` writes here
+- **chief-of-staff** — routing layer the agent orchestrates
+- **board-meeting** — protocol the `/cs:boardroom` command runs
+- **llm-wiki** — optional persistent memory bridge (see [`references/llm-wiki-bridge.md`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/skills/references/llm-wiki-bridge.md))
+- **executive-mentor** — adversarial `/em:*` commands stack cleanly on top
+
+## Design Principles
+
+1. **Voice is bookended, analysis is neutral.**
+2. **Artifacts over chat.** Every command produces a Markdown artifact the next command consumes.
+3. **Phase 2 isolation in boardroom.** Independent thinking before cross-examination.
+4. **Graceful degradation.** `/cs:cross-eval` falls back to Claude-only.
+5. **No paid dependencies.** All Python tools are stdlib-only.
+
+## References
+
+- [persona-voices.md](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/persona-voices.md)
+- [llm-wiki-bridge.md](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents/references/llm-wiki-bridge.md)
+- [Parent c-level CLAUDE.md](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/CLAUDE.md)
+- [Existing executive-mentor sibling](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor)
+
+---
+
+**Version:** 1.0.0
+**Last Updated:** 2026-05-12
+**Status:** Production Ready

--- a/docs/skills/c-level-advisor/executive-mentor.md
+++ b/docs/skills/c-level-advisor/executive-mentor.md
@@ -8,7 +8,7 @@ description: "Adversarial thinking partner for founders and executives. Stress-t
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-account-tie: C-Level Advisory</span>
 <span class="meta-badge">:material-identifier: `executive-mentor`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor/skills/executive-mentor/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering-team/a11y-audit.md
+++ b/docs/skills/engineering-team/a11y-audit.md
@@ -8,7 +8,7 @@ description: "Accessibility audit skill for scanning, fixing, and verifying WCAG
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-code-braces: Engineering - Core</span>
 <span class="meta-badge">:material-identifier: `a11y-audit`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>
@@ -92,7 +92,7 @@ python scripts/a11y_scanner.py /path/to/project --format table
 
 **Phase 2: Fix** -- Apply framework-specific fixes for each violation.
 
-> See [references/framework-a11y-patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/framework-a11y-patterns.md) for the complete fix patterns catalog.
+> See [references/framework-a11y-patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/framework-a11y-patterns.md) for the complete fix patterns catalog.
 
 **Phase 3: Verify** -- Re-run the scanner to confirm fixes and check for regressions.
 
@@ -137,7 +137,7 @@ function ProductCard({ product }) {
 }
 ```
 
-> See [references/examples-by-framework.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/examples-by-framework.md) for Vue, Angular, Next.js, and Svelte examples.
+> See [references/examples-by-framework.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/examples-by-framework.md) for Vue, Angular, Next.js, and Svelte examples.
 
 ## Tools Reference
 
@@ -204,15 +204,15 @@ Options:
 
 | Reference | Description |
 |-----------|-------------|
-| [wcag-quick-ref.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/wcag-quick-ref.md) | WCAG 2.2 Level A & AA criteria quick reference |
-| [wcag-22-new-criteria.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/wcag-22-new-criteria.md) | New WCAG 2.2 success criteria (Focus Appearance, Target Size, etc.) |
-| [aria-patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/aria-patterns.md) | ARIA patterns, keyboard interaction, and live regions |
-| [framework-a11y-patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/framework-a11y-patterns.md) | Framework-specific fix patterns (React, Vue, Angular, Svelte, HTML) |
-| [color-contrast-guide.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/color-contrast-guide.md) | Color contrast checker details, Tailwind palette mapping, sr-only class |
-| [ci-cd-integration.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/ci-cd-integration.md) | GitHub Actions, GitLab CI, Azure DevOps, pre-commit hook configs |
-| [audit-report-template.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/audit-report-template.md) | Stakeholder-ready audit report template |
-| [testing-checklist.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/testing-checklist.md) | Manual testing checklist (keyboard, screen reader, visual, forms) |
-| [examples-by-framework.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/references/examples-by-framework.md) | Full audit examples for Vue, Angular, Next.js, and Svelte |
+| [wcag-quick-ref.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/wcag-quick-ref.md) | WCAG 2.2 Level A & AA criteria quick reference |
+| [wcag-22-new-criteria.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/wcag-22-new-criteria.md) | New WCAG 2.2 success criteria (Focus Appearance, Target Size, etc.) |
+| [aria-patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/aria-patterns.md) | ARIA patterns, keyboard interaction, and live regions |
+| [framework-a11y-patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/framework-a11y-patterns.md) | Framework-specific fix patterns (React, Vue, Angular, Svelte, HTML) |
+| [color-contrast-guide.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/color-contrast-guide.md) | Color contrast checker details, Tailwind palette mapping, sr-only class |
+| [ci-cd-integration.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/ci-cd-integration.md) | GitHub Actions, GitLab CI, Azure DevOps, pre-commit hook configs |
+| [audit-report-template.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/audit-report-template.md) | Stakeholder-ready audit report template |
+| [testing-checklist.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/testing-checklist.md) | Manual testing checklist (keyboard, screen reader, visual, forms) |
+| [examples-by-framework.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit/skills/a11y-audit/references/examples-by-framework.md) | Full audit examples for Vue, Angular, Next.js, and Svelte |
 
 ## Resources
 

--- a/docs/skills/engineering-team/google-workspace-cli.md
+++ b/docs/skills/engineering-team/google-workspace-cli.md
@@ -8,7 +8,7 @@ description: "Google Workspace administration via the gws CLI. Install, authenti
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-code-braces: Engineering - Core</span>
 <span class="meta-badge">:material-identifier: `google-workspace-cli`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/google-workspace-cli/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/google-workspace-cli/skills/google-workspace-cli/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering-team/playwright-pro-pw.md
+++ b/docs/skills/engineering-team/playwright-pro-pw.md
@@ -1,0 +1,135 @@
+---
+title: "Playwright Pro — Agent Skill & Codex Plugin"
+description: "Production-grade Playwright testing toolkit. Use when the user mentions Playwright tests, end-to-end testing, browser automation, fixing flaky tests. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Playwright Pro
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-code-braces: Engineering - Core</span>
+<span class="meta-badge">:material-identifier: `pw`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/playwright-pro/skills/pw/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install engineering-skills</code>
+</div>
+
+
+Production-grade Playwright testing toolkit for AI coding agents.
+
+## Available Commands
+
+When installed as a Claude Code plugin, these are available as `/pw:` commands:
+
+| Command | What it does |
+|---|---|
+| `/pw:init` | Set up Playwright — detects framework, generates config, CI, first test |
+| `/pw:generate <spec>` | Generate tests from user story, URL, or component |
+| `/pw:review` | Review tests for anti-patterns and coverage gaps |
+| `/pw:fix <test>` | Diagnose and fix failing or flaky tests |
+| `/pw:migrate` | Migrate from Cypress or Selenium to Playwright |
+| `/pw:coverage` | Analyze what's tested vs. what's missing |
+| `/pw:testrail` | Sync with TestRail — read cases, push results |
+| `/pw:browserstack` | Run on BrowserStack, pull cross-browser reports |
+| `/pw:report` | Generate test report in your preferred format |
+
+## Quick Start Workflow
+
+The recommended sequence for most projects:
+
+```
+1. /pw:init          → scaffolds config, CI pipeline, and a first smoke test
+2. /pw:generate      → generates tests from your spec or URL
+3. /pw:review        → validates quality and flags anti-patterns      ← always run after generate
+4. /pw:fix <test>    → diagnoses and repairs any failing/flaky tests  ← run when CI turns red
+```
+
+**Validation checkpoints:**
+- After `/pw:generate` — always run `/pw:review` before committing; it catches locator anti-patterns and missing assertions automatically.
+- After `/pw:fix` — re-run the full suite locally (`npx playwright test`) to confirm the fix doesn't introduce regressions.
+- After `/pw:migrate` — run `/pw:coverage` to confirm parity with the old suite before decommissioning Cypress/Selenium tests.
+
+### Example: Generate → Review → Fix
+
+```bash
+# 1. Generate tests from a user story
+/pw:generate "As a user I can log in with email and password"
+
+# Generated: tests/auth/login.spec.ts
+# → Playwright Pro creates the file using the auth template.
+
+# 2. Review the generated tests
+/pw:review tests/auth/login.spec.ts
+
+# → Flags: one test used page.locator('input[type=password]') — suggests getByLabel('Password')
+# → Fix applied automatically.
+
+# 3. Run locally to confirm
+npx playwright test tests/auth/login.spec.ts --headed
+
+# 4. If a test is flaky in CI, diagnose it
+/pw:fix tests/auth/login.spec.ts
+# → Identifies missing web-first assertion; replaces waitForTimeout(2000) with expect(locator).toBeVisible()
+```
+
+## Golden Rules
+
+1. `getByRole()` over CSS/XPath — resilient to markup changes
+2. Never `page.waitForTimeout()` — use web-first assertions
+3. `expect(locator)` auto-retries; `expect(await locator.textContent())` does not
+4. Isolate every test — no shared state between tests
+5. `baseURL` in config — zero hardcoded URLs
+6. Retries: `2` in CI, `0` locally
+7. Traces: `'on-first-retry'` — rich debugging without slowdown
+8. Fixtures over globals — `test.extend()` for shared state
+9. One behavior per test — multiple related assertions are fine
+10. Mock external services only — never mock your own app
+
+## Locator Priority
+
+```
+1. getByRole()        — buttons, links, headings, form elements
+2. getByLabel()       — form fields with labels
+3. getByText()        — non-interactive text
+4. getByPlaceholder() — inputs with placeholder
+5. getByTestId()      — when no semantic option exists
+6. page.locator()     — CSS/XPath as last resort
+```
+
+## What's Included
+
+- **9 skills** with detailed step-by-step instructions
+- **3 specialized agents**: test-architect, test-debugger, migration-planner
+- **55 test templates**: auth, CRUD, checkout, search, forms, dashboard, settings, onboarding, notifications, API, accessibility
+- **2 MCP servers** (TypeScript): TestRail and BrowserStack integrations
+- **Smart hooks**: auto-validate test quality, auto-detect Playwright projects
+- **6 reference docs**: golden rules, locators, assertions, fixtures, pitfalls, flaky tests
+- **Migration guides**: Cypress and Selenium mapping tables
+
+## Integration Setup
+
+### TestRail (Optional)
+```bash
+export TESTRAIL_URL="https://your-instance.testrail.io"
+export TESTRAIL_USER="your@email.com"
+export TESTRAIL_API_KEY="your-api-key"
+```
+
+### BrowserStack (Optional)
+```bash
+export BROWSERSTACK_USERNAME="your-username"
+export BROWSERSTACK_ACCESS_KEY="your-access-key"
+```
+
+## Quick Reference
+
+See `reference/` directory for:
+- `golden-rules.md` — The 10 non-negotiable rules
+- `locators.md` — Complete locator priority with cheat sheet
+- `assertions.md` — Web-first assertions reference
+- `fixtures.md` — Custom fixtures and storageState patterns
+- `common-pitfalls.md` — Top 10 mistakes and fixes
+- `flaky-tests.md` — Diagnosis commands and quick fixes
+
+See `templates/README.md` for the full template index.

--- a/docs/skills/engineering-team/self-improving-agent-extract.md
+++ b/docs/skills/engineering-team/self-improving-agent-extract.md
@@ -65,6 +65,20 @@ Rules for naming:
 - Descriptive but concise (2-4 words)
 - Examples: `docker-m1-fixes`, `api-timeout-patterns`, `pnpm-workspace-setup`
 
+**Reserved fragments — must NOT appear in the skill name:**
+- `claude`
+- `anthropic`
+
+For skills about Claude Code itself, use the `cc-` prefix instead:
+- ❌ `claude-code-settings` → ✅ `cc-settings`
+- ❌ `claude-code-maintenance` → ✅ `cc-maintenance`
+- ❌ `claude-mcp-tools` → ✅ `cc-mcp-tools`
+- ❌ `claude-plugin-development` → ✅ `cc-plugin-development`
+
+Before writing the skill directory, check the proposed name against this list.
+If a reserved fragment is present, transform it (drop the fragment or replace
+the `claude*`/`anthropic*` prefix with `cc-`) and confirm with the user.
+
 ### Step 4: Create the skill files
 
 **Spawn the `skill-extractor` agent** for the actual file generation.
@@ -133,6 +147,7 @@ Before finalizing, verify:
 
 - [ ] SKILL.md has valid YAML frontmatter with `name` and `description`
 - [ ] `name` matches the folder name (lowercase, hyphens)
+- [ ] `name` does NOT contain reserved fragments `claude` or `anthropic` (use `cc-` prefix for Claude Code skills)
 - [ ] Description includes "Use when:" trigger conditions
 - [ ] Solutions are self-contained (no external context needed)
 - [ ] Code examples are complete and copy-pasteable

--- a/docs/skills/engineering-team/self-improving-agent.md
+++ b/docs/skills/engineering-team/self-improving-agent.md
@@ -8,7 +8,7 @@ description: "Curate Claude Code's auto-memory into durable project knowledge. A
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-code-braces: Engineering - Core</span>
 <span class="meta-badge">:material-identifier: `self-improving-agent`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent/skills/self-improving-agent/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>
@@ -170,4 +170,4 @@ Monitors command output for errors. When detected, appends a structured entry to
 
 - [Claude Code Memory Docs](https://code.claude.com/docs/en/memory)
 - [pskoett/self-improving-agent](https://clawhub.ai/pskoett/self-improving-agent) — inspiration
-- [playwright-pro](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/playwright-pro) — sister plugin in this repo
+- [playwright-pro](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent/skills/playwright-pro) — sister plugin in this repo

--- a/docs/skills/engineering-team/snowflake-development.md
+++ b/docs/skills/engineering-team/snowflake-development.md
@@ -8,7 +8,7 @@ description: "Use when writing Snowflake SQL, building data pipelines with Dynam
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-code-braces: Engineering - Core</span>
 <span class="meta-badge">:material-identifier: `snowflake-development`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/snowflake-development/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/snowflake-development/skills/snowflake-development/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/agenthub.md
+++ b/docs/skills/engineering/agenthub.md
@@ -8,7 +8,7 @@ description: "Multi-agent collaboration plugin that spawns N parallel subagents 
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `agenthub`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/agenthub/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/agenthub/skills/agenthub/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/autoresearch-agent.md
+++ b/docs/skills/engineering/autoresearch-agent.md
@@ -8,7 +8,7 @@ description: "Autonomous experiment loop that optimizes any file by a measurable
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `autoresearch-agent`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/autoresearch-agent/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/autoresearch-agent/skills/autoresearch-agent/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/behuman.md
+++ b/docs/skills/engineering/behuman.md
@@ -8,7 +8,7 @@ description: "Use when the user wants more human-like AI responses — less robo
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `behuman`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/behuman/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/behuman/skills/behuman/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/code-tour.md
+++ b/docs/skills/engineering/code-tour.md
@@ -8,7 +8,7 @@ description: "Use when the user asks to create a CodeTour .tour file — persona
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `code-tour`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/code-tour/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/code-tour/skills/code-tour/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/data-quality-auditor.md
+++ b/docs/skills/engineering/data-quality-auditor.md
@@ -8,7 +8,7 @@ description: "Audit datasets for completeness, consistency, accuracy, and validi
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `data-quality-auditor`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/data-quality-auditor/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/data-quality-auditor/skills/data-quality-auditor/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/demo-video.md
+++ b/docs/skills/engineering/demo-video.md
@@ -8,7 +8,7 @@ description: "Use when the user asks to create a demo video, product walkthrough
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `demo-video`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video/skills/demo-video/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>
@@ -93,7 +93,7 @@ If MCPs are unavailable, still produce items 1-3. Include the ffmpeg commands in
 
 ## Scene Design System
 
-See [references/scene-design-system.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video/references/scene-design-system.md) for the full design system: color language, animation timing, typography, HTML layout, voice options, and pacing guide.
+See [references/scene-design-system.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video/skills/demo-video/references/scene-design-system.md) for the full design system: color language, animation timing, typography, HTML layout, voice options, and pacing guide.
 
 ## Quality Checklist
 

--- a/docs/skills/engineering/docker-development.md
+++ b/docs/skills/engineering/docker-development.md
@@ -8,7 +8,7 @@ description: "Docker and container development agent skill and plugin for Docker
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `docker-development`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/docker-development/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/docker-development/skills/docker-development/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/helm-chart-builder.md
+++ b/docs/skills/engineering/helm-chart-builder.md
@@ -8,7 +8,7 @@ description: "Helm chart development agent skill and plugin for Claude Code, Cod
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `helm-chart-builder`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/helm-chart-builder/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/helm-chart-builder/skills/helm-chart-builder/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/karpathy-coder.md
+++ b/docs/skills/engineering/karpathy-coder.md
@@ -8,7 +8,7 @@ description: "Use when writing, reviewing, or committing code to enforce Karpath
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `karpathy-coder`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder/skills/karpathy-coder/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/llm-cost-optimizer.md
+++ b/docs/skills/engineering/llm-cost-optimizer.md
@@ -1,6 +1,6 @@
 ---
 title: "LLM Cost Optimizer — Agent Skill for Codex & OpenClaw"
-description: "Use when you need to reduce LLM API spend, control token usage, route between models by cost/quality, implement prompt caching, or build cost. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+description: "Use proactively whenever LLM API costs come up -- or should. Triggers include: 'my AI costs are too high', 'optimize token usage', 'which model. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
 ---
 
 # LLM Cost Optimizer
@@ -8,7 +8,7 @@ description: "Use when you need to reduce LLM API spend, control token usage, ro
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `llm-cost-optimizer`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-cost-optimizer/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-cost-optimizer/skills/llm-cost-optimizer/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>
@@ -16,57 +16,56 @@ description: "Use when you need to reduce LLM API spend, control token usage, ro
 </div>
 
 
-> Originally contributed by [chad848](https://github.com/chad848) — enhanced and integrated by the claude-skills team.
-
-You are an expert in LLM cost engineering with deep experience reducing AI API spend at scale. Your goal is to cut LLM costs by 40-80% without degrading user-facing quality -- using model routing, caching, prompt compression, and observability to make every token count.
+You are an expert in LLM cost engineering with deep experience reducing AI API spend at scale. Your goal is to cut LLM costs by 40–80% without degrading user-facing quality -- using model routing, caching, prompt compression, and observability to make every token count.
 
 AI API costs are engineering costs. Treat them like database query costs: measure first, optimize second, monitor always.
 
-## Before Starting
+---
 
-**Check for context first:** If project-context.md exists, read it before asking questions. Pull the tech stack, architecture, and AI feature details already there.
+## Step 0: Classify Before You Ask
 
-Gather this context (ask in one shot):
+Before gathering context, classify which mode applies based on what the user has already said. Pull answers from the conversation first -- don't ask for what you already have.
 
-### 1. Current State
-- Which LLM providers and models are you using today?
-- What is your monthly spend? Which features/endpoints drive it?
-- Do you have token usage logging? Cost-per-request visibility?
+| Mode | When to use |
+|---|---|
+| **Cost Audit** | Spend exists but no clear picture of where it goes |
+| **Optimize Existing System** | Cost drivers are known; apply targeted fixes |
+| **Design Cost-Efficient Architecture** | Building new AI features; wire in cost controls before launch |
 
-### 2. Goals
-- Target cost reduction? (e.g., "cut spend by 50%", "stay under $X/month")
-- Latency constraints? (caching and routing tradeoffs)
+If the mode is ambiguous, ask in one shot using the context questions below. Only ask what you don't already know.
+
+---
+
+## Context You Need
+
+**Current State**
+- Which LLM providers and models are in use?
+- Monthly spend? Which features/endpoints drive it?
+- Token usage logging in place? Cost-per-request visibility?
+
+**Goals**
+- Target cost reduction? (e.g., "cut 50%", "stay under $X/month")
+- Latency constraints? (affects caching and routing tradeoffs)
 - Quality floor? (what degradation is acceptable?)
 
-### 3. Workload Profile
+**Workload Profile**
 - Request volume and distribution (p50, p95, p99 token counts)?
-- Repeated/similar prompts? (caching potential)
+- Repeated or similar prompts? (caching potential)
 - Mix of task types? (classification vs. generation vs. reasoning)
-
-## How This Skill Works
-
-### Mode 1: Cost Audit
-You have spend but no clear picture of where it goes. Instrument, measure, and identify the top cost drivers before touching a single prompt.
-
-### Mode 2: Optimize Existing System
-Cost drivers are known. Apply targeted techniques: model routing, caching, compression, batching. Measure impact of each change.
-
-### Mode 3: Design Cost-Efficient Architecture
-Building new AI features. Design cost controls in from the start -- budget envelopes, routing logic, caching strategy, and cost alerts before launch.
 
 ---
 
 ## Mode 1: Cost Audit
 
+Use when spend exists but the breakdown is unknown. Instrument first; optimize second.
+
 **Step 1 -- Instrument Every Request**
 
 Log per-request: model, input tokens, output tokens, latency, endpoint/feature, user segment, cost (calculated).
 
-Build a per-request cost breakdown from your logs: group by feature, model, and token count to identify top spend drivers.
-
 **Step 2 -- Find the 20% Causing 80% of Spend**
 
-Sort by: feature x model x token count. Usually 2-3 endpoints drive the majority of cost. Target those first.
+Sort by: feature × model × token count. Usually 2–3 endpoints drive the majority of cost. Target those first.
 
 **Step 3 -- Classify Requests by Complexity**
 
@@ -74,52 +73,61 @@ Sort by: feature x model x token count. Usually 2-3 endpoints drive the majority
 |---|---|---|
 | Simple | Classification, extraction, yes/no, short output | Small (Haiku, GPT-4o-mini, Gemini Flash) |
 | Medium | Summarization, structured output, moderate reasoning | Mid (Sonnet, GPT-4o) |
-| Complex | Multi-step reasoning, code gen, long context | Large (Opus, GPT-4o, o3) |
+| Complex | Multi-step reasoning, code gen, long context | Large (Opus, o3) |
+
+**If token logging doesn't exist yet:** That's the first deliverable -- not prompt compression, not routing. You cannot optimize what you cannot see. Provide a logging schema and move to optimization only once baseline data exists.
 
 ---
 
 ## Mode 2: Optimize Existing System
 
-Apply techniques in this order (highest ROI first):
+Apply techniques in ROI order. Don't skip ahead -- measure impact at each step before moving to the next.
 
-### 1. Model Routing (typically 60-80% cost reduction on routed traffic)
+### 1. Model Routing (60–80% cost reduction on routed traffic)
 
 Route by task complexity, not by default. Use a lightweight classifier or rule engine.
 
-Decision framework:
-- **Use small models** for: classification, extraction, simple Q&A, formatting, short summaries
-- **Use mid models** for: structured output, moderate summarization, code completion
-- **Use large models** for: complex reasoning, long-context analysis, agentic tasks, code generation
+- **Small models**: classification, extraction, simple Q&A, formatting, short summaries
+- **Mid models**: structured output, moderate summarization, code completion
+- **Large models**: complex reasoning, long-context analysis, agentic tasks, code generation
 
-### 2. Prompt Caching (40-90% reduction on cacheable traffic)
+Even routing 20% of traffic to a cheaper model produces meaningful savings. Start there.
 
-Supported by: Anthropic (cache_control), OpenAI (prompt caching, automatic on some models), Google (context caching).
+### 2. Prompt Caching (40–90% reduction on cacheable traffic)
+
+Supported by Anthropic (`cache_control`), OpenAI (automatic on some models), Google (context caching).
 
 Cache-eligible content: system prompts, static context, document chunks, few-shot examples.
 
-Cache hit rates to target: >60% for document Q&A, >40% for chatbots with static system prompts.
+Target hit rates: >60% for document Q&A, >40% for chatbots with static system prompts.
 
-### 3. Output Length Control (20-40% reduction)
+**Flag immediately** if a system prompt exceeds ~2,000 tokens and is sent on every request -- this is a high-value caching target.
+
+### 3. Output Length Control (20–40% reduction)
 
 LLMs over-generate by default. Force conciseness:
 
 - Explicit length instructions: "Respond in 3 sentences or fewer."
 - Schema-constrained output: JSON with defined fields beats free-text
-- max_tokens hard caps: Set per-endpoint, not globally
-- Stop sequences: Define terminators for list/structured outputs
+- `max_tokens` hard caps: set per endpoint, not globally
+- Stop sequences: define terminators for list and structured outputs
 
-### 4. Prompt Compression (15-30% input token reduction)
+**Flag immediately** if `max_tokens` is not set per endpoint -- every uncapped endpoint is a cost leak.
 
-Remove filler without losing meaning. Audit each prompt for token efficiency by comparing instruction length to actual task requirements.
+### 4. Prompt Compression (15–30% input token reduction)
+
+Remove filler without losing meaning. Audit each prompt for token efficiency.
 
 | Before | After |
 |---|---|
 | "Please carefully analyze the following text and provide..." | "Analyze:" |
 | "It is important that you remember to always..." | "Always:" |
-| Repeating context already in system prompt | Remove |
-| HTML/markdown when plain text works | Strip tags |
+| Context already in system prompt, repeated in user message | Remove |
+| HTML or markdown when plain text works | Strip tags |
 
-### 5. Semantic Caching (30-60% hit rate on repeated queries)
+**Caution:** Over-compression causes hallucination and low-quality outputs, triggering retries that erase the savings. Compress filler; preserve task-critical instructions.
+
+### 5. Semantic Caching (30–60% hit rate on repeated queries)
 
 Cache LLM responses keyed by embedding similarity, not exact match. Serve cached responses for semantically equivalent questions.
 
@@ -127,7 +135,7 @@ Tools: GPTCache, LangChain cache, custom Redis + embedding lookup.
 
 Threshold guidance: cosine similarity >0.95 = safe to serve cached response.
 
-### 6. Request Batching (10-25% reduction via amortized overhead)
+### 6. Request Batching (10–25% reduction via amortized overhead)
 
 Batch non-latency-sensitive requests. Process async queues off-peak.
 
@@ -135,49 +143,75 @@ Batch non-latency-sensitive requests. Process async queues off-peak.
 
 ## Mode 3: Design Cost-Efficient Architecture
 
-Build these controls in before launch:
+Wire these controls in before launch -- retrofitting is more expensive.
 
 **Budget Envelopes** -- per feature, per user tier, per day. Set hard limits and soft alerts at 80% of limit.
 
-**Routing Layer** -- classify then route then call. Never call the large model by default.
+**Routing Layer** -- classify → route → call. Never call the large model by default.
 
-**Cost Observability** -- dashboard with: spend by feature, spend by model, cost per active user, week-over-week trend, anomaly alerts.
+**Tier Your Model Access** -- free users do not need the most expensive model. Assign model tiers by user tier at design time.
 
-**Graceful Degradation** -- when budget exceeded: switch to smaller model, return cached response, queue for async processing.
+**Cost Observability Dashboard** -- spend by feature, spend by model, cost per active user, week-over-week trend, anomaly alerts. This is not optional; it is the monitoring foundation.
+
+**Graceful Degradation** -- when budget is exceeded: switch to smaller model → serve cached response → queue for async processing.
 
 ---
 
-## Proactive Triggers
+## Proactive Flags
 
-Surface these without being asked:
+Surface these without being asked, regardless of which mode is active:
 
-- **No per-feature cost breakdown** -- You cannot optimize what you cannot see. Instrument logging before any other change.
-- **All requests hitting the same model** -- Model monoculture is the #1 overspend pattern. Even 20% routing to a cheaper model cuts spend significantly.
-- **System prompt >2,000 tokens sent on every request** -- This is a caching opportunity worth flagging immediately.
-- **Output max_tokens not set** -- LLMs pad outputs. Every uncapped endpoint is a cost leak.
-- **No cost alerts configured** -- Spend spikes go undetected for days. Set p95 cost-per-request alerts on every AI endpoint.
-- **Free tier users consuming same model as paid** -- Tier your model access. Free users do not need the most expensive model.
+| Signal | Action |
+|---|---|
+| No per-feature cost breakdown | Instrument logging before any other change |
+| All requests hitting one model | Model monoculture = #1 overspend pattern; initiate routing design |
+| System prompt >2,000 tokens, sent every request | Flag as high-value caching target |
+| `max_tokens` not set per endpoint | Flag as active cost leak |
+| No cost alerts configured | Spend spikes go undetected for days; set p95 cost-per-request alerts |
+| Free tier users consuming same model as paid | Tier model access by user tier |
+
+---
+
+## Failure Modes and Recovery
+
+| Situation | Response |
+|---|---|
+| No token logs exist | Stop. Logging schema is deliverable #1. Return once baseline data is available. |
+| User can't identify which feature drives spend | Provide an instrumentation plan; schedule a cost review after 2 weeks of data. |
+| Routing classifier adds latency that exceeds constraint | Fall back to rule-based routing (token count thresholds, endpoint tags) instead of ML classifier. |
+| Cache hit rate is below 20% | Diagnose: are prompts highly variable? Is context dynamic? Recommend semantic caching or rethink what's being cached. |
+| Prompt compression degrades quality | Restore compressed section. Flag the specific instruction as compression-resistant. |
+
+---
+
+## Handoff Triggers
+
+If the conversation shifts to one of these, pause and invoke the relevant skill rather than continuing inline:
+
+- **Prompt quality or effectiveness deteriorates** → invoke `senior-prompt-engineer`
+- **Retrieval pipeline design comes up** → invoke `rag-architect`
+- **Broader monitoring stack beyond cost metrics** → invoke `observability-designer`
+- **Latency profiling becomes the primary concern** → invoke `performance-profiler`
 
 ---
 
 ## Output Artifacts
 
-| When you ask for... | You get... |
+| Request | Deliverable |
 |---|---|
-| Cost audit | Per-feature spend breakdown with top 3 optimization targets and projected savings |
+| Cost audit | Per-feature spend breakdown, top 3 optimization targets, projected savings |
 | Model routing design | Routing decision tree with model recommendations per task type and estimated cost delta |
-| Caching strategy | Which content to cache, cache key design, expected hit rate, implementation pattern |
+| Caching strategy | What to cache, cache key design, expected hit rate, implementation pattern |
 | Prompt optimization | Token-by-token audit with compression suggestions and before/after token counts |
-| Architecture review | Cost-efficiency scorecard (0-100) with prioritized fixes and projected monthly savings |
+| Architecture review | Cost-efficiency scorecard (0–100) with prioritized fixes and projected monthly savings |
 
 ---
 
-## Communication
+## Communication Standard
 
-All output follows the structured standard:
 - **Bottom line first** -- cost impact before explanation
 - **What + Why + How** -- every finding includes all three
-- **Actions have owners and deadlines** -- no "consider optimizing..."
+- **Actions have owners and deadlines** -- no vague "consider optimizing..."
 - **Confidence tagging** -- verified / medium / assumed
 
 ---
@@ -186,18 +220,10 @@ All output follows the structured standard:
 
 | Anti-Pattern | Why It Fails | Better Approach |
 |---|---|---|
-| Using the largest model for every request | 80%+ of requests are simple tasks that a smaller model handles equally well, wasting 5-10x on cost | Implement a routing layer that classifies request complexity and selects the cheapest adequate model |
-| Optimizing prompts without measuring first | You cannot know what to optimize without per-feature spend visibility | Instrument token logging and cost-per-request before making any changes |
+| Using the largest model for every request | 80%+ of requests are simple tasks a smaller model handles equally well, wasting 5–10x on cost | Implement a routing layer that classifies complexity and selects the cheapest adequate model |
+| Optimizing prompts without measuring first | You cannot know what to optimize without per-feature spend visibility | Instrument token logging and cost-per-request before any changes |
 | Caching by exact string match only | Minor phrasing differences cause cache misses on semantically identical queries | Use embedding-based semantic caching with a cosine similarity threshold |
-| Setting a single global max_tokens | Some endpoints need 2000 tokens, others need 50 — a global cap either wastes or truncates | Set max_tokens per endpoint based on measured p95 output length |
-| Ignoring system prompt size | A 3000-token system prompt sent on every request is a hidden cost multiplier | Use prompt caching for static system prompts and strip unnecessary instructions |
-| Treating cost optimization as a one-time project | Model pricing changes, traffic patterns shift, and new features launch — costs drift | Set up continuous cost monitoring with weekly spend reports and anomaly alerts |
-| Compressing prompts to the point of ambiguity | Over-compressed prompts cause the model to hallucinate or produce low-quality output, requiring retries | Compress filler words and redundant context but preserve all task-critical instructions |
-
-## Related Skills
-
-- **rag-architect**: Use when designing retrieval pipelines. NOT for cost optimization of the LLM calls within RAG (that is this skill).
-- **senior-prompt-engineer**: Use when improving prompt quality and effectiveness. NOT for token reduction or cost control (that is this skill).
-- **observability-designer**: Use when designing the broader monitoring stack. Pairs with this skill for LLM cost dashboards.
-- **performance-profiler**: Use for latency profiling. Pairs with this skill when optimizing the cost-latency tradeoff.
-- **api-design-reviewer**: Use when reviewing AI feature APIs. Cross-reference for cost-per-endpoint analysis.
+| Setting a single global max_tokens | Some endpoints need 2,000 tokens, others need 50 -- a global cap either wastes or truncates | Set max_tokens per endpoint based on measured p95 output length |
+| Ignoring system prompt size | A 3,000-token system prompt sent on every request is a hidden cost multiplier | Use prompt caching for static system prompts; strip unnecessary instructions |
+| Treating cost optimization as a one-time project | Model pricing changes, traffic patterns shift, new features launch -- costs drift | Set up continuous cost monitoring with weekly spend reports and anomaly alerts |
+| Compressing prompts to the point of ambiguity | Over-compressed prompts cause hallucination or low-quality output, requiring retries | Compress filler and redundant context; preserve all task-critical instructions |

--- a/docs/skills/engineering/llm-wiki.md
+++ b/docs/skills/engineering/llm-wiki.md
@@ -8,7 +8,7 @@ description: "Use when building or maintaining a persistent personal knowledge b
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `llm-wiki`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki/skills/llm-wiki/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/prompt-governance.md
+++ b/docs/skills/engineering/prompt-governance.md
@@ -8,7 +8,7 @@ description: "Use when managing prompts in production at scale: versioning promp
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `prompt-governance`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/prompt-governance/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/prompt-governance/skills/prompt-governance/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/statistical-analyst.md
+++ b/docs/skills/engineering/statistical-analyst.md
@@ -8,7 +8,7 @@ description: "Run hypothesis tests, analyze A/B experiment results, calculate sa
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `statistical-analyst`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/statistical-analyst/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/statistical-analyst/skills/statistical-analyst/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/engineering/terraform-patterns.md
+++ b/docs/skills/engineering/terraform-patterns.md
@@ -8,7 +8,7 @@ description: "Terraform infrastructure-as-code agent skill and plugin for Claude
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
 <span class="meta-badge">:material-identifier: `terraform-patterns`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/terraform-patterns/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/terraform-patterns/skills/terraform-patterns/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/finance/business-investment-advisor.md
+++ b/docs/skills/finance/business-investment-advisor.md
@@ -8,7 +8,7 @@ description: "Business investment analysis and capital allocation advisor. Use w
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-calculator-variant: Finance</span>
 <span class="meta-badge">:material-identifier: `business-investment-advisor`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/finance/business-investment-advisor/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/finance/business-investment-advisor/skills/business-investment-advisor/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/marketing-skill/video-content-strategist.md
+++ b/docs/skills/marketing-skill/video-content-strategist.md
@@ -8,7 +8,7 @@ description: "Use when planning video content strategy, writing video scripts, o
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-bullhorn-outline: Marketing</span>
 <span class="meta-badge">:material-identifier: `video-content-strategist`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/video-content-strategist/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/video-content-strategist/skills/video-content-strategist/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/product-team/agile-product-owner.md
+++ b/docs/skills/product-team/agile-product-owner.md
@@ -8,7 +8,7 @@ description: "Agile product ownership for backlog management and sprint executio
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-lightbulb-outline: Product</span>
 <span class="meta-badge">:material-identifier: `agile-product-owner`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner/skills/agile-product-owner/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>
@@ -22,6 +22,7 @@ Backlog management and sprint execution toolkit for product owners, including us
 
 ## Table of Contents
 
+- [What Makes This Skill Different](#what-makes-this-skill-different)
 - [User Story Generation Workflow](#user-story-generation-workflow)
 - [Acceptance Criteria Patterns](#acceptance-criteria-patterns)
 - [Epic Breakdown Workflow](#epic-breakdown-workflow)
@@ -31,6 +32,14 @@ Backlog management and sprint execution toolkit for product owners, including us
 - [Tools](#tools)
 
 ---
+
+## What Makes This Skill Different
+
+- **Capacity math that aligns with reality:** sprint capacity is based on velocity × availability factor, not hope.
+- **Acceptance criteria scaled by story size:** minimum AC counts map to story points to avoid under-spec'ing large items.
+- **Weighted prioritization that stays consistent:** value 40%, impact 30%, risk 15%, effort 15% keeps tradeoffs explicit.
+- **Systematic epic splitting techniques:** five concrete split patterns prevent oversized stories.
+- **INVEST validation baked into workflows:** every story includes a validation step, not just guidance.
 
 ## User Story Generation Workflow
 

--- a/docs/skills/product-team/apple-hig-expert.md
+++ b/docs/skills/product-team/apple-hig-expert.md
@@ -8,7 +8,7 @@ description: "Expert guidance on Apple Human Interface Guidelines (HIG). Covers 
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-lightbulb-outline: Product</span>
 <span class="meta-badge">:material-identifier: `apple-hig-expert`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/skills/apple-hig-expert/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>
@@ -36,7 +36,7 @@ This skill supports 2 primary modes:
 When starting fresh. Focus on atomic design, layout primitives, and navigation paradigms that align with Apple's core philosophies (Clarity, Deference, Depth).
 
 ### Mode 2: HIG Audit 
-When reviewing mockups or code. Use the [templates/hig-audit-template.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/templates/hig-audit-template.md) to systematically identify violations and refinement opportunities.
+When reviewing mockups or code. Use the [templates/hig-audit-template.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/skills/apple-hig-expert/templates/hig-audit-template.md) to systematically identify violations and refinement opportunities.
 
 ## Core Design Principles (2026)
 
@@ -56,11 +56,11 @@ Design for everyone from Day 1.
 
 ### Phase 1: Navigation & Layout
 Choose the right navigation pattern (Sidebars for macOS, Tab Bars for iOS, Ornaments for visionOS).
-See [references/platform-specifics.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/references/platform-specifics.md) for details.
+See [references/platform-specifics.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/skills/apple-hig-expert/references/platform-specifics.md) for details.
 
 ### Phase 2: Visual Styling
 Apply typography (San Francisco family) and semantic colors. 
-See [references/visual-design.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/references/visual-design.md).
+See [references/visual-design.md](https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert/skills/apple-hig-expert/references/visual-design.md).
 
 ### Phase 3: Final Audit
 Run the `hig_checker.py` tool to automate contrast and layout checks.

--- a/docs/skills/product-team/code-to-prd.md
+++ b/docs/skills/product-team/code-to-prd.md
@@ -8,7 +8,7 @@ description: "Reverse-engineer any codebase into a complete Product Requirements
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-lightbulb-outline: Product</span>
 <span class="meta-badge">:material-identifier: `code-to-prd`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/code-to-prd/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/code-to-prd/skills/code-to-prd/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/docs/skills/product-team/research-summarizer.md
+++ b/docs/skills/product-team/research-summarizer.md
@@ -8,7 +8,7 @@ description: "Structured research summarization agent skill for non-dev users. H
 <div class="page-meta" markdown>
 <span class="meta-badge">:material-lightbulb-outline: Product</span>
 <span class="meta-badge">:material-identifier: `research-summarizer`</span>
-<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/research-summarizer/SKILL.md">Source</a></span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/product-team/research-summarizer/skills/research-summarizer/SKILL.md">Source</a></span>
 </div>
 
 <div class="install-banner" markdown>

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -414,6 +414,7 @@ def main():
     for domain_key, skills in skills_by_domain.items():
         top_level = [s for s in skills if not s["is_sub_skill"]]
         sub_skills = [s for s in skills if s["is_sub_skill"]]
+        top_level_names = {s["name"] for s in top_level}
 
         for skill in top_level:
             slug = slugify(skill["name"])
@@ -429,6 +430,39 @@ def main():
                 child_slug = slugify(child["name"])
                 child_content = generate_skill_page(child, domain_key)
                 child_path = os.path.join(DOCS_DIR, "skills", domain_key, f"{slug}-{child_slug}.md")
+                with open(child_path, "w", encoding="utf-8") as f:
+                    f.write(child_content)
+                total += 1
+
+        # Render orphan sub-skills (sub-skills whose parent is a plugin folder,
+        # not a top-level skill at <domain>/skills/<name>/). Without this,
+        # standalone-only plugins like executive-mentor, agenthub, autoresearch-agent,
+        # playwright-pro, self-improving-agent, c-level-agents, and llm-wiki have
+        # their sub-skills silently dropped (~79 pages missing from the docs site).
+        orphan_sub_skills = [s for s in sub_skills if s["parent"] not in top_level_names]
+        # Group by plugin parent
+        by_parent = {}
+        for s in orphan_sub_skills:
+            by_parent.setdefault(s["parent"], []).append(s)
+        for parent, children in by_parent.items():
+            parent_slug = slugify(parent)
+            # If a child has the same name as parent, it's the plugin's index skill;
+            # render as <parent>.md (preserves existing URLs like executive-mentor.md).
+            index_sub = next((s for s in children if s["name"] == parent), None)
+            if index_sub:
+                page_content = generate_skill_page(index_sub, domain_key)
+                page_path = os.path.join(DOCS_DIR, "skills", domain_key, f"{parent_slug}.md")
+                with open(page_path, "w", encoding="utf-8") as f:
+                    f.write(page_content)
+                total += 1
+            # Render non-index children as <parent>-<child>.md
+            # (preserves existing URLs like executive-mentor-challenge.md).
+            for child in children:
+                if child["name"] == parent:
+                    continue
+                child_slug = slugify(child["name"])
+                child_content = generate_skill_page(child, domain_key)
+                child_path = os.path.join(DOCS_DIR, "skills", domain_key, f"{parent_slug}-{child_slug}.md")
                 with open(child_path, "w", encoding="utf-8") as f:
                     f.write(child_content)
                 total += 1


### PR DESCRIPTION
## Release: v2.5.7 second hotfix — recover 79 dropped sub-skill pages

**Single-purpose release:** ship PR #632 (the orphan sub-skill fix) to production so previously-dropped pages are surfaced on the docs site.

## What's in this release

One commit since the previous hotfix release:

| PR | Change |
|---|---|
| #632 | `fix(docs): render orphan sub-skills (recover 79 missing skill pages)` |

## What this fixes

`generate-docs.py` had a longstanding bug — the rendering loop only iterated **top-level** skills and only rendered their direct children. Sub-skills whose parent is a plugin folder (not a top-level skill at `<domain>/skills/<name>/`) were silently dropped.

**Affected plugins** (all standalone-only):
- `c-level-agents` — 1 + 17 sub-skills (this session's new `/cs:*` commands)
- `executive-mentor` — 1 + 5 sub-skills (`/em:*` commands)
- `playwright-pro` — 1 + 9 sub-skills
- `agenthub` — 1 + 7 sub-skills
- `autoresearch-agent` — 1 + 5 sub-skills
- `self-improving-agent` — 1 + 5 sub-skills
- `llm-wiki` — 1 + sub-skills
- Single-skill plugins: behuman, code-tour, demo-video, helm-chart-builder, karpathy-coder, llm-cost-optimizer, prompt-governance, statistical-analyst, terraform-patterns, data-quality-auditor, docker-development

**Total:** 79 sub-skill pages + 12 plugin-index pages = ~91 pages were missing.

## After this release

- Skill pages: 193 → **272** (+79 recovered)
- Total docs pages: 280 → **359**
- The docs site has **1:1 correspondence** between `SKILL.md` files in the repo and pages on the site
- URL convention preserved (e.g., `executive-mentor-challenge.md`, `agenthub-board.md`, `playwright-pro-coverage.md`) — SEO equity preserved

## What triggers after merge

1. `static.yml` workflow fires on push to `main`
2. Runs `pip install mkdocs-material mkdocs-redirects` + `python scripts/generate-docs.py` + `mkdocs build`
3. Deploys ~440 HTML pages (up from ~380 after the previous hotfix) to `alirezarezvani.github.io/claude-skills/`
4. All 79 previously-dropped pages become navigable by URL (mkdocs.yml nav doesn't include them yet — that's a follow-up if desired)

## Verification

- ✅ All 91 previously-dropped pages now generated
- ✅ `mkdocs build` succeeds (no new warnings; only 13 pre-existing INFO warnings)
- ✅ karpathy `diff_surgeon`: 0 findings on the fix
- ✅ PR #632 passed all CI in `dev`
- ✅ Existing URL convention preserved (no SEO loss)

## Sequencing note

This is the third release in close succession (v2.5.7 → v2.5.7-hotfix → v2.5.7-hotfix-2). After this merges and deploys, `generate-docs.py` is complete — both plugin-internal agents (PR #630) and orphan sub-skills (PR #632) are now rendered. No more silent drops.

## Test plan

- [ ] CI on this release: `Lint, Tests, Docs, Security` passes
- [ ] CI: `claude-review` passes
- [ ] After merge: `static.yml` Pages deploy succeeds
- [ ] After deploy: spot-check 3 recovered pages (executive-mentor, agenthub-board, playwright-pro-coverage)
- [ ] After deploy: spot-check c-level-agents sub-skill pages (e.g., c-level-agents-cco-review)

https://claude.ai/code/session_012WtZMm5NJHqkYoRqA9fHMN

---
_Generated by [Claude Code](https://claude.ai/code/session_012WtZMm5NJHqkYoRqA9fHMN)_