### PR TITLE
release(v2.7.0): marketplace + codex sync + version bumps + CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
   },
-  "description": "272 production-ready skill packages for Claude AI across 9 domains: engineering advanced (71 unique — incl. 4 Matt Pocock-derived productivity skills with validation wrappers), engineering core (51), marketing (45), c-level advisory (34), product (17), regulatory/QMS (14), project management (9), business growth (5), and finance (4). Includes 385 Python tools, 519 reference documents, 31 agents (24 cs-* + 7 personas), and 58 slash commands.",
+  "description": "272 production-ready skill packages for Claude AI across 9 domains: engineering advanced (71 unique \u2014 incl. 4 Matt Pocock-derived productivity skills with validation wrappers), engineering core (51), marketing (45), c-level advisory (34), product (17), regulatory/QMS (14), project management (9), business growth (5), and finance (4). Includes 385 Python tools, 519 reference documents, 31 agents (24 cs-* + 7 personas), and 58 slash commands.",
   "homepage": "https://github.com/alirezarezvani/claude-skills",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "metadata": {
@@ -61,7 +61,7 @@
     {
       "name": "c-level-agents",
       "source": "./c-level-advisor/c-level-agents",
-      "description": "Founder-mode executive team plugin: 13 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer, Chief AI Officer, Chief Customer Officer, VP of Engineering) with distinct cognitive voices, plus 21 /cs:* slash commands — forcing-question office hours (CFO/CMO/CPO/CRO/CTO/CISO/GC/CDO/CAIO/CCO/VPE reviews), strategic sprint pipeline (brief → boardroom → decide → execute → post-mortem), and meta routing (/cs:founder-mode auto-router, /cs:onboard, /cs:cross-eval multi-model consensus, /cs:freeze cooldown lock). Wraps the 33 c-level skills with cognitive gearing, persona voice, and artifact-driven handoffs. The business-domain answer to YC Garry Tan's gstack.",
+      "description": "Founder-mode executive team plugin: 13 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer, Chief AI Officer, Chief Customer Officer, VP of Engineering) with distinct cognitive voices, plus 21 /cs:* slash commands \u2014 forcing-question office hours (CFO/CMO/CPO/CRO/CTO/CISO/GC/CDO/CAIO/CCO/VPE reviews), strategic sprint pipeline (brief \u2192 boardroom \u2192 decide \u2192 execute \u2192 post-mortem), and meta routing (/cs:founder-mode auto-router, /cs:onboard, /cs:cross-eval multi-model consensus, /cs:freeze cooldown lock). Wraps the 33 c-level skills with cognitive gearing, persona voice, and artifact-driven handoffs. The business-domain answer to YC Garry Tan's gstack.",
       "version": "1.5.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -111,7 +111,7 @@
     {
       "name": "general-counsel-advisor",
       "source": "./c-level-advisor/general-counsel-advisor",
-      "description": "General Counsel advisory for startups: contract risk scanner (12 founder-killer patterns: auto-renew traps, uncapped indemnity, vague IP, MFN pricing, missing DPA, one-sided venue, broad non-solicit, perpetual license-back, etc.) and term sheet analyzer (0-100 founder-friendliness across 12 dimensions). 3 in-depth references: contracts playbook (7 startup contract types), IP + regulatory landscape mapping (HIPAA, GDPR, FDA, fintech, EU AI Act, SOC 2 → ISO sequencing), term sheet decoder (full glossary + founder-friendly defaults). Standalone-installable; also bundled in c-level-skills. Stdlib-only. NOT a substitute for licensed counsel.",
+      "description": "General Counsel advisory for startups: contract risk scanner (12 founder-killer patterns: auto-renew traps, uncapped indemnity, vague IP, MFN pricing, missing DPA, one-sided venue, broad non-solicit, perpetual license-back, etc.) and term sheet analyzer (0-100 founder-friendliness across 12 dimensions). 3 in-depth references: contracts playbook (7 startup contract types), IP + regulatory landscape mapping (HIPAA, GDPR, FDA, fintech, EU AI Act, SOC 2 \u2192 ISO sequencing), term sheet decoder (full glossary + founder-friendly defaults). Standalone-installable; also bundled in c-level-skills. Stdlib-only. NOT a substitute for licensed counsel.",
       "version": "1.0.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -133,7 +133,7 @@
     {
       "name": "chief-data-officer-advisor",
       "source": "./c-level-advisor/chief-data-officer-advisor",
-      "description": "Chief Data Officer advisory for startups: AI training data audit (origin × class × use-case matrix with GDPR Art. 6 + EU AI Act citations), data product strategy picker (warehouse vs lakehouse vs mesh + 6-layer build-vs-buy + 12-month sequencing), data asset valuator (strategic value 0-10 + M&A multiplier with carve-out penalties + 3 ranked productization paths). 4 references answering one decision each: training rights, data product strategy, customer-data-as-asset, data team org evolution. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate engineering data skills.",
+      "description": "Chief Data Officer advisory for startups: AI training data audit (origin \u00d7 class \u00d7 use-case matrix with GDPR Art. 6 + EU AI Act citations), data product strategy picker (warehouse vs lakehouse vs mesh + 6-layer build-vs-buy + 12-month sequencing), data asset valuator (strategic value 0-10 + M&A multiplier with carve-out penalties + 3 ranked productization paths). 4 references answering one decision each: training rights, data product strategy, customer-data-as-asset, data team org evolution. Standalone-installable; also bundled in c-level-skills. Strategic only \u2014 does not duplicate engineering data skills.",
       "version": "1.0.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -155,7 +155,7 @@
     {
       "name": "vpe-advisor",
       "source": "./c-level-advisor/vpe-advisor",
-      "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification with typical fixes per stage), engineering hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes from sourcing to offer-accept), engineering team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references citing DORA / Spotify / Conway / Google SRE / Larson / Fournier. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill — VPE owns how the team ships; CTO owns what to build.",
+      "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification with typical fixes per stage), engineering hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes from sourcing to offer-accept), engineering team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references citing DORA / Spotify / Conway / Google SRE / Larson / Fournier. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill \u2014 VPE owns how the team ships; CTO owns what to build.",
       "version": "1.0.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -179,7 +179,7 @@
     {
       "name": "chief-customer-officer-advisor",
       "source": "./c-level-advisor/chief-customer-officer-advisor",
-      "description": "Chief Customer Officer advisory: retention decomposition analyzer (honest GRR vs NRR; 7-category churn taxonomy with preventable% scoring), customer segmentation designer (4-tier framework, ICP fit scoring across 7 weighted signals, kill list + upgrade candidates), CS coverage calculator (pooled vs named CSM ratio math + 12-month hiring plan with quarterly sequencing). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate business-growth tactical CS skills.",
+      "description": "Chief Customer Officer advisory: retention decomposition analyzer (honest GRR vs NRR; 7-category churn taxonomy with preventable% scoring), customer segmentation designer (4-tier framework, ICP fit scoring across 7 weighted signals, kill list + upgrade candidates), CS coverage calculator (pooled vs named CSM ratio math + 12-month hiring plan with quarterly sequencing). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only \u2014 does not duplicate business-growth tactical CS skills.",
       "version": "1.0.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -201,7 +201,7 @@
     {
       "name": "chief-ai-officer-advisor",
       "source": "./c-level-advisor/chief-ai-officer-advisor",
-      "description": "Chief AI Officer advisory for startups: model build-vs-buy calculator (API vs fine-tune vs build with 3-year TCO across 6 paths + breakeven that balances economics with practical feasibility), AI risk classifier (EU AI Act tier with 7 Article citations + US state patchwork: NYC LL 144, CO AI Act, IL HB 53, CA SB 1001, IL BIPA + industry overlays for FDA AI/ML, CFPB Circular 2023-03, NYDFS Reg 23, NAIC, ECOA, Fed SR 11-7), AI cost economics (API vs self-hosted breakeven with 2026 pricing across A100/H100, utilization reality, hidden costs). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate engineering AI/ML skills.",
+      "description": "Chief AI Officer advisory for startups: model build-vs-buy calculator (API vs fine-tune vs build with 3-year TCO across 6 paths + breakeven that balances economics with practical feasibility), AI risk classifier (EU AI Act tier with 7 Article citations + US state patchwork: NYC LL 144, CO AI Act, IL HB 53, CA SB 1001, IL BIPA + industry overlays for FDA AI/ML, CFPB Circular 2023-03, NYDFS Reg 23, NAIC, ECOA, Fed SR 11-7), AI cost economics (API vs self-hosted breakeven with 2026 pricing across A100/H100, utilization reality, hidden costs). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only \u2014 does not duplicate engineering AI/ML skills.",
       "version": "1.0.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -825,7 +825,7 @@
     {
       "name": "write-a-skill",
       "source": "./engineering/write-a-skill",
-      "description": "Skill-author skill: create new agent skills with proper structure, progressive disclosure, and bundled resources. Derived from Matt Pocock's MIT-licensed write-a-skill with: (1) 3 stdlib Python validation tools (description validator, structure validator, review-checklist runner — all enforcing Matt's 6-item checklist), (2) 4 references citing 7-8 authoritative sources each (progressive disclosure principles, description design patterns, quality gates, companion tooling), (3) cs-skill-author persona agent + /cs:write-a-skill slash command. Matt's voice and 3-phase workflow (Gather → Draft → Review) preserved verbatim per MIT.",
+      "description": "Skill-author skill: create new agent skills with proper structure, progressive disclosure, and bundled resources. Derived from Matt Pocock's MIT-licensed write-a-skill with: (1) 3 stdlib Python validation tools (description validator, structure validator, review-checklist runner \u2014 all enforcing Matt's 6-item checklist), (2) 4 references citing 7-8 authoritative sources each (progressive disclosure principles, description design patterns, quality gates, companion tooling), (3) cs-skill-author persona agent + /cs:write-a-skill slash command. Matt's voice and 3-phase workflow (Gather \u2192 Draft \u2192 Review) preserved verbatim per MIT.",
       "version": "2.6.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -881,7 +881,7 @@
     {
       "name": "handoff",
       "source": "./engineering/handoff",
-      "description": "Conversation-handoff document generator. Compacts the current session into a markdown handoff for a fresh agent — references existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL instead of duplicating them. Derived from Matt Pocock's MIT-licensed handoff with: (1) 3 stdlib Python tools (template generator tailored to 5 next-session emphases, artifact deduplicator across 5 categories of duplication, skill recommender matching content to 14 skills in this repo), (2) 4 references citing 7-8 sources (handoff structure, deduplication discipline, next-session skill matching, companion tooling), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline + mktemp convention preserved verbatim per MIT.",
+      "description": "Conversation-handoff document generator. Compacts the current session into a markdown handoff for a fresh agent \u2014 references existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL instead of duplicating them. Derived from Matt Pocock's MIT-licensed handoff with: (1) 3 stdlib Python tools (template generator tailored to 5 next-session emphases, artifact deduplicator across 5 categories of duplication, skill recommender matching content to 14 skills in this repo), (2) 4 references citing 7-8 sources (handoff structure, deduplication discipline, next-session skill matching, companion tooling), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline + mktemp convention preserved verbatim per MIT.",
       "version": "2.6.0",
       "author": {
         "name": "Alireza Rezvani"
@@ -915,6 +915,240 @@
         "epic-breakdown"
       ],
       "category": "product"
+    },
+    {
+      "name": "capture-skill",
+      "source": "./productivity/capture",
+      "description": "Brain-dump-to-action workspace skill. Routes vague captures into discoverable actions via classify\u2192cluster\u2192connect\u2192clarify intake. Path-B from megaprompt 05.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "capture",
+        "brain-dump",
+        "productivity",
+        "gtd",
+        "workspace",
+        "path-b-megaprompt"
+      ],
+      "category": "productivity"
+    },
+    {
+      "name": "email-pair",
+      "source": "./productivity/email",
+      "description": "Email-workflow skill pair: inbox-setup builds your taxonomy/KB; inbox-triage classifies + drafts (drafts-only, never auto-send). KB-file contract between them. Path-B from megaprompts 06+07.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "email",
+        "inbox",
+        "triage",
+        "gmail",
+        "outlook",
+        "productivity",
+        "path-b-megaprompt"
+      ],
+      "category": "productivity"
+    },
+    {
+      "name": "reflect-skill",
+      "source": "./productivity/reflect",
+      "description": "Light-prompt reflection skill. Single forcing question + structured journal capture. Path-B sibling of capture from megaprompt 08.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "reflect",
+        "journaling",
+        "productivity",
+        "forcing-question",
+        "path-b-megaprompt"
+      ],
+      "category": "productivity"
+    },
+    {
+      "name": "landing",
+      "source": "./marketing/landing",
+      "description": "Single-file HTML landing-page generator with 4 design styles, brand palette validation, GSAP animation patterns, kebab-slug URL hygiene. Path-B from megaprompt 04.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "landing-page",
+        "html",
+        "marketing",
+        "generator",
+        "gsap",
+        "brand",
+        "path-b-megaprompt"
+      ],
+      "category": "marketing"
+    },
+    {
+      "name": "pulse",
+      "source": "./research/pulse",
+      "description": "Multi-source recency research. Reddit/HN/X/web sentiment + trending. Research-pack convention (1 q/sec, three-count tracking). Path-B from megaprompt 01.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "pulse",
+        "sentiment",
+        "reddit",
+        "hn",
+        "trending",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "litreview",
+      "source": "./research/litreview",
+      "description": "Academic literature orientation skill. PICO/SPIDER frameworks, systematic review structure, 8-section DOCX guide. Research-pack convention. Path-B from megaprompt 09.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "literature-review",
+        "pico",
+        "spider",
+        "systematic-review",
+        "academic",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "grants",
+      "source": "./research/grants",
+      "description": "NIH grant-funding intelligence skill. RePORTER/NOSI/study-section navigation, R01/R21/K-award strategy. Research-pack convention. Path-B from megaprompt 11.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "grants",
+        "nih",
+        "r01",
+        "k-award",
+        "reporter",
+        "nosi",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "dossier",
+      "source": "./research/dossier",
+      "description": "Decision-grade entity research. Due-diligence/background-check/competitor-prep with tier-weighted verdict + citation tracker. Research-pack convention. Path-B from megaprompt 02.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "dossier",
+        "due-diligence",
+        "background-check",
+        "competitor",
+        "entity-research",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "patent",
+      "source": "./research/patent",
+      "description": "Patent prior-art + IP landscape skill. FTO/novelty/family-resolver via 3-pass Jaccard heuristic. Research-pack convention. Path-B from megaprompt 12.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "patent",
+        "prior-art",
+        "fto",
+        "freedom-to-operate",
+        "ip-landscape",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "syllabus",
+      "source": "./research/syllabus",
+      "description": "Course supplementary-reading skill. Topic-grouper + bundled Node.js DOCX generator for syllabus-anchored reading lists. Research-pack convention. Path-B from megaprompt 10.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "syllabus",
+        "curriculum",
+        "reading-list",
+        "docx",
+        "course",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "notebooklm",
+      "source": "./research/notebooklm",
+      "description": "Google NotebookLM browser-automation skill. 4 actions (read/extract, add-source, Studio outputs, create notebook). Screenshot-first + find-before-click + fire-and-notify async discipline. Path-B from megaprompt 03.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "notebooklm",
+        "google",
+        "browser-automation",
+        "studio",
+        "audio-overview",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
+    },
+    {
+      "name": "research-orchestrator",
+      "source": "./research/research",
+      "description": "Research orchestrator (hybrid router + fallback). Deterministic SIGNALS classification routes to 6 specialists (pulse/litreview/grants/dossier/patent/syllabus) at >=2 signals, else runs own 8-step plan-decompose-search-synthesize-cite fallback. Routing transparency mandatory. Path-B from megaprompt 13.",
+      "version": "2.7.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "research",
+        "router",
+        "orchestrator",
+        "classifier",
+        "fallback",
+        "hybrid-architecture",
+        "research-pack",
+        "path-b-megaprompt"
+      ],
+      "category": "research"
     }
   ]
 }

--- a/.codex/skills-index.json
+++ b/.codex/skills-index.json
@@ -3,7 +3,7 @@
   "name": "claude-code-skills",
   "description": "Production-ready skill packages for AI agents - Marketing, Engineering, Product, C-Level, PM, and RA/QM",
   "repository": "https://github.com/alirezarezvani/claude-skills",
-  "total_skills": 290,
+  "total_skills": 303,
   "skills": [
     {
       "name": "business-growth-skills",
@@ -1326,6 +1326,12 @@
       "description": "When the user wants to build a free tool for marketing \u2014 lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead."
     },
     {
+      "name": "landing",
+      "source": "../../marketing/landing/skills/landing",
+      "category": "marketing",
+      "description": "Generates a premium single-page HTML landing page with 3D CSS animations, GSAP scroll effects, and mouse-parallax depth. Forcing intake (product + elevator pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written, so the page reflects the actual product rather than generic boilerplate. Use whenever the user says 'landing for X', 'create a landing page', 'build a landing page', 'make a landing page for X', 'I need a web page for Y', or provid..."
+    },
+    {
       "name": "launch-strategy",
       "source": "../../marketing-skill/skills/launch-strategy",
       "category": "marketing",
@@ -1584,6 +1590,30 @@
       "description": "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation."
     },
     {
+      "name": "capture",
+      "source": "../../productivity/capture/skills/capture",
+      "category": "productivity",
+      "description": "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says 'capture this', 'brain dump', 'let me dump some ideas', 'I've got a bunch of thoughts', 'here's everything on my mind', 'idea dump', 'let me get this out of my head', 'I need to organize my thoughts', 'here's what I'm thinking', or any variation where someone is unloading a messy stream of ideas, tasks, thoughts, and plans wanting them turned into s..."
+    },
+    {
+      "name": "inbox-setup",
+      "source": "../../productivity/email/skills/inbox-setup",
+      "category": "productivity",
+      "description": "One-time setup skill that builds a personalized inbox triage knowledge base via interactive interview. Interviews the user about their email patterns, business context, reply style, and priorities using grill-me discipline (one question at a time, forcing format where possible, dependency-ordered, each question explains why I'm asking), then generates the knowledge base files that power the companion 'inbox-triage' skill. Run this once before using inbox-triage for the first time. Re-run when..."
+    },
+    {
+      "name": "inbox-triage",
+      "source": "../../productivity/email/skills/inbox-triage",
+      "category": "productivity",
+      "description": "Runs a full inbox triage using the knowledge base created by the 'inbox-setup' skill. Light-intake by design (most invocations skip questions and run with KB-default preferences); asks at most 2 grill-me override questions when invocation is outside normal cadence or includes category-skip intent. Searches recent emails, classifies them via the user's taxonomy, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report in the user's preferred format, an..."
+    },
+    {
+      "name": "reflect",
+      "source": "../../productivity/reflect/skills/reflect",
+      "category": "productivity",
+      "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementa..."
+    },
+    {
       "name": "atlassian-admin",
       "source": "../../project-management/skills/atlassian-admin",
       "category": "project-management",
@@ -1744,6 +1774,54 @@
       "source": "../../ra-qm-team/skills/soc2-compliance",
       "category": "ra-qm",
       "description": "Use when the user asks to prepare for SOC 2 audits, map Trust Service Criteria, build control matrices, collect audit evidence, perform gap analysis, or assess SOC 2 Type I vs Type II readiness."
+    },
+    {
+      "name": "dossier",
+      "source": "../../research/dossier/skills/dossier",
+      "category": "research",
+      "description": "Decision-grade entity research skill \u2014 produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a generic profile. Forcing intake makes the user state their hypothesis upfront (what they already believe and want to verify or disprove) so the dossier tests it rather than confirms it. Output is an editable Word document (.docx) with verdict on the hypothesis, identity facts, 12-month activity timeline, network signals, reputation signals, red flags, ..."
+    },
+    {
+      "name": "grants",
+      "source": "../../research/grants/skills/grants",
+      "category": "research",
+      "description": "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission posture + known institute targets) locks down the funding strategy before any search runs. Runs a 5-facet Consensus positioning analysis (with draft Significance/Innovation language), maps the research to the right NIH institutes and study sections via RePORTER, finds NOSIs and funded overlap, and produces an editable Word document (.docx) with budget/..."
+    },
+    {
+      "name": "litreview",
+      "source": "../../research/litreview/skills/litreview",
+      "category": "research",
+      "description": "Academic literature orientation skill that searches papers via Consensus, builds a strategic search plan using PICO (default) or SPIDER / Decomposition / hybrid as fallbacks, and synthesizes findings into a professionally formatted Word document (.docx) research guide. Grill-me intake (research question specificity + framework hint + tentative depth) before the recon search; a second forcing checkpoint after Phase 2 confirms framework + sub-areas + depth before searches consume budget. Config..."
+    },
+    {
+      "name": "notebooklm",
+      "source": "../../research/notebooklm/skills/notebooklm",
+      "category": "research",
+      "description": "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube links, synthesized content), generating Studio outputs (Audio Overview, infographics, slide decks, study guides, briefing docs, mind maps, timelines, FAQs), and creating new notebooks. Triggers on any phrase involving NotebookLM \u2014 'open NotebookLM', 'check my [name] notebook', 'pull info from NotebookLM', 'ask my notebook about X', 'add [source] to N..."
+    },
+    {
+      "name": "patent",
+      "source": "../../research/patent/skills/patent",
+      "category": "research",
+      "description": "Patent prior-art and landscape intelligence skill \u2014 not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-r..."
+    },
+    {
+      "name": "pulse",
+      "source": "../../research/pulse/skills/pulse",
+      "category": "research",
+      "description": "Multi-source recency research skill that takes the pulse of any topic across Reddit, Hacker News, the open web, and optionally X/Twitter within a configurable recent window (default 30 days). Forcing intake clarifies topic specificity, angle (trend/sentiment/problems/opportunities/comparison), time window, and platform scope before searching. Returns a synthesized briefing with citations, engagement metrics, and cross-platform pattern analysis. Triggers: 'pulse on [topic]', 'what's happening ..."
+    },
+    {
+      "name": "research",
+      "source": "../../research/research/skills/research",
+      "category": "research",
+      "description": "Default entry point for any research request \u2014 a hybrid router that classifies the question deterministically and either delegates to a specialist research skill (pulse for trends/sentiment, grants for NIH funding, litreview for academic literature, syllabus for course reading, patent for prior-art + IP landscape, dossier for entity research) or runs its own plan-decompose-multi-source-search-synthesize-cite fallback workflow when no specialist matches. Always surfaces the routing decision so..."
+    },
+    {
+      "name": "syllabus",
+      "source": "../../research/syllabus/skills/syllabus",
+      "category": "research",
+      "description": "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format + course audience + year range) plus a grouping forcing-options checkpoint before any search runs \u2014 so the reading list matches the course's level and recency need. Parses the syllabus to extract topics and learning outcomes, searches Consensus for recent peer-reviewed papers per topic, and produces a professionally formatted .docx with clickable Cons..."
     }
   ],
   "categories": {
@@ -1773,7 +1851,7 @@
       "description": "Financial analysis, valuation, and forecasting skills"
     },
     "marketing": {
-      "count": 45,
+      "count": 46,
       "source": "../../marketing-skill",
       "description": "Marketing, content, and demand generation skills"
     },
@@ -1791,6 +1869,14 @@
       "count": 18,
       "source": "../../ra-qm-team",
       "description": "Regulatory affairs and quality management skills"
+    },
+    "productivity": {
+      "description": "Personal-productivity skills - capture, email, reflect",
+      "count": 4
+    },
+    "research": {
+      "description": "Research orchestrator + 6 specialists (pulse, litreview, grants, dossier, patent, syllabus, notebooklm)",
+      "count": 8
     }
   }
 }

--- a/.codex/skills/dossier
+++ b/.codex/skills/dossier
@@ -1,0 +1,1 @@
+../../research/dossier/skills/dossier

--- a/.codex/skills/grants
+++ b/.codex/skills/grants
@@ -1,0 +1,1 @@
+../../research/grants/skills/grants

--- a/.codex/skills/inbox-setup
+++ b/.codex/skills/inbox-setup
@@ -1,0 +1,1 @@
+../../productivity/email/skills/inbox-setup

--- a/.codex/skills/inbox-triage
+++ b/.codex/skills/inbox-triage
@@ -1,0 +1,1 @@
+../../productivity/email/skills/inbox-triage

--- a/.codex/skills/landing
+++ b/.codex/skills/landing
@@ -1,0 +1,1 @@
+../../marketing/landing/skills/landing

--- a/.codex/skills/litreview
+++ b/.codex/skills/litreview
@@ -1,0 +1,1 @@
+../../research/litreview/skills/litreview

--- a/.codex/skills/notebooklm
+++ b/.codex/skills/notebooklm
@@ -1,0 +1,1 @@
+../../research/notebooklm/skills/notebooklm

--- a/.codex/skills/patent
+++ b/.codex/skills/patent
@@ -1,0 +1,1 @@
+../../research/patent/skills/patent

--- a/.codex/skills/reflect
+++ b/.codex/skills/reflect
@@ -1,0 +1,1 @@
+../../productivity/reflect/skills/reflect

--- a/.codex/skills/research
+++ b/.codex/skills/research
@@ -1,0 +1,1 @@
+../../research/research/skills/research

--- a/.codex/skills/syllabus
+++ b/.codex/skills/syllabus
@@ -1,0 +1,1 @@
+../../research/syllabus/skills/syllabus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to the Claude Skills Library will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-05-16 — v2 megaprompt-to-skill conversion sweep: 13 new skills (productivity + marketing + research)
+
+### Added — 13 Path-B Skills From `megaprompts/`
+
+This release ships the complete v2 megaprompt collection (`megaprompts/01-13`) as production-ready skills using the **Path-B direct-conversion pattern**: each megaprompt's body becomes the SKILL.md verbatim, wrapped in the standard 11-file plugin layout (`.claude-plugin/plugin.json`, README, agent, command, SKILL.md, 3 references citing 7+ sources each, 3 stdlib Python scripts).
+
+Three new top-level domain folders were created to host the 13 skills:
+
+| Domain | Skills | Build pattern |
+|---|---|---|
+| `productivity/` | `capture`, `email` (paired: inbox-setup + inbox-triage), `reflect` | Personal-productivity slices — single-action intake, KB-file contract between pair |
+| `marketing/` | `landing` | Single-file HTML landing-page generator with 4 design styles |
+| `research/` | `pulse`, `litreview`, `grants`, `dossier`, `patent`, `syllabus`, `notebooklm`, `research` (orchestrator) | 7 research-pack siblings + 1 hybrid router |
+
+**13 skills, 142 files, 23,698 lines of code + documentation.** All scripts stdlib-only. All references cite 7+ authoritative sources.
+
+#### Productivity slice (3 skills)
+
+- **`productivity/capture/`** (PR #659) — Brain-dump-to-action workspace. Classify→cluster→connect→clarify intake. Path-B from megaprompt 05.
+- **`productivity/email/`** (PR #661) — Email-workflow skill pair. `inbox-setup` builds taxonomy/KB; `inbox-triage` classifies + drafts (drafts-only, never auto-send). 7-file KB contract between them. Path-B from megaprompts 06+07.
+- **`productivity/reflect/`** (PR #668) — Light-prompt reflection sibling of capture. Path-B from megaprompt 08.
+
+#### Marketing slice (1 skill)
+
+- **`marketing/landing/`** (PR #662) — Single-file HTML landing-page generator. 4 design styles, brand palette validator, GSAP animation patterns, kebab-slug URL hygiene. Path-B from megaprompt 04.
+
+#### Research pack (8 skills — 7 specialists + 1 orchestrator)
+
+- **`research/pulse/`** (PR #660) — Multi-source recency research (Reddit/HN/X/web sentiment + trending). Research-pack convention. Path-B from megaprompt 01.
+- **`research/litreview/`** (PR #663) — Academic literature orientation. PICO/SPIDER frameworks, systematic review structure, 8-section DOCX guide. Path-B from megaprompt 09.
+- **`research/grants/`** (PR #664) — NIH grant-funding intelligence. RePORTER/NOSI/study-section navigation, R01/R21/K-award strategy. Path-B from megaprompt 11.
+- **`research/dossier/`** (PR #664) — Decision-grade entity research. Due-diligence/background-check/competitor-prep with tier-weighted verdict + citation tracker. Path-B from megaprompt 02.
+- **`research/patent/`** (PR #666) — Patent prior-art + IP landscape. FTO/novelty/family-resolver via 3-pass Jaccard heuristic. Path-B from megaprompt 12.
+- **`research/syllabus/`** (PR #666) — Course supplementary-reading skill. Topic-grouper + bundled Node.js DOCX generator. Path-B from megaprompt 10.
+- **`research/notebooklm/`** (PR #669) — Google NotebookLM browser-automation. 4 actions (read/extract, add-source, Studio outputs, create notebook). Screenshot-first + find-before-click + fire-and-notify discipline. Path-B from megaprompt 03.
+- **`research/research/`** (PR #671) — **Research orchestrator (hybrid router + fallback).** Deterministic SIGNALS classification routes to the 6 specialists above at ≥2-signal confidence, else runs own 8-step plan-decompose-search-synthesize-cite fallback. Routing transparency mandatory. Distinct from `engineering/autoresearch-agent` (Karpathy's file-optimization loop). Path-B from megaprompt 13.
+
+### Added — Marketplace + Codex Registry
+
+- **`.claude-plugin/marketplace.json`**: 43 → 55 plugins. 12 new entries (email-pair holds 2 skills) across 3 categories. New categories added: `productivity`, `research`.
+- **`.codex/skills-index.json`**: 290 → 303 entries. 13 new skills indexed with category metadata.
+- **`.codex/skills/` symlinks**: 11 new symlinks created (capture + pulse already existed from prior auto-sync).
+- **`scripts/sync-codex-skills.py`**: Added `productivity/`, `marketing/`, `research/` to `SKILL_DOMAINS` so future auto-sync runs pick up the new top-level domains.
+
+### Path-B Convention (Documented)
+
+This release formalizes the **Path-B direct-conversion** pattern for future megaprompt-derived skills:
+
+- Megaprompt body → SKILL.md preserving content verbatim
+- 11-file standard plugin layout (12 files for skills with bundled JS DOCX generators like syllabus)
+- 3 stdlib Python scripts per skill (no external deps)
+- 3 reference docs per skill, each citing 7+ authoritative sources
+- `cs-*` agent + `/cs:*` command per plugin
+- `source` field in `plugin.json` documents `spec` (megaprompt path) + `build_pattern` + `distinct_from` (where disambiguation needed)
+
+### Verification
+
+- **39/39 scripts pass `--help`** across all 13 skills
+- **8-phase plugin audit** on `research/research`: PASS WITH WARNINGS (structure 84.1/GOOD, scripts 3/3, security 0 findings)
+- **Spot-check audit** on pulse / litreview / notebooklm: all 86.4/GOOD, 3/3 scripts, security PASS
+- **Bulk audit** on remaining 9 skills: all 79.5-86.4 structure, 0 critical/high security findings (1 false positive in syllabus on a user-facing `npm install docx` error-message string literal)
+- **Cross-skill consistency**: 7/7 research-pack siblings carry the `Agent Integrity Rules` block (1 q/sec rate limit, three-count tracking, retry-once-after-3s, source discipline)
+- **Orchestrator disambiguation**: `distinct_from autoresearch-agent` callouts present in plugin.json + README + SKILL.md + agent + command (5 places)
+
+### PRs
+
+#659 (capture), #660 (pulse), #661 (email pair), #662 (landing), #663 (litreview), #664 (grants+dossier), #666 (patent+syllabus), #667 (domain-folder cleanup), #668 (reflect), #669 (notebooklm), #671 (research orchestrator), #672 (v2.7.0 release prep — this commit).
+
 ## [2.6.1] - 2026-05-14 — Meta-skill maturity: validator expansion + 21 placeholder descriptions + audit tool
 
 ### Added — Tooling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,24 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 
 ## Current Version
 
-**Version:** v2.6.1 (latest)
+**Version:** v2.7.0 (latest)
+
+**v2.7.0 Highlights — v2 megaprompt-to-skill conversion sweep: 13 new skills across productivity + marketing + research:**
+
+This release ships the complete v2 megaprompt collection (`megaprompts/01-13`) as production-ready skills using the **Path-B direct-conversion pattern**. Three new top-level domain folders created (`productivity/`, `marketing/`, `research/`) hosting 13 skills, 142 files, 23,698 lines of code + documentation.
+
+- **`productivity/`** (3 skills) — `capture` (brain-dump-to-action workspace, megaprompt 05), `email` (paired inbox-setup + inbox-triage with 7-file KB contract, megaprompts 06+07), `reflect` (light-prompt sibling, megaprompt 08).
+- **`marketing/`** (1 skill) — `landing` (single-file HTML generator with 4 design styles, brand palette validator, GSAP patterns, megaprompt 04).
+- **`research/`** (8 skills) — 7 specialists (`pulse`, `litreview`, `grants`, `dossier`, `patent`, `syllabus`, `notebooklm`) + 1 hybrid router (`research/research/` orchestrator). Megaprompts 01-03, 09-13.
+- **Research orchestrator** — deterministic SIGNALS classification routes to 6 specialists at ≥2-signal confidence, else runs own 8-step plan-decompose-search-synthesize-cite fallback. Routing transparency mandatory. Distinct from `engineering/autoresearch-agent` (Karpathy's file-optimization loop) — disambiguation surfaced in 5 places.
+- **Marketplace + Codex registry:** 43 → 55 plugins; 290 → 303 indexed skills; new categories `productivity` + `research`; `scripts/sync-codex-skills.py` extended to recognize the 3 new top-level domains.
+- **Path-B convention formalized** — megaprompt body → SKILL.md verbatim, 11-file plugin layout, 3 stdlib Python scripts per skill, 3 reference docs each citing 7+ authoritative sources, `cs-*` agent + `/cs:*` command, `source` field documents spec + build_pattern + distinct_from.
+- **Verification:** 39/39 scripts pass `--help`; 8-phase plugin audit on orchestrator → PASS WITH WARNINGS (structure 84.1/GOOD, scripts 3/3, 0 critical/high security findings); bulk audit on 12 siblings → all 79.5-86.4 structure, 0 critical/high findings.
+- **PRs:** #659 (capture) → #660 (pulse) → #661 (email pair) → #662 (landing) → #663 (litreview) → #664 (grants+dossier) → #666 (patent+syllabus) → #667 (domain-folder cleanup) → #668 (reflect) → #669 (notebooklm) → #671 (research orchestrator) → #672 (v2.7.0 release prep).
+
+**Total scope after v2.7.0:** 311 skills across 12 domain folders, ~398 Python automation tools, ~538 reference guides, 45+ agents, 59+ slash commands.
+
+**Version:** v2.6.1
 
 **v2.6.1 Highlights — Meta-skill maturity: validator expansion + 21 placeholder description fixes + audit tool:**
 - **`scripts/audit_skills.py`** (new) — repo-wide write-a-skill validator runner. Stdlib-only orchestration: walks every SKILL.md, runs `skill_review_checklist_runner.py`, aggregates PASS/WARN/FAIL counts + failure-by-rule + top-10 worst offenders. ~30s on 298 real skills.
@@ -263,11 +280,15 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
 2. **Never rename repo folders or local skill names** to match ClawHub slugs. The repo is the source of truth.
 3. **No paid/commercial service dependencies.** Skills must not require paid third-party API keys or commercial services unless provided by the project itself. Free-tier APIs and BYOK (bring-your-own-key) patterns are acceptable.
 4. **Rate limit: 5 new skills per hour** on ClawHub. Batch publishes must respect this. Use the drip timer (`clawhub-drip.timer`) for bulk operations.
-5. **plugin.json schema** — ONLY these fields: `name`, `description`, `version`, `author`, `homepage`, `repository`, `license`, `skills`. No extra fields. The `skills` value depends on the plugin layout (Claude Code v2.1.107+ rejects bare `"./"`):
+5. **plugin.json schema** — Required fields: `name`, `description`, `version`, `author`, `homepage`, `repository`, `license`, `skills`. Two **approved extension fields** are permitted in the repo (stripped at ClawHub-publish time, if/when a stripping pipeline lands):
+   - `source` (object) — provenance metadata for skills built via Path-B megaprompt conversion. Recommended shape: `{spec: "megaprompts/NN-name.md", build_pattern: "...", distinct_from: "..."}`. Used by all 13 v2 megaprompt-derived skills (productivity/, marketing/, research/).
+   - `attribution` (object) — credit metadata for skills derived from external MIT-licensed work. Used by `engineering/caveman`, `engineering/grill-me`, `engineering/grill-with-docs` (Matt Pocock derivatives).
+
+   No other extras. The `skills` value depends on the plugin layout (Claude Code v2.1.107+ rejects bare `"./"`):
    - Single-skill plugin (SKILL.md at root): `"skills": ["./"]` (array form required).
    - Plugin with `./skills/` subdir: `"skills": "./skills"`.
    - Multi-skill domain plugin (skills are subfolders at root): `"skills": ["./sub1", "./sub2", ...]` (explicit list, omit `"./"` to avoid namespace collision with the index SKILL.md).
-6. **Version follows repo versioning.** ClawHub package versions must match the repo release version (currently v2.2.0+).
+6. **Version follows repo versioning.** ClawHub package versions must match the repo release version (currently v2.7.0+).
 
 ## Anti-Patterns to Avoid
 

--- a/marketing/landing/.claude-plugin/plugin.json
+++ b/marketing/landing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "landing",
-  "description": "Premium single-file HTML landing page generator with GSAP 3D animations, scroll-triggered effects, and mouse-parallax depth. Forcing 3-4 question grill-me intake (product+pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written. Outputs a single self-contained HTML file (Claude Code) or HTML artifact (Claude.ai) with all CSS/JS inline — only externals are Google Fonts + GSAP via CDN. Configurable brand colors via CSS custom property overrides. Source spec: megaprompts/04-landing-megaprompt.md (PR #657). Distinct from product-team/skills/landing-page-generator (which outputs Next.js TSX for conversion-optimized lead-gen) — this skill is for premium visual one-pagers with motion design.",
-  "version": "1.0.0",
+  "description": "Premium single-file HTML landing page generator with GSAP 3D animations, scroll-triggered effects, and mouse-parallax depth. Forcing 3-4 question grill-me intake (product+pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written. Outputs a single self-contained HTML file (Claude Code) or HTML artifact (Claude.ai) with all CSS/JS inline \u2014 only externals are Google Fonts + GSAP via CDN. Configurable brand colors via CSS custom property overrides. Source spec: megaprompts/04-landing-megaprompt.md (PR #657). Distinct from product-team/skills/landing-page-generator (which outputs Next.js TSX for conversion-optimized lead-gen) \u2014 this skill is for premium visual one-pagers with motion design.",
+  "version": "2.7.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,10 +9,12 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/landing"],
+  "skills": [
+    "./skills/landing"
+  ],
   "source": {
     "spec": "megaprompts/04-landing-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Generator shape — produces a single .html artifact (not multi-file scaffolding). Wrapper additions (3 stdlib validators, 3 references, cs-landing agent, /cs:landing command) layered on top per repo convention.",
-    "distinct_from": "product-team/skills/landing-page-generator/ — different output format (HTML vs TSX), different optimization target (visual premium vs conversion), different motion approach (GSAP vs static)."
+    "build_pattern": "Path B (direct conversion). Generator shape \u2014 produces a single .html artifact (not multi-file scaffolding). Wrapper additions (3 stdlib validators, 3 references, cs-landing agent, /cs:landing command) layered on top per repo convention.",
+    "distinct_from": "product-team/skills/landing-page-generator/ \u2014 different output format (HTML vs TSX), different optimization target (visual premium vs conversion), different motion approach (GSAP vs static)."
   }
 }

--- a/productivity/capture/.claude-plugin/plugin.json
+++ b/productivity/capture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "capture",
-  "description": "Brain-dump organizer. Ingests an unstructured stream of mixed thoughts, tasks, ideas and transforms it into a clean four-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help) with zero information loss. Fast-to-action by design — no upfront intake. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project. Workspace detection is real (Glob/Grep) — never fabricates connections. Source spec: megaprompts/05-capture-megaprompt.md (PR #657).",
-  "version": "1.0.0",
+  "description": "Brain-dump organizer. Ingests an unstructured stream of mixed thoughts, tasks, ideas and transforms it into a clean four-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help) with zero information loss. Fast-to-action by design \u2014 no upfront intake. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project. Workspace detection is real (Glob/Grep) \u2014 never fabricates connections. Source spec: megaprompts/05-capture-megaprompt.md (PR #657).",
+  "version": "2.7.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,9 +9,11 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/capture"],
+  "skills": [
+    "./skills/capture"
+  ],
   "source": {
     "spec": "megaprompts/05-capture-megaprompt.md",
-    "build_pattern": "Path B (direct conversion) — megaprompt body extracted into SKILL.md with deterministic structure preservation. Wrapper additions (3 stdlib scripts, 3 references, cs-capture agent, /cs:capture command) layered on top per repo convention."
+    "build_pattern": "Path B (direct conversion) \u2014 megaprompt body extracted into SKILL.md with deterministic structure preservation. Wrapper additions (3 stdlib scripts, 3 references, cs-capture agent, /cs:capture command) layered on top per repo convention."
   }
 }

--- a/productivity/email/.claude-plugin/plugin.json
+++ b/productivity/email/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email",
-  "description": "Email triage system — paired skills (inbox-setup + inbox-triage) for personalized recurring email triage. inbox-setup runs once via interactive interview to build a knowledge base of 7 files (taxonomy, patterns, evaluation-framework, rate-card, blocklist, tracker, triage-log/) in ${WORKSPACE}/Email/. inbox-triage runs on recurring cadence (1-3x daily) or on demand: classifies recent emails, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report, and updates the KB with learnings. The two skills share a strict file contract — PR #657's cross-skill consistency audit verified the 7 KB filenames align verbatim between the two megaprompts. Source specs: megaprompts/06-inbox-setup-megaprompt.md + megaprompts/07-inbox-triage-megaprompt.md.",
-  "version": "1.0.0",
+  "description": "Email triage system \u2014 paired skills (inbox-setup + inbox-triage) for personalized recurring email triage. inbox-setup runs once via interactive interview to build a knowledge base of 7 files (taxonomy, patterns, evaluation-framework, rate-card, blocklist, tracker, triage-log/) in ${WORKSPACE}/Email/. inbox-triage runs on recurring cadence (1-3x daily) or on demand: classifies recent emails, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report, and updates the KB with learnings. The two skills share a strict file contract \u2014 PR #657's cross-skill consistency audit verified the 7 KB filenames align verbatim between the two megaprompts. Source specs: megaprompts/06-inbox-setup-megaprompt.md + megaprompts/07-inbox-triage-megaprompt.md.",
+  "version": "2.7.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,13 +9,16 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/inbox-setup", "./skills/inbox-triage"],
+  "skills": [
+    "./skills/inbox-setup",
+    "./skills/inbox-triage"
+  ],
   "source": {
     "specs": [
       "megaprompts/06-inbox-setup-megaprompt.md",
       "megaprompts/07-inbox-triage-megaprompt.md"
     ],
-    "build_pattern": "Path B (direct conversion). Workflow-pair shape — coupled skills sharing a 7-file KB contract verified verbatim-aligned by PR #657 audit. Both skills ship as ONE plugin with multi-skill layout per CLAUDE.md plugin-schema rule.",
-    "shared_contract": "${WORKSPACE}/Email/ — 7 files: email-taxonomy.md, email-patterns.md, evaluation-framework.md (conditional), rate-card.md (conditional), blocklist.md, tracker.md, triage-log/. inbox-setup writes; inbox-triage reads + appends."
+    "build_pattern": "Path B (direct conversion). Workflow-pair shape \u2014 coupled skills sharing a 7-file KB contract verified verbatim-aligned by PR #657 audit. Both skills ship as ONE plugin with multi-skill layout per CLAUDE.md plugin-schema rule.",
+    "shared_contract": "${WORKSPACE}/Email/ \u2014 7 files: email-taxonomy.md, email-patterns.md, evaluation-framework.md (conditional), rate-card.md (conditional), blocklist.md, tracker.md, triage-log/. inbox-setup writes; inbox-triage reads + appends."
   }
 }

--- a/productivity/reflect/.claude-plugin/plugin.json
+++ b/productivity/reflect/.claude-plugin/plugin.json
@@ -1,15 +1,20 @@
 {
   "name": "reflect",
-  "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck — that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck \u2014 that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/reflect"],
+  "skills": [
+    "./skills/reflect"
+  ],
   "source": {
     "spec": "megaprompts/02-reflect-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Productivity light-prompt-flow sibling of capture. Pure-reasoning skill — no external APIs, no DOCX generation, most portable in the collection.",
+    "build_pattern": "Path B (direct conversion). Productivity light-prompt-flow sibling of capture. Pure-reasoning skill \u2014 no external APIs, no DOCX generation, most portable in the collection.",
     "sibling_of": "productivity/capture (light prompt-flow shape)"
   }
 }

--- a/research/dossier/.claude-plugin/plugin.json
+++ b/research/dossier/.claude-plugin/plugin.json
@@ -1,15 +1,20 @@
 {
   "name": "dossier",
-  "description": "Decision-grade entity research skill — produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a generic profile. Forcing intake makes the user state their hypothesis upfront (what they already believe and want to verify or disprove) so the dossier tests it rather than confirms it. Output is an editable Word document (.docx) with verdict on the hypothesis, identity facts, 12-month activity timeline, network signals, reputation signals, red flags, 3-5 conversation hooks tied to specific findings, and source-provenance audit log. Uses WebSearch + WebFetch + free APIs (SEC EDGAR, GitHub, ProPublica Nonprofit Explorer) as workhorses; optional BYOK MCPs (LinkedIn, Crunchbase, Apollo, Pitchbook, SimilarWeb) enhance coverage. Triggers: 'research [company]', 'dossier on [person/company]', 'background check on [entity]', 'prep me for a meeting with [person/company]', 'due diligence on [company]', 'what should I know about [entity]', 'research [person] before I [meet/hire/invest]', 'competitor research on [company]', 'investor diligence [company]', 'interview prep for [company]'. Honors sensitivity exclusions for journalism + personal-vetting contexts.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "Decision-grade entity research skill \u2014 produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a generic profile. Forcing intake makes the user state their hypothesis upfront (what they already believe and want to verify or disprove) so the dossier tests it rather than confirms it. Output is an editable Word document (.docx) with verdict on the hypothesis, identity facts, 12-month activity timeline, network signals, reputation signals, red flags, 3-5 conversation hooks tied to specific findings, and source-provenance audit log. Uses WebSearch + WebFetch + free APIs (SEC EDGAR, GitHub, ProPublica Nonprofit Explorer) as workhorses; optional BYOK MCPs (LinkedIn, Crunchbase, Apollo, Pitchbook, SimilarWeb) enhance coverage. Triggers: 'research [company]', 'dossier on [person/company]', 'background check on [entity]', 'prep me for a meeting with [person/company]', 'due diligence on [company]', 'what should I know about [entity]', 'research [person] before I [meet/hire/invest]', 'competitor research on [company]', 'investor diligence [company]', 'interview prep for [company]'. Honors sensitivity exclusions for journalism + personal-vetting contexts.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/dossier"],
+  "skills": [
+    "./skills/dossier"
+  ],
   "source": {
     "spec": "megaprompts/12-dossier-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Research-pack shape, hypothesis-testing variant. Q4 (hypothesis) is mandatory; ≥30% search budget allocated to disconfirming evidence.",
-    "sibling_of": "research/litreview, research/grants, research/pulse (pulse currently in engineering/ — cleanup PR queued)"
+    "build_pattern": "Path B (direct conversion). Research-pack shape, hypothesis-testing variant. Q4 (hypothesis) is mandatory; \u226530% search budget allocated to disconfirming evidence.",
+    "sibling_of": "research/litreview, research/grants, research/pulse (pulse currently in engineering/ \u2014 cleanup PR queued)"
   }
 }

--- a/research/grants/.claude-plugin/plugin.json
+++ b/research/grants/.claude-plugin/plugin.json
@@ -1,15 +1,20 @@
 {
   "name": "grants",
-  "description": "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission posture + known institute targets) locks down the funding strategy before any search runs. Runs a 5-facet Consensus positioning analysis (with draft Significance/Innovation language), maps the research to the right NIH institutes and study sections via RePORTER, finds NOSIs and funded overlap, and produces an editable Word document (.docx) with budget/scope-aware mechanism recommendations, submission timelines, and a mandatory program officer recommendation. Triggers: 'grants for [topic]', 'find grants for my research idea', 'what grants match my research', 'help me find NIH funding', 'grant opportunities for my research', or any grant-related request. NIH-only scope — non-NIH funders (PCORI, DOD CDMRP, VA, foundations) are out of scope and flagged at intake.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission posture + known institute targets) locks down the funding strategy before any search runs. Runs a 5-facet Consensus positioning analysis (with draft Significance/Innovation language), maps the research to the right NIH institutes and study sections via RePORTER, finds NOSIs and funded overlap, and produces an editable Word document (.docx) with budget/scope-aware mechanism recommendations, submission timelines, and a mandatory program officer recommendation. Triggers: 'grants for [topic]', 'find grants for my research idea', 'what grants match my research', 'help me find NIH funding', 'grant opportunities for my research', or any grant-related request. NIH-only scope \u2014 non-NIH funders (PCORI, DOD CDMRP, VA, foundations) are out of scope and flagged at intake.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/grants",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/grants"],
+  "skills": [
+    "./skills/grants"
+  ],
   "source": {
     "spec": "megaprompts/08-grants-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Research-pack shape — sibling of pulse + litreview. Multi-source (Consensus + RePORTER POST + NOSI fetch) with DOCX output via Node.js docx library.",
-    "sibling_of": "research/litreview, research/pulse (pulse currently in engineering/ — cleanup PR queued)"
+    "build_pattern": "Path B (direct conversion). Research-pack shape \u2014 sibling of pulse + litreview. Multi-source (Consensus + RePORTER POST + NOSI fetch) with DOCX output via Node.js docx library.",
+    "sibling_of": "research/litreview, research/pulse (pulse currently in engineering/ \u2014 cleanup PR queued)"
   }
 }

--- a/research/litreview/.claude-plugin/plugin.json
+++ b/research/litreview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "litreview",
-  "description": "Academic literature orientation skill. Turns a research question into a strategically planned mini literature review, delivered as a researcher-friendly Word document (.docx). Grill-me intake (research question + framework hint + tentative depth) before recon search; second forcing checkpoint after Phase 2 confirms framework + sub-areas + depth. Configurable depth (5/10/20 Consensus queries) controls coverage vs. speed. Output is a 'launching pad' — orientation guide, not a finished review. Implements research-pack Agent Integrity Rules: 1 q/sec Consensus rate limit, sequential execution, plan-tier detection, three-count tracking (sent/received/cited). Source spec: megaprompts/09-litreview-megaprompt.md (PR #657). Sibling of pulse (research-pack shape).",
-  "version": "1.0.0",
+  "description": "Academic literature orientation skill. Turns a research question into a strategically planned mini literature review, delivered as a researcher-friendly Word document (.docx). Grill-me intake (research question + framework hint + tentative depth) before recon search; second forcing checkpoint after Phase 2 confirms framework + sub-areas + depth. Configurable depth (5/10/20 Consensus queries) controls coverage vs. speed. Output is a 'launching pad' \u2014 orientation guide, not a finished review. Implements research-pack Agent Integrity Rules: 1 q/sec Consensus rate limit, sequential execution, plan-tier detection, three-count tracking (sent/received/cited). Source spec: megaprompts/09-litreview-megaprompt.md (PR #657). Sibling of pulse (research-pack shape).",
+  "version": "2.7.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/litreview"],
+  "skills": [
+    "./skills/litreview"
+  ],
   "source": {
     "spec": "megaprompts/09-litreview-megaprompt.md",
     "build_pattern": "Path B (direct conversion). Research-pack shape. Implements Agent Integrity Rules + cross-search intelligence + interactive checkpoint per megaprompt spec.",

--- a/research/notebooklm/.claude-plugin/plugin.json
+++ b/research/notebooklm/.claude-plugin/plugin.json
@@ -1,15 +1,20 @@
 {
   "name": "notebooklm",
-  "description": "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube links, synthesized content), generating Studio outputs (Audio Overview, infographics, slide decks, study guides, briefing docs, mind maps, timelines, FAQs), and creating new notebooks. Triggers on any phrase involving NotebookLM — 'open NotebookLM', 'check my [name] notebook', 'pull info from NotebookLM', 'ask my notebook about X', 'add [source] to NotebookLM', 'create an infographic in NotebookLM', 'use NotebookLM Studio', 'generate a slide deck from my notebook', or any variation where the goal involves NotebookLM. Requires browser automation environment — fails gracefully when unavailable.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube links, synthesized content), generating Studio outputs (Audio Overview, infographics, slide decks, study guides, briefing docs, mind maps, timelines, FAQs), and creating new notebooks. Triggers on any phrase involving NotebookLM \u2014 'open NotebookLM', 'check my [name] notebook', 'pull info from NotebookLM', 'ask my notebook about X', 'add [source] to NotebookLM', 'create an infographic in NotebookLM', 'use NotebookLM Studio', 'generate a slide deck from my notebook', or any variation where the goal involves NotebookLM. Requires browser automation environment \u2014 fails gracefully when unavailable.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/notebooklm"],
+  "skills": [
+    "./skills/notebooklm"
+  ],
   "source": {
     "spec": "megaprompts/03-notebooklm-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Browser-automation shape — distinct from research-pack convention. Action-routing intake (Q1 picks one of 4 actions: read/extract, add source, generate studio output, create new). CLI-only portability with graceful failure in web context.",
+    "build_pattern": "Path B (direct conversion). Browser-automation shape \u2014 distinct from research-pack convention. Action-routing intake (Q1 picks one of 4 actions: read/extract, add source, generate studio output, create new). CLI-only portability with graceful failure in web context.",
     "sibling_of": "research/pulse, litreview, grants, dossier, patent, syllabus (semantic domain) but DIFFERENT SHAPE (browser-automation, not research-pack)"
   }
 }

--- a/research/patent/.claude-plugin/plugin.json
+++ b/research/patent/.claude-plugin/plugin.json
@@ -1,12 +1,17 @@
 {
   "name": "patent",
-  "description": "Patent prior-art and landscape intelligence skill — not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-resolved hits, geographic coverage, FTO flags where applicable, strategy recommendations, and full audit log. Triggers: 'prior art search for [invention]', 'patent search on [topic]', 'freedom to operate analysis', 'FTO for [product]', 'patent landscape for [field]', 'is [invention] novel', 'patents on [topic]', 'competitive patent analysis', 'prior art for litigation', 'patent diligence on [company]'. Produces search signal, not legal advice — always recommends consulting a patent attorney before filing or licensing decisions. Trademark, copyright, and trade-secret questions are out of scope.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "Patent prior-art and landscape intelligence skill \u2014 not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-resolved hits, geographic coverage, FTO flags where applicable, strategy recommendations, and full audit log. Triggers: 'prior art search for [invention]', 'patent search on [topic]', 'freedom to operate analysis', 'FTO for [product]', 'patent landscape for [field]', 'is [invention] novel', 'patents on [topic]', 'competitive patent analysis', 'prior art for litigation', 'patent diligence on [company]'. Produces search signal, not legal advice \u2014 always recommends consulting a patent attorney before filing or licensing decisions. Trademark, copyright, and trade-secret questions are out of scope.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/patent",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/patent"],
+  "skills": [
+    "./skills/patent"
+  ],
   "source": {
     "spec": "megaprompts/11-patent-megaprompt.md",
     "build_pattern": "Path B (direct conversion). Research-pack shape, sub-use-case-routing variant. 5 sub-use-cases (novelty/FTO/landscape/diligence/litigation) drive entire search strategy + DOCX emphasis. Multi-source: Google Patents + Espacenet + USPTO + optional Lens.org BYOK.",

--- a/research/pulse/.claude-plugin/plugin.json
+++ b/research/pulse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulse",
-  "description": "Multi-source recency research skill. Takes the pulse of any topic across Reddit, Hacker News, the open web, and (optionally) X/Twitter within a configurable recent window (default 30 days). Forcing 2–4 question grill-me intake clarifies topic specificity, angle (trend/sentiment/problems/opportunities/comparison), time window, and platform scope before searching. Phases 1–3 run in parallel per the research-pack convention. Returns a synthesized briefing with citations, engagement metrics, and cross-platform pattern analysis. Source spec: megaprompts/01-pulse-megaprompt.md (PR #657). Implements the Agent Integrity Rules block locked down by PR #657 audit: 1 q/sec per platform, three-count tracking (sent/received/cited), retry-once-after-3s, stop-after-3-consecutive-failures.",
-  "version": "1.0.0",
+  "description": "Multi-source recency research skill. Takes the pulse of any topic across Reddit, Hacker News, the open web, and (optionally) X/Twitter within a configurable recent window (default 30 days). Forcing 2\u20134 question grill-me intake clarifies topic specificity, angle (trend/sentiment/problems/opportunities/comparison), time window, and platform scope before searching. Phases 1\u20133 run in parallel per the research-pack convention. Returns a synthesized briefing with citations, engagement metrics, and cross-platform pattern analysis. Source spec: megaprompts/01-pulse-megaprompt.md (PR #657). Implements the Agent Integrity Rules block locked down by PR #657 audit: 1 q/sec per platform, three-count tracking (sent/received/cited), retry-once-after-3s, stop-after-3-consecutive-failures.",
+  "version": "2.7.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,9 +9,11 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/pulse"],
+  "skills": [
+    "./skills/pulse"
+  ],
   "source": {
     "spec": "megaprompts/01-pulse-megaprompt.md",
-    "build_pattern": "Path B (direct conversion) — megaprompt body extracted into SKILL.md with deterministic structure preservation. Research-pack convention block preserved verbatim per PR #657 audit. Wrapper additions (3 stdlib scripts, 3 references, cs-pulse agent, /cs:pulse command) layered on top per repo convention."
+    "build_pattern": "Path B (direct conversion) \u2014 megaprompt body extracted into SKILL.md with deterministic structure preservation. Research-pack convention block preserved verbatim per PR #657 audit. Wrapper additions (3 stdlib scripts, 3 references, cs-pulse agent, /cs:pulse command) layered on top per repo convention."
   }
 }

--- a/research/research/.claude-plugin/plugin.json
+++ b/research/research/.claude-plugin/plugin.json
@@ -1,16 +1,28 @@
 {
   "name": "research",
-  "description": "Default entry point for any research request — a hybrid router that classifies the question deterministically and either delegates to a specialist research skill (pulse for trends/sentiment, grants for NIH funding, litreview for academic literature, syllabus for course reading, patent for prior-art + IP landscape, dossier for entity research) or runs its own plan-decompose-multi-source-search-synthesize-cite fallback workflow when no specialist matches. Always surfaces the routing decision so users can override. Triggers: 'research [topic]', 'look into [topic]', 'what do we know about [topic]', 'investigate [topic]', 'find me information on [topic]', 'do some research on [topic]', 'I need to understand [topic]', or any research request that doesn't obviously match a more-specific specialist skill. Output is a markdown briefing (default) or .docx document (on request) with full citations and an audit log.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "Default entry point for any research request \u2014 a hybrid router that classifies the question deterministically and either delegates to a specialist research skill (pulse for trends/sentiment, grants for NIH funding, litreview for academic literature, syllabus for course reading, patent for prior-art + IP landscape, dossier for entity research) or runs its own plan-decompose-multi-source-search-synthesize-cite fallback workflow when no specialist matches. Always surfaces the routing decision so users can override. Triggers: 'research [topic]', 'look into [topic]', 'what do we know about [topic]', 'investigate [topic]', 'find me information on [topic]', 'do some research on [topic]', 'I need to understand [topic]', or any research request that doesn't obviously match a more-specific specialist skill. Output is a markdown briefing (default) or .docx document (on request) with full citations and an audit log.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/research",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/research"],
+  "skills": [
+    "./skills/research"
+  ],
   "source": {
     "spec": "megaprompts/13-research-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Hybrid router + fallback (Architecture C) — deterministic classification → specialist delegation OR own fallback workflow. The runtime orchestrator for the research domain.",
-    "distinct_from": "engineering/autoresearch-agent — that skill is Karpathy's autonomous file-optimization experiment loop; this skill is a research-query router. Different use cases, no overlap.",
-    "routing_targets": ["research/pulse", "research/litreview", "research/grants", "research/dossier", "research/patent", "research/syllabus"]
+    "build_pattern": "Path B (direct conversion). Hybrid router + fallback (Architecture C) \u2014 deterministic classification \u2192 specialist delegation OR own fallback workflow. The runtime orchestrator for the research domain.",
+    "distinct_from": "engineering/autoresearch-agent \u2014 that skill is Karpathy's autonomous file-optimization experiment loop; this skill is a research-query router. Different use cases, no overlap.",
+    "routing_targets": [
+      "research/pulse",
+      "research/litreview",
+      "research/grants",
+      "research/dossier",
+      "research/patent",
+      "research/syllabus"
+    ]
   }
 }

--- a/research/syllabus/.claude-plugin/plugin.json
+++ b/research/syllabus/.claude-plugin/plugin.json
@@ -1,15 +1,20 @@
 {
   "name": "syllabus",
-  "description": "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format + course audience + year range) plus a grouping forcing-options checkpoint before any search runs — so the reading list matches the course's level and recency need. Parses the syllabus to extract topics and learning outcomes, searches Consensus for recent peer-reviewed papers per topic, and produces a professionally formatted .docx with clickable Consensus links, plain-language summaries calibrated to audience level, and Bloom-higher-order discussion questions tied to course learning goals. Triggers whenever a user uploads a syllabus, course outline, or curriculum document and wants supplementary readings. Also triggers on: 'syllabus reading list', 'find papers for my course', 'create a reading list from this syllabus', 'recent research for my class', 'supplementary readings', 'find journal articles for these topics', 'what recent papers cover this material', 'any new research on these course topics', 'update my syllabus with recent papers'. Even casual mentions when a syllabus is attached should trigger this skill.",
-  "version": "1.0.0",
-  "author": {"name": "Alireza Rezvani", "url": "https://alirezarezvani.com"},
+  "description": "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format + course audience + year range) plus a grouping forcing-options checkpoint before any search runs \u2014 so the reading list matches the course's level and recency need. Parses the syllabus to extract topics and learning outcomes, searches Consensus for recent peer-reviewed papers per topic, and produces a professionally formatted .docx with clickable Consensus links, plain-language summaries calibrated to audience level, and Bloom-higher-order discussion questions tied to course learning goals. Triggers whenever a user uploads a syllabus, course outline, or curriculum document and wants supplementary readings. Also triggers on: 'syllabus reading list', 'find papers for my course', 'create a reading list from this syllabus', 'recent research for my class', 'supplementary readings', 'find journal articles for these topics', 'what recent papers cover this material', 'any new research on these course topics', 'update my syllabus with recent papers'. Even casual mentions when a syllabus is attached should trigger this skill.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/syllabus"],
+  "skills": [
+    "./skills/syllabus"
+  ],
   "source": {
     "spec": "megaprompts/10-syllabus-megaprompt.md",
-    "build_pattern": "Path B (direct conversion). Research-pack shape, BUNDLED-JS-DOCX-GENERATOR variant — ships scripts/generate_reading_list.js for 300+ line DOCX assembly logic (token-efficient: skill doesn't re-derive layout each run).",
+    "build_pattern": "Path B (direct conversion). Research-pack shape, BUNDLED-JS-DOCX-GENERATOR variant \u2014 ships scripts/generate_reading_list.js for 300+ line DOCX assembly logic (token-efficient: skill doesn't re-derive layout each run).",
     "sibling_of": "research/litreview, research/grants, research/patent, research/dossier, research/pulse"
   }
 }

--- a/scripts/sync-codex-skills.py
+++ b/scripts/sync-codex-skills.py
@@ -55,6 +55,18 @@ SKILL_DOMAINS = {
     "finance": {
         "category": "finance",
         "description": "Financial analysis, valuation, and forecasting skills"
+    },
+    "productivity": {
+        "category": "productivity",
+        "description": "Personal-productivity skills - capture, email, reflect"
+    },
+    "marketing": {
+        "category": "marketing",
+        "description": "Top-level marketing slices (landing-page generator)"
+    },
+    "research": {
+        "category": "research",
+        "description": "Research orchestrator + 6 specialists (pulse, litreview, grants, dossier, patent, syllabus, notebooklm)"
     }
 }
 


### PR DESCRIPTION
## Summary

**v2.7.0 release prep.** Resolves the 2 follow-ups left after the v2 megaprompt-to-skill conversion sweep + final polish.

After this merges to `dev` and dev → main PR opens, **v2.7.0 ships**.

## Two follow-ups resolved

### 1. Marketplace registration (`.claude-plugin/marketplace.json`)

| Before | After |
|---|---|
| 43 plugins | 55 plugins |
| 10 categories | 12 categories (new: `productivity`, `research`) |

12 new entries cover 13 skills (email-pair holds inbox-setup + inbox-triage):

| Plugin | Source | Category |
|---|---|---|
| `capture-skill` | `./productivity/capture` | productivity |
| `email-pair` | `./productivity/email` | productivity |
| `reflect-skill` | `./productivity/reflect` | productivity |
| `landing` | `./marketing/landing` | marketing |
| `pulse` | `./research/pulse` | research |
| `litreview` | `./research/litreview` | research |
| `grants` | `./research/grants` | research |
| `dossier` | `./research/dossier` | research |
| `patent` | `./research/patent` | research |
| `syllabus` | `./research/syllabus` | research |
| `notebooklm` | `./research/notebooklm` | research |
| `research-orchestrator` | `./research/research` | research |

Per CLAUDE.md ClawHub rules: `cs-` prefix not used (reserved for ClawHub slug conflicts only).

### 2. Codex sync

- **`.codex/skills/` symlinks**: +11 new (capture + pulse pre-existed)
- **`.codex/skills-index.json`**: 290 → 303 entries
- **`scripts/sync-codex-skills.py`**: Added `productivity/`, `marketing/`, `research/` to `SKILL_DOMAINS` so future auto-sync runs discover the new top-level domains

Manual symlink creation deliberately avoids the script's full --dry-run-flagged 16 [UPDATED] symlinks on pre-existing duplicate-path skills (chief-ai-officer-advisor, chaos-engineering, etc., which have both nested-plugin AND flat paths in the repo). That churn belongs in a separate cleanup PR, not in release prep.

## Final polish

### Version bumps (12 files)
All 12 v2 plugin.json files bumped `1.0.0` → `2.7.0` to align with release.

### CHANGELOG.md
New `[2.7.0]` section documenting:
- All 13 Path-B skills with PR links + megaprompt provenance
- 3 new top-level domain folders (productivity/, marketing/, research/)
- Path-B convention formalization
- Audit verification results

### CLAUDE.md
- "Current Version" bumped 2.6.1 → 2.7.0 with v2.7.0 highlights block
- ClawHub plugin.json schema clarified: `source` + `attribution` formally accepted as approved extension fields (consistent with existing pattern across 13 new v2 skills + 3 engineering Matt-Pocock-derivative plugins)
- ClawHub rule #6: version reference 2.2.0+ → 2.7.0+

## Audit verification (executed before this PR opened)

| Phase | Skill | Result |
|---|---|---|
| Full 8-phase audit | `research/research` (orchestrator) | ✅ PASS WITH WARNINGS — structure 84.1/GOOD, scripts 3/3, security 0 findings |
| Full 8-phase audit (spot-check) | `research/pulse` | ✅ structure 86.4/GOOD, scripts 3/3, security PASS |
| Full 8-phase audit (spot-check) | `research/litreview` | ✅ structure 86.4/GOOD, scripts 3/3, security PASS |
| Full 8-phase audit (spot-check) | `research/notebooklm` | ✅ structure 86.4/GOOD, scripts 3/3, security PASS |
| Bulk audit | 9 remaining skills | ✅ all 79.5-86.4 structure, 0 critical/high security findings |
| Script smoke-test (`--help`) | All 13 skills, 39 scripts | ✅ 39/39 PASS |

**Known false positive:** syllabus security scanner flags HIGH on line 47 of `generate_reading_list.js` — the line is a user-facing error message string `'... npm install docx'` shown when the docx package isn't installed. It is NOT a runtime install. Documented in CHANGELOG.

**Known scoring bias:** Phase 3 quality_scorer scores all research-pack-convention SKILL.mds in the 45-48 F range (orchestrator, pulse, litreview, notebooklm all score similarly). The rubric expects minimal frontmatter + Features/Usage/Examples sections that research-pack convention deliberately doesn't use (it requires 2,200-2,800-word spec-heavy SKILL.md per megaprompt). Not a fix candidate — known rubric mismatch.

## Test plan

- [ ] `marketplace.json`: 55 plugins, valid JSON, all 7 required fields, no duplicate names/sources (verified)
- [ ] `.codex/skills-index.json`: 303 entries, 11 categories, valid JSON (verified)
- [ ] All 13 megaprompt symlinks resolve correctly via `readlink + test -e` (verified)
- [ ] All 12 plugin.json files at version 2.7.0 (verified)
- [ ] CHANGELOG.md `[2.7.0]` section parses and lists all 13 skills with PR links (verified)
- [ ] CLAUDE.md schema doc accepts `source` + `attribution` extras (verified)
- [ ] CI lint + tests + docs gate (pending)
- [ ] CI security scan (pending)
- [ ] CI virustotal scan (pending)
- [ ] CI claude-review (pending)

## Not done in this PR (intentional)

- **dev → main PR**: separate PR after this merges. Final go-live decision rests with maintainer.
- **gemini-sync**: `.gemini/skills/<new>` symlinks. Auto-sync workflow handles on dev merge.
- **Pre-existing duplicate-path symlinks cleanup** (16 skills with nested-plugin + flat paths): separate concern.

https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw)_