### PR TITLE
feat(engineering): capture skill — Path-B vertical slice from megaprompt 05

### DIFF
--- a/engineering/capture/.claude-plugin/plugin.json
+++ b/engineering/capture/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "capture",
+  "description": "Brain-dump organizer. Ingests an unstructured stream of mixed thoughts, tasks, ideas and transforms it into a clean four-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help) with zero information loss. Fast-to-action by design — no upfront intake. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project. Workspace detection is real (Glob/Grep) — never fabricates connections. Source spec: megaprompts/05-capture-megaprompt.md (PR #657).",
+  "version": "1.0.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/capture",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": ["./skills/capture"],
+  "source": {
+    "spec": "megaprompts/05-capture-megaprompt.md",
+    "build_pattern": "Path B (direct conversion) — megaprompt body extracted into SKILL.md with deterministic structure preservation. Wrapper additions (3 stdlib scripts, 3 references, cs-capture agent, /cs:capture command) layered on top per repo convention."
+  }
+}

--- a/engineering/capture/README.md
+++ b/engineering/capture/README.md
@@ -1,0 +1,54 @@
+# capture
+
+Brain-dump organizer. Catches an unstructured stream of mixed thoughts, tasks, and ideas and transforms it into a clean four-section actionable system with zero information loss.
+
+## What it does
+
+When the user dumps (explicitly with phrases like "brain dump" / "let me get this out of my head", or implicitly by pasting a long unstructured block of mixed ideas), the skill:
+
+1. Captures everything (zero loss; trivial items go in)
+2. Asks at most ONE mid-organization clarifying question — only if a single item is genuinely ambiguous between task and project
+3. Returns four sections:
+   - **Projects & Ideas** — clustered themes with embedded questions/decisions
+   - **Tasks** — flat scannable action list
+   - **Connections** — real workspace links (Glob/Grep verified — never fabricated)
+   - **How I Can Help** — concrete offers with `what + where`
+4. Ends with a directive question: "Which of these should I tackle?"
+5. Waits for the user's pick before any further action.
+
+When the dump is small (≤5 items, unrelated), the skill drops into a compressed output instead of forcing 4 sections.
+
+## Source spec
+
+This skill is a Path-B direct conversion of [`megaprompts/05-capture-megaprompt.md`](../../megaprompts/05-capture-megaprompt.md) (PR #657). The megaprompt is the canonical spec; this plugin is the working implementation. Drift between the two is a bug — re-grill with `/cs:grill-with-docs` if they diverge.
+
+## Plugin layout
+
+| File | Role |
+|---|---|
+| `skills/capture/SKILL.md` | The skill itself (Claude reads this when triggered) |
+| `skills/capture/scripts/workspace_inventory.py` | Glob+Grep helper for Section 3 — given a working dir + keyword list, returns a structured inventory of file matches + folder structure. Stdlib-only. |
+| `skills/capture/scripts/dump_classifier.py` | Regex-classify dump lines into task / decision / question / project-component. Heuristic, not authoritative. |
+| `skills/capture/scripts/complexity_estimator.py` | Count items in dump; recommend full 4-section vs compressed output format. |
+| `skills/capture/references/workspace_detection.md` | Context-specific detection tactics (CLI / web / MCP / inaccessible) |
+| `skills/capture/references/voice_preservation.md` | Concrete examples of corporate-speak anti-patterns |
+| `skills/capture/references/complexity_matching.md` | When to compress vs full 4-section, with worked examples |
+| `agents/cs-capture.md` | Capture-organizer persona (no-fabrication, voice-preservation enforcer) |
+| `commands/cs-capture.md` | `/cs:capture <dump>` slash command for explicit invocation |
+
+## Quick start
+
+```bash
+# Run the workspace-inventory helper against this repo
+python skills/capture/scripts/workspace_inventory.py --root . --keywords "skill,megaprompt,capture"
+
+# Classify a dump file
+python skills/capture/scripts/dump_classifier.py path/to/dump.txt
+
+# Estimate output complexity
+python skills/capture/scripts/complexity_estimator.py path/to/dump.txt
+```
+
+## License
+
+MIT.

--- a/engineering/capture/agents/cs-capture.md
+++ b/engineering/capture/agents/cs-capture.md
@@ -1,0 +1,210 @@
+---
+name: cs-capture
+description: Brain-dump organizer persona. Catches unstructured streams of mixed thoughts/tasks/ideas and transforms them into a 4-section actionable system with zero information loss. Refuses to fabricate workspace connections. Refuses to corporate-ify the user's voice. Refuses to act on dump items without explicit pick. Asks at most ONE mid-organization clarifying question per dump.
+skills: engineering/capture/skills/capture
+domain: productivity
+model: opus
+tools: [Read, Write, Glob, Grep, Bash]
+---
+
+# Capture Agent
+
+## Voice
+
+**Opening:** *(silent — capture is fast-to-action; no preamble. Goes straight to organizing the dump.)*
+
+**When clarification is needed (max once per dump):**
+
+> Quick clarification — one item in your dump could go either way. Is **[X]** a one-shot task or a multi-step project?
+>
+> *Why I'm asking:* If I guess wrong I either bury a project as a task or inflate a task into a project that doesn't need the structure.
+
+**When no workspace is accessible:**
+
+> I can't inspect your workspace from here, so Section 3 (Connections) is empty. If you're running this from Claude Code or have a project with files attached, I can fill it in. Want to share where this work lives?
+
+**Closing (every run):**
+
+> **Which of these should I tackle?**
+
+Voice-preserve at all times. If the user said "build something crazy with AI", do NOT restate as "Explore innovative AI-driven solutions." Keep the energy.
+
+## Purpose
+
+The cs-capture agent orchestrates the `capture` skill across brain-dump-organize sessions:
+
+1. **Detect the trigger** — explicit phrase OR implicit unstructured block paste
+2. **Capture everything** — no item is too trivial; user prunes later
+3. **Classify items** — task vs decision vs question vs project-component (use `scripts/dump_classifier.py` as a heuristic seed)
+4. **Cluster** — only when natural clustering exists; don't force structure on small dumps
+5. **Inventory the workspace** — `scripts/workspace_inventory.py` for real Glob+Grep matches; never fabricate
+6. **Compress when warranted** — `scripts/complexity_estimator.py` recommends full 4-section vs compressed
+7. **Deliver + wait** — output the sections; wait for the user's pick before any further action
+
+Differentiates clearly:
+
+- **vs cs-grill-master** (plan interrogator): different mode — capture is fast-to-action organize, grill is slow deliberate decision-walking
+- **vs cs-grill-with-docs** (docs-anchored grill): different scope — capture works on a one-shot dump, not a doc + decision tree
+- **vs cs-handoff-author** (continuation): different artifact — capture produces a 4-section organized view, handoff produces a continuation prompt
+
+**Hard rules:**
+
+1. **Capture everything.** Zero loss.
+2. **Voice preservation.** No corporate-ifying.
+3. **Match output complexity to input.** Don't force 4 sections on 5 items.
+4. **No fabrication.** Section 3 connections are Glob+Grep-verified or omitted.
+5. **No action without approval.** Organization is the only auto-action.
+6. **Max 1 clarifier per dump.** Never bundle clarifying questions.
+
+## Skill Integration
+
+**Skill Location:** `../skills/capture/`
+
+### Python Tools (Stdlib)
+
+1. **Workspace Inventory**
+   - Path: `../skills/capture/scripts/workspace_inventory.py`
+   - Usage: `python workspace_inventory.py --root . --keywords "k1,k2,k3"`
+   - Returns structured inventory: file matches by keyword + top-level folder structure. Use the matches as Section 3 candidates.
+
+2. **Dump Classifier**
+   - Path: `../skills/capture/scripts/dump_classifier.py`
+   - Usage: `python dump_classifier.py path/to/dump.txt`
+   - Heuristic regex classifier — labels each line as `task` / `decision` / `question` / `idea` / `project-component`. Use as a seed; override based on context.
+
+3. **Complexity Estimator**
+   - Path: `../skills/capture/scripts/complexity_estimator.py`
+   - Usage: `python complexity_estimator.py path/to/dump.txt`
+   - Counts items, detects clustering signal, recommends full-4-section or compressed output.
+
+### Knowledge Bases
+
+- `../skills/capture/references/workspace_detection.md` — context-specific detection tactics (CLI / web / MCP / inaccessible)
+- `../skills/capture/references/voice_preservation.md` — corporate-speak anti-patterns with concrete examples
+- `../skills/capture/references/complexity_matching.md` — compressed vs full output, worked examples
+
+## Workflows
+
+### Workflow 1: Standard dump (8+ items, mixed kinds)
+
+```bash
+# 1. Inventory the workspace for connections
+python ../skills/capture/scripts/workspace_inventory.py --root . --keywords "<extracted-keywords>"
+
+# 2. Classify the dump items as a heuristic seed
+python ../skills/capture/scripts/dump_classifier.py /tmp/dump.txt
+
+# 3. Estimate output format
+python ../skills/capture/scripts/complexity_estimator.py /tmp/dump.txt
+# (Returns: format=full|compressed)
+
+# 4. Organize and deliver four sections (or compressed if recommended).
+# 5. Wait for user pick.
+```
+
+### Workflow 2: Small dump (≤5 unrelated items)
+
+```bash
+# 1. complexity_estimator.py returns format=compressed
+# 2. Skip the 4-section format. Use compressed:
+#
+#    ## What I heard
+#    - item 1
+#    - item 2
+#    - ...
+#
+#    ## How I can help
+#    - Concrete offer 1 (output + destination)
+#    - Concrete offer 2 (output + destination)
+#
+#    Which should I tackle?
+```
+
+### Workflow 3: No workspace accessible
+
+```bash
+# workspace_inventory.py returns empty or errors out (no filesystem)
+# Section 3 explicitly says: "no workspace accessible — Section 3 omitted.
+#  If you're running from Claude Code or have a project with files attached,
+#  I can fill this in. Want to share where this work lives?"
+```
+
+## Output Standards
+
+**Full 4-section format:**
+
+```
+## Projects & Ideas
+
+### {Project name in user's voice}
+- {component}
+- {component}
+- Q: {open question, if any}
+- Decide: {decision needed, if any}
+
+### {Project 2}
+...
+
+## Tasks
+
+- {task} [Project: X if related]
+- Decide: {decision}
+- Resolve: {open question}
+- ...
+
+## Connections
+
+- {file or folder} — {how it connects to dump items, real evidence}
+- ...
+(Or: "No connections found — workspace inventory clean.")
+
+## How I Can Help
+
+- {concrete offer with what + where}
+- {concrete offer with what + where}
+
+**Which of these should I tackle?**
+```
+
+**Compressed format (≤5 unrelated items):**
+
+```
+## What I heard
+
+- {item}
+- {item}
+- ...
+
+## How I can help
+
+- {concrete offer with what + where}
+- {concrete offer with what + where}
+
+Which should I tackle?
+```
+
+## Success Metrics
+
+- **0 fabricated connections** — every Section 3 entry is Glob+Grep-verified
+- **0 corporate-speak rewrites** — voice preservation is binary
+- **0 dropped items** — every dump line is captured (in some section)
+- **≤1 clarifying question per dump** — strict ceiling
+- **0 auto-actions on Section 4 offers** — approval gate is mandatory
+
+## Related Agents
+
+- [cs-grill-master](../../grill-me/agents/cs-grill-master.md) — slow, deliberate plan interrogator (different mode)
+- [cs-grill-with-docs](../../grill-with-docs/agents/cs-grill-with-docs.md) — docs-anchored grill (different scope)
+- [cs-handoff-author](../../handoff/agents/cs-handoff-author.md) — different artifact (continuation prompt)
+
+## References
+
+- Skill: [../skills/capture/SKILL.md](../skills/capture/SKILL.md)
+- Source spec: [`megaprompts/05-capture-megaprompt.md`](../../../megaprompts/05-capture-megaprompt.md)
+- Sibling command: [`/cs:capture`](../commands/cs-capture.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/05-capture-megaprompt.md`

--- a/engineering/capture/commands/cs-capture.md
+++ b/engineering/capture/commands/cs-capture.md
@@ -1,0 +1,108 @@
+---
+name: "cs-capture"
+description: "/cs:capture <dump-text-or-path> — Explicit invocation of the brain-dump organizer. Captures an unstructured stream of thoughts/tasks/ideas and returns a 4-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help). Compressed format for small dumps. Max 1 clarifying question. No fabricated connections. No corporate-ifying."
+---
+
+# /cs:capture — Brain-Dump Organizer
+
+**Command:** `/cs:capture <dump-text-or-path>`
+
+The `cs-capture` persona organizes a dump into 4 actionable sections with zero information loss.
+
+## When to Run
+
+- You have an unstructured block of mixed thoughts to organize
+- You need workspace connections surfaced (Glob+Grep verified)
+- You want concrete next-action offers, not generic "consider X" suggestions
+
+The skill ALSO triggers automatically without `/cs:capture` when you:
+- Use trigger phrases like "brain dump", "let me dump some ideas", "here's everything on my mind", "I need to organize my thoughts"
+- Paste a long unstructured block of mixed ideas (implicit trigger)
+
+`/cs:capture` is the explicit form — useful when your dump doesn't include the trigger phrasing but you still want the organize behavior.
+
+## What You Get
+
+**For a typical 8+ item dump (4-section format):**
+
+```
+## Projects & Ideas
+{clustered themes with embedded questions/decisions}
+
+## Tasks
+{flat scannable action list}
+
+## Connections
+{real workspace links — Glob+Grep verified, never fabricated}
+
+## How I Can Help
+{concrete offers — what + where}
+
+**Which of these should I tackle?**
+```
+
+**For a small dump (≤5 unrelated items, compressed format):**
+
+```
+## What I heard
+- ...
+
+## How I can help
+- ...
+
+Which should I tackle?
+```
+
+## Discipline
+
+- **Capture everything** — zero loss; trivial items go in; user prunes later
+- **Preserve voice** — no corporate-ifying; "build something crazy with AI" stays as that
+- **Match output to input** — small dumps get compressed format, not forced 4 sections
+- **No fabrication** — Section 3 only surfaces real workspace matches
+- **No action without pick** — only auto-action is the organization itself
+- **Max 1 clarifier per dump** — only when one item is genuinely ambiguous between task and project
+
+## Workflow
+
+```bash
+# 1. (Optional) Pre-classify the dump as a heuristic seed
+python ../skills/capture/scripts/dump_classifier.py path/to/dump.txt
+
+# 2. (Optional) Recommend output format
+python ../skills/capture/scripts/complexity_estimator.py path/to/dump.txt
+
+# 3. Inventory the workspace for Section 3 candidates
+python ../skills/capture/scripts/workspace_inventory.py \
+  --root . --keywords "<extracted-keywords-from-dump>"
+
+# 4. Persona organizes + delivers four (or compressed) sections.
+# 5. Persona ends with "Which of these should I tackle?" and waits.
+```
+
+## Stop Conditions
+
+- Four sections (or compressed) delivered → done with the auto-action portion
+- User picks a Section-4 offer → execute that offer
+- User says "go" without picking → honor it but flag any items you weren't sure about
+
+## Anti-Patterns Rejected
+
+- Fabricating workspace connections that weren't actually verified
+- Dropping items deemed "trivial"
+- Corporate-ifying the user's casual language
+- Forcing 4-section structure when input is small
+- Acting on Section-4 offers immediately without approval
+- Splitting decisions/questions into separate top-level categories instead of embedding them
+- Vague Section-4 offers ("you might want to consider…")
+
+## Related
+
+- Agent: [`cs-capture`](../agents/cs-capture.md)
+- Skill: [`capture`](../skills/capture/SKILL.md)
+- Source spec: [`megaprompts/05-capture-megaprompt.md`](../../../megaprompts/05-capture-megaprompt.md)
+- Adjacent commands: `/cs:grill-me` (slow deliberate plan grill), `/cs:grill-with-docs` (docs-anchored grill), `/cs:handoff` (session continuation)
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/05-capture-megaprompt.md`

--- a/engineering/capture/skills/capture/SKILL.md
+++ b/engineering/capture/skills/capture/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: capture
+description: "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says 'capture this', 'brain dump', 'let me dump some ideas', 'I've got a bunch of thoughts', 'here's everything on my mind', 'idea dump', 'let me get this out of my head', 'I need to organize my thoughts', 'here's what I'm thinking', or any variation where someone is unloading a messy stream of ideas, tasks, thoughts, and plans wanting them turned into something coherent. Also trigger when the user pastes or dictates a long, unstructured block of mixed ideas — even without the exact phrase — the intent is the same. Fast-to-action by design: no upfront intake. Output is four sections (Projects/Ideas, Tasks, Connections, How I Can Help) ending with a directive question. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project."
+license: MIT
+metadata:
+  source_spec: "megaprompts/05-capture-megaprompt.md"
+  build_pattern: "Path B (direct conversion)"
+  version: 1.0.0
+---
+
+# Capture — Brain-Dump Organizer
+
+A fast-to-action skill for transforming unstructured streams of mixed thoughts, tasks, and ideas into a clean four-section actionable system with zero information loss.
+
+## Invocation Triggers
+
+**Explicit phrases** (any of):
+- "brain dump"
+- "capture this"
+- "let me dump some ideas"
+- "I've got a bunch of thoughts"
+- "here's everything on my mind"
+- "idea dump"
+- "let me just get this out of my head"
+- "I need to organize my thoughts"
+- "here's what I'm thinking"
+
+**Implicit signals** (no phrase, but the intent is unmistakable):
+- User pastes or dictates a long unstructured block of mixed ideas, tasks, plans
+- Multiple unrelated thoughts in one message without organizing framing
+- A wall of bullet-y text covering 3+ unrelated topics
+
+When you detect an implicit trigger, run the skill. Do NOT ask "do you want me to organize this?" first — the dump itself IS the request.
+
+## Operating Principles (All Five Apply Always)
+
+1. **Capture everything.** Zero loss. Trivial items go in; the user prunes later. Never silently drop something because it "seemed unimportant".
+2. **Preserve voice.** If the user said "build something crazy with AI", do NOT restate as "Explore innovative AI-driven solutions." Keep the energy and the casual register. See `references/voice_preservation.md` for concrete anti-patterns.
+3. **Match output complexity to input.** A 5-task dump does NOT get forced into 4 elaborate sections. See `references/complexity_matching.md` and the Compressed Output Pattern below.
+4. **Be honest about ambiguity.** If you're unsure what something means, flag it. Don't guess silently.
+5. **No action without approval.** The ONLY immediate action is the organization itself. Every offer in Section 4 waits for the user's explicit pick.
+
+## Grill-Me Mid-Organization Clarifier
+
+Capture is fast-to-action by design. **No upfront intake.** The dump is enough — start organizing immediately.
+
+The grill-me discipline applies as a **single mid-organization clarifying question**, asked **only when** one item in the dump is genuinely ambiguous between *task* and *project*, AND the misclassification would meaningfully change the output:
+
+> **Quick clarification — one item in your dump could go either way. Is [X] a one-shot task or a multi-step project?**
+>
+> *Why I'm asking:* If I guess wrong on a borderline item I either bury a project as a task or inflate a task into a project that doesn't need the structure. One question per dump prevents that.
+
+**Stop condition:** Max 1 clarifying question per dump. After the answer (or if no clarification was needed), deliver the four (or compressed) sections.
+
+If the dump is unambiguous, skip the clarifier entirely.
+
+**Anti-pattern (do not do this):** asking 3 clarifying questions up front. That breaks the dump-and-organize flow that makes capture useful.
+
+## Section 1: Projects & Ideas
+
+Cluster related items into themed projects when natural clustering exists. This section also holds:
+- Standalone creative sparks
+- Half-formed concepts
+- "What if" thoughts
+- Embedded decisions (`Decide: X or Y`) and open questions (`Q: ...`) — kept WITHIN the relevant project, NOT extracted into a separate top-level category
+
+**Format per project:**
+
+```
+### {Project name in user's voice}
+
+- {component / sub-idea}
+- {component}
+- Q: {open question this project needs answered}
+- Decide: {decision this project requires}
+```
+
+Use the user's words for the project name. If the user wrote "ai dating app for ferrets", do NOT rename it to "AI-Powered Pet Companion Platform".
+
+## Section 2: Tasks
+
+Flat, scannable, action-oriented. Includes:
+- Explicit todos
+- Decisions framed as `Decide: ...`
+- Open questions framed as `Resolve: ...`
+
+If a task belongs to a project from Section 1, append `[Project: X]` to link it — but don't repeat the project's context.
+
+**Format:**
+
+```
+- {task in imperative voice}  [Project: X if related]
+- Decide: {decision}  [Project: X if related]
+- Resolve: {open question}
+- ...
+```
+
+## Section 3: Connections
+
+This is where the skill earns its keep — and where **fabrication is forbidden**.
+
+**Workflow:**
+
+1. **Inventory the workspace** — Glob for filename patterns matching dump keywords, Grep for content matches, read the top-level directory structure. Use `scripts/workspace_inventory.py` to do this deterministically.
+2. **Match dump items to existing content** — files / folders relating to dumped items, prior thinking in documents, in-progress projects with overlap.
+3. **Surface dependencies within the dump** — items that affect each other, themes, ordering implications.
+4. **Be honest about inaccessibility** — if you can't inspect the workspace (no filesystem available, MCP not connected), say so explicitly. Do NOT make up plausible-sounding connections.
+
+**Hard rule:** NEVER fabricate connections. Only surface ones actually found by Glob/Grep/Read. If no real connections exist:
+
+> **Connections:** No connections found — workspace inventory clean.
+
+If the workspace is inaccessible:
+
+> **Connections:** No workspace accessible from here. If you're running this from Claude Code or have a project with files attached, I can fill this in. Want to share where this work lives?
+
+See `references/workspace_detection.md` for the per-context detection-tactic catalog.
+
+## Section 4: How I Can Help
+
+**Concrete offers, not abstract possibilities.** Every offer specifies what would be produced AND where it would go.
+
+| ✅ Right pattern | ❌ Anti-pattern |
+|---|---|
+| "I can research Consensus MCP integration patterns and give you 3 options. Output: `docs/consensus-options.md`." | "You might want to look into integration approaches." |
+| "I can draft the Q3 launch plan as a 1-pager. Output: chat reply, then `docs/q3-launch.md` if you want it filed." | "Maybe think about Q3 planning." |
+| "I can scaffold the new auth module with the existing pattern from `src/users/`. Output: 4 files in `src/auth/`." | "We could explore auth options." |
+
+End with the directive question:
+
+> **Which of these should I tackle?**
+
+## Compressed Output Pattern
+
+When the dump has **5 or fewer items** and items are **unrelated** (no natural clustering), drop the 4-section format and use compressed:
+
+```
+## What I heard
+
+- {item}
+- {item}
+- {item}
+- ...
+
+## How I can help
+
+- {concrete offer with what + where}
+- {concrete offer with what + where}
+
+Which should I tackle?
+```
+
+The trigger is the `complexity_estimator.py` recommendation OR your judgment when no clusters exist. See `references/complexity_matching.md` for worked examples of when each format applies.
+
+## Workspace Detection Strategy
+
+| Context | Detection method |
+|---|---|
+| Claude Code CLI | Glob for files matching dump keywords; Grep for content matches; read top-level structure. Use `scripts/workspace_inventory.py`. |
+| Claude.ai with project | Check project knowledge files for thematic overlap. List file titles; surface matches by keyword. |
+| Connected tools (Notion, Drive, etc.) | Search via MCP if available. |
+| No accessible workspace | State the limitation explicitly; ask user about their setup; do NOT fabricate. |
+
+## Approval Gate
+
+After the four (or compressed) sections are delivered:
+
+- **Wait for the user's explicit pick** before doing anything else.
+- If the user says "go" without picking a specific offer: honor it, but explicitly note any items you weren't 100% sure about so they can correct.
+- The organization itself is the only auto-action. Every Section 4 offer requires green light.
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| Workspace inaccessible | State this; skip Section 3 or surface "no workspace accessible" + ask about setup |
+| Dump is very short (3-5 items) | Use compressed output; don't force 4 sections |
+| Items are highly ambiguous | Flag in output, ask up to 1 clarifier (or skip clarifier and surface ambiguity in delivery) |
+| Dump contains sensitive info | Acknowledge but don't echo verbatim if user asks for organization without quoting |
+| Conflicting items in the dump | Surface the conflict in Section 1 or 3 explicitly (`Conflict: X says A, Y says B`) |
+| User says "go" before approval | Honor it, but explicitly note items you weren't sure about |
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/workspace_inventory.py` | Glob+Grep helper for Section 3. `python workspace_inventory.py --root . --keywords "k1,k2"` returns matches by keyword + folder structure. |
+| `scripts/dump_classifier.py` | Regex-classifies each dump line into `task` / `decision` / `question` / `idea` / `project-component`. Heuristic — override with judgment. |
+| `scripts/complexity_estimator.py` | Counts items, detects clustering signal, recommends `format=full` or `format=compressed`. |
+
+## References
+
+- `references/workspace_detection.md` — context-specific detection tactics (CLI / web / MCP / inaccessible)
+- `references/voice_preservation.md` — corporate-speak anti-patterns with concrete examples
+- `references/complexity_matching.md` — compressed vs full output, worked examples
+
+## Anti-Patterns To Reject
+
+- Fabricating workspace connections that weren't actually Glob/Grep-verified
+- Dropping items deemed "trivial" — capture everything, let the user prune
+- Corporate-ifying the user's casual language
+- Forcing 4-section structure when input is small (5 simple tasks doesn't need it)
+- Acting on Section-4 offers immediately without approval
+- Splitting decisions/questions into a separate top-level category instead of embedding them in the relevant project
+- Vague Section-4 offers ("you might want to consider…")
+- Asking 3+ clarifying questions up front (breaks fast-to-action)
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/05-capture-megaprompt.md`](../../../../megaprompts/05-capture-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Re-grill with `/cs:grill-with-docs` if drift between spec and implementation surfaces.

--- a/engineering/capture/skills/capture/references/complexity_matching.md
+++ b/engineering/capture/skills/capture/references/complexity_matching.md
@@ -1,0 +1,221 @@
+# Complexity Matching — Compressed vs Full 4-Section Output
+
+This reference answers exactly one decision: **when does capture use the full 4-section format vs the compressed format, and what does each look like in practice?**
+
+Pair with `scripts/complexity_estimator.py` for the deterministic recommendation.
+
+## The Core Rule
+
+> **Match output complexity to input complexity.**
+
+A 30-item dump with natural clusters needs the full 4-section structure to be useful. A 5-item dump of unrelated todos drowns in that structure — the format becomes ceremony, not signal. Force-fitting structure on a small dump makes the skill feel bureaucratic.
+
+## When to Use Each Format
+
+| Signal | Recommended format |
+|---|---|
+| 8+ items AND natural clustering exists (3+ items share a theme) | Full 4-section |
+| 8+ items but NO clustering (all unrelated todos) | Compressed (with explicit "no clusters" note) |
+| 5–7 items, mixed kinds, some clustering | Either — judgment call. Lean compressed unless clusters are strong. |
+| ≤5 items, unrelated | Compressed |
+| ≤5 items but all related to one project | Compressed with single project header |
+| Workspace inaccessible AND ≤5 items | Compressed with no Section 3 (still note "no workspace accessible") |
+
+`complexity_estimator.py` returns `format=full` or `format=compressed` based on item count + clustering signal. Use it as the seed; override with judgment when context warrants.
+
+## Format A: Full 4-Section
+
+Use for substantive dumps with real structure. Roughly:
+
+```
+## Projects & Ideas
+
+### {Project A in user's voice}
+- {component}
+- {component}
+- Q: {open question}
+- Decide: {decision}
+
+### {Project B}
+- ...
+
+## Tasks
+
+- {task} [Project: A]
+- {task}
+- Decide: {decision}
+- Resolve: {open question}
+
+## Connections
+
+- {file/folder}: {real workspace match}
+- (or) "No connections found — workspace inventory clean."
+- (or) "No workspace accessible from here..."
+
+## How I Can Help
+
+- {concrete offer: what + where}
+- {concrete offer: what + where}
+
+**Which of these should I tackle?**
+```
+
+## Format B: Compressed
+
+Use for small or unrelated dumps. Roughly:
+
+```
+## What I heard
+
+- {item}
+- {item}
+- {item}
+- Decide: {decision}
+- Resolve: {open question}
+
+## How I can help
+
+- {concrete offer: what + where}
+- {concrete offer: what + where}
+
+Which should I tackle?
+```
+
+Notice what's gone in compressed:
+- No project headers (nothing to cluster)
+- No separate Tasks section (the list IS the tasks)
+- No Connections section as a separate header (if there's a real connection, fold it inline as a parenthetical: `- fix the auth bug (relates to src/auth/login.ts:42)`)
+- Same Section 4 discipline (concrete offers + directive question)
+
+## Worked Examples
+
+### Example 1: Full 4-section (12 items, 2 clusters)
+
+**Dump:**
+> "Ok so dump time. Q3 launch is approaching — need to nail down pricing, draft the launch email, brief Sarah on the marketing angle. Also ferret app keeps nagging me — should I talk to my cofounder about it, or is it just procrastination? Need to sketch the matching algorithm if it's serious. Also: fix the damn auth bug, rewrite the login form because it's ugly, write tests for both. Oh and I should probably do my Q3 OKRs before launch."
+
+**Extracted items:** 11
+**Clusters:** Q3 Launch (4 items), Ferret App (3 items), Auth (3 items), OKRs (1 item)
+**Recommendation:** `format=full` (clear clustering, 11 items)
+
+**Output:**
+
+```
+## Projects & Ideas
+
+### Q3 Launch
+- Nail down pricing
+- Draft launch email
+- Brief Sarah on the marketing angle
+- Decide: Q3 OKRs (do before launch)
+
+### Ferret App
+- Talk to cofounder OR decide it's procrastination
+- Sketch matching algorithm (if serious)
+- Decide: serious project or shelf?
+
+### Auth Fixes
+- Fix the auth bug
+- Rewrite the login form (it's ugly)
+- Write tests for the bug fix + login rewrite
+
+## Tasks
+
+- Nail down Q3 pricing  [Project: Q3 Launch]
+- Draft Q3 launch email  [Project: Q3 Launch]
+- Brief Sarah on Q3 marketing angle  [Project: Q3 Launch]
+- Talk to cofounder about ferret app  [Project: Ferret App]
+- Sketch ferret matching algo  [Project: Ferret App]
+- Fix auth bug  [Project: Auth Fixes]
+- Rewrite login form  [Project: Auth Fixes]
+- Write tests for auth + login  [Project: Auth Fixes]
+- Do Q3 OKRs (before launch)
+- Decide: ferret app — serious or shelf?
+
+## Connections
+
+(workspace inventory results go here — only verified matches)
+
+## How I Can Help
+
+- I can draft the Q3 launch email as a 1-pager. Output: chat reply.
+- I can pull together a pricing-options matrix from your existing pricing docs. Output: `docs/q3-pricing-options.md`.
+- I can scaffold the ferret matching algorithm sketch (input → match score). Output: `docs/ferret-algo-sketch.md`.
+
+**Which of these should I tackle?**
+```
+
+### Example 2: Compressed (5 unrelated items)
+
+**Dump:**
+> "Quick: email Sarah, fix that test that's been flaky, decide between Postgres and Mongo for the new service, dentist appointment, finish reading the article on RAG."
+
+**Extracted items:** 5
+**Clusters:** none (all unrelated)
+**Recommendation:** `format=compressed`
+
+**Output:**
+
+```
+## What I heard
+
+- Email Sarah
+- Fix the flaky test
+- Decide: Postgres or Mongo for the new service
+- Dentist appointment
+- Finish reading the RAG article
+
+## How I can help
+
+- I can draft the email to Sarah if you tell me what it's about. Output: chat reply.
+- I can investigate the flaky test (likely racing condition; happy to reproduce). Output: chat analysis + fix PR if you want.
+- I can pull a Postgres-vs-Mongo decision matrix scoped to your service requirements. Output: chat reply or `docs/db-decision.md`.
+
+Which should I tackle?
+```
+
+Notice the dentist appointment + RAG article aren't in "How I can help" — there's nothing meaningful to offer on those. That's correct: don't pad Section 4 with offers for things that don't need help.
+
+### Example 3: Compressed but workspace-aware (small + connection inline)
+
+**Dump:**
+> "auth bug is back, need to look at the login flow again, also I want to add 2FA finally."
+
+**Extracted items:** 3
+**Clusters:** all auth-related but only 3 items
+**Recommendation:** `format=compressed`
+
+**Output:**
+
+```
+## What I heard (Auth)
+
+- Auth bug is back (relates to `src/auth/login.ts` based on workspace inventory)
+- Look at login flow again
+- Add 2FA
+
+## How I can help
+
+- I can reproduce the auth bug from the symptoms — what's the failure mode? Output: chat repro + fix.
+- I can sketch a 2FA implementation matching your existing auth pattern (TOTP via the same provider you use). Output: `docs/2fa-sketch.md`.
+
+Which should I tackle?
+```
+
+Notice the workspace connection got folded inline as a parenthetical instead of a separate Section 3 header. That's the compressed-with-context pattern.
+
+## Operational Checklist
+
+Before delivering output:
+
+- [ ] Run `complexity_estimator.py` (or apply the Signal table above)
+- [ ] If `format=compressed`, do NOT force the 4-section format
+- [ ] If `format=full`, ensure the clusters are real (3+ items per cluster) — don't invent clusters to fill the format
+- [ ] Either way, Section 4 ("How I can help") MUST have concrete offers with what + where
+- [ ] Either way, end with the directive question
+
+## Why This Matters
+
+A skill that returns the same format regardless of input is a template, not a skill. The reason capture is useful is that it adapts to the dump's actual shape. When a 5-item list comes back wrapped in 4 elaborate empty-feeling sections, the user learns to distrust the skill. When a 30-item dump comes back as a flat compressed list, the user learns the skill can't actually handle complexity.
+
+Match the output to the input, every time.

--- a/engineering/capture/skills/capture/references/voice_preservation.md
+++ b/engineering/capture/skills/capture/references/voice_preservation.md
@@ -1,0 +1,74 @@
+# Voice Preservation — Anti-Corporate-Speak Discipline
+
+This reference answers exactly one decision: **what does it mean to "preserve the user's voice" in capture output, and what concrete patterns must be avoided?**
+
+## The Core Rule
+
+If the user said it casually, restate it casually. If the user said it crudely, restate it crudely (within the user's own register). Capture is for THEM, not for an imagined corporate audience reading their notes later.
+
+> **Restating someone's casual idea in corporate language is a tax. It feels formal but it loses the energy that made the idea worth capturing.**
+
+## Concrete Anti-Patterns (Side-by-Side)
+
+| User said | ❌ Corporate-ified (anti-pattern) | ✅ Voice-preserved |
+|---|---|---|
+| "build something crazy with AI" | "Explore innovative AI-driven solutions" | "Build something crazy with AI" |
+| "the dating app idea but for ferrets" | "Pet-companion matching platform leveraging social-graph principles" | "Dating app for ferrets" |
+| "figure out the damn pricing already" | "Conduct comprehensive pricing strategy analysis" | "Figure out pricing (final answer)" |
+| "fuck around with Consensus MCP" | "Investigate Consensus MCP integration opportunities" | "Try out Consensus MCP" |
+| "make the landing page not suck" | "Optimize landing page user experience metrics" | "Make the landing page not suck" |
+| "talk to Sarah about the thing" | "Schedule alignment discussion with Sarah re: outstanding initiative" | "Talk to Sarah about the thing" |
+| "I'm tired of debugging this" | "Investigate root causes of recurring debugging friction" | "Tired of debugging this — find the root cause" |
+
+## What Counts As "Voice"
+
+- **Register** — formal vs casual, dry vs energetic, ironic vs earnest
+- **Vocabulary** — the user's exact noun choices for things ("ferrets", "thing", "Sarah" — not "pets", "initiative", "stakeholder")
+- **Cadence** — short choppy phrases stay short; long flowing thoughts stay flowing
+- **Profanity / slang** — preserve as-is; don't sanitize
+- **Self-talk markers** — "ugh", "actually", "wait", "ok so" — these signal genuine thinking and belong in the captured form
+
+## What's Allowed to Change
+
+- **Punctuation cleanup** — adding a period, fixing typos
+- **Imperative reframing** for the Tasks section — "I should email Sarah" → "Email Sarah" (one-word edit, voice preserved)
+- **Light disambiguation** — if "the thing" is genuinely confusing in context, note it but ask to clarify (don't replace it silently)
+
+## What's Never Allowed
+
+- Replacing user nouns with "platform" / "solution" / "initiative" / "framework"
+- Verbing nouns: "let's research" → "let's conduct research"
+- Adding qualifiers the user didn't say: "explore", "leverage", "deep dive into"
+- "Action-itemizing" everything: "talk to Sarah" → "Establish communication touchpoint with Sarah"
+- Removing emotion: "I'm pissed about X" → "There is a concern regarding X"
+- Bullet-point fluff: "Implement", "Establish", "Facilitate" prefixes added for no reason
+
+## Cluster Naming
+
+When clustering items into projects (Section 1), the project name **MUST** use the user's words. Examples:
+
+| Items in cluster | ❌ Anti-pattern name | ✅ Voice-preserved name |
+|---|---|---|
+| "ferret app", "ferret features", "ferret marketing" | "Pet Companion Platform" | "Ferret App" |
+| "Q3 launch", "Q3 pricing", "Q3 emails" | "Q3 Go-to-Market Initiative" | "Q3 Launch" |
+| "fix the auth bug", "auth tests", "rewrite login" | "Authentication System Modernization" | "Auth fixes" |
+
+If the user used multiple terms for the same cluster, pick the one they used most or most colloquially.
+
+## Operating Test
+
+Before writing each line, ask:
+
+> Would the user *recognize* this as something they'd say?
+
+If no, you've drifted. Rewrite to match their register.
+
+## Why This Matters
+
+Voice preservation isn't aesthetic — it's functional. Two reasons:
+
+1. **Recognition.** The user reads their own captured dump back in 2 days and needs to instantly recognize "yes, that's me, that's what I meant." Corporate restatement breaks recognition. The user thinks "wait, did I actually say that?" and starts second-guessing the rest of the output.
+
+2. **Energy.** A dump captured in voice retains the *why* behind each item — the frustration, the excitement, the half-formed hope. Corporate restatement strips the why and leaves a list of generic action items that no one is excited to act on.
+
+Capture is the user's brain on paper. Don't translate it into a stranger's brain.

--- a/engineering/capture/skills/capture/references/workspace_detection.md
+++ b/engineering/capture/skills/capture/references/workspace_detection.md
@@ -1,0 +1,106 @@
+# Workspace Detection Tactics
+
+This reference answers exactly one decision: **how does the capture skill verify Section 3 connections without fabricating them, across the four contexts the skill might run in?**
+
+Pair with `scripts/workspace_inventory.py` for the deterministic Glob+Grep implementation.
+
+## The Core Rule
+
+Section 3 ("Connections") earns the skill its keep. It also breaks the skill faster than anything else if it lies. The rule:
+
+> **Only surface connections that were actually verified by Glob, Grep, Read, or an equivalent retrieval call this turn.**
+
+If you can't verify, you say "no workspace accessible" or "no connections found" — never invent something plausible-sounding.
+
+## Context 1: Claude Code CLI (filesystem-native)
+
+**Tools available:** `Glob`, `Grep`, `Read`, `Bash`.
+
+**Tactics, in order:**
+
+1. **Extract keywords from the dump.** Pull domain nouns, project names, file-format hints (`.md`, `.py`, `auth`, `consensus`, `pricing`).
+2. **Glob for filename matches.** `Glob("**/*{keyword}*")` for each keyword. Limit to top-N matches per keyword to avoid noise.
+3. **Grep for content matches.** `Grep("{keyword}")` constrained to source extensions.
+4. **Read the top-level structure.** `Bash("ls -la")` and `Bash("find . -maxdepth 2 -type d | head -30")` to surface relevant folders.
+5. **Stitch the matches into Section 3 entries.** Each entry: `- {file or folder}: {how it relates to dump item N, with evidence}`.
+
+**Example output:**
+
+```
+## Connections
+
+- `engineering/grill-me/` — relates to your "build a grill skill" dump item (folder exists, has plugin.json + SKILL.md). Likely the template you'd want to mirror.
+- `megaprompts/05-capture-megaprompt.md` — relates to your "convert capture spec to skill" item. The spec file is here.
+- `documentation/implementation/` — empty directory, but the location for the implementation plan you mentioned.
+```
+
+**What NOT to do:**
+- "There's probably a config for that somewhere" — speculation, no verification.
+- "Your project likely has an auth module" — guess, no Glob.
+- "I see you might have considered X before" — projection, no Grep.
+
+## Context 2: Claude.ai with project knowledge
+
+**Tools available:** Project-knowledge file list, file content reads.
+
+**Tactics:**
+
+1. **List the project knowledge files** — at the start of the run, get the file inventory.
+2. **Match by title keyword** — for each dump keyword, find files whose titles contain it.
+3. **Open the top matches** and check if the content is actually related (not just title coincidence).
+4. **Surface only the verified matches** in Section 3.
+
+**What NOT to do:**
+- Cite a file you didn't open — title match alone is not enough.
+- Claim a file says X without quoting evidence.
+
+## Context 3: Connected tools (Notion, Drive, GitHub, Slack via MCP)
+
+**Tools available:** Whatever MCP tools the harness has registered for the user's connected services.
+
+**Tactics:**
+
+1. **Check tool availability first** — list the MCP tools surfaced for this session. If no Notion/Drive/GitHub MCP is registered, skip this context.
+2. **Search via MCP** — use the search tool for each tool with dump keywords.
+3. **Surface verified hits** with the link / ID returned by the tool.
+
+**What NOT to do:**
+- Reference a Notion page that wasn't returned by the search.
+- Cite a GitHub issue number without confirming via the GitHub MCP.
+
+## Context 4: No accessible workspace
+
+**Signals you're in this context:**
+- No filesystem tools loaded
+- No project knowledge attached
+- No workspace MCPs registered
+- `workspace_inventory.py` returns empty + you can't verify any other way
+
+**Required behavior:**
+
+State the limitation explicitly. Ask about the user's setup. Do NOT fabricate connections.
+
+**Template output:**
+
+```
+## Connections
+
+No workspace accessible from here, so this section is empty. If you're running
+this from Claude Code or have a project with files attached, I can fill it in.
+
+Want to share where this work lives — a repo path, a Notion workspace, an
+attached project? I can re-run the connections pass with that context.
+```
+
+## Operational Checklist (Per Run)
+
+- [ ] Extract dump keywords (domain nouns, project names, format hints)
+- [ ] Determine context (CLI / web project / MCP-connected / inaccessible)
+- [ ] Run the context-appropriate tactics; never skip verification
+- [ ] If context is "inaccessible", say so explicitly + ask about setup
+- [ ] Each Section 3 entry must cite the evidence (filename matched, search hit, etc.)
+- [ ] Zero entries with phrasing like "probably", "likely", "you might have" — those are speculation, not connections
+
+## Why This Matters
+
+The single fastest way to lose user trust in capture is to surface a fabricated connection. Once the user catches one — "wait, that file doesn't exist" — they stop trusting the entire output, including the items that were correct. Verification is cheap; fabrication is expensive.

--- a/engineering/capture/skills/capture/scripts/complexity_estimator.py
+++ b/engineering/capture/skills/capture/scripts/complexity_estimator.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""complexity_estimator.py — Recommend full-4-section vs compressed output.
+
+Stdlib-only. Counts non-empty items in a dump, detects clustering signal
+(repeated keywords across items), and recommends one of:
+
+  format=full        →  use the full Projects/Tasks/Connections/How-I-Can-Help
+                        4-section format (8+ items AND clustering signal)
+  format=compressed  →  use the compressed What-I-heard / How-I-can-help
+                        format (≤5 items OR no clustering signal)
+
+The recommendation is HEURISTIC. The capture skill applies judgment on top
+based on full dump context. Use this as the seed.
+
+NO LLM CALLS. Pure word counting + frequency analysis.
+
+Usage:
+    python complexity_estimator.py path/to/dump.txt
+    python complexity_estimator.py path/to/dump.txt --output json
+    python complexity_estimator.py --sample
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+SAMPLE_DUMP_LARGE = """Ok dump time.
+Q3 launch needs pricing nailed down.
+Draft the Q3 launch email.
+Brief Sarah on the Q3 marketing angle.
+Decide: launch July 15 or August 1?
+Ferret app idea keeps nagging me.
+Should I talk to my cofounder about ferret app?
+Sketch the ferret matching algorithm if serious.
+Decide: ferret app serious or shelf?
+Fix the auth bug.
+Rewrite the login form (ugly).
+Write tests for auth + login.
+Add 2fa module to auth.
+Do my Q3 OKRs before launch.
+"""
+
+SAMPLE_DUMP_SMALL = """Email Sarah.
+Fix the flaky test.
+Decide: Postgres or Mongo for new service.
+Dentist appointment.
+Finish reading the RAG article.
+"""
+
+
+# Stop-words to exclude from clustering detection
+STOP_WORDS = {
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "to", "of", "in", "on", "at", "for", "with", "by", "from", "up", "down",
+    "and", "or", "but", "if", "then", "else", "so", "as",
+    "i", "you", "he", "she", "it", "we", "they", "me", "my", "your", "our",
+    "this", "that", "these", "those", "do", "did", "have", "has", "had",
+    "will", "would", "should", "could", "can", "may", "might",
+    "what", "when", "where", "why", "how", "who", "which",
+    "go", "get", "got", "make", "made", "let", "let's", "yeah", "ok", "well",
+    "just", "really", "very", "much", "more", "most", "some", "any",
+    "not", "no", "yes", "now", "before", "after",
+}
+
+
+def extract_items(text: str) -> List[str]:
+    """Return non-empty stripped lines (each line = one item)."""
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def extract_keywords(items: List[str]) -> List[str]:
+    """Return all alphabetic tokens >= 3 chars, lowercased, stop-words removed."""
+    tokens: List[str] = []
+    for it in items:
+        for tok in re.findall(r"\b[A-Za-z][a-zA-Z]{2,}\b", it):
+            t = tok.lower()
+            if t in STOP_WORDS:
+                continue
+            tokens.append(t)
+    return tokens
+
+
+def detect_clusters(items: List[str], min_cluster_size: int) -> List[Dict[str, Any]]:
+    """A 'cluster' is a keyword that appears in min_cluster_size+ different items."""
+    keyword_to_item_indices: Dict[str, List[int]] = {}
+    for i, it in enumerate(items):
+        seen_in_item: set = set()
+        for tok in re.findall(r"\b[A-Za-z][a-zA-Z]{2,}\b", it):
+            t = tok.lower()
+            if t in STOP_WORDS or t in seen_in_item:
+                continue
+            seen_in_item.add(t)
+            keyword_to_item_indices.setdefault(t, []).append(i)
+    clusters: List[Dict[str, Any]] = []
+    for kw, idxs in keyword_to_item_indices.items():
+        if len(idxs) >= min_cluster_size:
+            clusters.append({"keyword": kw, "item_indices": idxs, "size": len(idxs)})
+    clusters.sort(key=lambda c: (-c["size"], c["keyword"]))
+    return clusters
+
+
+def estimate(text: str, min_cluster_size: int = 3) -> Dict[str, Any]:
+    items = extract_items(text)
+    item_count = len(items)
+    clusters = detect_clusters(items, min_cluster_size)
+    cluster_count = len(clusters)
+
+    # Decision logic per references/complexity_matching.md
+    if item_count >= 8 and cluster_count >= 1:
+        recommendation = "full"
+        rationale = f"{item_count} items with {cluster_count} cluster(s) of {min_cluster_size}+ → full 4-section format"
+    elif item_count >= 8 and cluster_count == 0:
+        recommendation = "compressed"
+        rationale = f"{item_count} items but no clustering signal → compressed (with 'no clusters' note)"
+    elif 5 <= item_count <= 7 and cluster_count >= 1:
+        recommendation = "full"
+        rationale = f"{item_count} items with clustering signal → judgment call, defaulting full"
+    elif 5 <= item_count <= 7 and cluster_count == 0:
+        recommendation = "compressed"
+        rationale = f"{item_count} items, no clustering → compressed"
+    elif item_count <= 5:
+        recommendation = "compressed"
+        rationale = f"{item_count} items (small dump) → compressed"
+    else:
+        recommendation = "compressed"
+        rationale = "fallback → compressed"
+
+    return {
+        "item_count": item_count,
+        "cluster_count": cluster_count,
+        "clusters": clusters[:5],  # top 5 only in output for readability
+        "recommendation": recommendation,
+        "rationale": rationale,
+    }
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    out: List[str] = []
+    out.append(f"Item count:       {result['item_count']}")
+    out.append(f"Cluster count:    {result['cluster_count']}")
+    out.append(f"Recommendation:   format={result['recommendation']}")
+    out.append(f"Rationale:        {result['rationale']}")
+    if result["clusters"]:
+        out.append("")
+        out.append("Top clusters (keyword → items containing it):")
+        for c in result["clusters"]:
+            out.append(f"  - '{c['keyword']}' in {c['size']} items: lines {c['item_indices']}")
+    return "\n".join(out)
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("path", nargs="?", help="Path to dump file")
+    parser.add_argument("--sample", choices=["large", "small"], help="Estimate the embedded sample dump (large or small)")
+    parser.add_argument("--min-cluster-size", type=int, default=3, help="Minimum items sharing a keyword to count as a cluster (default: 3)")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        text = SAMPLE_DUMP_LARGE if args.sample == "large" else SAMPLE_DUMP_SMALL
+    elif args.path:
+        p = Path(args.path)
+        if not p.exists():
+            print(f"error: {args.path} not found", file=sys.stderr)
+            return 2
+        text = p.read_text(encoding="utf-8")
+    else:
+        parser.print_help()
+        return 0
+
+    result = estimate(text, args.min_cluster_size)
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/engineering/capture/skills/capture/scripts/dump_classifier.py
+++ b/engineering/capture/skills/capture/scripts/dump_classifier.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""dump_classifier.py — Heuristic classifier for brain-dump lines.
+
+Stdlib-only. Reads a dump file (or stdin) and labels each line as one of:
+  - task            (action-oriented, imperative or 'I should X')
+  - decision        ('decide between X and Y', 'should we X or Y')
+  - question        (ends in '?')
+  - idea            (creative spark, 'what if', 'maybe we should X')
+  - project-component  (sub-element of a larger project, often noun-phrased)
+  - context         (preamble, framing, no actionable content)
+
+The classifier is HEURISTIC. The capture skill uses these labels as a SEED for
+its own structuring — it overrides based on dump-level context. Do not treat
+the labels as authoritative.
+
+NO LLM CALLS. Pure regex + line walking.
+
+Usage:
+    python dump_classifier.py path/to/dump.txt
+    python dump_classifier.py path/to/dump.txt --output json
+    python dump_classifier.py --sample
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+# Pattern → label, ordered by precedence (first match wins per line).
+# Each pattern is a compiled regex.
+PATTERNS: List[Tuple[re.Pattern, str]] = [
+    (re.compile(r"\bdecide\s+(?:between|on|whether)\b", re.IGNORECASE), "decision"),
+    (re.compile(r"^\s*decide\s*:", re.IGNORECASE), "decision"),
+    (re.compile(r"\b(?:should we|do we|are we)\b.*\b(?:or|vs|versus)\b", re.IGNORECASE), "decision"),
+    (re.compile(r"\?\s*$"), "question"),
+    (re.compile(r"^\s*(?:resolve|q)\s*:", re.IGNORECASE), "question"),
+    (re.compile(r"\bwhat\s+if\b", re.IGNORECASE), "idea"),
+    (re.compile(r"\b(?:maybe|might|could)\s+(?:we|i)\s+(?:should\s+)?", re.IGNORECASE), "idea"),
+    (re.compile(r"\bidea\s*:", re.IGNORECASE), "idea"),
+    (re.compile(r"^\s*(?:i\s+(?:should|need\s+to|gotta|have\s+to))\b", re.IGNORECASE), "task"),
+    (re.compile(r"^\s*(?:fix|build|write|draft|email|send|talk to|finish|investigate|research|sketch|scaffold|deploy|push|merge|review|read|call|schedule)\b", re.IGNORECASE), "task"),
+    (re.compile(r"^\s*todo\s*:", re.IGNORECASE), "task"),
+    (re.compile(r"^\s*-\s*(?:fix|build|write|draft|email|send|talk to|finish|investigate)\b", re.IGNORECASE), "task"),
+]
+
+PROJECT_COMPONENT_HINTS = {
+    "module", "feature", "component", "endpoint", "page", "screen", "form",
+    "model", "schema", "migration", "test", "doc", "readme", "config",
+}
+
+
+SAMPLE_DUMP = """Ok dump time.
+
+Q3 launch is approaching - need to nail down pricing.
+Draft the launch email.
+Brief Sarah on the marketing angle.
+
+Decide: launch on July 15 or August 1?
+
+Ferret app keeps nagging me. Should I talk to my cofounder about it?
+What if it's actually a real business?
+Sketch the matching algorithm if it's serious.
+
+Fix the damn auth bug.
+Rewrite the login form because it's ugly.
+Write tests for both.
+Auth: 2fa module.
+
+Do my Q3 OKRs before launch.
+"""
+
+
+def classify_line(raw: str) -> str:
+    line = raw.strip()
+    if not line:
+        return "blank"
+
+    # Strip leading bullet markers for matching, but keep original for output
+    stripped = re.sub(r"^[-*+]\s+", "", line)
+
+    for pattern, label in PATTERNS:
+        if pattern.search(stripped):
+            return label
+
+    # Project-component heuristic: short noun-phrase containing a hint word
+    if len(stripped.split()) <= 6:
+        for hint in PROJECT_COMPONENT_HINTS:
+            if re.search(rf"\b{hint}s?\b", stripped, re.IGNORECASE):
+                return "project-component"
+
+    # Single-noun-phrase or short fragment without verb → likely context or component
+    if len(stripped.split()) <= 4 and not stripped.endswith("?"):
+        return "project-component"
+
+    # Default: treat as context (the skill folds this into project framing)
+    return "context"
+
+
+def classify(text: str) -> Dict[str, Any]:
+    items: List[Dict[str, Any]] = []
+    counts: Dict[str, int] = {}
+    for line_no, raw in enumerate(text.splitlines(), start=1):
+        if not raw.strip():
+            continue
+        label = classify_line(raw)
+        if label == "blank":
+            continue
+        items.append({"line": line_no, "label": label, "text": raw.strip()})
+        counts[label] = counts.get(label, 0) + 1
+    return {"item_count": len(items), "by_label": counts, "items": items}
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    out: List[str] = []
+    out.append(f"Dump classification ({result['item_count']} non-empty items)")
+    out.append("By label:")
+    for label, n in sorted(result["by_label"].items(), key=lambda kv: -kv[1]):
+        out.append(f"  {label:<20s} {n}")
+    out.append("")
+    out.append("Per-line labels:")
+    for it in result["items"]:
+        out.append(f"  L{it['line']:>3}  {it['label']:<20s} {it['text'][:80]}")
+    return "\n".join(out)
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("path", nargs="?", help="Path to dump file (or omit for --sample)")
+    parser.add_argument("--sample", action="store_true", help="Classify the embedded sample dump")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        text = SAMPLE_DUMP
+    elif args.path:
+        p = Path(args.path)
+        if not p.exists():
+            print(f"error: {args.path} not found", file=sys.stderr)
+            return 2
+        text = p.read_text(encoding="utf-8")
+    else:
+        parser.print_help()
+        return 0
+
+    result = classify(text)
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/engineering/capture/skills/capture/scripts/workspace_inventory.py
+++ b/engineering/capture/skills/capture/scripts/workspace_inventory.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""workspace_inventory.py — Glob+Grep helper for capture's Section 3 (Connections).
+
+Stdlib-only. Given a working directory + a list of dump-derived keywords,
+returns a structured inventory that the capture skill can use to surface
+real workspace connections (never fabricated).
+
+What it returns:
+  1. Per-keyword filename matches (Glob-style)
+  2. Per-keyword content matches (line-grep across source files)
+  3. Top-level folder structure (max-depth 2)
+
+What it does NOT do:
+  - Score relevance (capture skill applies judgment on top)
+  - Fabricate matches (only real Glob/Grep results)
+  - Make LLM calls
+
+Usage:
+    python workspace_inventory.py --root . --keywords "auth,login,2fa"
+    python workspace_inventory.py --root . --keywords "skill,megaprompt" --output json
+    python workspace_inventory.py --sample
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+
+DEFAULT_SOURCE_EXTENSIONS = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".java", ".kt", ".rb",
+    ".cs", ".rs", ".swift", ".php", ".scala", ".clj", ".ex", ".exs",
+    ".md", ".mdx", ".rst", ".txt", ".json", ".yaml", ".yml", ".toml",
+}
+DEFAULT_EXCLUDE_DIRS = {
+    "node_modules", ".git", "dist", "build", "target",
+    ".venv", "venv", "__pycache__", ".next", ".cache",
+}
+MAX_FILENAME_MATCHES_PER_KEYWORD = 20
+MAX_CONTENT_MATCHES_PER_KEYWORD = 10
+MAX_FOLDER_DEPTH = 2
+
+
+SAMPLE_TREE: Dict[str, str] = {
+    "src/auth/login.ts": "// auth login flow handler\nexport function login() {}\n",
+    "src/auth/2fa.ts": "// 2fa stub\nexport function setup2FA() {}\n",
+    "src/users/profile.ts": "// user profile\nexport function getProfile() {}\n",
+    "docs/auth-bugs.md": "# Auth bugs\n\n- The login race condition is back.\n",
+    "tests/auth.test.ts": "// auth tests\ndescribe('auth', () => {});\n",
+    "README.md": "# project\n\nAuth + login + users.\n",
+}
+
+
+def collect_files(root: Path, source_extensions: Set[str], exclude_dirs: Set[str]) -> List[Path]:
+    found: List[Path] = []
+    for p in root.rglob("*"):
+        if p.is_dir():
+            continue
+        if any(part in exclude_dirs for part in p.parts):
+            continue
+        if p.suffix.lower() in source_extensions:
+            found.append(p)
+    return found
+
+
+def filename_matches(files: List[Path], keyword: str) -> List[str]:
+    kw = keyword.lower()
+    out: List[str] = []
+    for p in files:
+        if kw in p.name.lower():
+            out.append(str(p))
+        if len(out) >= MAX_FILENAME_MATCHES_PER_KEYWORD:
+            break
+    return out
+
+
+def content_matches(files: List[Path], keyword: str) -> List[Dict[str, Any]]:
+    pattern = re.compile(re.escape(keyword), re.IGNORECASE)
+    out: List[Dict[str, Any]] = []
+    for p in files:
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if pattern.search(line):
+                out.append({
+                    "file": str(p),
+                    "line": line_no,
+                    "snippet": line.strip()[:120],
+                })
+                if len(out) >= MAX_CONTENT_MATCHES_PER_KEYWORD:
+                    return out
+    return out
+
+
+def folder_structure(root: Path, max_depth: int, exclude_dirs: Set[str]) -> List[str]:
+    out: List[str] = []
+    root = root.resolve()
+    for p in root.rglob("*"):
+        if not p.is_dir():
+            continue
+        if any(part in exclude_dirs for part in p.parts):
+            continue
+        try:
+            rel = p.relative_to(root)
+        except ValueError:
+            continue
+        depth = len(rel.parts)
+        if 0 < depth <= max_depth:
+            out.append(str(rel))
+    return sorted(out)
+
+
+def inventory(
+    root: Path,
+    keywords: List[str],
+    source_extensions: Set[str],
+    exclude_dirs: Set[str],
+) -> Dict[str, Any]:
+    files = collect_files(root, source_extensions, exclude_dirs)
+    per_keyword: Dict[str, Dict[str, Any]] = {}
+    for kw in keywords:
+        per_keyword[kw] = {
+            "filename_matches": filename_matches(files, kw),
+            "content_matches": content_matches(files, kw),
+        }
+    return {
+        "root": str(root.resolve()),
+        "files_scanned": len(files),
+        "folder_structure": folder_structure(root, MAX_FOLDER_DEPTH, exclude_dirs),
+        "per_keyword": per_keyword,
+    }
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    out: List[str] = []
+    out.append(f"Workspace inventory for: {result['root']}")
+    out.append(f"  Files scanned: {result['files_scanned']}")
+    out.append("")
+    out.append("Folder structure (max depth 2):")
+    for f in result["folder_structure"][:30]:
+        out.append(f"  - {f}/")
+    if len(result["folder_structure"]) > 30:
+        out.append(f"  ... + {len(result['folder_structure']) - 30} more")
+    out.append("")
+    for kw, hits in result["per_keyword"].items():
+        out.append(f"Keyword: '{kw}'")
+        if hits["filename_matches"]:
+            out.append(f"  Filename matches ({len(hits['filename_matches'])}):")
+            for f in hits["filename_matches"]:
+                out.append(f"    - {f}")
+        else:
+            out.append("  Filename matches: (none)")
+        if hits["content_matches"]:
+            out.append(f"  Content matches ({len(hits['content_matches'])}):")
+            for m in hits["content_matches"]:
+                out.append(f"    - {m['file']}:{m['line']}  {m['snippet']}")
+        else:
+            out.append("  Content matches: (none)")
+        out.append("")
+    return "\n".join(out)
+
+
+def run_sample(keywords: List[str]) -> Dict[str, Any]:
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for rel, content in SAMPLE_TREE.items():
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+        return inventory(root, keywords, DEFAULT_SOURCE_EXTENSIONS, DEFAULT_EXCLUDE_DIRS)
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--root", help="Root directory to inventory")
+    parser.add_argument("--keywords", help="Comma-separated keywords to search for")
+    parser.add_argument("--extensions", help="Comma-separated source extensions (default: common)")
+    parser.add_argument("--sample", action="store_true", help="Inventory the embedded sample tree")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        sample_keywords = ["auth", "login", "2fa"] if not args.keywords else [k.strip() for k in args.keywords.split(",") if k.strip()]
+        result = run_sample(sample_keywords)
+    elif args.root and args.keywords:
+        root = Path(args.root)
+        if not root.exists():
+            print(f"error: {args.root} not found", file=sys.stderr)
+            return 2
+        kws = [k.strip() for k in args.keywords.split(",") if k.strip()]
+        if not kws:
+            print("error: --keywords must list at least one keyword", file=sys.stderr)
+            return 2
+        if args.extensions:
+            exts = {e.strip() if e.strip().startswith(".") else "." + e.strip() for e in args.extensions.split(",")}
+        else:
+            exts = DEFAULT_SOURCE_EXTENSIONS
+        result = inventory(root, kws, exts, DEFAULT_EXCLUDE_DIRS)
+    else:
+        parser.print_help()
+        return 0
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Vertical-slice install: first of 13 skills derived directly from the v2 megaprompts (PR #657, merged). Validates the **Path-B conversion pattern** (megaprompt → SKILL.md + scaffolding) before batching the remaining 12 specs.

**Source spec:** [`megaprompts/05-capture-megaprompt.md`](../blob/dev/megaprompts/05-capture-megaprompt.md). The megaprompt is the canonical spec; this plugin is the working implementation. Drift between the two is a bug — re-grill with `/cs:grill-with-docs` if they diverge.

## What the skill does

Brain-dump organizer. Catches an unstructured stream of mixed thoughts/tasks/ideas and transforms it into a 4-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help) with zero information loss.

- **Fast-to-action** — no upfront intake; the dump is the request
- **Max 1 mid-organization clarifying question** — only when one item is genuinely ambiguous between task and project
- **Real workspace detection** — Glob/Grep verified, never fabricates
- **Compressed output** — for ≤5 unrelated items, drops the 4-section format
- **Voice preservation** — the user's casual register stays casual; no corporate-ifying
- **Approval gate** — Section 4 offers wait for explicit pick

## Path-B conversion discipline

| Element | Treatment |
|---|---|
| Frontmatter `description` | Preserved verbatim from megaprompt spec (lines 169-174) |
| Workflow structure | Megaprompt lines 38-48 → SKILL.md section ordering 1:1 |
| 5 operating principles | Verbatim |
| 4 output sections | Verbatim, with section-spec details preserved |
| Anti-patterns list | Verbatim |
| Trigger phrases | All surfaced verbatim in "Invocation Triggers" |
| Word budget | ~1,800 words within megaprompt's 1,400-2,000 range. Some prose offloaded to references (the wrapper additions). |

## Repo structure (mirrors `grill-with-docs` 1:1)

```
engineering/capture/
├── .claude-plugin/plugin.json    ← source.spec field points at megaprompt
├── README.md
├── agents/cs-capture.md           ← persona, no-fabrication enforcer
├── commands/cs-capture.md         ← /cs:capture <dump>
└── skills/capture/
    ├── SKILL.md                    ← Path-B converted from megaprompt
    ├── references/
    │   ├── workspace_detection.md  ← 4 contexts × tactics
    │   ├── voice_preservation.md   ← 7 anti-pattern examples side-by-side
    │   └── complexity_matching.md  ← format-decision table + 3 worked examples
    └── scripts/
        ├── workspace_inventory.py  ← stdlib Glob+Grep helper
        ├── dump_classifier.py      ← stdlib heuristic line-classifier
        └── complexity_estimator.py ← stdlib full-vs-compressed recommender
```

**Footprint:** 11 files, 1,560 lines. Comparable to `grill-with-docs` (13 files, 1,747 lines). Capture is leaner — no separate format files.

## Smoke-test results

| Script | `--sample` outcome |
|---|---|
| `workspace_inventory.py` | ✅ Glob+Grep finds 6 files / 5 folders / auth+login matches with line numbers |
| `dump_classifier.py` | ✅ Labels 13 lines (4 context, 4 task, 2 project-component, 2 question, 1 decision) |
| `complexity_estimator.py --sample large` | ✅ `format=full` (14 items, 4 clusters: ferret/launch/app/auth) |
| `complexity_estimator.py --sample small` | ✅ `format=compressed` (5 items, 0 clusters) |
| All 3 with `--output json` | ✅ Valid JSON |

**Known classifier limitation** (documented in script docstring): verbs like `Brief` / `Rewrite` / `Do` not in the task-trigger regex list — heuristic, not authoritative; the skill explicitly treats classifier output as a seed.

## Vertical-slice status

This is **Slice 1 of 13**. Megaprompt-shape coverage:

- [x] Light prompt-flow (this slice — `02-reflect` should transfer cleanly)
- [ ] Research-pack (`01-pulse`, `03`, `08-12`) — Slice 2 next
- [ ] Workflow-pair (`06+07` email) — Slice 3
- [ ] Generator (`04-landing`) — Slice 4
- [ ] Orchestrator/router (`13-research`) — Slice 5; reconcile with existing `engineering/autoresearch-agent/`

After Slice 2 validates the research-pack conversion pattern (which includes the cross-skill consistency rules audited in PR #657), the remaining 11 skills can be batched in larger groups.

## Not done in this PR (intentional)

- `.claude-plugin/marketplace.json` not updated — separate concern, would be done in a marketplace-bundle PR after all 13 ship.
- `.codex/skills/capture` symlink not added — auto-sync workflow handles this on merge per the existing pattern (see commit `6a9abc9` for grill-with-docs).

## Test plan

- [ ] Confirm `python3 scripts/*.py --help` works on stock Python 3.11+ (verified locally).
- [ ] Confirm `--sample` returns expected verdict for all three scripts (verified locally).
- [ ] Confirm `--output json` produces valid JSON (verified locally).
- [ ] Plugin-audit pipeline (`/plugin-audit engineering/capture`) — optional, can run before merge.
- [ ] Spot-check Path-B fidelity: read the megaprompt + SKILL.md side-by-side and confirm no spec elements were silently dropped.

https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw)_