### PR TITLE
fix: drop leading "./" from plugin manifest "skills" paths

### DIFF
--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/compliance-os/.claude-plugin/plugin.json
+++ b/compliance-os/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/compliance-os",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/compliance-os", "./skills/compliance-readiness", "./skills/aims-audit", "./skills/ai-act-readiness", "./skills/iso27001-audit-prep", "./skills/iso13485-audit-prep", "./skills/gdpr-audit-prep", "./skills/soc2-audit-prep", "./skills/fda-qsr-audit-prep"]
+  "skills": ["skills/compliance-os", "skills/compliance-readiness", "skills/aims-audit", "skills/ai-act-readiness", "skills/iso27001-audit-prep", "skills/iso13485-audit-prep", "skills/gdpr-audit-prep", "skills/soc2-audit-prep", "skills/fda-qsr-audit-prep"]
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }


### PR DESCRIPTION
## Summary

Claude Code's plugin loader rejects manifest `skills` field values that begin with `./`, surfacing the warning:

> Plugin (engineering-skills @ engineering-skills@claude-code-skills): Path escapes plugin directory: ./ (skills)

The canonical form is a path relative to the plugin root **without** the leading `./` prefix. This PR strips the prefix across all manifests that still use it.

## Changes

10 plugin manifests updated:

- `business-growth`, `c-level-advisor`, `engineering`, `engineering-team`, `finance`, `marketing-skill`, `product-team`, `project-management`, `ra-qm-team`: `"skills": "./skills"` → `"skills": "skills"`
- `compliance-os`: every entry in the `skills` array stripped of its `./` prefix

No behavioral change beyond silencing the loader warning — resolved paths are identical.

## Test plan

- [ ] Install one of the affected plugins (e.g. `engineering-team`) in Claude Code.
- [ ] Run `/doctor` and confirm no "Path escapes plugin directory" warning is reported for it.
- [ ] Confirm skills from the plugin appear in the available-skills list.