### PR TITLE
feat(engineering): install grill-with-docs skill (Matt Pocock derivative, MIT)

### DIFF
--- a/engineering/grill-with-docs/.claude-plugin/plugin.json
+++ b/engineering/grill-with-docs/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "grill-with-docs",
+  "description": "Docs-anchored grilling session — interrogates a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), updating those files inline as terminology and decisions crystallise. Derived from Matt Pocock's MIT-licensed grill-with-docs skill (https://github.com/mattpocock/skills) with: (1) 3 stdlib Python tools (CONTEXT.md linter, ADR scanner, glossary-to-code consistency check), (2) 3 reference docs each citing 7+ authoritative sources on ubiquitous language, ADR practice, and CONTEXT.md as a living artifact, (3) cs-grill-with-docs persona agent + /cs:grill-with-docs slash command. Matt's interview discipline + domain-awareness rules + ADR-when-3-criteria-are-met gate preserved verbatim per MIT.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": ["./skills/grill-with-docs"],
+  "attribution": {
+    "derived_from": "https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs",
+    "original_author": "Matt Pocock (@mattpocock)",
+    "original_license": "MIT",
+    "derivation_note": "Matt's SKILL.md content (with embedded references to ADR-FORMAT.md and CONTEXT-FORMAT.md) reproduced under MIT. Additions: 3 stdlib validators (CONTEXT.md linter, ADR scanner, glossary-code consistency), 3 deep references citing 7+ authoritative sources each, cs-grill-with-docs persona agent, /cs:grill-with-docs slash command. Matt's interview discipline + 3-criteria ADR gate preserved verbatim."
+  }
+}

--- a/engineering/grill-with-docs/README.md
+++ b/engineering/grill-with-docs/README.md
@@ -1,0 +1,53 @@
+# grill-with-docs
+
+Docs-anchored grilling session. Walks the decision tree of a plan one branch at a time, but does so against the project's existing **language** (`CONTEXT.md`) and recorded **decisions** (`docs/adr/`). Sharpens terminology + records architecturally-significant decisions inline as they crystallise.
+
+## Attribution
+
+**Derived from [Matt Pocock's grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs)** (MIT, © 2026 Matt Pocock). Matt's interview discipline + domain-awareness rules preserved verbatim per his MIT license — relentless one-question-at-a-time grilling, codebase-and-docs-first exploration, the three-criterion gate for offering an ADR (hard-to-reverse + surprising-without-context + real-trade-off).
+
+## How this differs from `grill-me`
+
+| Aspect | `grill-me` | `grill-with-docs` |
+|---|---|---|
+| Grounding | Plan text only | Plan + `CONTEXT.md` + `docs/adr/` + codebase |
+| Output | Session notes | Session notes **plus** inline updates to CONTEXT.md and (when warranted) new ADRs |
+| Question source | Decision tree extracted from plan | Decision tree **plus** language conflicts, fuzzy terms, code-vs-glossary contradictions |
+| When to use | Stress-testing a fresh plan | Onboarding a plan into an established codebase with documented language |
+
+Both ship as separate plugins; pick whichever matches the situation. The `grill-me` skill is plan-only; `grill-with-docs` is plan + project memory.
+
+## What this adds on top of Matt's original
+
+| Addition | Where | Why |
+|---|---|---|
+| **3 stdlib Python tools** | `skills/grill-with-docs/scripts/` | Lint CONTEXT.md format · Walk docs/adr/ for numbering + body integrity · Cross-reference bold terms in CONTEXT.md against codebase usage (dead glossary + code-only common nouns) |
+| **3 in-depth references** (7+ sources each) | `skills/grill-with-docs/references/` | Ubiquitous language canon · ADR practice canon · CONTEXT.md as living artifact |
+| **cs-grill-with-docs persona agent** | `agents/cs-grill-with-docs.md` | Docs-aware grill voice; pre-flights the linters before the first question |
+| **`/cs:grill-with-docs` slash command** | `commands/cs-grill-with-docs.md` | Activation + workflow handoff |
+
+## Matt's original (preserved)
+
+> "Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer. Ask the questions one at a time, waiting for feedback on each question before continuing. If a question can be answered by exploring the codebase, explore the codebase instead."
+
+> "Only offer to create an ADR when all three are true: hard to reverse, surprising without context, the result of a real trade-off. If any of the three is missing, skip the ADR."
+
+## Quick start
+
+```bash
+# 1. Lint existing CONTEXT.md (if present)
+python skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+
+# 2. Scan existing ADRs (if present)
+python skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+
+# 3. Cross-reference glossary terms against codebase
+python skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+
+# 4. Use /cs:grill-with-docs to start the session
+```
+
+## License
+
+MIT (matching Matt's upstream).

--- a/engineering/grill-with-docs/agents/cs-grill-with-docs.md
+++ b/engineering/grill-with-docs/agents/cs-grill-with-docs.md
@@ -1,0 +1,200 @@
+---
+name: cs-grill-with-docs
+description: Docs-anchored plan interrogator. Walks a plan's decision tree against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/). Pre-flights the glossary + ADR linters before asking the first question. Refuses to grill in a vacuum when documented language exists. Refuses to offer ADRs unless all 3 criteria are met (hard-to-reverse, surprising-without-context, real-trade-off).
+skills: engineering/grill-with-docs/skills/grill-with-docs
+domain: engineering
+model: opus
+tools: [Read, Write, Edit, Bash, Grep, Glob]
+---
+
+# Grill With Docs Agent
+
+## Voice
+
+**Opening:** "Drop your plan. I'm going to read CONTEXT.md and walk docs/adr/ first — that's how I know which terms I'm allowed to use and which trade-offs are already locked in. Then we walk your plan one decision at a time."
+
+**Forcing question patterns (docs-anchored):**
+- "Your glossary defines '{term}' as X. You just used it to mean Y. Which is it — or do we have two concepts hiding under one word?"
+- "ADR-{nnnn} locked in {choice}. Your plan implies {opposing-choice}. Are we superseding the ADR, or did the plan drift?"
+- "You said 'account'. CONTEXT.md doesn't define 'account'. Do you mean Customer, User, or something new?"
+- "Your code says X. You just said Y. Which is the current state — and which are we changing?"
+- "This decision is reversible in an afternoon. Why does it need an ADR? (If 'it doesn't' — skip it.)"
+
+**Closing:** "Glossary updated with {N} new/refined terms. {M} ADRs written (each met the 3-criteria gate). {K} flagged ambiguities resolved. Open items: {list}. Re-grill when the project's language drifts."
+
+Relentless, one-at-a-time, docs-and-codebase-first. Refuses to grill against an empty `CONTEXT.md` without first proposing the seed glossary from the plan. Refuses to write an ADR when any of the 3 criteria fails.
+
+## Purpose
+
+The `cs-grill-with-docs` agent orchestrates the `grill-with-docs` skill across docs-anchored grilling sessions:
+
+1. **Pre-flight** — run the 3 stdlib validators (CONTEXT.md linter, ADR scanner, glossary↔code consistency) on the repo's current state. Use their findings as opening questions.
+2. **Interview** — Matt's discipline applies: one forcing question per turn, codebase exploration before speculation, recommended answer attached to every question, depth-first walk.
+3. **Update inline** — when a term is sharpened, edit `CONTEXT.md` immediately (don't batch). Re-run `context_md_linter.py` if the edit is structural.
+4. **ADR gate** — when an architectural-shape decision is reached, evaluate against the 3-criteria gate. Write the ADR only if all 3 pass; re-run `adr_scanner.py` to confirm numbering integrity.
+5. **Close** — final `glossary_code_consistency.py` run; summarize terms, ADRs, scenarios, open items.
+
+Differentiates clearly:
+
+- **vs `cs-grill-master`** (the plan-only grill): different grounding (docs+code vs plan-only)
+- **vs `cs-skill-author`** (skill authoring): different mode (interrogate vs build)
+- **vs `cs-caveman-mode`** (compression): different concern (depth vs brevity)
+
+**Hard rules:**
+
+1. **Pre-flight the linters first.** Never grill without the docs-state snapshot in hand.
+2. **One question per turn.** Never bundle.
+3. **Recommended answer attached.** Every question carries a position + 1-sentence rationale.
+4. **Explore codebase + docs before asking.** If `grep` / `Read` resolves it, do that first.
+5. **Update CONTEXT.md inline.** Never defer glossary edits to a "later batch".
+6. **ADR 3-criteria gate.** Hard-to-reverse + surprising + real-trade-off. All three or skip.
+
+## Skill Integration
+
+**Skill Location:** `../skills/grill-with-docs/`
+
+### Python Tools (Stdlib)
+
+1. **CONTEXT.md Linter**
+   - Path: `../skills/grill-with-docs/scripts/context_md_linter.py`
+   - Usage: `python context_md_linter.py CONTEXT.md`
+   - Validates structure (H1, Language section with bold terms + `_Avoid_:` aliases, Relationships, example dialogue) and flags rule violations as PASS/WARN/FAIL.
+
+2. **ADR Scanner**
+   - Path: `../skills/grill-with-docs/scripts/adr_scanner.py`
+   - Usage: `python adr_scanner.py docs/adr/`
+   - Walks the ADR directory, checks `NNNN-slug.md` filename pattern, surfaces numbering gaps/duplicates, validates each ADR has an H1 + non-empty body, sanity-checks optional status frontmatter values.
+
+3. **Glossary↔Code Consistency**
+   - Path: `../skills/grill-with-docs/scripts/glossary_code_consistency.py`
+   - Usage: `python glossary_code_consistency.py --context CONTEXT.md --code src/`
+   - Extracts bold terms from CONTEXT.md, greps the codebase, flags defined-but-unused terms (dead glossary) and high-frequency code-only proper nouns that may need definitions. Outputs grilling-question seeds.
+
+### Knowledge Bases
+
+- `../skills/grill-with-docs/references/ubiquitous_language.md` — why a glossary belongs in source control (7 sources: Evans, Vernon, Khononov, Wlaschin, Brandolini, Avram & Marinescu, Fowler)
+- `../skills/grill-with-docs/references/adr_practice.md` — when an ADR earns its keep (7 sources: Nygard, Tyree & Akerman IEEE 2005, Zimmermann Y-statements, MADR, ThoughtWorks Tech Radar, adr-tools, Backstage)
+- `../skills/grill-with-docs/references/context_md_as_artifact.md` — CONTEXT.md as living artifact (7 sources: Khononov, Kernighan, BoundedContext bliki, Confluent data contracts, EventStorming, ubiquitous-language-as-architecture, conformist pattern)
+
+## Workflows
+
+### Workflow 1: Pre-flight before first question
+
+```bash
+# A. Snapshot the docs state
+python ../skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+python ../skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+python ../skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+
+# B. From the findings, seed the first 1-3 questions:
+#    - Any WARN/FAIL from context_md_linter → "before grilling the new plan, let's resolve this glossary issue"
+#    - Any numbering gap from adr_scanner → "ADR-0003 is missing; was it withdrawn or never written?"
+#    - Any dead-glossary term → "CONTEXT.md defines '{term}' but no code uses it. Is it stale?"
+#    - Any code-only proper noun → "Code uses '{term}' but CONTEXT.md doesn't define it. Add to glossary?"
+```
+
+### Workflow 2: Inline CONTEXT.md update mid-session
+
+```bash
+# When a term gets resolved during grilling:
+# 1. Edit CONTEXT.md right there (don't batch)
+# 2. If structural change: re-lint
+python ../skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+
+# 3. If a new term appears in code that the glossary doesn't define:
+#    update CONTEXT.md, then:
+python ../skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+```
+
+### Workflow 3: ADR write decision
+
+```
+Before writing ADR-NNNN, ask:
+  1. Hard to reverse? (cost of changing your mind > a day's work)
+  2. Surprising without context? (a future reader will wonder why)
+  3. Real trade-off? (genuine alternatives existed)
+
+If all 3 → write under docs/adr/NNNN-slug.md (next number).
+If any fails → skip. State why aloud.
+
+After writing:
+  python ../skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+```
+
+## Output Standards
+
+Per question turn:
+
+```
+Q[i]/[total] (anchor: CONTEXT.md§{section} | ADR-{nnnn} | code:{path}:{line} | plan:L{line}):
+
+[question]
+
+Recommended: [position] because [1-sentence rationale, grounded in the docs/code anchor]
+```
+
+When a glossary edit lands:
+
+```
+✏️  CONTEXT.md updated: defined '{term}' as [definition]. Avoid aliases: [list].
+(Pre-existing terms touched: [list, or "none"].)
+```
+
+When an ADR is written:
+
+```
+📝 ADR-{nnnn}: {title}
+    3-criteria check: ✓ hard-to-reverse  ✓ surprising  ✓ real-trade-off
+    Body: [first sentence of ADR]
+```
+
+When the session closes:
+
+```
+## Grill-with-Docs Summary: <session-name>
+Started: YYYY-MM-DD  Closed: YYYY-MM-DD
+Branches resolved: N / open: M
+
+Glossary changes:
+  - Added: [terms]
+  - Refined: [terms]
+  - Flagged ambiguities resolved: [list]
+
+ADRs written:
+  - ADR-{nnnn}: [title]  (3-criteria: ✓✓✓)
+
+Open items (deferred):
+  - [item] — [reason for deferral]
+
+Re-grill trigger: [language drift signal, ADR supersession, new bounded context]
+```
+
+## Success Metrics
+
+- **0 question bundles** — strict one-per-turn discipline
+- **>= 30% codebase-or-docs-resolved** — questions answered by lint/grep/Read instead of asking
+- **100% questions anchored** — every question references CONTEXT.md, an ADR, code, or the plan
+- **100% ADRs pass the 3-criteria gate** — no "fluff ADRs" written
+- **Glossary edits land inline** — no deferred glossary batches
+- **Final lint state is clean** — context_md_linter.py + adr_scanner.py both PASS at close
+
+## Related Agents
+
+- [cs-grill-master](../../grill-me/agents/cs-grill-master.md) — plan-only grill (sibling skill, no docs anchor)
+- [cs-skill-author](../../write-a-skill/agents/cs-skill-author.md) — different domain (skill authoring)
+- [cs-caveman-mode](../../caveman/agents/cs-caveman-mode.md) — different mode (compression)
+- [cs-handoff-author](../../handoff/agents/cs-handoff-author.md) — uses grill output for session handoff
+
+## References
+
+- Skill: [../skills/grill-with-docs/SKILL.md](../skills/grill-with-docs/SKILL.md)
+- Format specs: [ADR-FORMAT.md](../skills/grill-with-docs/ADR-FORMAT.md), [CONTEXT-FORMAT.md](../skills/grill-with-docs/CONTEXT-FORMAT.md)
+- Sibling command: [`/cs:grill-with-docs`](../commands/cs-grill-with-docs.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Derived:** Matt Pocock's grill-with-docs (MIT) + this repo's wrapper

--- a/engineering/grill-with-docs/commands/cs-grill-with-docs.md
+++ b/engineering/grill-with-docs/commands/cs-grill-with-docs.md
@@ -1,0 +1,100 @@
+---
+name: "cs-grill-with-docs"
+description: "/cs:grill-with-docs <path-to-plan> — Start a docs-anchored grilling session. Pre-flights CONTEXT.md + docs/adr/ linters, then interrogates the plan one decision at a time, updating glossary + writing ADRs inline as they crystallise."
+---
+
+# /cs:grill-with-docs — Docs-Anchored Plan Interrogation
+
+**Command:** `/cs:grill-with-docs <path-to-plan>`
+
+The `cs-grill-with-docs` persona pre-flights the project's documented language and decisions, then walks the plan one branch at a time — challenging fuzzy terms against `CONTEXT.md`, surfacing code-vs-glossary contradictions, and writing ADRs only when the 3-criteria gate is met.
+
+## When to Run
+
+- Stress-testing a plan that touches an established codebase with documented language
+- Onboarding a new feature into an existing bounded context
+- Resolving ambiguity introduced by drift between glossary and code
+- Pre-mortem on an architectural decision before it lands
+
+## When NOT to Run (use `/cs:grill-me` instead)
+
+- The repo has no `CONTEXT.md` and no `docs/adr/` and you don't want to seed them
+- You want a plan-only grill in a vacuum (the docs anchor would add no signal)
+- The plan is exploratory / pre-language-decision
+
+## The Six Forcing-Question Patterns (Docs-Anchored)
+
+1. **Glossary conflict:** "CONTEXT.md defines '{term}' as X. You just used it to mean Y. Which is it — or are these two concepts?"
+2. **ADR contradiction:** "ADR-{nnnn} locked in {choice}. Your plan implies {opposite}. Are we superseding, or did the plan drift?"
+3. **Undefined term:** "You said '{term}'. CONTEXT.md doesn't define it. Do you mean {candidate-1}, {candidate-2}, or something new?"
+4. **Code vs claim:** "Your code says X. You just said Y. Which is current state — and which are we changing?"
+5. **ADR 3-criteria gate:** "This decision is reversible in an afternoon. Why does it need an ADR? If 'it doesn't' — skip it."
+6. **Boundary check:** "Which bounded context owns this concept? If two contexts both touch it, what's the contract between them?"
+
+## Discipline
+
+- **Pre-flight the linters first.** Never grill without the docs-state snapshot.
+- **One question per turn.** Never bundle.
+- **Recommended answer attached.** Every question carries a position + rationale.
+- **Codebase + docs before speculation.** `grep` / `Read` / lint resolves before asking.
+- **CONTEXT.md edited inline.** No deferred glossary batches.
+- **ADR 3-criteria gate.** Hard-to-reverse + surprising + real-trade-off. All three or skip.
+
+## Workflow
+
+```bash
+# 1. Pre-flight — snapshot the docs state
+python ../skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+python ../skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+python ../skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+
+# 2. Read the plan
+#    Use the linter findings as opening question seeds.
+
+# 3. Walk one question at a time:
+#    Persona asks Q1 with recommendation (anchored to docs/code).
+#    User answers.
+#    Apply edits inline if the answer changes the glossary or warrants an ADR.
+
+# 4. Re-lint after any structural CONTEXT.md edit:
+python ../skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+
+# 5. Re-scan after any new ADR:
+python ../skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+
+# 6. At close — final consistency sweep:
+python ../skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+```
+
+## When to Stop
+
+- Every branch has an answer, AND
+- Final lint state is clean (context_md_linter + adr_scanner both PASS), AND
+- No new fuzzy terms surfaced in the last 3 turns
+
+Produce a "glossary changes + ADRs + open items" summary at close.
+
+## Output Format
+
+```
+Q[i]/[total] (anchor: CONTEXT.md§Language | ADR-0003 | code:src/orders/cancel.ts:42 | plan:L18):
+
+[question]
+
+Recommended: [position] because [rationale grounded in the anchor]
+```
+
+## Related
+
+- Agent: [`cs-grill-with-docs`](../agents/cs-grill-with-docs.md)
+- Skill: [`grill-with-docs`](../skills/grill-with-docs/SKILL.md)
+- Format specs: [ADR-FORMAT](../skills/grill-with-docs/ADR-FORMAT.md), [CONTEXT-FORMAT](../skills/grill-with-docs/CONTEXT-FORMAT.md)
+- Sibling skill: `/cs:grill-me` (plan-only grill)
+- Adjacent: `/cs:caveman`, `/cs:handoff`, `/cs:write-a-skill`
+
+---
+
+**Version:** 1.0.0
+**Derived:** Matt Pocock's grill-with-docs (MIT) + this repo's wrapper

--- a/engineering/grill-with-docs/skills/grill-with-docs/ADR-FORMAT.md
+++ b/engineering/grill-with-docs/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,53 @@
+<!--
+Derived from Matt Pocock's grill-with-docs:
+https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs/ADR-FORMAT.md
+MIT License © 2026 Matt Pocock. Reproduced verbatim under MIT.
+-->
+
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/engineering/grill-with-docs/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/engineering/grill-with-docs/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,83 @@
+<!--
+Derived from Matt Pocock's grill-with-docs:
+https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md
+MIT License © 2026 Matt Pocock. Reproduced verbatim under MIT.
+-->
+
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/engineering/grill-with-docs/skills/grill-with-docs/SKILL.md
+++ b/engineering/grill-with-docs/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: grill-with-docs
+description: Docs-anchored grilling session — challenges a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), and updates those files inline as terminology and decisions crystallise. Use when user wants to stress-test a plan against documented domain language, or mentions "grill with docs".
+license: MIT
+metadata:
+  derived_from: "https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs"
+  original_author: "Matt Pocock (@mattpocock)"
+  original_license: MIT
+  voice: "Matt Pocock — relentless, one-at-a-time, codebase-and-docs-first, ADRs only when 3 criteria are met"
+  version: 1.0.0
+---
+
+# Grill with Docs
+
+> Derived from [Matt Pocock's grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) (MIT, © 2026 Matt Pocock). Matt's interview discipline + docs-anchored grilling rules preserved verbatim under MIT. Additions in this repo: 3 stdlib validators (CONTEXT.md linter, ADR scanner, glossary↔code consistency check), 3 in-depth references each citing 7+ authoritative sources, `cs-grill-with-docs` agent, `/cs:grill-with-docs` command. See [Wrapper additions](#wrapper-additions) below.
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>
+
+## Wrapper Additions
+
+The additions below are **not** part of Matt's upstream skill. They operationalize the upstream's rules into deterministic, stdlib-only validators that pair naturally with the interview loop.
+
+### Workflow (with wrapper tools)
+
+1. **Pre-flight (before the first question):**
+   - Run `scripts/context_md_linter.py CONTEXT.md` if a `CONTEXT.md` exists — confirms the glossary is well-formed before grilling against it.
+   - Run `scripts/adr_scanner.py docs/adr/` if `docs/adr/` exists — surfaces numbering gaps, malformed ADRs, status-frontmatter inconsistencies.
+   - Run `scripts/glossary_code_consistency.py --context CONTEXT.md --code src/` — flags defined-but-unused terms (dead glossary) and code-only common nouns that may need definitions. Use these flags as opening grill questions.
+
+2. **During the session (Matt's rules apply):**
+   - One question per turn, walking depth-first.
+   - When a term is sharpened: edit `CONTEXT.md` immediately; re-run `context_md_linter.py` if the edit is structural.
+   - When an ADR is warranted: write it under `docs/adr/`; re-run `adr_scanner.py` to confirm numbering.
+
+3. **Closing:**
+   - Final `glossary_code_consistency.py` run to confirm no new orphan terms were introduced.
+   - Summarize: terms added/refined, ADRs written, scenarios discussed, open items.
+
+### Tools (stdlib-only)
+
+| Tool | One-line role |
+|---|---|
+| `scripts/context_md_linter.py` | Validate `CONTEXT.md` against the CONTEXT-FORMAT.md structure. PASS/WARN/FAIL per rule. |
+| `scripts/adr_scanner.py` | Walk `docs/adr/`, check `NNNN-slug.md` pattern, numbering integrity, body completeness. |
+| `scripts/glossary_code_consistency.py` | Cross-reference bold terms in `CONTEXT.md` against codebase usage. Flag dead glossary + code-only common nouns. |
+
+### References (citations behind each rule)
+
+- [`references/ubiquitous_language.md`](references/ubiquitous_language.md) — why a glossary belongs in source control (Evans, Vernon, Khononov, Wlaschin, Brandolini, Avram & Marinescu, Fowler)
+- [`references/adr_practice.md`](references/adr_practice.md) — when an ADR earns its keep (Nygard, Tyree & Akerman, Zimmermann Y-statements, MADR, ThoughtWorks Radar, adr-tools, Backstage)
+- [`references/context_md_as_artifact.md`](references/context_md_as_artifact.md) — CONTEXT.md as living artifact (Khononov on language drift, Kernighan on naming, BoundedContext bliki, Confluent on data contracts, Brandolini on EventStorming glossary)
+
+### Companion
+
+- Agent: `cs-grill-with-docs` (see `../../agents/cs-grill-with-docs.md`)
+- Command: `/cs:grill-with-docs` (see `../../commands/cs-grill-with-docs.md`)
+
+---
+
+**Version:** 1.0.0
+**Derived:** Matt Pocock's grill-with-docs (MIT) + this repo's wrapper

--- a/engineering/grill-with-docs/skills/grill-with-docs/references/adr_practice.md
+++ b/engineering/grill-with-docs/skills/grill-with-docs/references/adr_practice.md
@@ -1,0 +1,111 @@
+# ADR Practice — When Does a Decision Earn an ADR?
+
+This reference answers exactly one decision: **what bar must an architectural decision clear to be worth writing down as an ADR, and what format keeps the ADR useful 18 months later?**
+
+Pair with `scripts/adr_scanner.py` for filename + numbering + structural validation.
+
+## The Core Claim
+
+ADRs are not a compliance ritual. They exist to answer a single future question: **"Why on earth did they do it this way?"** If a future reader will never ask that question — because the choice is obvious, easy to reverse, or had no real alternatives — the ADR is doc-rot waiting to happen.
+
+The matt-pocock 3-criteria gate (preserved verbatim in `ADR-FORMAT.md`) is the strict version of this principle:
+
+1. **Hard to reverse** — the cost of changing your mind is meaningful (not "an afternoon of refactoring").
+2. **Surprising without context** — a future reader will look at the code and wonder why.
+3. **Result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons.
+
+**All three must be true.** Two-out-of-three is not enough. If a decision was hard to reverse but obvious and uncontested (e.g., "we used HTTPS"), no ADR. If it was a real trade-off but easy to reverse (e.g., "we used React Query over SWR"), no ADR.
+
+## What Earns an ADR (Examples)
+
+- **Architectural shape.** "Write model is event-sourced, read model is projected into Postgres." Hard-to-reverse + surprising + real-trade-off.
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP." Hard-to-reverse (rewiring eventing is expensive) + surprising (HTTP is the obvious choice) + real-trade-off (eventual consistency vs simpler API).
+- **Technology choices with lock-in.** Database engine, message bus, auth provider. Not "we picked Lodash" — those swap in an afternoon.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We use manual SQL instead of an ORM because X." Stops the next engineer from "fixing" something deliberate.
+- **Constraints not visible in code.** "Can't use AWS due to compliance." "Response times must be <200ms due to partner API contract."
+- **Rejected alternatives with non-obvious rejections.** "We considered GraphQL and picked REST because subscription complexity didn't match our actual real-time needs." Otherwise someone will suggest GraphQL again in 6 months.
+
+## What Does NOT Earn an ADR
+
+- **Library choices.** Lodash vs Ramda, axios vs ky, dayjs vs date-fns — these swap in an afternoon. Comment in code if you must.
+- **Style guide decisions.** "We use Prettier" — record in `package.json`, not an ADR.
+- **Defaults you didn't deviate from.** "We use the framework's recommended router." No trade-off, no ADR.
+- **Decisions that are easy to reverse.** If the future-you can undo it in a day, future-you doesn't need the why.
+- **Decisions where the alternative was never seriously considered.** No real trade-off → no ADR.
+
+## Format Discipline
+
+ADRs are markdown files at `docs/adr/NNNN-slug.md`, numbered sequentially.
+
+**Default format (minimum viable):**
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+**Optional sections (only when they add genuine value):**
+
+- **Status frontmatter** (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited.
+- **Considered Options** — only when rejected alternatives are worth remembering.
+- **Consequences** — only when non-obvious downstream effects need to be called out.
+
+If a section is included but empty or boilerplate ("none"), delete the section.
+
+## Numbering Discipline
+
+- Sequential, zero-padded to 4 digits: `0001`, `0002`, ..., `9999`.
+- No gaps. If an ADR is abandoned mid-draft, either commit it as `proposed → withdrawn` or renumber.
+- Slug is short, kebab-case, intent-revealing: `0042-event-sourced-orders.md`, not `0042-adr.md` or `0042-decision-about-events.md`.
+
+`scripts/adr_scanner.py` enforces the pattern and surfaces gaps.
+
+## Status Lifecycle (Optional)
+
+For repos that revisit decisions, the status field is useful:
+
+```
+proposed  →  accepted     ← default lifecycle for a new ADR
+accepted  →  deprecated   ← decision no longer applies; no replacement
+accepted  →  superseded   ← replaced by ADR-NNNN; link to successor in frontmatter
+```
+
+When superseding, the new ADR references the old (`supersedes: ADR-0017`) and the old ADR is updated with `superseded by: ADR-0042`. This back-link is the single most useful piece of ADR metadata for archeology.
+
+## Anti-Patterns
+
+- **The ADR factory.** Writing an ADR for every PR. Within a year, you have 200 ADRs and no one reads any. The 3-criteria gate is the firewall.
+- **The proposal that never accepts.** ADR sits in `proposed` for months. Either accept it (do it) or withdraw it (delete the file or mark withdrawn).
+- **The TOC-only ADR.** Filled-in section headers but no actual content. Worse than not writing the ADR — it implies a decision was recorded when nothing was.
+- **The future-tense ADR.** "We will use X." ADRs are records, not plans. Write in past tense ("We chose X because ...") so it reads correctly 2 years later.
+- **The unanchored ADR.** ADR with no link to the PR/issue/discussion that drove it. The "why" loses fidelity over time without the source thread.
+
+## Operational Checklist (Per ADR Decision Point)
+
+When grilling and a candidate decision emerges:
+
+- [ ] **Reversibility test.** "If we change our mind in 6 months, what's the cost?" If "an afternoon" → skip the ADR.
+- [ ] **Surprise test.** "Will a future engineer look at this and wonder why?" If no → skip.
+- [ ] **Trade-off test.** "What alternatives did we seriously consider, and why did each lose?" If none → skip.
+- [ ] **All three pass.** Write the ADR. Use the minimum format. Re-run `scripts/adr_scanner.py` to confirm numbering.
+- [ ] **Frontmatter status.** Only add `status` if revisiting is expected. Default is "implicit accepted".
+
+## Citations (7 sources)
+
+1. **Michael Nygard, "Documenting Architecture Decisions" (cognitect.com, November 2011).** The original ADR essay. Introduces the format (Title / Context / Decision / Status / Consequences) and the core insight that "architecturally significant" decisions deserve records. Nygard's framing of ADRs as "memory aids for future architects" is the source of the 3-criteria gate's first rule (hard-to-reverse).
+
+2. **Jeff Tyree & Art Akerman, "Architecture Decisions: Demystifying Architecture" — *IEEE Software* 22(2), March–April 2005, pp. 19–27.** Pre-dates Nygard. Introduces the concept of an "Architecture Decision Record" as a first-class artifact and argues for explicit recording of rejected alternatives. The "rejected alternatives" section in Nygard's format inherits from Tyree & Akerman.
+
+3. **Olaf Zimmermann et al., "Y-Statements: A Lightweight Architectural Decision Format" — published at various venues including ozimmer.ch.** Proposes the "In the context of {use case / requirement}, facing {concern}, we decided for {option} to achieve {quality}, accepting {downside}" template. Used widely as a compact alternative to the full Nygard format.
+
+4. **MADR (Markdown Architectural Decision Records) — adr.github.io/madr.** Open-source template maintained by a community of practitioners. Specifies frontmatter format (status, deciders, date, consulted, informed) and a discoverable file structure. Useful when ADRs need machine-readable metadata for indexing.
+
+5. **ThoughtWorks Technology Radar — thoughtworks.com/radar.** Has covered "Lightweight Architecture Decision Records" since Vol. 18 (2018) in the Techniques quadrant, with periodic upgrades to "Adopt". TW's "use ADRs sparingly" guidance aligns with the 3-criteria gate.
+
+6. **Joel Parker Henderson, adr-tools (github.com/npryce/adr-tools).** CLI tool implementing Nygard's format with numbering helpers, supersession linking, and a `new` / `link` / `accept` command set. Establishes the de-facto convention of `0001-slug.md` filenames and `docs/adr/` directory location.
+
+7. **Spotify Backstage — backstage.io.** Backstage's TechDocs catalog includes an ADR plugin that surfaces per-service ADRs in the service catalog UI. Demonstrates how ADRs become discoverable at scale (>1000 services) when treated as first-class catalog entries, not just files in a repo.

--- a/engineering/grill-with-docs/skills/grill-with-docs/references/context_md_as_artifact.md
+++ b/engineering/grill-with-docs/skills/grill-with-docs/references/context_md_as_artifact.md
@@ -1,0 +1,105 @@
+# CONTEXT.md as a Living Artifact — Preventing Glossary Decay
+
+This reference answers exactly one decision: **how does a glossary stay alive vs decay into doc rot, and what operational practices prevent the drift?**
+
+Pair with `scripts/glossary_code_consistency.py` for the lint-against-codebase reality check and `scripts/context_md_linter.py` for structural validation.
+
+## The Core Claim
+
+Every glossary decays by default. The decay path is well-documented:
+
+```
+Month 1: Glossary written during initial DDD workshop. Terms are precise.
+Month 3: New feature ships. Two new domain terms used in code, neither added to glossary.
+Month 6: A term in the glossary is renamed in code. Glossary still has old name.
+Month 9: New engineer joins. Reads glossary. Asks "what's a 'Booking'?" — answer is "we don't call those Bookings anymore, we call them Reservations now."
+Month 12: Glossary is officially declared stale. Engineers stop reading it. Drift becomes invisible.
+```
+
+The decay is not preventable by good intentions. It is prevented by **inline edits during the work that introduces the term** plus **automated lint runs at PR time** to flag mismatches.
+
+## Three Forces That Drive Drift
+
+1. **Language pressure from outside the bounded context.** A new partner integration uses different terminology ("subscriber" vs your "customer"). Engineers copy the partner's term into code without first reconciling with the glossary.
+2. **Refactor pressure inside the bounded context.** A rename in code feels obvious ("`Booking` → `Reservation` is just a better name"), but the glossary isn't updated alongside.
+3. **Convergence pressure between teams.** Multiple teams contributing to the same context use slightly different words for the same concept. Without a glossary as referee, all variants end up in code.
+
+`scripts/glossary_code_consistency.py` operationalizes the lint against these three forces:
+
+- **Defined-but-unused term** → a glossary entry that no code references. Either dead glossary (delete) or a rename happened (update glossary to match code).
+- **Code-only proper noun** → a frequently-used capitalized term in code that the glossary doesn't define. Either generic (ignore) or domain (add to glossary now).
+
+## Five Practices That Keep CONTEXT.md Alive
+
+1. **Edit inline during the work.** Never batch glossary updates. When a term is introduced or refined during a feature, the same PR that adds the code edits `CONTEXT.md`. Reviewers reject PRs that introduce domain terms without glossary edits.
+2. **Lint at PR time.** Run `scripts/context_md_linter.py` and `scripts/glossary_code_consistency.py` in CI. A new term in code without a glossary entry is a build warning; an outright rename mismatch is a build failure.
+3. **Per-context glossaries, not one mega-glossary.** Multi-context repos use `CONTEXT-MAP.md` to point at per-context `CONTEXT.md` files. Cross-context terms get explicit translation entries ("Billing's `Customer` is Ordering's `Account`").
+4. **Pruning passes.** Quarterly, run `glossary_code_consistency.py` and review the dead-glossary report. Delete entries that no code uses. Keeping dead entries dilutes signal.
+5. **One sentence per definition.** If a definition runs to a paragraph, the term is hiding two concepts. Split or sharpen. Long definitions are correlated with imprecise terms.
+
+## How CONTEXT.md Differs from Other "Documentation"
+
+| Artifact | Purpose | Update cadence | Audience |
+|---|---|---|---|
+| `README.md` | Onboarding + setup | Once at project start, occasionally after | New contributors |
+| `ARCHITECTURE.md` | High-level system shape | Quarterly to yearly | New architects, senior engineers |
+| `docs/adr/*.md` | Record of specific decisions | Per-decision (rare; days to months apart) | Anyone asking "why did we do X this way?" |
+| **`CONTEXT.md`** | **The domain glossary — what each term means in this bounded context** | **Per-feature (continuous; hours to days apart)** | **Every engineer on every PR** |
+
+A `CONTEXT.md` is touched far more often than any other doc because it tracks the language as it evolves. If yours hasn't been edited in 6 months, it's almost certainly drifting.
+
+## Single vs Multi-Context Repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root. All terms in scope.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts and their relationships. Each bounded context has its own `CONTEXT.md` (and its own `docs/adr/` for context-specific decisions). Shared terms appear in both with cross-references.
+
+```
+/
+├── CONTEXT-MAP.md         ← lists contexts + relationships
+├── docs/adr/              ← system-wide ADRs
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md     ← ordering-context glossary
+    │   └── docs/adr/      ← ordering-context ADRs
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+When a term spans contexts, define it in each `CONTEXT.md` with the context's perspective + a translation note pointing at the other. Don't try to define "Customer" once and have both contexts share it — that's the path back to the mega-glossary.
+
+## Anti-Patterns
+
+- **The spec masquerading as a glossary.** `CONTEXT.md` includes implementation details, sequence diagrams, API responses. It is a glossary, not a spec. Move spec content elsewhere.
+- **The wiki masquerading as a glossary.** General programming concepts ("retry", "timeout", "config") appearing in `CONTEXT.md`. They are not domain-specific. Remove.
+- **The glossary that defines without forbidding.** Each term needs `_Avoid_: <aliases>` to push back on drift. A glossary that says "Customer means X" but doesn't forbid "Client" / "Account" / "User" cannot push back when those drift in.
+- **The frozen glossary.** No commits in 6+ months. Either the project is dormant or the language has drifted away from the document. Re-grill.
+- **The orphan glossary.** Sits in a repo but no CI/PR process references it. It will decay within two quarters.
+
+## Operational Checklist
+
+When grilling against `CONTEXT.md`:
+
+- [ ] Lint structure: `python scripts/context_md_linter.py CONTEXT.md`
+- [ ] Lint vs code: `python scripts/glossary_code_consistency.py --context CONTEXT.md --code src/`
+- [ ] For each "defined but unused": ask "dead term, or rename happened?"
+- [ ] For each "code-only proper noun": ask "domain term that needs definition, or generic?"
+- [ ] For each new term introduced during the grill: edit `CONTEXT.md` *now*, not "later"
+- [ ] Multi-context repo: verify the right `CONTEXT.md` is being edited (not the wrong context's, not the root one when a per-context one applies)
+
+## Citations (7 sources)
+
+1. **Vladimir Khononov, *Learning Domain-Driven Design* (O'Reilly, 2021).** Chapter 9, "Communication Patterns" + Chapter 12, "Building Domain Expertise" — Khononov is the sharpest writer on language drift between bounded contexts and on how to detect it. His "linguistic boundaries are observable boundaries" framing is the foundation of the `glossary_code_consistency.py` check.
+
+2. **Brian Kernighan & Rob Pike, *The Practice of Programming* (Addison-Wesley, 1999).** Chapter 1, "Style" — the section on naming. Kernighan's "names should reflect the role of the variable, not its type" generalizes to glossary terms: a glossary term names a role in the domain, not a data structure. Kernighan-style naming discipline is what keeps `CONTEXT.md` precise.
+
+3. **Martin Fowler, "BoundedContext" — martinfowler.com bliki (2014, updated).** The canonical argument that ubiquitous language is **bounded** — it applies inside one context, not across all contexts. The justification for per-context `CONTEXT.md` files. https://martinfowler.com/bliki/BoundedContext.html
+
+4. **Martin Fowler, "UbiquitousLanguage" — martinfowler.com bliki.** Companion entry to BoundedContext. Articulates the discipline of using the same vocabulary in conversation, in the model, and in the code. The justification for editing `CONTEXT.md` inline alongside code changes, not as separate doc work. https://martinfowler.com/bliki/UbiquitousLanguage.html
+
+5. **Confluent Schema Registry / Data Contracts community — confluent.io/blog/data-contracts.** The data-contracts movement applies UL discipline to inter-service / inter-context boundaries: when two contexts exchange events or API payloads, the schema is a binding glossary. Drift between contexts becomes a schema-evolution problem, not a free-form documentation problem.
+
+6. **Alberto Brandolini, *Introducing EventStorming* (Leanpub, ongoing).** Chapter on "Pivotal Events" + the convergence-workshop chapter. Brandolini documents how a glossary emerges from EventStorming workshops as a by-product of mapping events. The pattern of "capture the term on a sticky note when it surfaces" is the offline equivalent of the inline `CONTEXT.md` edit discipline.
+
+7. **Eric Evans, *Domain-Driven Design: Tackling Complexity in the Heart of Software* (Addison-Wesley, 2003).** Chapter 14, "Maintaining Model Integrity" — covers the Conformist, Anticorruption Layer, and Shared Kernel patterns. Each of these is a strategy for managing the boundary between two bounded contexts that have different languages. Justifies the multi-context `CONTEXT-MAP.md` pattern and the translation-note discipline for cross-context terms.

--- a/engineering/grill-with-docs/skills/grill-with-docs/references/ubiquitous_language.md
+++ b/engineering/grill-with-docs/skills/grill-with-docs/references/ubiquitous_language.md
@@ -1,0 +1,66 @@
+# Ubiquitous Language — Why a Glossary Belongs in Source Control
+
+This reference answers exactly one decision: **why should a project's domain glossary (`CONTEXT.md`) live next to the code in source control, and what bar must it clear to earn its keep?**
+
+Pair with `scripts/context_md_linter.py` for structural validation and `scripts/glossary_code_consistency.py` for the language-vs-code reality check.
+
+## The Core Claim
+
+A bounded context has **one** language. The same word must mean the same thing in conversation, in the glossary, in the type system, in the database schema, and in the UI. When language fractures across these surfaces, design defects follow: ambiguous bug reports, mismatched API contracts, broken refactors, junior engineers asking what an "account" is and getting three different answers.
+
+The glossary is the contract that prevents the fracture. It earns its place in source control because it changes at the same cadence as the code — every time a domain term is introduced, refined, or retired, the glossary must move with it. A wiki page that lives outside the repo will drift within a quarter.
+
+## Why a Glossary in Source Control (vs Wiki, Notion, Confluence)
+
+| Property | In-repo `CONTEXT.md` | External wiki |
+|---|---|---|
+| Reviewable in PR | Yes — diff is visible alongside code | No — reviewer must remember to check |
+| Versioned with code | Yes — `git log` shows term evolution | No — wikis rarely have meaningful history |
+| Discoverable by new engineers | Yes — `ls` of repo root finds it | No — depends on onboarding tribal knowledge |
+| Mergeable | Yes — text format, conflict-resolvable | Often no — UI-driven |
+| Linter-targetable | Yes — `scripts/context_md_linter.py` | No — usually not |
+| Refactor-safe | Yes — renames are grep-able | No — wiki links rot silently |
+
+The glossary is a **language artifact**, not a documentation artifact. Documentation describes the system; the glossary **is** part of the system's design surface.
+
+## Five Rules That Make a Glossary Survive
+
+1. **One sentence per definition.** If the definition needs a paragraph, the term is hiding two concepts. Split it.
+2. **Define what it IS, not what it does.** "An **Invoice** is a request for payment sent after delivery." Not "An invoice handles billing."
+3. **List aliases to avoid.** When users say "bill" or "payment request" but mean "invoice", record that "bill" is forbidden. Without the `_Avoid_:` field, the glossary cannot push back on drift.
+4. **Show relationships, not just terms.** "An **Order** produces one or more **Invoices**" tells you the cardinality. A list of bare terms doesn't.
+5. **Exclude generic programming concepts.** "Timeout", "retry", "config" do not belong. Only terms specific to this project's domain qualify.
+
+## Anti-Patterns
+
+- **The "everything goes in" glossary.** When `CONTEXT.md` includes general programming concepts (timeout, error, util), it dilutes signal and degenerates into a wiki page.
+- **The orphan glossary.** Terms defined but never used in code. Either the term is dead (delete it) or the code is using a synonym (rename code).
+- **The opaque glossary.** Terms used in code but not defined. Either the term is generic (don't define it) or it's a domain concept that snuck in (define it now).
+- **The deferred glossary edit.** "I'll batch up the glossary changes at the end of the sprint." By the end of the sprint, three more drift cases will have shipped. Glossary edits must land inline.
+- **The frozen glossary.** No commits in 6+ months. Either the project is dormant or the language has drifted away from the document.
+
+## Operational Checklist (for the Grill Session)
+
+When grilling a plan against `CONTEXT.md`:
+
+- [ ] Pre-flight `scripts/context_md_linter.py CONTEXT.md` — is the glossary well-formed?
+- [ ] Run `scripts/glossary_code_consistency.py` — what's defined but unused? what's used but undefined?
+- [ ] For every novel term in the plan, ask: "Is this in CONTEXT.md? If not, do we add it, or do we rephrase using an existing term?"
+- [ ] For every existing term used in the plan, ask: "Does the plan use it consistent with the definition?"
+- [ ] At every clarification moment, edit `CONTEXT.md` immediately — never batch.
+
+## Citations (7 sources)
+
+1. **Eric Evans, *Domain-Driven Design: Tackling Complexity in the Heart of Software* (Addison-Wesley, 2003).** Chapter 2, "Communication and the Use of Language" — the canonical statement of Ubiquitous Language as a design tool, not just documentation. The line "The vocabulary of that UBIQUITOUS LANGUAGE includes the names of classes and prominent operations" is the bridge between conversation and code.
+
+2. **Vaughn Vernon, *Implementing Domain-Driven Design* (Addison-Wesley, 2013).** Chapter 1, "Getting Started with DDD" + Chapter 2, "Domains, Subdomains, and Bounded Contexts" — operationalizes Evans's UL into a workshop format and per-context discipline. Vernon's "linguistic boundaries are the most reliable boundary" framing is the source of the per-bounded-context glossary pattern.
+
+3. **Vladimir Khononov, *Learning Domain-Driven Design* (O'Reilly, 2021).** Chapter 5, "Implementing Simple Business Logic" + Chapter 9, "Communication Patterns" — Khononov is sharpest on what happens when bounded contexts share a language vs maintain separate languages (translation layer required) and on language drift over time.
+
+4. **Scott Wlaschin, *Domain Modeling Made Functional* (Pragmatic Bookshelf, 2018).** Part 1, "Understanding the Domain" — treats the type system as the executable form of the glossary. Wlaschin's "make illegal states unrepresentable" is the strongest form of glossary-as-contract: if the glossary says an Order must have at least one line item, the type prevents zero-item Orders at compile time.
+
+5. **Alberto Brandolini, *Introducing EventStorming: An Act of Deliberate Collective Learning* (Leanpub, 2017–ongoing).** Chapter on "Sticky note color codes" + chapter on convergence — EventStorming workshops produce a glossary as a by-product of mapping the domain. Brandolini's pattern of capturing terms as they emerge on sticky notes is the offline equivalent of the inline `CONTEXT.md` edit.
+
+6. **Abel Avram & Floyd Marinescu, *Domain-Driven Design Quickly* (InfoQ, 2006, free e-book).** Chapter 2, "Ubiquitous Language" — the most concise distillation of Evans's UL chapter. Useful as a reference to hand to engineers who won't read the blue book.
+
+7. **Martin Fowler, "BoundedContext" — martinfowler.com bliki (2014, updated).** Fowler's framing of "Ubiquitous Language … doesn't apply to the whole project, it only has to apply within a particular Bounded Context" justifies the per-context glossary pattern in `CONTEXT-MAP.md`-style multi-context repos. https://martinfowler.com/bliki/BoundedContext.html

--- a/engineering/grill-with-docs/skills/grill-with-docs/scripts/adr_scanner.py
+++ b/engineering/grill-with-docs/skills/grill-with-docs/scripts/adr_scanner.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""adr_scanner.py — Walk docs/adr/ and validate ADR files against the format.
+
+Stdlib-only. Applies the rules from Matt Pocock's upstream ADR-FORMAT.md
+(preserved verbatim in the skill's ADR-FORMAT.md):
+
+  1. Each file matches the `NNNN-slug.md` pattern (4-digit zero-padded number + kebab-case slug)
+  2. Numbering is sequential — no gaps, no duplicates
+  3. Each ADR has an H1 (the title)
+  4. Each ADR has a non-empty body after the H1 (at least the 1-3 sentence context+decision)
+  5. Optional status frontmatter, if present, has a valid value
+     (proposed | accepted | deprecated | superseded by ADR-NNNN)
+  6. Superseded-by references point at an existing ADR number
+
+Output: directory-level summary + per-file findings.
+
+NO LLM CALLS. Pure regex + filesystem walking.
+
+Usage:
+    python adr_scanner.py docs/adr/
+    python adr_scanner.py docs/adr/ --output json
+    python adr_scanner.py --sample          # scan an embedded sample directory layout
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+ADR_FILENAME_RE = re.compile(r"^(\d{4})-([a-z0-9]+(?:-[a-z0-9]+)*)\.md$")
+VALID_STATUSES = {"proposed", "accepted", "deprecated"}
+SUPERSEDED_RE = re.compile(r"^superseded\s+by\s+ADR-?(\d{1,4})$", re.IGNORECASE)
+
+
+SAMPLE_ADRS: Dict[str, str] = {
+    "0001-event-sourced-orders.md": (
+        "# Event-source the Order write model\n"
+        "\n"
+        "We need an audit trail of every state change on an Order for compliance + analytics. "
+        "We chose event sourcing for the Order write model and a Postgres projection for the read model. "
+        "Trade-off accepted: eventual consistency on the read side in exchange for the audit trail and replay.\n"
+    ),
+    "0002-postgres-for-write-model.md": (
+        "---\n"
+        "status: accepted\n"
+        "---\n"
+        "\n"
+        "# Postgres for the write-side event store\n"
+        "\n"
+        "We considered EventStore and Kafka. Postgres won on operational familiarity + transactional guarantees + cost.\n"
+    ),
+    "0003-rest-over-graphql.md": (
+        "---\n"
+        "status: accepted\n"
+        "---\n"
+        "\n"
+        "# REST over GraphQL for the public API\n"
+        "\n"
+        "GraphQL would have given clients more flexibility but added subscription complexity we don't need at our scale.\n"
+    ),
+}
+
+
+def parse_frontmatter(text: str) -> Tuple[Dict[str, str], str]:
+    """Return (frontmatter_dict, body) for a file that may have YAML-ish frontmatter.
+
+    Only handles simple `key: value` lines (no nested YAML, no lists) — stdlib-only.
+    """
+    if not text.startswith("---\n"):
+        return {}, text
+    end_marker = text.find("\n---\n", 4)
+    if end_marker == -1:
+        return {}, text
+    fm_block = text[4:end_marker]
+    body = text[end_marker + 5 :]
+    fm: Dict[str, str] = {}
+    for line in fm_block.splitlines():
+        if ":" in line:
+            k, v = line.split(":", 1)
+            fm[k.strip().lower()] = v.strip()
+    return fm, body
+
+
+def scan_directory(adr_dir: Path) -> Dict[str, Any]:
+    findings: List[Dict[str, Any]] = []
+    files: List[Tuple[int, str, Path]] = []
+
+    def add(file: str, rule: str, level: str, message: str) -> None:
+        findings.append({"file": file, "rule": rule, "level": level, "message": message})
+
+    if not adr_dir.exists():
+        add("(root)", "directory", "FAIL", f"Directory does not exist: {adr_dir}")
+        return finalize(findings, 0)
+
+    if not adr_dir.is_dir():
+        add("(root)", "directory", "FAIL", f"Path is not a directory: {adr_dir}")
+        return finalize(findings, 0)
+
+    md_files = sorted(p for p in adr_dir.iterdir() if p.is_file() and p.suffix == ".md")
+    if not md_files:
+        add("(root)", "directory", "WARN", "Directory is empty — no ADRs scanned. Create lazily when the first ADR is needed.")
+        return finalize(findings, 0)
+
+    # Rule 1: filename pattern
+    for p in md_files:
+        m = ADR_FILENAME_RE.match(p.name)
+        if not m:
+            add(p.name, "filename-pattern", "FAIL", f"Filename does not match NNNN-slug.md pattern. Expected e.g. 0001-event-sourced-orders.md.")
+            continue
+        number = int(m.group(1))
+        files.append((number, p.name, p))
+        add(p.name, "filename-pattern", "PASS", f"Filename matches pattern (number={number:04d}).")
+
+    files.sort(key=lambda t: t[0])
+
+    # Rule 2: numbering sequence (no gaps, no duplicates)
+    seen: Dict[int, List[str]] = {}
+    for number, name, _ in files:
+        seen.setdefault(number, []).append(name)
+    for number, names in seen.items():
+        if len(names) > 1:
+            add(", ".join(names), "numbering-duplicate", "FAIL", f"Duplicate ADR number {number:04d}.")
+    if files:
+        expected = list(range(1, files[-1][0] + 1))
+        actual = sorted(seen.keys())
+        gaps = [n for n in expected if n not in actual]
+        if gaps:
+            add("(root)", "numbering-gap", "WARN", f"Number gap(s) in sequence: {', '.join(f'{g:04d}' for g in gaps)}. Either commit withdrawn ADRs as 'proposed → withdrawn' or renumber.")
+        else:
+            add("(root)", "numbering-sequence", "PASS", f"Sequential numbering 0001..{files[-1][0]:04d} with no gaps.")
+
+    # Rules 3, 4, 5, 6: per-ADR
+    numbers_present = {n for n, _, _ in files}
+    for number, name, path in files:
+        text = path.read_text(encoding="utf-8") if path.is_file() else SAMPLE_ADRS.get(name, "")
+        fm, body = parse_frontmatter(text)
+
+        # Rule 3: H1 present
+        h1_match = re.search(r"^#\s+(.+?)\s*$", body, re.MULTILINE)
+        if not h1_match:
+            add(name, "h1-present", "FAIL", "No H1 (`# Title`) found in body.")
+            continue
+        else:
+            add(name, "h1-present", "PASS", f"H1 found: '{h1_match.group(1).strip()}'.")
+
+        # Rule 4: non-empty body after H1
+        after_h1 = body[h1_match.end():].strip()
+        if not after_h1:
+            add(name, "body-non-empty", "FAIL", "ADR has H1 but no body. The 1-3 sentence context+decision is required.")
+        else:
+            word_count = len(re.findall(r"\b\w+\b", after_h1))
+            if word_count < 10:
+                add(name, "body-non-empty", "WARN", f"ADR body is very short ({word_count} words). Confirm context+decision+why are all stated.")
+            else:
+                add(name, "body-non-empty", "PASS", f"Body present ({word_count} words).")
+
+        # Rule 5: optional status frontmatter sanity
+        status = fm.get("status", "").strip().lower() if fm else ""
+        if status:
+            if status in VALID_STATUSES:
+                add(name, "status-frontmatter", "PASS", f"Status '{status}' is valid.")
+            elif SUPERSEDED_RE.match(status):
+                m = SUPERSEDED_RE.match(status)
+                target = int(m.group(1))
+                # Rule 6: superseded-by points at existing ADR
+                if target in numbers_present:
+                    add(name, "status-supersede-target", "PASS", f"Superseded by ADR-{target:04d} which exists.")
+                else:
+                    add(name, "status-supersede-target", "FAIL", f"Superseded by ADR-{target:04d} but that ADR is not present in this directory.")
+            else:
+                add(name, "status-frontmatter", "FAIL", f"Status '{status}' is not one of {sorted(VALID_STATUSES)} or 'superseded by ADR-NNNN'.")
+
+    return finalize(findings, len(files))
+
+
+def finalize(findings: List[Dict[str, Any]], adr_count: int) -> Dict[str, Any]:
+    counts = {"PASS": 0, "WARN": 0, "FAIL": 0}
+    for f in findings:
+        counts[f["level"]] += 1
+    if counts["FAIL"] > 0:
+        verdict = "FAIL"
+    elif counts["WARN"] > 0:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+    return {"verdict": verdict, "adr_count": adr_count, "counts": counts, "findings": findings}
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    out: List[str] = []
+    out.append(f"ADR directory scan verdict: {result['verdict']}")
+    out.append(f"  ADRs scanned: {result['adr_count']}")
+    counts = result["counts"]
+    out.append(f"  PASS: {counts['PASS']}  WARN: {counts['WARN']}  FAIL: {counts['FAIL']}")
+    out.append("")
+    out.append("Findings:")
+    for f in result["findings"]:
+        marker = {"PASS": "[ok]", "WARN": "[warn]", "FAIL": "[FAIL]"}[f["level"]]
+        out.append(f"  {marker} {f['file']:<40s} {f['rule']}: {f['message']}")
+    return "\n".join(out)
+
+
+def run_sample() -> Dict[str, Any]:
+    """Scan the embedded sample by writing it to a tempdir."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / "adr"
+        d.mkdir()
+        for name, content in SAMPLE_ADRS.items():
+            (d / name).write_text(content, encoding="utf-8")
+        return scan_directory(d)
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("adr_dir", nargs="?", help="Path to docs/adr/ directory")
+    parser.add_argument("--sample", action="store_true", help="Scan the embedded sample ADR layout")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        result = run_sample()
+    elif args.adr_dir:
+        result = scan_directory(Path(args.adr_dir))
+    else:
+        parser.print_help()
+        return 0
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0 if result["verdict"] != "FAIL" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/engineering/grill-with-docs/skills/grill-with-docs/scripts/context_md_linter.py
+++ b/engineering/grill-with-docs/skills/grill-with-docs/scripts/context_md_linter.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""context_md_linter.py — Validate a CONTEXT.md against the CONTEXT-FORMAT.md structure.
+
+Stdlib-only. Walks a CONTEXT.md and applies the format rules from Matt Pocock's
+upstream CONTEXT-FORMAT.md (preserved verbatim in the skill's CONTEXT-FORMAT.md):
+
+  1. H1 present at top (the context name)
+  2. One-or-two-sentence description follows the H1
+  3. ## Language section present
+  4. Inside Language: each term is in `**Term**:` bold form
+  5. Inside Language: each term has a one-sentence definition
+  6. Inside Language: each term has a `_Avoid_:` aliases line (WARN if missing)
+  7. ## Relationships section present (WARN if missing)
+  8. ## Example dialogue section present (WARN if missing)
+  9. Optional: ## Flagged ambiguities section
+
+Output: PASS / WARN / FAIL per rule + an overall verdict.
+
+NO LLM CALLS. Pure regex + line walking.
+
+Usage:
+    python context_md_linter.py CONTEXT.md
+    python context_md_linter.py CONTEXT.md --output json
+    python context_md_linter.py --sample        # lint the embedded sample
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+SAMPLE_CONTEXT_MD = """# Ordering
+
+The ordering context receives customer orders and tracks them through to handoff to Fulfillment.
+
+## Language
+
+**Order**:
+A confirmed request from a Customer to acquire one or more Products.
+_Avoid_: Purchase, transaction, cart
+
+**Customer**:
+A person or organization that places Orders.
+_Avoid_: Client, buyer, account
+
+**Product**:
+A single SKU that can appear on an Order line.
+_Avoid_: Item, good, SKU
+
+## Relationships
+
+- An **Order** belongs to exactly one **Customer**
+- An **Order** has one or more **Products** via line items
+- A **Customer** can have many **Orders**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, are the **Products** locked at order time?"
+> **Domain expert:** "Yes — Product price + spec is snapshotted onto the Order line. Subsequent Product edits don't change historical Orders."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and "billing account" — resolved: billing account moves to Billing context.
+"""
+
+
+def split_into_sections(text: str) -> Dict[str, str]:
+    """Split markdown into top-level ## sections keyed by header text."""
+    sections: Dict[str, str] = {}
+    current_header = "_preamble_"
+    buffer: List[str] = []
+    for line in text.splitlines():
+        m = re.match(r"^##\s+(.+?)\s*$", line)
+        if m:
+            sections[current_header] = "\n".join(buffer).strip()
+            current_header = m.group(1).strip().lower()
+            buffer = []
+        else:
+            buffer.append(line)
+    sections[current_header] = "\n".join(buffer).strip()
+    return sections
+
+
+def extract_terms(language_section: str) -> List[Tuple[str, str, str]]:
+    """Return list of (term, definition_line, avoid_line) tuples from the Language section.
+
+    Each term entry looks like:
+        **Term**:
+        Definition sentence.
+        _Avoid_: alias1, alias2
+    """
+    results: List[Tuple[str, str, str]] = []
+    # Match `**Term**:` followed by the next non-empty line as definition,
+    # and optionally an `_Avoid_:` line within the next 3 lines.
+    pattern = re.compile(
+        r"\*\*([^*]+?)\*\*\s*:\s*\n([^\n]+)\n?(?:([^\n]*_Avoid_[^\n]*)\n?)?",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(language_section):
+        term = match.group(1).strip()
+        definition = match.group(2).strip()
+        avoid = (match.group(3) or "").strip()
+        results.append((term, definition, avoid))
+    return results
+
+
+def lint(text: str) -> Dict[str, Any]:
+    findings: List[Dict[str, str]] = []
+
+    def add(rule: str, level: str, message: str) -> None:
+        findings.append({"rule": rule, "level": level, "message": message})
+
+    # Rule 1: H1 present
+    lines = text.splitlines()
+    h1_line_index = None
+    for i, line in enumerate(lines):
+        if re.match(r"^#\s+\S", line):
+            h1_line_index = i
+            break
+    if h1_line_index is None:
+        add("h1-present", "FAIL", "No H1 (top-level '# Title') found. CONTEXT.md must start with the context name as H1.")
+    else:
+        add("h1-present", "PASS", f"H1 found at line {h1_line_index + 1}.")
+
+    # Rule 2: one-or-two-sentence description after H1
+    if h1_line_index is not None:
+        desc_lines: List[str] = []
+        for line in lines[h1_line_index + 1 :]:
+            if re.match(r"^##\s", line):
+                break
+            if line.strip():
+                desc_lines.append(line.strip())
+        desc = " ".join(desc_lines).strip()
+        sentence_count = len(re.findall(r"[.!?](?:\s|$)", desc))
+        if not desc:
+            add("description-present", "FAIL", "No description sentence between the H1 and the first ## section.")
+        elif sentence_count > 3:
+            add(
+                "description-length",
+                "WARN",
+                f"Description has {sentence_count} sentences. CONTEXT-FORMAT.md asks for one or two.",
+            )
+        else:
+            add("description-present", "PASS", f"Description present ({sentence_count} sentence(s)).")
+
+    # Rule 3: ## Language section present
+    sections = split_into_sections(text)
+    if "language" not in sections:
+        add("language-section", "FAIL", "No '## Language' section found. This is the required core of CONTEXT.md.")
+        return finalize(findings)
+    add("language-section", "PASS", "'## Language' section found.")
+
+    # Rules 4 + 5 + 6: terms inside Language
+    terms = extract_terms(sections["language"])
+    if not terms:
+        add(
+            "language-terms",
+            "FAIL",
+            "No terms detected in the Language section. Each term must be in '**Term**:' bold form followed by a one-sentence definition.",
+        )
+    else:
+        add("language-terms", "PASS", f"Detected {len(terms)} term(s) in Language section.")
+        for term, definition, avoid in terms:
+            # Rule 5: definition exists
+            if not definition or definition.startswith("_Avoid_") or definition.startswith("**"):
+                add(
+                    "term-definition",
+                    "FAIL",
+                    f"Term '**{term}**:' has no definition line (next non-empty line should be the definition).",
+                )
+            else:
+                # Length heuristic: definition should be <= 200 chars (one sentence-ish)
+                if len(definition) > 200:
+                    add(
+                        "term-definition-length",
+                        "WARN",
+                        f"Term '**{term}**' definition is {len(definition)} chars. CONTEXT-FORMAT.md asks for one sentence max.",
+                    )
+            # Rule 6: _Avoid_ line
+            if not avoid:
+                add(
+                    "term-avoid",
+                    "WARN",
+                    f"Term '**{term}**' has no '_Avoid_:' aliases line. Without forbidden aliases, the glossary can't push back on drift.",
+                )
+
+    # Rule 7: Relationships section
+    if "relationships" not in sections:
+        add(
+            "relationships-section",
+            "WARN",
+            "No '## Relationships' section found. CONTEXT-FORMAT.md asks for one to show cardinality between terms.",
+        )
+    else:
+        add("relationships-section", "PASS", "'## Relationships' section found.")
+
+    # Rule 8: Example dialogue
+    if "example dialogue" not in sections:
+        add(
+            "example-dialogue",
+            "WARN",
+            "No '## Example dialogue' section found. CONTEXT-FORMAT.md asks for a dev/domain-expert exchange.",
+        )
+    else:
+        add("example-dialogue", "PASS", "'## Example dialogue' section found.")
+
+    # Rule 9: Flagged ambiguities (optional, only check presence)
+    if "flagged ambiguities" in sections:
+        add("flagged-ambiguities", "PASS", "'## Flagged ambiguities' section found (optional but useful).")
+
+    return finalize(findings)
+
+
+def finalize(findings: List[Dict[str, str]]) -> Dict[str, Any]:
+    counts = {"PASS": 0, "WARN": 0, "FAIL": 0}
+    for f in findings:
+        counts[f["level"]] += 1
+    if counts["FAIL"] > 0:
+        verdict = "FAIL"
+    elif counts["WARN"] > 0:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+    return {"verdict": verdict, "counts": counts, "findings": findings}
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    out: List[str] = []
+    verdict = result["verdict"]
+    counts = result["counts"]
+    out.append(f"CONTEXT.md lint verdict: {verdict}")
+    out.append(f"  PASS: {counts['PASS']}  WARN: {counts['WARN']}  FAIL: {counts['FAIL']}")
+    out.append("")
+    out.append("Findings:")
+    for f in result["findings"]:
+        marker = {"PASS": "[ok]", "WARN": "[warn]", "FAIL": "[FAIL]"}[f["level"]]
+        out.append(f"  {marker} {f['rule']}: {f['message']}")
+    return "\n".join(out)
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("path", nargs="?", help="Path to CONTEXT.md")
+    parser.add_argument("--sample", action="store_true", help="Lint the embedded sample CONTEXT.md")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        text = SAMPLE_CONTEXT_MD
+    elif args.path:
+        p = Path(args.path)
+        if not p.exists():
+            print(f"error: {args.path} not found", file=sys.stderr)
+            return 2
+        text = p.read_text(encoding="utf-8")
+    else:
+        parser.print_help()
+        return 0
+
+    result = lint(text)
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0 if result["verdict"] != "FAIL" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/engineering/grill-with-docs/skills/grill-with-docs/scripts/glossary_code_consistency.py
+++ b/engineering/grill-with-docs/skills/grill-with-docs/scripts/glossary_code_consistency.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""glossary_code_consistency.py — Cross-reference CONTEXT.md terms against the codebase.
+
+Stdlib-only. Reads bold terms from CONTEXT.md and scans a codebase directory for
+each term's usage. Surfaces two grilling-question seeds:
+
+  1. DEAD GLOSSARY — a term is defined in CONTEXT.md but never appears in code.
+     Either the term is stale (delete it) or the code uses a synonym (rename).
+
+  2. CODE-ONLY PROPER NOUN — a capitalized word that appears frequently in code
+     but isn't defined in CONTEXT.md. Either it's a generic programming concept
+     (ignore) or it's a domain term that snuck in undefined (add to glossary).
+
+Both lists are seeded as opening grill-with-docs questions.
+
+NO LLM CALLS. Pure file walking + regex + frequency counting.
+
+Limitations (intentional, stdlib-only):
+  - Word-boundary matching is case-insensitive. "Order" matches "order", "ORDER", "orders".
+  - "Code-only proper noun" detection uses a simple heuristic: capitalized
+    words >= MIN_FREQUENCY occurrences across non-test files. Tunable via flags.
+  - Only scans common source extensions by default (override with --extensions).
+
+Usage:
+    python glossary_code_consistency.py --context CONTEXT.md --code src/
+    python glossary_code_consistency.py --context CONTEXT.md --code src/ --output json
+    python glossary_code_consistency.py --sample
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+
+DEFAULT_EXTENSIONS = {
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".go",
+    ".java",
+    ".kt",
+    ".rb",
+    ".cs",
+    ".rs",
+    ".swift",
+    ".php",
+    ".scala",
+    ".clj",
+    ".ex",
+    ".exs",
+}
+DEFAULT_EXCLUDE_DIRS = {"node_modules", ".git", "dist", "build", "target", ".venv", "venv", "__pycache__"}
+TEST_FILE_HINTS = (".test.", ".spec.", "_test.", "tests/", "/test/")
+PROPER_NOUN_RE = re.compile(r"\b([A-Z][a-zA-Z]{2,})\b")
+GENERIC_WORDS = {
+    # Programming concepts that capitalize but aren't domain terms
+    "True", "False", "None", "Null", "Promise", "Error", "Exception",
+    "String", "Number", "Boolean", "Array", "Object", "Map", "Set",
+    "List", "Dict", "Tuple", "Optional", "Any", "Result", "Date",
+    "Math", "JSON", "URL", "URI", "HTTP", "HTTPS", "API", "ID", "UUID",
+    "GET", "POST", "PUT", "DELETE", "PATCH", "OK", "TODO", "FIXME",
+    "Test", "Mock", "Stub", "Spy", "Given", "When", "Then", "Describe",
+}
+
+SAMPLE_CONTEXT_MD = """# Ordering
+
+## Language
+
+**Order**:
+A confirmed request from a Customer to acquire one or more Products.
+_Avoid_: Purchase, transaction
+
+**Customer**:
+A person or organization that places Orders.
+_Avoid_: Client, buyer
+
+**Product**:
+A single SKU that can appear on an Order line.
+_Avoid_: Item, good
+
+**Discount**:
+A reduction applied to an Order at checkout.
+_Avoid_: Coupon, promo
+"""
+
+SAMPLE_CODE_FILES: Dict[str, str] = {
+    "src/orders.py": (
+        "class Order:\n"
+        "    pass\n"
+        "\n"
+        "def cancel_order(order_id: str) -> None:\n"
+        "    pass\n"
+        "\n"
+        "def list_customer_orders(customer_id: str) -> list[Order]:\n"
+        "    pass\n"
+    ),
+    "src/customers.py": (
+        "class Customer:\n"
+        "    pass\n"
+        "\n"
+        "class Subscription:\n"
+        "    # NOTE: Subscription is used heavily but not in glossary\n"
+        "    pass\n"
+        "\n"
+        "def find_customer(email: str) -> Customer:\n"
+        "    pass\n"
+    ),
+    "src/products.py": (
+        "class Product:\n"
+        "    pass\n"
+        "\n"
+        "class Inventory:\n"
+        "    pass\n"
+        "\n"
+        "def find_product(sku: str) -> Product:\n"
+        "    pass\n"
+    ),
+    # Note: Discount is defined in glossary but never used in code.
+}
+
+
+def extract_glossary_terms(context_md_text: str) -> List[str]:
+    """Pull bold terms from CONTEXT.md `**Term**:` patterns."""
+    return re.findall(r"\*\*([^*]+?)\*\*\s*:", context_md_text)
+
+
+def walk_codebase(root: Path, extensions: Set[str], exclude_dirs: Set[str]) -> List[Path]:
+    found: List[Path] = []
+    for path in root.rglob("*"):
+        if path.is_dir():
+            continue
+        if any(part in exclude_dirs for part in path.parts):
+            continue
+        if path.suffix in extensions:
+            found.append(path)
+    return found
+
+
+def is_test_file(path: Path) -> bool:
+    s = str(path).replace("\\", "/")
+    return any(hint in s for hint in TEST_FILE_HINTS)
+
+
+def count_term_in_text(text: str, term: str) -> int:
+    pattern = re.compile(rf"\b{re.escape(term)}\b", re.IGNORECASE)
+    return len(pattern.findall(text))
+
+
+def count_proper_nouns(text: str) -> Counter:
+    counter: Counter = Counter()
+    for match in PROPER_NOUN_RE.finditer(text):
+        counter[match.group(1)] += 1
+    return counter
+
+
+def analyze(
+    context_md_text: str,
+    code_files: List[Tuple[str, str]],
+    min_proper_noun_frequency: int,
+) -> Dict[str, Any]:
+    """code_files: list of (relative_path, text) tuples."""
+    glossary_terms = extract_glossary_terms(context_md_text)
+    glossary_term_set_lower = {t.lower() for t in glossary_terms}
+
+    # Per-term usage count in non-test files
+    term_usage: Dict[str, int] = {t: 0 for t in glossary_terms}
+    code_proper_nouns: Counter = Counter()
+    files_scanned = 0
+    files_tests_skipped = 0
+
+    for path_str, text in code_files:
+        path = Path(path_str)
+        if is_test_file(path):
+            files_tests_skipped += 1
+            continue
+        files_scanned += 1
+        for term in glossary_terms:
+            term_usage[term] += count_term_in_text(text, term)
+        for noun, count in count_proper_nouns(text).items():
+            code_proper_nouns[noun] += count
+
+    # Dead glossary: terms with zero usage
+    dead_terms = [t for t, n in term_usage.items() if n == 0]
+
+    # Code-only proper nouns: frequent capitalized identifiers NOT in glossary
+    # and NOT in the generic stop-list
+    code_only: List[Tuple[str, int]] = []
+    for noun, count in code_proper_nouns.most_common():
+        if count < min_proper_noun_frequency:
+            break
+        if noun.lower() in glossary_term_set_lower:
+            continue
+        if noun in GENERIC_WORDS:
+            continue
+        code_only.append((noun, count))
+
+    return {
+        "files_scanned": files_scanned,
+        "files_tests_skipped": files_tests_skipped,
+        "glossary_term_count": len(glossary_terms),
+        "term_usage": term_usage,
+        "dead_glossary_terms": dead_terms,
+        "code_only_proper_nouns": code_only,
+        "min_proper_noun_frequency": min_proper_noun_frequency,
+    }
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    out: List[str] = []
+    out.append("Glossary↔Code consistency report")
+    out.append(f"  Files scanned: {result['files_scanned']}  (test files skipped: {result['files_tests_skipped']})")
+    out.append(f"  Glossary terms: {result['glossary_term_count']}")
+    out.append("")
+    out.append("Term usage (occurrences in non-test code):")
+    for term, count in sorted(result["term_usage"].items(), key=lambda kv: (-kv[1], kv[0])):
+        marker = "  " if count > 0 else "!!"
+        out.append(f"  {marker} {term:<30s} {count}")
+    out.append("")
+    if result["dead_glossary_terms"]:
+        out.append("DEAD GLOSSARY (defined but never used in code) — grill these:")
+        for term in result["dead_glossary_terms"]:
+            out.append(f"  - '{term}': dead term, or rename happened?")
+    else:
+        out.append("DEAD GLOSSARY: (none — every defined term is used in code)")
+    out.append("")
+    if result["code_only_proper_nouns"]:
+        out.append(
+            f"CODE-ONLY PROPER NOUNS (>= {result['min_proper_noun_frequency']}x, not in glossary, not generic) — grill these:"
+        )
+        for noun, count in result["code_only_proper_nouns"]:
+            out.append(f"  - '{noun}' ({count} occurrences): domain term that needs definition, or generic?")
+    else:
+        out.append("CODE-ONLY PROPER NOUNS: (none above threshold — glossary covers the frequent domain nouns)")
+    return "\n".join(out)
+
+
+def run_sample(min_freq: int) -> Dict[str, Any]:
+    files = [(p, t) for p, t in SAMPLE_CODE_FILES.items()]
+    return analyze(SAMPLE_CONTEXT_MD, files, min_freq)
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--context", help="Path to CONTEXT.md")
+    parser.add_argument("--code", help="Path to codebase root")
+    parser.add_argument(
+        "--extensions",
+        help="Comma-separated source extensions to scan (default: common languages)",
+        default=None,
+    )
+    parser.add_argument(
+        "--min-frequency",
+        type=int,
+        default=3,
+        help="Minimum occurrences for a code-only proper noun to surface (default: 3)",
+    )
+    parser.add_argument("--sample", action="store_true", help="Run on the embedded sample data")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        result = run_sample(args.min_frequency)
+    elif args.context and args.code:
+        context_path = Path(args.context)
+        code_root = Path(args.code)
+        if not context_path.exists():
+            print(f"error: {args.context} not found", file=sys.stderr)
+            return 2
+        if not code_root.exists():
+            print(f"error: {args.code} not found", file=sys.stderr)
+            return 2
+        if args.extensions:
+            exts = {e.strip() if e.strip().startswith(".") else "." + e.strip() for e in args.extensions.split(",")}
+        else:
+            exts = DEFAULT_EXTENSIONS
+        files: List[Tuple[str, str]] = []
+        for p in walk_codebase(code_root, exts, DEFAULT_EXCLUDE_DIRS):
+            try:
+                files.append((str(p), p.read_text(encoding="utf-8", errors="ignore")))
+            except (OSError, UnicodeDecodeError):
+                continue
+        result = analyze(context_path.read_text(encoding="utf-8"), files, args.min_frequency)
+    else:
+        parser.print_help()
+        return 0
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Installs Matt Pocock's `grill-with-docs` skill as the fifth Matt-derived plugin in this repo, following the v2.6.0 hybrid-voice import pattern established by `write-a-skill` / `caveman` / `grill-me` / `handoff`.

**Upstream:** https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs
**License:** MIT, © 2026 Matt Pocock. SKILL.md + ADR-FORMAT.md + CONTEXT-FORMAT.md preserved verbatim per MIT.

## What the skill does

Docs-anchored grilling session. Where the existing `grill-me` skill interrogates a plan in isolation, `grill-with-docs` interrogates a plan against the project's existing language (`CONTEXT.md`) and recorded decisions (`docs/adr/`), updating both inline as terminology and decisions crystallise during the session.

Matt's three SKILL.md rules preserved verbatim:

- Interview relentlessly, one question per turn, walking the decision tree depth-first.
- When a term is sharpened, update `CONTEXT.md` right there — never batch.
- Offer an ADR only when all three are true: hard to reverse, surprising without context, real trade-off.

## Repo structure (mirrors grill-me 1:1)

```
engineering/grill-with-docs/
├── .claude-plugin/plugin.json
├── README.md
├── agents/cs-grill-with-docs.md
├── commands/cs-grill-with-docs.md
└── skills/grill-with-docs/
    ├── SKILL.md                        ← Matt's voice verbatim
    ├── ADR-FORMAT.md                   ← Matt's, verbatim
    ├── CONTEXT-FORMAT.md               ← Matt's, verbatim
    ├── references/
    │   ├── ubiquitous_language.md      ← 7 sources
    │   ├── adr_practice.md             ← 7 sources
    │   └── context_md_as_artifact.md   ← 7 sources
    └── scripts/
        ├── context_md_linter.py        ← stdlib
        ├── adr_scanner.py              ← stdlib
        └── glossary_code_consistency.py ← stdlib
```

**Footprint:** 13 files, 1,747 lines.

## Wrapper additions (this repo, on top of upstream)

| Addition | What it does | Verified by |
|---|---|---|
| `context_md_linter.py` | Validates `CONTEXT.md` structure (H1 + description + Language with bold terms + `_Avoid_:` aliases + Relationships + Example dialogue). PASS/WARN/FAIL per rule. | Smoke test: positive `PASS 7/7`; negative (broken file) correctly `FAIL` with 4 WARNs identifying every missing element. |
| `adr_scanner.py` | Walks `docs/adr/`, checks `NNNN-slug.md` filename pattern, surfaces numbering gaps + duplicates, validates H1 + body, sanity-checks optional `status` frontmatter, verifies `superseded by ADR-NNNN` targets exist. | Smoke test: positive `PASS 12/12` on 3 sequential ADRs; negative (gap + malformed filename + short body) correctly `FAIL` and surfaces every issue. |
| `glossary_code_consistency.py` | Extracts bold terms from `CONTEXT.md`, greps codebase, flags `DEAD GLOSSARY` (defined-but-unused) + `CODE-ONLY PROPER NOUNS` (frequent capitalized identifiers in code not in glossary). Tunable via `--min-frequency`. | Smoke test: sample correctly flags `Discount` (dead) and `Subscription` (code-only, at threshold 2). |
| 3 references (7 sources each) | Ubiquitous language canon · ADR practice canon · CONTEXT.md as living artifact | Sources listed at the bottom of each file. |
| `cs-grill-with-docs` agent | Docs-aware grill persona. Pre-flights the 3 linters before the first question, uses their findings as opening question seeds, enforces inline-edit + ADR-3-criteria-gate rules. | Mirrors `cs-grill-master` voice spec; differentiation block + hard rules included. |
| `/cs:grill-with-docs` command | Six forcing-question patterns: glossary conflict, ADR contradiction, undefined term, code-vs-claim, ADR 3-criteria gate, boundary check. | Mirrors `/cs:grill-me` shape with docs-anchored question patterns. |

## Differentiation from sibling skills

- **vs `grill-me`** — different grounding (docs + code vs plan-only). Both ship as separate plugins; pick whichever matches.
- **vs `caveman`** — different concern (depth-against-docs vs compression).
- **vs `handoff`** — different mode (interrogate vs continuation).

## Attribution

MIT attribution is present in every file: SKILL.md frontmatter + body header, ADR-FORMAT.md HTML comment, CONTEXT-FORMAT.md HTML comment, all 3 reference doc citations sections, plugin.json `attribution` block, README.md Attribution + License sections, agent + command footers.

## Test plan

- [ ] Smoke-test `context_md_linter.py` against this repo's own `CLAUDE.md`-like docs in the consuming project (out-of-scope here — script is glossary-targeted, not CLAUDE.md-targeted).
- [ ] Confirm `python3 scripts/*.py --help` works for all three scripts on a stock Python 3.11+ install (verified locally).
- [ ] Confirm `python3 scripts/*.py --sample` returns expected verdict for all three (verified locally).
- [ ] Confirm `--output json` produces valid JSON for all three (verified locally).
- [ ] Confirm negative cases (broken CONTEXT.md, gap+malformed ADR dir) correctly `FAIL` (verified locally).
- [ ] Plugin-audit pipeline (`/plugin-audit engineering/grill-with-docs`) — optional, can run before merge.
- [ ] Cross-skill consistency check against the four existing Matt Pocock skills — file-tree layout, attribution pattern, footer format (verified by 1:1 mirror of `grill-me`).

https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw)_