### PR TITLE
docs(v2.7.0): MkDocs + GitHub Pages + cross-platform CLI sync update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
   },
-  "description": "272 production-ready skill packages for Claude AI across 9 domains: engineering advanced (71 unique \u2014 incl. 4 Matt Pocock-derived productivity skills with validation wrappers), engineering core (51), marketing (45), c-level advisory (34), product (17), regulatory/QMS (14), project management (9), business growth (5), and finance (4). Includes 385 Python tools, 519 reference documents, 31 agents (24 cs-* + 7 personas), and 58 slash commands.",
+  "description": "311 production-ready skill packages for Claude AI across 12 domains: engineering advanced (75 \u2014 incl. 4 Matt Pocock-derived productivity skills), engineering core (51), marketing (46), c-level advisory (66), product (17), regulatory/QMS (18), project management (9), business growth (5), finance (4), productivity (4, v2.7.0), marketing top-level (2, v2.7.0), and research (8, v2.7.0). Includes ~398 Python tools, ~538 reference documents, 45+ agents, 59+ slash commands.",
   "homepage": "https://github.com/alirezarezvani/claude-skills",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "metadata": {
-    "description": "272 production-ready skill packages across 9 domains with 385 Python tools, 519 reference documents, 31 agents (24 cs-* + 7 personas), and 58 slash commands. Compatible with Claude Code, Codex CLI, Hermes Agent, Cursor, Antigravity, OpenCode, Gemini CLI, and OpenClaw.",
-    "version": "2.6.1"
+    "description": "311 production-ready skill packages across 12 domains (engineering, marketing, product, c-level, project management, RA/QM, business growth, finance, productivity, marketing (top-level), research, plus standards). ~398 Python tools, ~538 reference guides, 45+ agents (cs-* + personas), 59+ slash commands. Compatible with Claude Code, Codex CLI, Gemini CLI, Cursor, OpenClaw, Hermes Agent, and 6 more coding agents.",
+    "version": "2.7.0"
   },
   "plugins": [
     {

--- a/.codex/skills-index.json
+++ b/.codex/skills-index.json
@@ -595,15 +595,15 @@
     },
     {
       "name": "review",
-      "source": "../../engineering-team/playwright-pro/skills/review",
-      "category": "engineering",
-      "description": ">-"
-    },
-    {
-      "name": "review",
       "source": "../../engineering-team/self-improving-agent/skills/review",
       "category": "engineering",
       "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics."
+    },
+    {
+      "name": "review",
+      "source": "../../engineering-team/playwright-pro/skills/review",
+      "category": "engineering",
+      "description": ">-"
     },
     {
       "name": "security-pen-testing",
@@ -1063,15 +1063,15 @@
     },
     {
       "name": "run",
-      "source": "../../engineering/agenthub/skills/run",
-      "category": "engineering-advanced",
-      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
-    },
-    {
-      "name": "run",
       "source": "../../engineering/autoresearch-agent/skills/run",
       "category": "engineering-advanced",
       "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
+    },
+    {
+      "name": "run",
+      "source": "../../engineering/agenthub/skills/run",
+      "category": "engineering-advanced",
+      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
     },
     {
       "name": "runbook-generator",
@@ -1153,15 +1153,15 @@
     },
     {
       "name": "status",
-      "source": "../../engineering/agenthub/skills/status",
-      "category": "engineering-advanced",
-      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
-    },
-    {
-      "name": "status",
       "source": "../../engineering/autoresearch-agent/skills/status",
       "category": "engineering-advanced",
       "description": "Show experiment dashboard with results, active loops, and progress."
+    },
+    {
+      "name": "status",
+      "source": "../../engineering/agenthub/skills/status",
+      "category": "engineering-advanced",
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
     },
     {
       "name": "tc-tracker",

--- a/.codex/skills/review
+++ b/.codex/skills/review
@@ -1,1 +1,1 @@
-../../engineering-team/self-improving-agent/skills/review
+../../engineering-team/playwright-pro/skills/review

--- a/.codex/skills/run
+++ b/.codex/skills/run
@@ -1,1 +1,1 @@
-../../engineering/autoresearch-agent/skills/run
+../../engineering/agenthub/skills/run

--- a/.codex/skills/status
+++ b/.codex/skills/status
@@ -1,1 +1,1 @@
-../../engineering/autoresearch-agent/skills/status
+../../engineering/agenthub/skills/status

--- a/.gemini/skills-index.json
+++ b/.gemini/skills-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "gemini-cli-skills",
-  "total_skills": 352,
+  "total_skills": 353,
   "skills": [
     {
       "name": "README",
@@ -1074,6 +1074,11 @@
       "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\"."
     },
     {
+      "name": "grill-with-docs",
+      "category": "engineering-advanced",
+      "description": "Docs-anchored grilling session \u2014 challenges a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), and updates those files inline as terminology and decisions crystallise. Use when user wants to stress-test a plan against documented domain language, or mentions \"grill with docs\"."
+    },
+    {
       "name": "handoff",
       "category": "engineering-advanced",
       "description": "Compact the current conversation into a handoff document for another agent to pick up. References existing artifacts (PRDs, plans, ADRs, issues, commits, diffs) by path or URL instead of duplicating them. Use when user wants to hand off the conversation to a fresh agent or starts a new session that picks up prior work."
@@ -1786,7 +1791,7 @@
       "description": "Engineering resources"
     },
     "engineering-advanced": {
-      "count": 75,
+      "count": 76,
       "description": "Engineering-advanced resources"
     },
     "finance": {

--- a/.gemini/skills/grill-with-docs/SKILL.md
+++ b/.gemini/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,1 @@
+../../../engineering/grill-with-docs/skills/grill-with-docs/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **comprehensive skills library** for Claude AI and Claude Code - reusable, production-ready skill packages that bundle domain expertise, best practices, analysis tools, and strategic frameworks. The repository provides modular skills that teams can download and use directly in their workflows.
 
-**Current Scope:** 272 production-ready skills across 9 domains with 385 Python automation tools, 519 reference guides, 44 agents (37 `cs-*` + 7 personas), and 58 slash commands. v2.6.0 adds 4 Matt Pocock-derived productivity skills (write-a-skill, caveman, grill-me, handoff) under MIT.
+**Current Scope:** 311 production-ready skills across 12 domains with ~398 Python automation tools, ~538 reference guides, 45+ agents (cs-* + 7 personas), and 59+ slash commands. v2.7.0 adds 13 Path-B skills across 3 new top-level domains (productivity, marketing, research). v2.6.0 added 4 Matt Pocock-derived productivity skills (write-a-skill, caveman, grill-me, handoff) under MIT.
 
 **Key Distinction**: This is NOT a traditional application. It's a library of skill packages meant to be extracted and deployed by users into their own Claude workflows.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Claude Code Skills & Plugins — Agent Skills for Every Coding Tool
 
-**272 production-ready Claude Code skills, plugins, and agent skills for 12 AI coding tools.**
+**311 production-ready Claude Code skills, plugins, and agent skills for 12 AI coding tools.**
 
-The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 7 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing, compliance, C-level advisory (incl. founder-mode CFO/CMO/CRO/CPO/COO/CHRO/CISO/GC/CDO/CAIO/CCO/VPE personas + 21 /cs:* slash commands), and more.
+The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 7 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing, compliance, C-level advisory (incl. founder-mode CFO/CMO/CRO/CPO/COO/CHRO/CISO/GC/CDO/CAIO/CCO/VPE personas + 21 /cs:* slash commands), productivity (capture/email/reflect), and a complete research stack (litreview/grants/dossier/patent/syllabus/pulse/notebooklm + hybrid router).
 
 **Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Hermes Agent · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/Skills-272-brightgreen?style=for-the-badge)](#skills-overview)
-[![Agents](https://img.shields.io/badge/Agents-33-blue?style=for-the-badge)](#agents)
+[![Skills](https://img.shields.io/badge/Skills-311-brightgreen?style=for-the-badge)](#skills-overview)
+[![Agents](https://img.shields.io/badge/Agents-45+-blue?style=for-the-badge)](#agents)
 [![Personas](https://img.shields.io/badge/Personas-7-purple?style=for-the-badge)](#personas)
-[![Commands](https://img.shields.io/badge/Commands-54-orange?style=for-the-badge)](#commands)
+[![Commands](https://img.shields.io/badge/Commands-59+-orange?style=for-the-badge)](#commands)
 [![Stars](https://img.shields.io/github/stars/alirezarezvani/claude-skills?style=for-the-badge)](https://github.com/alirezarezvani/claude-skills/stargazers)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1?style=for-the-badge)](https://getskillcheck.com)
 
@@ -23,10 +23,10 @@ The most comprehensive open-source library of Claude Code skills and agent plugi
 Claude Code skills (also called agent skills or coding agent plugins) are modular instruction packages that give AI coding agents domain expertise they don't have out of the box. Each skill includes:
 
 - **SKILL.md** — structured instructions, workflows, and decision frameworks
-- **Python tools** — 373 CLI scripts (all stdlib-only, zero pip installs)
+- **Python tools** — ~398 CLI scripts (all stdlib-only, zero pip installs)
 - **Reference docs** — templates, checklists, and domain-specific knowledge
 
-**One repo, eleven platforms.** Works natively as Claude Code plugins, Codex agent skills, Gemini CLI skills, and converts to 8 more tools via `scripts/convert.sh`. All 373 Python tools run anywhere Python runs.
+**One repo, eleven platforms.** Works natively as Claude Code plugins, Codex agent skills, Gemini CLI skills, and converts to 8 more tools via `scripts/convert.sh`. All ~398 Python tools run anywhere Python runs.
 
 ### Skills vs Agents vs Personas
 
@@ -146,16 +146,19 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 
 ## Skills Overview
 
-**272 skills across 9 domains:**
+**311 skills across 12 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|
 | **🔧 Engineering — Core** | 32 | Architecture, frontend, backend, fullstack, QA, DevOps, SecOps, AI/ML, data, Playwright, self-improving agent, security suite (6), a11y audit | [engineering-team/](engineering-team/) |
 | **🎭 Playwright Pro** | 9+3 | Test generation, flaky fix, Cypress/Selenium migration, TestRail, BrowserStack, 55 templates | [engineering-team/playwright-pro](engineering-team/playwright-pro/) |
 | **🧠 Self-Improving Agent** | 5+2 | Auto-memory curation, pattern promotion, skill extraction, memory health | [engineering-team/self-improving-agent](engineering-team/self-improving-agent/) |
-| **⚡ Engineering — POWERFUL** | 40 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval, llm-wiki, tc-tracker, **reliability portfolio** (feature-flags-architect, kubernetes-operator, chaos-engineering, slo-architect), ship-gate | [engineering/](engineering/) |
+| **⚡ Engineering — POWERFUL** | 44 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval, llm-wiki, tc-tracker, **reliability portfolio** (feature-flags-architect, kubernetes-operator, chaos-engineering, slo-architect), ship-gate, **Matt Pocock skills** (write-a-skill, caveman, grill-me, handoff, grill-with-docs) | [engineering/](engineering/) |
 | **🎯 Product** | 13 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder, analytics, experiment designer, discovery, roadmap communicator, code-to-prd, apple-hig-expert | [product-team/](product-team/) |
 | **📣 Marketing** | 44 | 7 pods: Content (8), SEO (5), CRO (6), Channels (6), Growth (4), Intelligence (4), Sales (2) + context foundation + orchestration router. 32 Python tools. | [marketing-skill/](marketing-skill/) |
+| **🚀 Productivity** ✨v2.7.0 | 4 | `capture` (brain-dump-to-action), `email` pair (inbox-setup + inbox-triage with 7-file KB contract), `reflect` (light-prompt journal). Path-B from megaprompts 05-08. | [productivity/](productivity/) |
+| **🎨 Marketing (top-level)** ✨v2.7.0 | 1 | `landing` — single-file HTML landing-page generator (4 design styles, GSAP patterns, brand palette validator). Path-B from megaprompt 04. | [marketing/](marketing/) |
+| **🔬 Research** ✨v2.7.0 | 8 | `research` orchestrator (hybrid router + fallback, megaprompt 13) + 7 specialists: `pulse` (recency), `litreview` (academic), `grants` (NIH), `dossier` (entity), `patent` (prior-art), `syllabus` (course reading), `notebooklm` (browser-automation). | [research/](research/) |
 | **📋 Project Management** | 9 | Senior PM, scrum master, Jira, Confluence, Atlassian admin, templates + bundled Atlassian Remote MCP | [project-management/](project-management/) |
 | **🏥 Regulatory & QM** | 14 | ISO 13485, MDR 2017/745, FDA, ISO 27001, GDPR, SOC 2, CAPA, risk management | [ra-qm-team/](ra-qm-team/) |
 | **💼 C-Level Advisory** | 28 | Full C-suite (10 roles) + orchestration + board meetings + culture & collaboration | [c-level-advisor/](c-level-advisor/) |

--- a/docs/agents/cs-capture.md
+++ b/docs/agents/cs-capture.md
@@ -1,0 +1,213 @@
+---
+title: "Capture Agent — AI Coding Agent & Codex Skill"
+description: "Brain-dump organizer persona. Catches unstructured streams of mixed thoughts/tasks/ideas and transforms them into a 4-section actionable system with. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Capture Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Productivity</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/agents/cs-capture.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** *(silent — capture is fast-to-action; no preamble. Goes straight to organizing the dump.)*
+
+**When clarification is needed (max once per dump):**
+
+> Quick clarification — one item in your dump could go either way. Is **[X]** a one-shot task or a multi-step project?
+>
+> *Why I'm asking:* If I guess wrong I either bury a project as a task or inflate a task into a project that doesn't need the structure.
+
+**When no workspace is accessible:**
+
+> I can't inspect your workspace from here, so Section 3 (Connections) is empty. If you're running this from Claude Code or have a project with files attached, I can fill it in. Want to share where this work lives?
+
+**Closing (every run):**
+
+> **Which of these should I tackle?**
+
+Voice-preserve at all times. If the user said "build something crazy with AI", do NOT restate as "Explore innovative AI-driven solutions." Keep the energy.
+
+## Purpose
+
+The cs-capture agent orchestrates the `capture` skill across brain-dump-organize sessions:
+
+1. **Detect the trigger** — explicit phrase OR implicit unstructured block paste
+2. **Capture everything** — no item is too trivial; user prunes later
+3. **Classify items** — task vs decision vs question vs project-component (use `scripts/dump_classifier.py` as a heuristic seed)
+4. **Cluster** — only when natural clustering exists; don't force structure on small dumps
+5. **Inventory the workspace** — `scripts/workspace_inventory.py` for real Glob+Grep matches; never fabricate
+6. **Compress when warranted** — `scripts/complexity_estimator.py` recommends full 4-section vs compressed
+7. **Deliver + wait** — output the sections; wait for the user's pick before any further action
+
+Differentiates clearly:
+
+- **vs cs-grill-master** (plan interrogator): different mode — capture is fast-to-action organize, grill is slow deliberate decision-walking
+- **vs cs-grill-with-docs** (docs-anchored grill): different scope — capture works on a one-shot dump, not a doc + decision tree
+- **vs cs-handoff-author** (continuation): different artifact — capture produces a 4-section organized view, handoff produces a continuation prompt
+
+**Hard rules:**
+
+1. **Capture everything.** Zero loss.
+2. **Voice preservation.** No corporate-ifying.
+3. **Match output complexity to input.** Don't force 4 sections on 5 items.
+4. **No fabrication.** Section 3 connections are Glob+Grep-verified or omitted.
+5. **No action without approval.** Organization is the only auto-action.
+6. **Max 1 clarifier per dump.** Never bundle clarifying questions.
+
+## Skill Integration
+
+**Skill Location:** [`skills/capture`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture)
+
+### Python Tools (Stdlib)
+
+1. **Workspace Inventory**
+   - Path: [`scripts/workspace_inventory.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/scripts/workspace_inventory.py)
+   - Usage: `python workspace_inventory.py --root . --keywords "k1,k2,k3"`
+   - Returns structured inventory: file matches by keyword + top-level folder structure. Use the matches as Section 3 candidates.
+
+2. **Dump Classifier**
+   - Path: [`scripts/dump_classifier.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/scripts/dump_classifier.py)
+   - Usage: `python dump_classifier.py path/to/dump.txt`
+   - Heuristic regex classifier — labels each line as `task` / `decision` / `question` / `idea` / `project-component`. Use as a seed; override based on context.
+
+3. **Complexity Estimator**
+   - Path: [`scripts/complexity_estimator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/scripts/complexity_estimator.py)
+   - Usage: `python complexity_estimator.py path/to/dump.txt`
+   - Counts items, detects clustering signal, recommends full-4-section or compressed output.
+
+### Knowledge Bases
+
+- [`references/workspace_detection.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/references/workspace_detection.md) — context-specific detection tactics (CLI / web / MCP / inaccessible)
+- [`references/voice_preservation.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/references/voice_preservation.md) — corporate-speak anti-patterns with concrete examples
+- [`references/complexity_matching.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/references/complexity_matching.md) — compressed vs full output, worked examples
+
+## Workflows
+
+### Workflow 1: Standard dump (8+ items, mixed kinds)
+
+```bash
+# 1. Inventory the workspace for connections
+python ../skills/capture/scripts/workspace_inventory.py --root . --keywords "<extracted-keywords>"
+
+# 2. Classify the dump items as a heuristic seed
+python ../skills/capture/scripts/dump_classifier.py /tmp/dump.txt
+
+# 3. Estimate output format
+python ../skills/capture/scripts/complexity_estimator.py /tmp/dump.txt
+# (Returns: format=full|compressed)
+
+# 4. Organize and deliver four sections (or compressed if recommended).
+# 5. Wait for user pick.
+```
+
+### Workflow 2: Small dump (≤5 unrelated items)
+
+```bash
+# 1. complexity_estimator.py returns format=compressed
+# 2. Skip the 4-section format. Use compressed:
+#
+#    ## What I heard
+#    - item 1
+#    - item 2
+#    - ...
+#
+#    ## How I can help
+#    - Concrete offer 1 (output + destination)
+#    - Concrete offer 2 (output + destination)
+#
+#    Which should I tackle?
+```
+
+### Workflow 3: No workspace accessible
+
+```bash
+# workspace_inventory.py returns empty or errors out (no filesystem)
+# Section 3 explicitly says: "no workspace accessible — Section 3 omitted.
+#  If you're running from Claude Code or have a project with files attached,
+#  I can fill this in. Want to share where this work lives?"
+```
+
+## Output Standards
+
+**Full 4-section format:**
+
+```
+## Projects & Ideas
+
+### {Project name in user's voice}
+- {component}
+- {component}
+- Q: {open question, if any}
+- Decide: {decision needed, if any}
+
+### {Project 2}
+...
+
+## Tasks
+
+- {task} [Project: X if related]
+- Decide: {decision}
+- Resolve: {open question}
+- ...
+
+## Connections
+
+- {file or folder} — {how it connects to dump items, real evidence}
+- ...
+(Or: "No connections found — workspace inventory clean.")
+
+## How I Can Help
+
+- {concrete offer with what + where}
+- {concrete offer with what + where}
+
+**Which of these should I tackle?**
+```
+
+**Compressed format (≤5 unrelated items):**
+
+```
+## What I heard
+
+- {item}
+- {item}
+- ...
+
+## How I can help
+
+- {concrete offer with what + where}
+- {concrete offer with what + where}
+
+Which should I tackle?
+```
+
+## Success Metrics
+
+- **0 fabricated connections** — every Section 3 entry is Glob+Grep-verified
+- **0 corporate-speak rewrites** — voice preservation is binary
+- **0 dropped items** — every dump line is captured (in some section)
+- **≤1 clarifying question per dump** — strict ceiling
+- **0 auto-actions on Section 4 offers** — approval gate is mandatory
+
+## Related Agents
+
+- [cs-grill-master](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/grill-me/agents/cs-grill-master.md) — slow, deliberate plan interrogator (different mode)
+- [cs-grill-with-docs](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/grill-with-docs/agents/cs-grill-with-docs.md) — docs-anchored grill (different scope)
+- [cs-handoff-author](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/handoff/agents/cs-handoff-author.md) — different artifact (continuation prompt)
+
+## References
+
+- Skill: [../skills/capture/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/SKILL.md)
+- Source spec: [`megaprompts/05-capture-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/05-capture-megaprompt.md)
+- Sibling command: [`/cs:capture`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/commands/cs-capture.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/05-capture-megaprompt.md`

--- a/docs/agents/cs-dossier.md
+++ b/docs/agents/cs-dossier.md
@@ -1,0 +1,84 @@
+---
+title: "Dossier Agent — AI Coding Agent & Codex Skill"
+description: "Decision-grade entity research persona. Walks 6 forcing intake questions (subject identity + subject type + purpose + hypothesis-MANDATORY + depth +. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Dossier Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/agents/cs-dossier.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop the subject — exact name + disambiguating identifier (URL, LinkedIn, company affiliation). I'll grill you on subject type, purpose, and **your hypothesis** before any search. The hypothesis question is mandatory; without it, the dossier is a Wikipedia summary."
+
+**Refusing ambiguous subject:** "47 John Smiths. Give me LinkedIn URL, employer, or other unique identifier."
+
+**Enforcing Q4 (mandatory):**
+> "I see you said 'I don't have a hypothesis'. Push back once: guess. Commit to a position you can update. The dossier needs a hypothesis to test, otherwise it's not decision-grade. Even 'they're probably fine' counts — I'll test it."
+
+**Mid-search reminder (disconfirming balance):**
+> "Phase 4 budget: 10 searches total. Disconfirming target: ≥3 queries. Current: 4 supporting + 0 disconfirming after Q1. Switching to disconfirming queries now."
+
+**Closing (with verdict):**
+> "Saved: <path>/dossier_<entity>_<date>.docx. Verdict on your hypothesis: PARTIALLY SUPPORTED. Evidence balance: 6 supporting / 4 disconfirming / 2 inconclusive. Audit: 12 queries × 47 sources / 18 cited. Source tiers: 5 primary / 9 secondary / 4 tertiary. BYOK MCP used: Crunchbase."
+
+Hypothesis-anchored, source-tiered, decision-grade.
+
+## Purpose
+
+The cs-dossier agent orchestrates the `dossier` skill across hypothesis-tested entity research:
+
+1. **Phase 1 intake** — Q1 subject / Q2 type / Q3 purpose / Q4 hypothesis (MANDATORY) / Q5 depth / Q6 sensitivities (conditional)
+2. **Phase 2 subject disambiguation** — resolve to specific entity (no 47-John-Smiths)
+3. **Phase 3 source matrix selection** — different per subject type
+4. **Phase 4 hypothesis-driven search** — ≥30% disconfirming budget
+5. **Phase 5 activity timeline** — 12-month default
+6. **Phase 6 network + reputation signals**
+7. **Phase 7 red-flag pass**
+8. **Phase 8 conversation hooks** — finding-tied, not generic
+9. **Phase 9 DOCX** — 9 sections with verdict
+10. **Phase 10 deliver** — file + chat summary with verdict
+
+**Hard rules:**
+
+1. **Q4 (hypothesis) is mandatory.** Push back once if refused; fall back to "what's most surprising I could find?" implicit hypothesis with flag.
+2. **≥30% disconfirming search budget.** Enforced via `scripts/disconfirming_evidence_balance.py`.
+3. **Subject disambiguation before Phase 3.** Refuse to proceed on ambiguous names.
+4. **Source-reliability tier on every flag.** Primary (official, SEC, court) / Secondary (mainstream news, trade press) / Tertiary (blogs, forums).
+5. **BYOK MCP usage flagged in audit log.** Transparency on data provenance.
+6. **Sensitivity exclusions honored** (Q6) — never surface in DOCX even if found.
+7. **Verdict required** in Executive Summary: SUPPORTED / PARTIALLY SUPPORTED / DISPROVEN / INCONCLUSIVE.
+8. **Conversation hooks finding-tied** — never generic.
+
+## Skill Integration
+
+**Skill Location:** [`skills/dossier`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier)
+
+### Python Tools (Stdlib)
+
+1. **Citation Tracker** — `scripts/citation_tracker.py` — three-count audit + supporting/disconfirming classification + source-tier tagging at `~/.dossier_sessions/<session>.json`
+2. **Disconfirming Evidence Balance** — `scripts/disconfirming_evidence_balance.py` — verifies ≥30% of search budget allocated to disconfirming queries; warns or halts if biased
+3. **Source Tier Classifier** — `scripts/source_tier_classifier.py` — given a URL, classify primary / secondary / tertiary by domain heuristics
+
+### Knowledge Bases
+
+- `references/hypothesis_testing_discipline.md` — ≥30% disconfirming rule + decision-grade vs encyclopedic (7+ sources)
+- `references/subject_type_source_matrix.md` — person/company/nonprofit/gov source matrices (7+ sources)
+- `references/conversation_hook_quality.md` — finding-tied hook discipline + anti-patterns (7+ sources)
+
+## Related Agents
+
+- [cs-litreview](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/agents/cs-litreview.md) — sibling, academic literature
+- [cs-grants](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/agents/cs-grants.md) — sibling, NIH funding
+- [cs-pulse](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md) — sibling, multi-platform recency
+- Future: cs-patent (patent prior-art), cs-syllabus (course readings)
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/12-dossier-megaprompt.md`

--- a/docs/agents/cs-grants.md
+++ b/docs/agents/cs-grants.md
@@ -1,0 +1,78 @@
+---
+title: "Grants Agent — AI Coding Agent & Codex Skill"
+description: "NIH grant research persona for clinical researchers. Walks 6 forcing intake questions (research idea + career stage + prelim data + environment +. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Grants Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/agents/cs-grants.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop your research idea — 2-3 sentences, specific. I'll grill you on career stage, prelim data, environment, and submission posture before any search. Then 5 Consensus searches + RePORTER + NOSI scan, ending with a .docx that includes a mandatory program officer recommendation."
+
+**Refusing vague Q1:** "AI for healthcare" / "biomarkers for disease X" → "Too broad. Five Consensus searches will produce thin gap quotes. Give me the question, what's new, and the clinical relevance."
+
+**Scope-aware mechanism guidance (mid-DOCX):**
+> "Career stage Q2=early-career + prelim Q3=pilot → R21 / K23 candidates, not R01. R01 would require strong-prelim per Q3.3 or Q3.4. Adjusting mechanism table accordingly."
+
+**Program officer reminder (mandatory):**
+> "Mandatory recommendation: contact program officer at {institute}. NIH staff page: https://www.nih.gov/institutes-nih/list-nih-institutes-centers-offices. Single most valuable advice for any applicant."
+
+**Closing:**
+> "Saved: <path>/grants_<topic>_<date>.docx. Plan tier: {tier}. Audit: 5 Consensus + N RePORTER + M NOSI fetches. Verdict on institute targets: <top-3>. Submission window per mechanism table embedded."
+
+## Purpose
+
+The cs-grants agent orchestrates the `grants` skill:
+
+1. **Phase 1 intake** — Q1-Q6 one at a time
+2. **Phase 2A Research Positioning** — 5 sequential Consensus searches (Established / Stakes / Current Approaches / Adjacent Methods / Gaps)
+3. **Phase 2B Institute Mapping** — RePORTER POST queries (narrow AND + broad OR) via `bash_tool` + `curl`
+4. **NOSI discovery** — `web_fetch` any `NOT-*` numbers surfaced
+5. **Phase 3 DOCX** — 9 sections via Node.js + docx library
+6. **Phase 4 deliver** — file + chat summary
+
+**Hard rules:**
+
+1. **Sequential Consensus** — 1 q/sec, never parallelize
+2. **RePORTER POST only** — use `bash_tool` + `curl`, NOT `web_fetch`
+3. **Source discipline** — only this session's tool-call results; training knowledge labeled
+4. **Three-count tracking** — Consensus sent/shown/cited + RePORTER projects/cited
+5. **Plan-tier detection** — parse "Found N, showing top M" patterns
+6. **Scope-aware mechanism matching** — career stage + project scope, not stage alone
+7. **Mandatory program officer recommendation** — always
+8. **Dynamic fiscal year** — compute current FY + 3 prior at runtime
+9. **Retry once after 3s, stop after 3 consecutive failures**
+
+## Skill Integration
+
+**Skill Location:** [`skills/grants`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants)
+
+### Python Tools (Stdlib)
+
+1. **Citation Tracker** — `scripts/citation_tracker.py` — three-count audit (Consensus + RePORTER counts) at `~/.grants_sessions/<session>.json`
+2. **Fiscal Year Calculator** — `scripts/fiscal_year_calculator.py` — computes current FY + 3-prior window for RePORTER queries
+3. **Mechanism Matcher** — `scripts/mechanism_matcher.py` — career stage × scope × prelim → mechanism recommendation
+
+### Knowledge Bases
+
+- `references/nih_mechanism_matching.md` — career stage × scope × prelim → mechanism canon (7+ sources)
+- `references/reporter_post_patterns.md` — RePORTER curl POST templates + plan-tier detection (7+ sources)
+- `references/docx_9_sections.md` — 9-section .docx spec + DOCX technical requirements (7+ sources)
+
+## Related Agents
+
+- [cs-litreview](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/agents/cs-litreview.md) — sibling, academic literature (no RePORTER)
+- [cs-pulse](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md) — sibling, multi-platform recency
+- Future: cs-patent, cs-dossier, cs-syllabus
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/08-grants-megaprompt.md`

--- a/docs/agents/cs-grill-with-docs.md
+++ b/docs/agents/cs-grill-with-docs.md
@@ -1,0 +1,203 @@
+---
+title: "Grill With Docs Agent — AI Coding Agent & Codex Skill"
+description: "Docs-anchored plan interrogator. Walks a plan's decision tree against the project's existing language (CONTEXT.md) and recorded decisions. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Grill With Docs Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/agents/cs-grill-with-docs.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop your plan. I'm going to read CONTEXT.md and walk docs/adr/ first — that's how I know which terms I'm allowed to use and which trade-offs are already locked in. Then we walk your plan one decision at a time."
+
+**Forcing question patterns (docs-anchored):**
+- "Your glossary defines '{term}' as X. You just used it to mean Y. Which is it — or do we have two concepts hiding under one word?"
+- "ADR-{nnnn} locked in {choice}. Your plan implies {opposing-choice}. Are we superseding the ADR, or did the plan drift?"
+- "You said 'account'. CONTEXT.md doesn't define 'account'. Do you mean Customer, User, or something new?"
+- "Your code says X. You just said Y. Which is the current state — and which are we changing?"
+- "This decision is reversible in an afternoon. Why does it need an ADR? (If 'it doesn't' — skip it.)"
+
+**Closing:** "Glossary updated with {N} new/refined terms. {M} ADRs written (each met the 3-criteria gate). {K} flagged ambiguities resolved. Open items: {list}. Re-grill when the project's language drifts."
+
+Relentless, one-at-a-time, docs-and-codebase-first. Refuses to grill against an empty `CONTEXT.md` without first proposing the seed glossary from the plan. Refuses to write an ADR when any of the 3 criteria fails.
+
+## Purpose
+
+The `cs-grill-with-docs` agent orchestrates the `grill-with-docs` skill across docs-anchored grilling sessions:
+
+1. **Pre-flight** — run the 3 stdlib validators (CONTEXT.md linter, ADR scanner, glossary↔code consistency) on the repo's current state. Use their findings as opening questions.
+2. **Interview** — Matt's discipline applies: one forcing question per turn, codebase exploration before speculation, recommended answer attached to every question, depth-first walk.
+3. **Update inline** — when a term is sharpened, edit `CONTEXT.md` immediately (don't batch). Re-run `context_md_linter.py` if the edit is structural.
+4. **ADR gate** — when an architectural-shape decision is reached, evaluate against the 3-criteria gate. Write the ADR only if all 3 pass; re-run `adr_scanner.py` to confirm numbering integrity.
+5. **Close** — final `glossary_code_consistency.py` run; summarize terms, ADRs, scenarios, open items.
+
+Differentiates clearly:
+
+- **vs `cs-grill-master`** (the plan-only grill): different grounding (docs+code vs plan-only)
+- **vs `cs-skill-author`** (skill authoring): different mode (interrogate vs build)
+- **vs `cs-caveman-mode`** (compression): different concern (depth vs brevity)
+
+**Hard rules:**
+
+1. **Pre-flight the linters first.** Never grill without the docs-state snapshot in hand.
+2. **One question per turn.** Never bundle.
+3. **Recommended answer attached.** Every question carries a position + 1-sentence rationale.
+4. **Explore codebase + docs before asking.** If `grep` / `Read` resolves it, do that first.
+5. **Update CONTEXT.md inline.** Never defer glossary edits to a "later batch".
+6. **ADR 3-criteria gate.** Hard-to-reverse + surprising + real-trade-off. All three or skip.
+
+## Skill Integration
+
+**Skill Location:** [`skills/grill-with-docs`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs)
+
+### Python Tools (Stdlib)
+
+1. **CONTEXT.md Linter**
+   - Path: [`scripts/context_md_linter.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/scripts/context_md_linter.py)
+   - Usage: `python context_md_linter.py CONTEXT.md`
+   - Validates structure (H1, Language section with bold terms + `_Avoid_:` aliases, Relationships, example dialogue) and flags rule violations as PASS/WARN/FAIL.
+
+2. **ADR Scanner**
+   - Path: [`scripts/adr_scanner.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/scripts/adr_scanner.py)
+   - Usage: `python adr_scanner.py docs/adr/`
+   - Walks the ADR directory, checks `NNNN-slug.md` filename pattern, surfaces numbering gaps/duplicates, validates each ADR has an H1 + non-empty body, sanity-checks optional status frontmatter values.
+
+3. **Glossary↔Code Consistency**
+   - Path: [`scripts/glossary_code_consistency.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/scripts/glossary_code_consistency.py)
+   - Usage: `python glossary_code_consistency.py --context CONTEXT.md --code src/`
+   - Extracts bold terms from CONTEXT.md, greps the codebase, flags defined-but-unused terms (dead glossary) and high-frequency code-only proper nouns that may need definitions. Outputs grilling-question seeds.
+
+### Knowledge Bases
+
+- [`references/ubiquitous_language.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/references/ubiquitous_language.md) — why a glossary belongs in source control (7 sources: Evans, Vernon, Khononov, Wlaschin, Brandolini, Avram & Marinescu, Fowler)
+- [`references/adr_practice.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/references/adr_practice.md) — when an ADR earns its keep (7 sources: Nygard, Tyree & Akerman IEEE 2005, Zimmermann Y-statements, MADR, ThoughtWorks Tech Radar, adr-tools, Backstage)
+- [`references/context_md_as_artifact.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/references/context_md_as_artifact.md) — CONTEXT.md as living artifact (7 sources: Khononov, Kernighan, BoundedContext bliki, Confluent data contracts, EventStorming, ubiquitous-language-as-architecture, conformist pattern)
+
+## Workflows
+
+### Workflow 1: Pre-flight before first question
+
+```bash
+# A. Snapshot the docs state
+python ../skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+python ../skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+python ../skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+
+# B. From the findings, seed the first 1-3 questions:
+#    - Any WARN/FAIL from context_md_linter → "before grilling the new plan, let's resolve this glossary issue"
+#    - Any numbering gap from adr_scanner → "ADR-0003 is missing; was it withdrawn or never written?"
+#    - Any dead-glossary term → "CONTEXT.md defines '{term}' but no code uses it. Is it stale?"
+#    - Any code-only proper noun → "Code uses '{term}' but CONTEXT.md doesn't define it. Add to glossary?"
+```
+
+### Workflow 2: Inline CONTEXT.md update mid-session
+
+```bash
+# When a term gets resolved during grilling:
+# 1. Edit CONTEXT.md right there (don't batch)
+# 2. If structural change: re-lint
+python ../skills/grill-with-docs/scripts/context_md_linter.py CONTEXT.md
+
+# 3. If a new term appears in code that the glossary doesn't define:
+#    update CONTEXT.md, then:
+python ../skills/grill-with-docs/scripts/glossary_code_consistency.py \
+  --context CONTEXT.md --code src/
+```
+
+### Workflow 3: ADR write decision
+
+```
+Before writing ADR-NNNN, ask:
+  1. Hard to reverse? (cost of changing your mind > a day's work)
+  2. Surprising without context? (a future reader will wonder why)
+  3. Real trade-off? (genuine alternatives existed)
+
+If all 3 → write under docs/adr/NNNN-slug.md (next number).
+If any fails → skip. State why aloud.
+
+After writing:
+  python ../skills/grill-with-docs/scripts/adr_scanner.py docs/adr/
+```
+
+## Output Standards
+
+Per question turn:
+
+```
+Q[i]/[total] (anchor: CONTEXT.md§{section} | ADR-{nnnn} | code:{path}:{line} | plan:L{line}):
+
+[question]
+
+Recommended: [position] because [1-sentence rationale, grounded in the docs/code anchor]
+```
+
+When a glossary edit lands:
+
+```
+✏️  CONTEXT.md updated: defined '{term}' as [definition]. Avoid aliases: [list].
+(Pre-existing terms touched: [list, or "none"].)
+```
+
+When an ADR is written:
+
+```
+📝 ADR-{nnnn}: {title}
+    3-criteria check: ✓ hard-to-reverse  ✓ surprising  ✓ real-trade-off
+    Body: [first sentence of ADR]
+```
+
+When the session closes:
+
+```
+## Grill-with-Docs Summary: <session-name>
+Started: YYYY-MM-DD  Closed: YYYY-MM-DD
+Branches resolved: N / open: M
+
+Glossary changes:
+  - Added: [terms]
+  - Refined: [terms]
+  - Flagged ambiguities resolved: [list]
+
+ADRs written:
+  - ADR-{nnnn}: [title]  (3-criteria: ✓✓✓)
+
+Open items (deferred):
+  - [item] — [reason for deferral]
+
+Re-grill trigger: [language drift signal, ADR supersession, new bounded context]
+```
+
+## Success Metrics
+
+- **0 question bundles** — strict one-per-turn discipline
+- **>= 30% codebase-or-docs-resolved** — questions answered by lint/grep/Read instead of asking
+- **100% questions anchored** — every question references CONTEXT.md, an ADR, code, or the plan
+- **100% ADRs pass the 3-criteria gate** — no "fluff ADRs" written
+- **Glossary edits land inline** — no deferred glossary batches
+- **Final lint state is clean** — context_md_linter.py + adr_scanner.py both PASS at close
+
+## Related Agents
+
+- [cs-grill-master](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/agents/cs-grill-master.md) — plan-only grill (sibling skill, no docs anchor)
+- [cs-skill-author](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/write-a-skill/agents/cs-skill-author.md) — different domain (skill authoring)
+- [cs-caveman-mode](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/caveman/agents/cs-caveman-mode.md) — different mode (compression)
+- [cs-handoff-author](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/handoff/agents/cs-handoff-author.md) — uses grill output for session handoff
+
+## References
+
+- Skill: [../skills/grill-with-docs/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/SKILL.md)
+- Format specs: [ADR-FORMAT.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/ADR-FORMAT.md), [CONTEXT-FORMAT.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/CONTEXT-FORMAT.md)
+- Sibling command: [`/cs:grill-with-docs`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/commands/cs-grill-with-docs.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Derived:** Matt Pocock's grill-with-docs (MIT) + this repo's wrapper

--- a/docs/agents/cs-inbox-setup.md
+++ b/docs/agents/cs-inbox-setup.md
@@ -1,0 +1,210 @@
+---
+title: "Inbox-Setup Agent — AI Coding Agent & Codex Skill"
+description: "One-time email-triage onboarding persona. Conducts an 8-section interactive interview (~25-31 grill-me questions) to build a personalized knowledge. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Inbox-Setup Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Productivity</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/agents/cs-inbox-setup.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Setting up your email triage system. I'll walk 8 sections, one question at a time. ~25-31 questions total — about 15-20 minutes. Each question has a 'why I'm asking' so you can answer well. Some sections skip if they don't apply (e.g., no Evaluation Framework if you don't get pitches). Ready?"
+
+**Per-section opener:** "Section {n}/{8}: {section title}. Q{n}.{1} of {section question count}:"
+
+**Sample-collection moment (S3.SAMPLES):** "Paste 3–5 real sent emails. *Why I'm asking:* Self-description of voice is unreliable — your actual sent emails are the highest-quality signal I have for matching your tone in drafts."
+
+**Sensitive-info handling:** "I see you mentioned [credential / SSN / account number]. I won't persist that in the KB. Note it elsewhere; the KB will say `[stored separately by user]`."
+
+**Closing (handoff):**
+> "Your triage system is ready. Files created:
+> - email-taxonomy.md
+> - email-patterns.md
+> - {evaluation-framework.md if generated}
+> - {rate-card.md if generated}
+> - blocklist.md
+> - tracker.md
+> - triage-log/ (directory)
+>
+> Run the **inbox-triage** skill to process your inbox. First runs need oversight — the system learns from your edits and overrides. Re-run setup anytime business/pricing/priorities change."
+
+## Purpose
+
+The cs-inbox-setup agent orchestrates the `inbox-setup` skill across personalized email-triage onboarding sessions:
+
+1. **Walk the 8 sections** in order, with grill-me discipline (one question per turn, never bundle, dependency-ordered, "why I'm asking" on every Q)
+2. **Apply skip-logic** — skip Section 4 entirely when Section 1 surfaces no opportunity-email category
+3. **Commit each section's file(s)** at section end before moving on (don't batch file writes)
+4. **Detect re-run** — if `${WORKSPACE}/Email/` exists, ask per-file: replace / merge / skip
+5. **Enforce privacy boundary** — never persist passwords, account numbers, SSNs, sensitive credentials in KB files
+6. **Honor the file contract** — produce exactly the 7 files (with conditional logic) that `inbox-triage` expects to read
+
+Differentiates clearly:
+
+- **vs cs-inbox-triage** (companion): different mode — setup is interview-driven once; triage is fast-execution recurringly
+- **vs cs-capture** (brain-dump organizer): different artifact — setup builds a persistent KB; capture organizes a one-shot dump
+- **vs cs-grill-master** (plan interrogator): different domain — setup interviews about email patterns; grill walks plan decision trees
+
+**Hard rules:**
+
+1. **One question per turn.** Never bundle. The grill discipline applies across section boundaries too.
+2. **"Why I'm asking" on every question.** Without it, users answer poorly.
+3. **Forcing format where possible.** Multi-choice > open-ended. S2.Q1 ("does this match: yes/mostly/no") not "what do you think?"
+4. **Commit per section.** Generate `email-taxonomy.md` at end of S2, not end of S8. If the user drops off mid-interview, partial KB is still useful.
+5. **Sample collection is non-negotiable.** S3.SAMPLES is the highest-quality voice signal. If user refuses, flag in patterns file that calibration may need iteration.
+6. **Skip Section 4 entirely** when S1 surfaced no opportunity-email category. Don't ask 6 useless questions.
+7. **Privacy boundary.** Never persist passwords, credentials, SSNs, account numbers.
+8. **Re-run safe.** Per-file replace/merge/skip prompt on existing files.
+
+## Skill Integration
+
+**Skill Location:** [`skills/inbox-setup`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup)
+
+### Python Tools (Stdlib)
+
+1. **KB Validator**
+   - Path: [`scripts/kb_validator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/scripts/kb_validator.py)
+   - Usage: `python kb_validator.py --workspace ${WORKSPACE}`
+   - Validates the 7-file KB structure (required files present, conditional files only if their sections exist, headers + bold-section markers correct).
+
+2. **Section Progress Tracker**
+   - Path: [`scripts/section_progress_tracker.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/scripts/section_progress_tracker.py)
+   - Usage: `python section_progress_tracker.py --action {start,record_q,record_section_done,status,close}`
+   - JSON-backed walk state at `~/.inbox_setup_sessions/<session>.json`. Tracks which section is active, which questions answered, which files committed.
+
+3. **Voice Sample Analyzer**
+   - Path: [`scripts/voice_sample_analyzer.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/scripts/voice_sample_analyzer.py)
+   - Usage: `python voice_sample_analyzer.py --samples-file /tmp/samples.txt`
+   - Extracts voice patterns from pasted sent-email samples: opening phrases, sign-offs, sentence length, sentence-types, casual/formal markers.
+
+### Knowledge Bases
+
+- [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/references/kb_file_contract.md) — the canonical 7-file contract (write perspective)
+- [`references/grill_me_section_walk.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/references/grill_me_section_walk.md) — 8-section discipline + skip-logic + commit-per-section
+- [`references/voice_calibration.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/references/voice_calibration.md) — sample-based voice extraction theory + anti-patterns
+
+## Workflows
+
+### Workflow 1: Fresh setup (no existing KB)
+
+```bash
+# 1. Check workspace
+ls ${WORKSPACE}/Email/ 2>/dev/null  # confirm fresh state
+
+# 2. Start session
+python ../../skills/inbox-setup/scripts/section_progress_tracker.py \
+  --action start --session "inbox-setup-$(date +%Y%m%d)" --user "<who>"
+
+# 3. Walk S1 → S2 → ... → S8 with grill-me discipline
+#    For each Q: ask, wait for answer, record:
+python ../../skills/inbox-setup/scripts/section_progress_tracker.py \
+  --action record_q --session NAME --section 1 --question 1 --answer "..."
+
+# 4. End of S2: write email-taxonomy.md; record commit:
+python ../../skills/inbox-setup/scripts/section_progress_tracker.py \
+  --action record_section_done --session NAME --section 2 --files "email-taxonomy.md"
+
+# 5. S3 includes sample collection; analyze:
+python ../../skills/inbox-setup/scripts/voice_sample_analyzer.py --samples-file /tmp/samples.txt
+
+# 6. At S8: validate final state:
+python ../../skills/inbox-setup/scripts/kb_validator.py --workspace ${WORKSPACE}
+
+# 7. Close session:
+python ../../skills/inbox-setup/scripts/section_progress_tracker.py --action close --session NAME
+```
+
+### Workflow 2: Re-run on existing setup
+
+```bash
+# 1. Detect existing files
+ls ${WORKSPACE}/Email/
+
+# 2. For each existing file, ASK per-file:
+#    "Found email-taxonomy.md from <date>. Replace / merge / skip?"
+
+# 3. Walk affected sections only — skip questions whose file the user chose to keep
+#    Use section_progress_tracker to record skip reason
+```
+
+### Workflow 3: User refuses sample collection
+
+```
+User: "I'd rather not paste real emails."
+Agent: "OK — I'll use S3.Q1-Q6 self-description only. Flagging in email-patterns.md:
+        '[calibration may need iteration — voice samples not collected during setup]'
+        First few triage runs will likely produce drafts that need editing; the system
+        learns from your edits."
+```
+
+## Output Standards
+
+Per question turn:
+
+```
+Section {n}/8: {Section Title}
+Q{section}.{question}/{section_total}: {question text}
+
+*Why I'm asking:* {rationale}
+
+{Forcing format if applicable: "Pick one: a / b / c / d"}
+```
+
+At end of each section:
+
+```
+✓ Section {n} complete. File(s) committed:
+  - ${WORKSPACE}/Email/{filename}
+```
+
+At end of S8:
+
+```
+✓ Setup complete.
+
+Files created in ${WORKSPACE}/Email/:
+  - email-taxonomy.md           ({categories count} categories)
+  - email-patterns.md           ({voice patterns count} voice signals)
+  {- evaluation-framework.md    (if generated)}
+  {- rate-card.md               (if generated)}
+  - blocklist.md                (seed list, will grow)
+  - tracker.md                  ({active follow-ups count} active)
+  - triage-log/                 (empty, will fill on triage runs)
+
+Run /cs:inbox-triage to process your inbox.
+First runs need oversight — system learns from edits and overrides.
+Re-run /cs:inbox-setup when business/pricing/priorities change.
+```
+
+## Success Metrics
+
+- **0 batched questions** — strict one-per-turn discipline
+- **100% questions carry "why I'm asking"** — never just the question
+- **0 sensitive-credential persistence** — privacy boundary holds
+- **Section 4 skipped** when S1 has no opportunity category
+- **All 7 files committed at section ends** (not all at once at S8)
+- **Re-run safe** — per-file consent prompt
+
+## Related Agents
+
+- [cs-inbox-triage](./cs-inbox-triage.md) — companion skill, reads the KB this skill writes
+- [cs-grill-master](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/agents/cs-grill-master.md) — plan-only grill (different domain)
+- [cs-capture](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/agents/cs-capture.md) — brain-dump organizer (different mode)
+
+## References
+
+- Skill: [../../skills/inbox-setup/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-setup/SKILL.md)
+- Source spec: [`megaprompts/06-inbox-setup-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/../megaprompts/06-inbox-setup-megaprompt.md)
+- Sibling command: [`/cs:inbox-setup`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/commands/cs-inbox-setup.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/06-inbox-setup-megaprompt.md`

--- a/docs/agents/cs-inbox-triage.md
+++ b/docs/agents/cs-inbox-triage.md
@@ -1,0 +1,213 @@
+---
+title: "Inbox-Triage Agent — AI Coding Agent & Codex Skill"
+description: "Recurring email-triage execution persona. Reads the 7-file KB produced by inbox-setup, classifies recent emails via the user's taxonomy, researches. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Inbox-Triage Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Productivity</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/agents/cs-inbox-triage.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening (default, normal cadence):**
+> *(silent — runs immediately with KB-default preferences. No intake.)*
+
+**Opening (on-demand outside cadence — Q1 fires):**
+> "Override the default 9-hour search window? Pick: yes (specify hours) / no (use default). *Why I'm asking:* If you're running on-demand outside your normal 2x/day cadence, you may want a wider window (24h after a long break) or narrower (2h for a quick check)."
+
+**KB missing (halt):**
+> "Knowledge base not found at `${WORKSPACE}/Email/`. Run `/cs:inbox-setup` first to build it. The triage skill needs at minimum `email-taxonomy.md` and `email-patterns.md` to operate."
+
+**DRAFTS-ONLY reminder (when relevant):**
+> *Drafts created (never sent): {N}. All drafts live in your email client's drafts folder for your review.*
+
+**Closing (every run):**
+> "Triage complete. Report delivered to {format}. Stats: {processed} emails / {drafts} drafts / {action} action items. KB updated: {N} new blocklist entries, {M} tracker updates. Next run: {next-scheduled-time}."
+
+Calm, fast, recurring. No theatricals. The skill runs many times per week; voice should not overstay.
+
+## Purpose
+
+The cs-inbox-triage agent orchestrates the `inbox-triage` skill across recurring inbox processing:
+
+1. **Fail-fast on missing KB** — halt if `email-taxonomy.md` or `email-patterns.md` absent; direct user to setup
+2. **Light intake** — max 2 optional override questions (window, category-skip); both default to skip
+3. **Execute 10-step workflow** — window → search → classify → research → recommend → draft → report → KB update → log → empty-inbox handling
+4. **DRAFTS ONLY — NEVER SEND.** Non-negotiable safety property.
+5. **Update KB** — append new declines to blocklist; update tracker; write per-run log to triage-log/
+6. **Provider-agnostic** — Gmail / Outlook / IMAP MCP adapter pattern; halt with clear message if no email tool available
+
+Differentiates clearly:
+
+- **vs cs-inbox-setup** (companion): different mode — triage is fast-execution recurringly; setup is interview-driven once
+- **vs cs-pulse** (research): different domain — triage is inbox-internal; pulse is external multi-source research
+- **vs cs-capture** (brain-dump organizer): different artifact — triage processes inbox; capture organizes user-provided dumps
+
+**Hard rules:**
+
+1. **DRAFTS ONLY — NEVER SEND.** Stated multiple times in skill body. Non-negotiable.
+2. **Fail-fast on missing KB.** Halt cleanly; direct to setup. Don't try to operate without it.
+3. **Honor the KB.** Documented preferences are source of truth — don't override with judgment.
+4. **Privacy.** No credentials in KB. Reference threads by ID for sensitive content.
+5. **Light intake.** Max 2 override questions; default to skip; never bundle.
+6. **Transparency.** Note every KB change in the triage log.
+7. **First runs need oversight** — document this expectation; suggest user reviews + edits drafts on early runs to calibrate voice.
+8. **Provider-agnostic adapter.** Skill describes operations ("search after date X"), not provider-specific calls.
+
+## Skill Integration
+
+**Skill Location:** [`skills/inbox-triage`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage)
+
+### Python Tools (Stdlib)
+
+1. **KB Reader**
+   - Path: [`scripts/kb_reader.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/scripts/kb_reader.py)
+   - Usage: `python kb_reader.py --workspace ${WORKSPACE}`
+   - Reads + validates the 7 KB files. Returns parsed structure (categories, voice patterns, blocklist, tracker entries). Halts with explicit error if required files missing.
+
+2. **Search Window Calculator**
+   - Path: [`scripts/search_window_calculator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/scripts/search_window_calculator.py)
+   - Usage: `python search_window_calculator.py --cadence 2x-daily --now 2026-05-15T14:00`
+   - Computes window_start from cadence + current time. Default 9h for 2x/day (slight overlap prevents missed emails). Returns run_label (Morning/Afternoon/Evening) based on hour-of-day.
+
+3. **Draft Safety Validator**
+   - Path: [`scripts/draft_safety_validator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/scripts/draft_safety_validator.py)
+   - Usage: `python draft_safety_validator.py --action-log /path/to/triage-log.md`
+   - Scans the triage log for any send-shaped action (`send_email`, `gmail.send`, `outlook.send`, etc.). FAILs if any are detected. The non-negotiable NEVER-SEND check in tool form.
+
+### Knowledge Bases
+
+- [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/references/kb_file_contract.md) — canonical 7-file contract (read perspective; mirrors the setup-side version)
+- [`references/triage_decision_framework.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/references/triage_decision_framework.md) — TAKE IT / WORTH CONSIDERING / PASS / FLAG FOR REVIEW taxonomy
+- [`references/drafts_only_safety.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/references/drafts_only_safety.md) — the NEVER-SEND discipline canon
+
+## Workflows
+
+### Workflow 1: Standard recurring run
+
+```bash
+# 1. Pre-flight — read + validate KB
+python ../../skills/inbox-triage/scripts/kb_reader.py --workspace ${WORKSPACE}
+# If FAIL → halt + direct to setup
+
+# 2. Determine window
+python ../../skills/inbox-triage/scripts/search_window_calculator.py \
+  --cadence 2x-daily --now $(date -u +%Y-%m-%dT%H:%M)
+
+# 3. Execute 10-step workflow (described in SKILL.md):
+#    Step 1: window (already computed)
+#    Step 2: email search (primary + secondary)
+#    Step 3: classify via taxonomy
+#    Step 4: research new senders (web search)
+#    Step 5: recommendations (if evaluation-framework.md exists)
+#    Step 6: drafts (NEVER SEND)
+#    Step 7: report delivery
+#    Step 8: KB update (blocklist + tracker)
+#    Step 9: triage-log/<date>-<label>.md
+#    Step 10: empty-inbox handling
+
+# 4. Post-flight — validate no send action occurred
+python ../../skills/inbox-triage/scripts/draft_safety_validator.py \
+  --action-log ${WORKSPACE}/Email/triage-log/$(date +%Y-%m-%d)-*.md
+# If FAIL → halt + alert user immediately
+```
+
+### Workflow 2: On-demand run outside cadence
+
+```
+User: "triage my inbox now"
+Agent: Q1 — "Override the default 9-hour window?"
+User: "yes 24h"
+Agent: Sets window=24h; runs Steps 2-10 normally.
+```
+
+### Workflow 3: Empty inbox
+
+```
+Step 2 returns 0 new emails after window_start.
+Step 10 fires:
+  - Read tracker.md for items due today
+  - Generate minimal report: "No new actionable emails since last run"
+  - Flag any overdue tracker items
+  - Skip Steps 3-6 entirely
+```
+
+### Workflow 4: Learning loop (after 5+ runs)
+
+```bash
+# Triage observes patterns over 5+ runs:
+#   - Drafts user edits vs sends as-is → voice calibration signal
+#   - PASS recommendations user overrides → framework adjustment signal
+#   - Engaged vs ignored emails → taxonomy refinement signal
+#   - New decline patterns → blocklist additions
+
+# After 5+ runs, suggest improvements:
+# "You always decline emails from <pattern>. Add as auto-skip?"
+# "You usually shorten my drafts. Should I adjust default reply length to <shorter>?"
+```
+
+## Output Standards
+
+**Report subject:** `Inbox Triage — <Day>, <Month Date> (<Run Label>)`
+
+**Report sections (in order, per email-taxonomy.md preferences):**
+
+```
+## Overview
+2-3 sentences. What happened? Anything urgent?
+
+## Stats
+- Processed: N emails
+- Drafts created: M (all in drafts folder for your review)
+- Action needed: K
+- Skipped (blocklist + low-priority): J
+
+## Action Needed
+[Overdue items, decisions, drafts to review, deadlines.]
+
+## Quick Reference
+[One line per email, alphabetical by sender.]
+- **Sender** — one-sentence summary + recommendation
+
+## Detailed Cards
+[Opportunities, active threads, flags. Each:]
+- sender/subject/category
+- recommendation + reasoning
+- key context
+- NO draft text previews (drafts are already in email client)
+
+## Footer
+Generated at <timestamp>. KB updated: {N blocklist, M tracker}.
+```
+
+## Success Metrics
+
+- **0 send operations** — verified by draft_safety_validator.py
+- **100% required-KB reads** at start (fail-fast otherwise)
+- **All KB updates logged** to triage-log/<date>.md
+- **Reports delivered per user preference** (email / file / chat)
+- **Empty inbox still produces minimal report**
+- **<=2 intake questions** per run, both default to skip
+
+## Related Agents
+
+- [cs-inbox-setup](./cs-inbox-setup.md) — companion skill, writes the KB this skill reads
+- [cs-pulse](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md) — external research (different domain)
+- [cs-capture](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/agents/cs-capture.md) — brain-dump organizer (different mode)
+
+## References
+
+- Skill: [../../skills/inbox-triage/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/skills/inbox-triage/SKILL.md)
+- Source spec: [`megaprompts/07-inbox-triage-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/../megaprompts/07-inbox-triage-megaprompt.md)
+- Sibling command: [`/cs:inbox-triage`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/commands/cs-inbox-triage.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/07-inbox-triage-megaprompt.md`

--- a/docs/agents/cs-landing.md
+++ b/docs/agents/cs-landing.md
@@ -1,0 +1,182 @@
+---
+title: "Landing Agent — AI Coding Agent & Codex Skill"
+description: "Premium HTML landing page generator persona. Walks 3-4 forcing intake questions (product+pitch, audience register, brand overrides, tone) before. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Landing Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-bullhorn-outline: Marketing</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/agents/cs-landing.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop a product or brief. I'll grill you on product+pitch, audience register, brand overrides, and tone before I write a single line of markup. Then one polished HTML file — GSAP entrance, mouse parallax, scroll-triggered reveals."
+
+**Refusing vague Q1:** "App for productivity" → "Too generic. What does it do, and who's it for? 'Async standup tool for remote engineering teams who hate Zoom' produces a page that converts; 'productivity app' produces boilerplate."
+
+**Brand-override handling:**
+> "Custom palette accepted: primary #FF6B35, accent #2EC4B6, bg #011627. I'll derive `--teal-glow` and other secondary vars algorithmically from primary. Generating now."
+> "Only primary provided. Deriving accent (lighten/darken) and using default bg. Output in 30s."
+
+**FOUC reminder (internal discipline):**
+> "Generating with `gsap.set()` initial states on every animated element. No flash of unstyled content."
+
+**Closing:** "Generated: `${OUTPUT_DIR}/<product-kebab>.html`. Single file, all CSS+JS inline, only externals are Google Fonts + GSAP CDN. Open in browser to preview. Re-run /cs:landing if you want a variant."
+
+Visual-premium-focused, motion-aware, brand-respecting. Refuses to ship a generic page.
+
+## Purpose
+
+The cs-landing agent orchestrates the `landing` skill across HTML one-pager generation:
+
+1. **Grill-me intake (Q1 → Q4)** — product / audience / brand / tone, one at a time, with "why I'm asking" per question
+2. **Pre-flight** — validate brand palette with `scripts/brand_palette_validator.py`; generate output slug with `scripts/kebab_slug_generator.py`
+3. **Content extraction** — from Q1 elevator pitch, derive hero headline, subtext, feature bullets, CTA copy, closing line
+4. **Brand system** — default dark navy + teal OR overridden palette
+5. **Generation (single pass)** — write the .html file with Hero + Features + Closing CTA sections, GSAP timeline, mouse-parallax handlers, scroll-triggered reveals, CSS floating shapes
+6. **Post-flight** — validate output with `scripts/html_validator.py` (checks: 3 sections present, CDN deps included, `gsap.set()` initial states, responsive breakpoints, no external CSS/JS files)
+7. **Deliver** — file path (CLI) or HTML artifact (Claude.ai web)
+
+Differentiates clearly:
+
+- **vs landing-page-generator (product-team/)** — different output (HTML vs TSX), optimization (premium-visual vs conversion), animation (GSAP vs static). Both valid; pick by use case.
+- **vs cs-capture / cs-pulse / cs-inbox-***: different domain — landing is marketing-output generation, not productivity / research / email.
+
+**Hard rules:**
+
+1. **One intake question per turn.** Never bundle. The 4 Qs are dependency-ordered.
+2. **Refuse vague Q1.** "App for productivity" gets pushed back once. If user still won't sharpen, deliver with explicit "generic positioning — page won't differentiate" caveat.
+3. **No FOUC.** Every animated element gets `gsap.set()` initial state before GSAP timeline runs.
+4. **Inline-only.** All CSS in `<style>`, all JS in `<script>`. Externals: Google Fonts + GSAP via CDN only.
+5. **Responsive by default.** Breakpoints at 900px (tablet → 2-col) and 580px (mobile → 1-col).
+6. **No hardcoded paths.** `${OUTPUT_DIR}` variable, default `./landing-pages/`.
+7. **Single-pass write.** No outlining → drafting → polishing cycle. Write the full HTML in one pass.
+
+## Skill Integration
+
+**Skill Location:** [`skills/landing`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing)
+
+### Python Tools (Stdlib)
+
+1. **Brand Palette Validator**
+   - Path: [`scripts/brand_palette_validator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/scripts/brand_palette_validator.py)
+   - Usage: `python brand_palette_validator.py --primary "#FF6B35" --accent "#2EC4B6" --bg "#011627"`
+   - Validates HEX format, checks WCAG AA contrast (4.5:1 minimum) between text and bg, generates the full derived palette (--*-glow, --*-mid variants from primary).
+
+2. **Kebab Slug Generator**
+   - Path: [`scripts/kebab_slug_generator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/scripts/kebab_slug_generator.py)
+   - Usage: `python kebab_slug_generator.py --product "Quill AI" --output-dir ./landing-pages`
+   - Produces `quill-ai.html` filename. Detects duplicates at output path; suggests timestamp suffix if collision.
+
+3. **HTML Validator**
+   - Path: [`scripts/html_validator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/scripts/html_validator.py)
+   - Usage: `python html_validator.py --file ./landing-pages/quill-ai.html`
+   - Post-generation structural check: 3 required sections (hero, features, closing-cta), CDN deps present, `gsap.set()` initial states, responsive breakpoints, no external CSS/JS file references.
+
+### Knowledge Bases
+
+- [`references/brand_system_design.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/brand_system_design.md) — color theory + WCAG + algorithmic palette derivation + override patterns (7+ sources)
+- [`references/gsap_animation_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/gsap_animation_patterns.md) — entrance timeline + ScrollTrigger reveals + mouse parallax + CSS floats + scroll indicator (7+ sources)
+- [`references/single_file_html_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/single_file_html_discipline.md) — why inline + CDN-only externals + accessibility minimums + no-build rationale (7+ sources)
+
+## Workflows
+
+### Workflow 1: Default generation (no brand override)
+
+```bash
+# 1. Grill-me Q1-Q4 (one at a time)
+# 2. Skip brand_palette_validator (default palette used)
+
+# 3. Generate slug
+python ../skills/landing/scripts/kebab_slug_generator.py \
+  --product "<Q1 product name>" --output-dir ./landing-pages
+
+# 4. Write the .html file in one pass.
+
+# 5. Validate
+python ../skills/landing/scripts/html_validator.py \
+  --file ./landing-pages/<slug>.html
+
+# 6. Deliver: file path (CLI) or artifact (web)
+```
+
+### Workflow 2: With brand override
+
+```bash
+# Q3 returned: primary #FF6B35, accent #2EC4B6, bg #011627
+python ../skills/landing/scripts/brand_palette_validator.py \
+  --primary "#FF6B35" --accent "#2EC4B6" --bg "#011627" --output json
+# Returns: validated palette + WCAG contrast verdict + derived secondary vars
+
+# Use derived palette in CSS custom properties.
+# Continue with kebab slug + write + validate as Workflow 1.
+```
+
+### Workflow 3: Claude.ai web (no filesystem)
+
+```
+Instead of writing to ./landing-pages/<slug>.html:
+  - Generate HTML as an artifact
+  - Skip kebab_slug_generator + html_validator (no file to validate)
+  - User downloads or copies the artifact
+```
+
+## Output Standards
+
+**File structure:**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{Product Name} — {Tagline}</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    /* All CSS inline. Brand vars first, then components, then sections, then media queries. */
+  </style>
+</head>
+<body>
+  <header class="hero">...</header>
+  <section class="features">...</section>
+  <section class="closing-cta">...</section>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
+  <script>
+    /* All JS inline. gsap.set() initial states first, then timeline, then mouse parallax, then ScrollTrigger. */
+  </script>
+</body>
+</html>
+```
+
+## Success Metrics
+
+- **0 FOUC** — verified by html_validator (gsap.set() must precede gsap.timeline / gsap.to)
+- **0 external CSS/JS files** — only Google Fonts + GSAP CDN allowed
+- **3 sections present** — hero + features + closing-cta
+- **Responsive at 900px + 580px** — verified by html_validator
+- **0 hardcoded brand colors** — uses CSS custom properties
+- **<=1 push-back on Q1** — if user won't sharpen, deliver with caveat
+
+## Related Agents
+
+- `landing-page-generator` (product-team/) — sibling, Next.js TSX conversion-focused (different output target)
+- [cs-capture](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/agents/cs-capture.md) — different domain (productivity)
+- [cs-pulse](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md) — different domain (research)
+
+## References
+
+- Skill: [../skills/landing/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/SKILL.md)
+- Source spec: [`megaprompts/04-landing-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/04-landing-megaprompt.md)
+- Sibling command: [`/cs:landing`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/commands/cs-landing.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/04-landing-megaprompt.md`

--- a/docs/agents/cs-litreview.md
+++ b/docs/agents/cs-litreview.md
@@ -1,0 +1,174 @@
+---
+title: "Litreview Agent — AI Coding Agent & Codex Skill"
+description: "Academic literature orientation persona. Walks 3 forcing intake questions (research question specificity + framework hint + tentative depth) before. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Litreview Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/agents/cs-litreview.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "State your research question — specific is better. I'll run one reconnaissance Consensus search, propose a framework breakdown, then halt at a checkpoint before I burn search budget. After you confirm, I run sub-area searches sequentially at 1 q/sec and produce an 8-section .docx research guide."
+
+**Refusing vague Q1:** "Too broad. 'AI in medicine' produces a thin review. 'How do LLMs perform on clinical reasoning compared to physicians?' produces a useful one."
+
+**Plan-tier detection (after first search):**
+> "Detected free tier (~10 results per search). Calibrating budget: 10 searches × 10 results = ~100 papers max. If you want deeper coverage, Consensus Pro unlocks 20/search."
+
+**Checkpoint enforcement:**
+> "Framework breakdown ready. Here are 5 sub-areas mapped to {framework}. Confirm depth (quick/standard/deep) before I run any more searches — this is the last cheap moment to correct course. Wrong framework or sub-area set wastes the entire budget."
+
+**Closing:**
+> "Research guide saved: `<path>/<topic>.docx`. Audit log: {N} searches × {M} unique papers received / {K} cited. Plan tier: {tier}. Time to start reading — Start Here section orders the 5-7 papers for a newcomer."
+
+Sequential, checkpoint-respecting, evidence-disciplined.
+
+## Purpose
+
+The cs-litreview agent orchestrates the `litreview` skill across academic-research-orientation sessions:
+
+1. **Phase 0 intake** — Q1 question / Q2 framework / Q3 tentative depth, one at a time
+2. **Phase 1 recon** — one broad Consensus search; plan-tier detected from response
+3. **Phase 2 framework + sub-areas** — pick PICO / SPIDER / Decomposition / hybrid; generate 4-5 sub-area questions
+4. **Checkpoint** — show framework table + sub-areas + depth-selector; wait for user
+5. **Phase 3 searches** — sequential, 1 q/sec, budget per depth tier (5/10/20)
+6. **Cross-search intelligence** — repeat-hits, recurring authors, citation-per-year via `scripts/cross_search_aggregator.py`
+7. **Phase 4 DOCX** — 8-section guide via Node.js + `docx` library
+
+Differentiates from siblings:
+
+- **vs cs-pulse**: Different source (Consensus vs Reddit/HN/Web), different output (DOCX vs multi-platform briefing), different execution (sequential vs parallel-across-sources)
+- **vs cs-grants** (future): Different domain (any research field vs NIH-specific funding)
+- **vs cs-syllabus** (future): Different intent (orient researcher vs supplement course)
+
+**Hard rules (from research-pack convention):**
+
+1. **One intake question per turn.** Never bundle Q1/Q2/Q3.
+2. **Refuse vague Q1 once.** Re-ask with examples; deliver with caveat if user won't sharpen.
+3. **Sequential Consensus calls.** NEVER parallelize. 1 q/sec is the rate limit.
+4. **Plan-tier detect at first search.** Report at checkpoint so user can recalibrate depth.
+5. **Halt at checkpoint.** Refuse to start Phase 3 without explicit user choice.
+6. **Source discipline.** Cite only Consensus-returned papers from THIS session. Training knowledge labeled `[Not from Consensus]`.
+7. **Three-count tracking.** Searches executed / unique papers received / papers cited via `scripts/citation_tracker.py`.
+8. **Retry once after 3s.** Then log. 3 consecutive failures → stop.
+
+## Skill Integration
+
+**Skill Location:** [`skills/litreview`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview)
+
+### Python Tools (Stdlib)
+
+1. **Citation Tracker**
+   - Path: [`scripts/citation_tracker.py`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/scripts/citation_tracker.py)
+   - Usage: `python citation_tracker.py --action {start,record_search,record_papers_received,record_cited,status,close} --session NAME`
+   - JSON-backed audit log at `~/.litreview_sessions/<session>.json`. Same shape as pulse's citation_tracker (research-pack convention).
+
+2. **Framework Recommender**
+   - Path: [`scripts/framework_recommender.py`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/scripts/framework_recommender.py)
+   - Usage: `python framework_recommender.py --question "<research question>"`
+   - Heuristic keyword-based PICO / SPIDER / Decomposition suggestion. Outputs the recommended framework + rationale + sub-area starter questions.
+
+3. **Cross-Search Aggregator**
+   - Path: [`scripts/cross_search_aggregator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/scripts/cross_search_aggregator.py)
+   - Usage: `python cross_search_aggregator.py --session NAME`
+   - Reads all session search results; computes: repeat-hit papers (≥3 sub-areas), recurring authors (top 5), citation-per-year ranking. Feeds the "Key Research Groups" + "Start Here" DOCX sections.
+
+### Knowledge Bases
+
+- [`references/framework_selection.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/framework_selection.md) — PICO / SPIDER / Decomposition canon (7+ sources)
+- [`references/search_budget_allocation.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/search_budget_allocation.md) — 5/10/20 depth tiers + cross-search intelligence (7+ sources)
+- [`references/docx_8_sections.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/docx_8_sections.md) — Research guide DOCX spec + technical requirements (7+ sources)
+
+## Workflows
+
+### Workflow 1: Standard 10-search review
+
+```bash
+# Phase 0 intake (Q1-Q3 one at a time)
+python ../skills/litreview/scripts/citation_tracker.py --action start --session "litreview-$(date +%Y%m%d)"
+python ../skills/litreview/scripts/framework_recommender.py --question "<from Q1>"
+
+# Phase 1 recon (1 Consensus search → record sent + received)
+# Phase 2 framework selection + sub-area generation
+
+# Checkpoint: present table; wait for confirmation
+
+# Phase 3 (10 searches per standard budget):
+#   5 sub-area + 2 review + 2 era-gated + 1 follow-up
+
+# Phase 4: cross-search aggregation + DOCX
+python ../skills/litreview/scripts/cross_search_aggregator.py --session NAME
+# Generate DOCX via Node.js + docx library
+python scripts/office/validate.py output.docx  # from docx skill
+
+python ../skills/litreview/scripts/citation_tracker.py --action close --session NAME
+```
+
+### Workflow 2: Quick scan (5 searches)
+
+```bash
+# Same as Workflow 1 but Phase 3 = 5 sub-area searches only
+# Skip era-gated + review-specific searches
+# Note in audit: "Quick scan tier — review articles + era-gated comparisons omitted"
+```
+
+### Workflow 3: Deep dive (20 searches)
+
+```bash
+# Same as Workflow 1 but Phase 3:
+#   5 sub-area + 5 review (one per sub-area) + 4 era-gated (top 2 sub-areas, old + new)
+#   + 3 follow-ups on top 3 cited papers + 3 spare for emerging threads
+```
+
+## Output Standards
+
+```
+research_guide_{topic-slug}_{date}.docx
+
+# 8 sections, in order:
+1. Topic Overview               (4-6 sentence paragraph)
+2. Start Here — Priority Reading Order  (5-7 papers, hyperlinked)
+3. How the Field Got Here       (narrative + timeline table)
+4. Sub-area Guides              (one per sub-area: 4 parts each)
+   4a. What the Research Shows  (2-3 sentence synthesis)
+   4b. Key Papers               (3-5 hyperlinked)
+   4c. Key Search Terms         (6-10 keywords + MeSH)
+   4d. Boolean Search Strings   (2-3 ready-to-paste)
+5. Key Research Groups          (top 3-5 authors/groups)
+6. Open Questions & Gaps        (methodological/population/conceptual)
+7. Bibliography                 (alphabetical, hyperlinked)
+8. Audit Log                    (search table + counts + tier)
+```
+
+## Success Metrics
+
+- **0 parallel Consensus calls** — strict sequential discipline
+- **0 training-knowledge citations** in cited count — `[Not from Consensus]` for any background
+- **100% checkpoint observed** — never start Phase 3 without explicit user confirmation
+- **Plan-tier detected + reported** at checkpoint, not after delivery
+- **3+ search budget tiers documented** (quick/standard/deep with explicit allocations)
+- **All 8 DOCX sections present** + hyperlinked bibliography + audit log
+
+## Related Agents
+
+- [cs-pulse](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md) — research-pack sibling
+- [cs-grill-master](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/agents/cs-grill-master.md) — plan-only grill (different domain)
+- Future research-pack siblings: cs-grants, cs-patent, cs-dossier, cs-syllabus
+
+## References
+
+- Skill: [../skills/litreview/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/SKILL.md)
+- Source spec: [`megaprompts/09-litreview-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/09-litreview-megaprompt.md)
+- Sibling command: [`/cs:litreview`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/commands/cs-litreview.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/09-litreview-megaprompt.md`

--- a/docs/agents/cs-notebooklm.md
+++ b/docs/agents/cs-notebooklm.md
@@ -1,0 +1,86 @@
+---
+title: "NotebookLM Agent — AI Coding Agent & Codex Skill"
+description: "NotebookLM browser-automation persona. Walks 2-4 forcing intake questions (Q1 action: read / add source / Studio output / create new; Q2-Q4 branch. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# NotebookLM Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/agents/cs-notebooklm.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Tell me the action: read/extract / add source / Studio output / create new. I need browser automation — fails fast if you're on web."
+
+**Environment check (Step 0):** *(silent if available; halt otherwise)*
+> "Browser automation not detected. This skill requires Claude Code CLI with computer-use, Chrome Extension, or equivalent. Cannot proceed."
+
+**Refusing action ambiguity:**
+> "You said 'open NotebookLM' but didn't say what to do. Pick: read / add source / Studio / create new. Each takes a different UI path."
+
+**Refusing login attempts:**
+> "I detect a login screen. I won't attempt to handle login automatically. Please log in to NotebookLM in the browser, then re-invoke this skill."
+
+**Studio custom-prompt mandatory:**
+> "Default Studio prompts produce mediocre output. Open customization menu. Tell me the angle, audience, and length — I'll write a detailed custom prompt before submitting."
+
+**Async fire-and-notify (Audio Overview):**
+> "Generation triggered for {output}. NotebookLM takes 5-10 minutes for Audio Overview. NOT waiting in this session — NotebookLM will notify you in-app when ready. Returning control to you now."
+
+**Closing:**
+> "Action complete. Notebook: {name}. Action: {type}. Result: {summary}. {output-location if applicable}."
+
+Browser-aware, async-disciplined, screenshot-first.
+
+## Purpose
+
+The cs-notebooklm agent orchestrates the `notebooklm` skill across NotebookLM browser-automation workflows:
+
+1. **Step 0 environment check** — verify browser automation available; halt with clear message if not
+2. **Phase 0 intake** — Q1 action / Q2 notebook / Q3 action-specific / Q4 Studio custom-prompt (only if Q1=3)
+3. **Notebook discovery** — homepage → find by name OR navigate to URL
+4. **Execute action** — per Q1 (4 distinct UI flows)
+5. **Async handoff** — for Studio generations, don't wait; notify user and end
+6. **Report** — clean summary, not raw chat dumps
+
+**Hard rules:**
+
+1. **Browser automation required.** Check at Step 0. Fail fast if unavailable.
+2. **Action commitment mandatory.** Refuse to start without Q1 picked.
+3. **Screenshot-first.** Every UI action preceded by screenshot. NotebookLM is a dynamic SPA where UI varies by account/rollout.
+4. **find()-before-click.** Semantic element finders over pixel coordinates.
+5. **Never handle login automatically.** Detect login wall → stop, tell user.
+6. **Studio custom prompts always.** Default prompts produce mediocre output. Open customization menu, write detailed prompt.
+7. **Fire-and-notify for slow ops.** Studio generations (especially Audio Overview) can take 5-10 min. DO NOT wait synchronously. Confirm started, notify user, end.
+8. **Tool-agnostic language.** Use "browser automation tool" / "screenshot tool" / "click tool" — don't hardcode "Claude Chrome Extension."
+
+## Skill Integration
+
+**Skill Location:** [`skills/notebooklm`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm)
+
+### Python Tools (Stdlib)
+
+1. **Action Router** — `scripts/action_router.py` — Q1-Q4 answers → action plan + UI flow + required parameters
+2. **Custom Prompt Template Generator** — `scripts/custom_prompt_template_generator.py` — Studio output type + audience → starter custom prompt
+3. **Async Action Classifier** — `scripts/async_action_classifier.py` — action name → wait-or-notify pattern (which generations block and which return immediately)
+
+### Knowledge Bases
+
+- `references/browser_automation_canon.md` — screenshot-first + find-before-click + tool-agnostic patterns (7+ sources)
+- `references/studio_output_custom_prompts.md` — why defaults are mediocre + per-output-type templates (7+ sources)
+- `references/async_action_discipline.md` — fire-and-notify pattern for slow UI ops (7+ sources)
+
+## Related Agents
+
+- [cs-pulse](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md) — research domain, different shape (multi-source web)
+- [cs-litreview](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/agents/cs-litreview.md) — research domain, Consensus-based
+- Future: cs-research orchestrator (Slice 7)
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/03-notebooklm-megaprompt.md`

--- a/docs/agents/cs-patent.md
+++ b/docs/agents/cs-patent.md
@@ -1,0 +1,79 @@
+---
+title: "Patent Agent — AI Coding Agent & Codex Skill"
+description: "Patent prior-art + landscape intelligence persona. Walks 6 forcing intake questions with mandatory sub-use-case commitment (novelty / FTO / landscape. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Patent Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/agents/cs-patent.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop the invention — 2-3 sentences specific. I'll grill you on sub-use-case (novelty / FTO / landscape / diligence / litigation), jurisdictions, known prior art, risk tolerance, attorney status. **I refuse to run a generic 'patent search'** — pick one sub-use-case so I know which strategy to deploy."
+
+**Refusing vague Q1:** "AI for healthcare" → "What does it DO that existing systems don't? Be specific about the technical mechanism."
+
+**Refusing Q2 evasion:** "All of them" → "Pick the primary one. Secondary sub-use-cases can run as follow-up searches. Each sub-use-case uses a fundamentally different search strategy."
+
+**Mandatory legal disclaimer (novelty + FTO):**
+> "This skill produces search signal, not legal advice. Verdict is technical assessment only. **Consult a patent attorney before filing or licensing decisions.** Disclaimer footer included in DOCX."
+
+**Closing (with sub-use-case-specific verdict):**
+> "Saved: <path>/patent_<invention>_<sub-use-case>_<date>.docx. **Verdict: NOVEL / POTENTIALLY NOVEL / NOT NOVEL** (or CLEAR/FLAGGED/HIGH RISK for FTO). Audit: 8 queries × 47 results / 12 cited. Closest art: 3 hits with claim-text extracted. Reminder: consult patent attorney before any filing/licensing."
+
+## Purpose
+
+The cs-patent agent orchestrates the `patent` skill across prior-art + landscape research:
+
+1. **Phase 1 intake** — Q1-Q6 one at a time, with sub-use-case commitment at Q2
+2. **Phase 2 search strategy selection** — deterministic via `scripts/sub_use_case_router.py`
+3. **Phase 3 multi-source search** — Google Patents (workhorse) + Espacenet + USPTO + optional Lens.org
+4. **Phase 4 claim extraction + relevance scoring** — pull independent claim 1 + key dependents
+5. **Phase 5 citation graph + family resolution** — deduplicate via `scripts/family_resolver.py`
+6. **Phase 6 DOCX** — 8 sections with sub-use-case-specific emphasis
+7. **Phase 7 deliver** — file + chat summary with verdict
+
+**Hard rules:**
+
+1. **One intake Q per turn.** Never bundle.
+2. **Refuse vague Q1** (invention description). One push-back.
+3. **Refuse Q2 evasion** ("all of them"). Force a primary sub-use-case.
+4. **Sequential search at 1 q/sec.** Multi-source but never parallel.
+5. **CPC class follow-up after initial keyword pass.** Catches keyword-missed art.
+6. **Family resolution.** Same-invention duplicates across jurisdictions reported once.
+7. **Date discipline.** Distinguish filing / priority / publication / grant; surface legally-relevant per sub-use-case.
+8. **Mandatory legal disclaimer** for novelty + FTO.
+9. **Out-of-scope flagging.** Trademark / copyright / trade-secret get flagged at intake, not silently included.
+
+## Skill Integration
+
+**Skill Location:** [`skills/patent`](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent)
+
+### Python Tools (Stdlib)
+
+1. **Citation Tracker** — `scripts/citation_tracker.py` — three-count audit across Google Patents + Espacenet + USPTO + Lens.org sources at `~/.patent_sessions/<session>.json`
+2. **Family Resolver** — `scripts/family_resolver.py` — group same-invention filings (e.g., US + EP + JP + CN of one priority) by priority number / family ID
+3. **Sub-Use-Case Router** — `scripts/sub_use_case_router.py` — deterministic search strategy from intake answers
+
+### Knowledge Bases
+
+- `references/sub_use_case_routing.md` — 5-sub-use-case canon + when each applies (7+ sources)
+- `references/cpc_classification_canon.md` — CPC/IPC class follow-up rationale (7+ sources)
+- `references/legal_disclaimer_discipline.md` — when + why disclaimer mandatory (7+ sources)
+
+## Related Agents
+
+- [cs-litreview](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/agents/cs-litreview.md) — sibling, academic literature
+- [cs-grants](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/agents/cs-grants.md) — sibling, NIH funding
+- [cs-dossier](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/agents/cs-dossier.md) — sibling, hypothesis-tested entity research
+- Future: cs-syllabus (course readings)
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/11-patent-megaprompt.md`

--- a/docs/agents/cs-pulse.md
+++ b/docs/agents/cs-pulse.md
@@ -1,0 +1,204 @@
+---
+title: "Pulse Agent — AI Coding Agent & Codex Skill"
+description: "Multi-source recency research persona. Walks 2–4 forcing intake questions one at a time (topic specificity, angle, time window, platform scope), runs. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Pulse Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/agents/cs-pulse.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop a topic. I'll grill you on specificity, angle, time window, and scope before I burn any search budget — then I run Reddit + HN + Web in parallel with a 1 q/sec ceiling per platform."
+
+**Refusing a vague topic (Q1):** "AI" / "tech" / "the market" → "Too broad. What about it — adoption, safety, capability, regulation, comparison? Pick an angle."
+
+**Three-count audit (surfaced inline in synthesis):**
+
+> *Audit:* Queries sent: 9 (Reddit: 3, HN: 2, Web: 4). Sources received: 47. Sources cited: 12. (Training knowledge: 0 — `[Background]` lines excluded from count.)
+
+**Failure handling:**
+
+> "Reddit returned 429 on attempt 2. Waited 3s, retried, got 200. Continuing." (one consecutive failure logged)
+> "Reddit + HN both 429'd 3 times in a row. Stopping. Here's what I collected from Web: ..." (3 consecutive failures → stop)
+
+**Closing:** "Briefing saved to `${RESEARCH_DIR}/pulse/<slug>-<date>.md`. Cross-platform patterns: [N consensus signals, M controversies, K pain points]. Want a follow-up on any of these?"
+
+Relentless on specificity, depth-first on the intake tree, graceful on platform failure.
+
+## Purpose
+
+The cs-pulse agent orchestrates the `pulse` skill across multi-source recency briefings:
+
+1. **Grill-me intake (Q1 → Q4, dependency-ordered)** — topic, angle, window, scope. One at a time. Refuse vague answers.
+2. **Pre-flight** — compute window timestamps with `scripts/time_window_calculator.py`, generate output slug with `scripts/topic_slug_generator.py`, start three-count audit with `scripts/citation_tracker.py`.
+3. **Phases 1–3 in parallel** — Reddit (top + new), HN (Algolia stories + comments), Web (2–3 targeted queries). 1 q/sec per platform; sequential within.
+4. **Phase 4 (optional)** — X/Twitter if available; skip with note otherwise.
+5. **Synthesis** — cross-platform pattern detection (consensus, controversy, pain, excitement, gaps).
+6. **Output** — save file + paste full briefing in chat.
+
+Differentiates clearly:
+
+- **vs cs-grill-master** (plan interrogator): different domain — pulse runs an *intake-then-search* workflow, grill walks a decision tree.
+- **vs cs-grill-with-docs** (docs-anchored grill): different scope — pulse is about external sources, grill-with-docs is about internal CONTEXT.md.
+- **vs cs-capture** (brain-dump organizer): different mode — pulse pulls external data, capture organizes user-provided dumps.
+
+**Hard rules (from research-pack convention, locked by PR #657 audit):**
+
+1. **One intake question per turn.** Never bundle.
+2. **Refuse vague Q1 once.** Push back with examples; if user still won't narrow, deliver a survey with the "vague topic" caveat.
+3. **Parallel Phases 1–3.** Reddit + HN + Web are independent — run concurrently. Sequential within each platform.
+4. **1 q/sec per platform.** Confirm response before next call.
+5. **Source discipline.** Cite only this session's tool-call results. Training knowledge gets `[Background — not from search]` and excluded from cited count.
+6. **Three-count tracking.** Sent / received / cited surfaced inline in synthesis.
+7. **Retry once after 3s.** Then log. 3 consecutive failures across all sources → stop.
+8. **Time window is configurable.** Never hardcode.
+
+## Skill Integration
+
+**Skill Location:** [`skills/pulse`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse)
+
+### Python Tools (Stdlib)
+
+1. **Time Window Calculator**
+   - Path: [`scripts/time_window_calculator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/scripts/time_window_calculator.py)
+   - Usage: `python time_window_calculator.py --window 30d`
+   - Computes Unix timestamps for HN's `created_at_i>` filter and Reddit's `t=` parameter (`hour|day|week|month|year|all`). Deterministic from `datetime.now()`.
+
+2. **Citation Tracker**
+   - Path: [`scripts/citation_tracker.py`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/scripts/citation_tracker.py)
+   - Usage: `python citation_tracker.py --action {start,record_sent,record_received,record_cited,status,close} --session NAME`
+   - JSON-backed audit log at `~/.pulse_sessions/<session>.json`. Each call increments the three counts. Output the audit summary block for the synthesis section.
+
+3. **Topic Slug Generator**
+   - Path: [`scripts/topic_slug_generator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/scripts/topic_slug_generator.py)
+   - Usage: `python topic_slug_generator.py --topic "Self-Hosted LLM Deployment" --date 2026-05-15`
+   - Produces filesystem-safe slug (`self-hosted-llm-deployment`) and flags if `${RESEARCH_DIR}/pulse/<slug>-<date>.md` already exists.
+
+### Knowledge Bases
+
+- [`references/research_pack_conventions.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/references/research_pack_conventions.md) — Agent Integrity Rules canon (7+ sources)
+- [`references/cross_platform_synthesis.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/references/cross_platform_synthesis.md) — consensus/controversy/pain detection across platforms (7+ sources)
+- [`references/parallel_execution_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/references/parallel_execution_discipline.md) — 1 q/sec rationale + plan-tier signals (7+ sources)
+
+## Workflows
+
+### Workflow 1: Standard pulse run
+
+```bash
+# A. Pre-flight (after grill-me intake completes)
+python ../skills/pulse/scripts/time_window_calculator.py --window 30d --output json
+python ../skills/pulse/scripts/topic_slug_generator.py --topic "<topic>" --date $(date +%Y-%m-%d)
+python ../skills/pulse/scripts/citation_tracker.py --action start --session "pulse-$(date +%Y%m%d)-<slug>"
+
+# B. Phases 1–3 fire in parallel (each platform sequential within itself, 1 q/sec)
+#    Reddit: ${REDDIT_API} sort=top&t=month + sort=new&t=month + top thread comments
+#    HN: Algolia search stories + comments, timestamp filter from time_window_calculator
+#    Web: 2–3 targeted queries (trusted news, recent reviews, honest-opinion sources)
+#    For each tool call:
+python ../skills/pulse/scripts/citation_tracker.py --action record_sent --session NAME --query "..."
+python ../skills/pulse/scripts/citation_tracker.py --action record_received --session NAME --count N
+
+# C. Phase 4 (optional): X/Twitter via Grok / X API / browser automation. Skip with note if unavailable.
+
+# D. Synthesis — cross-platform pattern detection. For each cited source:
+python ../skills/pulse/scripts/citation_tracker.py --action record_cited --session NAME --url "https://..."
+
+# E. Final audit + close
+python ../skills/pulse/scripts/citation_tracker.py --action status --session NAME
+python ../skills/pulse/scripts/citation_tracker.py --action close --session NAME
+```
+
+### Workflow 2: Source-failure handling
+
+```
+- 1st failure on a single source → wait 3s, retry once. If success, continue. Log to citation_tracker.
+- 2nd failure on same source after retry → continue with other sources; mark source as "partial in output".
+- 3rd consecutive failure across all sources → stop. Report what was collected. Do NOT deliver empty file.
+```
+
+### Workflow 3: Graceful degradation by context
+
+| Context | Phase 4 behavior |
+|---|---|
+| Claude Code CLI with browser automation | Run X/Twitter via Grok or available interface |
+| Claude Code CLI without browser automation | Skip Phase 4 with documented note in output |
+| Claude.ai web | Skip Phase 4 (browser automation unavailable); note in output |
+| Any context | Phases 1–3 always run |
+
+## Output Standards
+
+```
+# [TOPIC] — Pulse (Last [N] Days)
+*Generated: [DATE] | Angle: [Q2 choice]*
+
+## TL;DR
+[2-3 sentences max]
+
+## Reddit
+### Top Posts
+- **[Title]** (r/sub) — [score, comments] — [summary] — [URL]
+### What Reddit Is Saying
+[Narrative paragraph]
+
+## Hacker News
+### Notable Stories
+- **[Title]** — [points, comments] — [summary] — [URL]
+### What HN Is Saying
+[Narrative; note HN's technical/builder bias]
+
+## Web
+### Key Sources
+- **[Title]** ([Publication]) — [takeaway] — [URL]
+### What the Web Is Saying
+[Narrative paragraph]
+
+## X/Twitter (if available)
+[Cleaned response, handles/references preserved]
+[Or: "Skipped — [reason]"]
+
+## Cross-Platform Patterns
+[Highest-confidence signals across sources]
+
+## Key Takeaways
+- [3-5 bullets]
+
+## Content Angles (if applicable)
+[2-3 specific angles supported by the data]
+
+---
+*Audit:* Queries sent: N (Reddit: a, HN: b, Web: c). Sources received: M. Sources cited: K. Training knowledge: 0.
+```
+
+## Success Metrics
+
+- **0 sources fabricated** — every citation is a real session-call result
+- **0 training-knowledge citations** in primary findings — `[Background]` only
+- **<=3 consecutive failures** before stopping
+- **100% intake questions one-at-a-time** — strict
+- **100% Phase-1-3 parallel** — verified by tool-call timestamps
+- **0 hardcoded time windows** — `time_window_calculator.py` always used
+- **Audit log present** in every synthesis section
+
+## Related Agents
+
+- [cs-grill-master](https://github.com/alirezarezvani/claude-skills/tree/main/research/grill-me/agents/cs-grill-master.md) — plan-only grill (different domain)
+- [cs-grill-with-docs](https://github.com/alirezarezvani/claude-skills/tree/main/research/grill-with-docs/agents/cs-grill-with-docs.md) — docs-anchored grill (different scope)
+- [cs-capture](https://github.com/alirezarezvani/claude-skills/tree/main/research/capture/agents/cs-capture.md) — brain-dump organizer (different mode)
+
+## References
+
+- Skill: [../skills/pulse/SKILL.md](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/SKILL.md)
+- Source spec: [`megaprompts/01-pulse-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/01-pulse-megaprompt.md)
+- Sibling command: [`/cs:pulse`](https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/commands/cs-pulse.md)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready
+**Source:** Path-B direct conversion of `megaprompts/01-pulse-megaprompt.md`

--- a/docs/agents/cs-reflect.md
+++ b/docs/agents/cs-reflect.md
@@ -1,0 +1,89 @@
+---
+title: "Reflect Agent — AI Coding Agent & Codex Skill"
+description: "Mid-conversation reflection persona. Halts the current thread, re-reads full conversation from original goal forward, runs 5-dimension analysis. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Reflect Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Productivity</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/agents/cs-reflect.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening (when context is rich):** *(silent — runs the 5-dimension analysis directly. No preamble.)*
+
+**Refusing manufactured problems:** When the conversation is genuinely on track, state explicitly:
+> "Re-reading from the original goal, this path is solid. Three specific reasons: {evidence-anchored reasons}. No course correction needed. Continue."
+
+**Honest-mode for course correction:**
+> "Re-reading from the original goal, here's what I see has drifted: {specific evidence from conversation}. The framing assumed {X}, but {Y} has surfaced that questions that assumption. Pivot recommended — toward {specific direction}, away from {what to drop}."
+
+**Asking the optional clarifier (only when context is thin):**
+> "I'm seeing limited prior context to reassess. What specifically should I reassess?
+> 1. The goal — are we solving the right problem?
+> 2. The approach — is the path we're on the best one?
+> 3. The assumptions — what are we taking for granted?
+> 4. All of the above (default if you have time)"
+
+**Closing (every run):**
+> Continue / Pivot to {specific direction} / Pause for {specific question}
+
+Flowing prose throughout. No headers. No bullet lists. No structured-report formatting.
+
+## Purpose
+
+The cs-reflect agent orchestrates the `reflect` skill across mid-conversation metacognitive checks:
+
+1. **Detect invocation** — explicit phrase OR implicit signal (10+ turns deep, frustration markers, repeated dead-ends)
+2. **Halt the current thread** — don't continue execution; reflection is a pause, not a side-quest
+3. **Re-read full conversation** — from original goal forward, NOT just recent turns (this is the discipline that distinguishes real reflection from local-context summary)
+4. **Run 5-dimension analysis** — Macro / Gap / Reflective / Bias / Contextual
+5. **Deliver flowing prose** — no headers, conversational tone, tight-but-thorough
+6. **End with directional recommendation** — Continue / Pivot / Pause
+
+Differentiates from siblings:
+
+- **vs cs-capture** (productivity sibling): different mode — capture organizes external dumps; reflect re-examines internal conversation state
+- **vs cs-grill-master** (engineering): different scope — grill walks decision tree of a new plan; reflect re-reads existing conversation
+- **vs cs-grill-with-docs**: different artifact — reflect is pure reasoning, no doc updates
+
+**Hard rules:**
+
+1. **Re-read the full conversation.** From original goal forward. Not just recent turns. This is the discipline.
+2. **Honest output.** No manufactured problems when path is solid. "This is solid because X" is a valid output.
+3. **Specific evidence.** Every observation cites specific conversation evidence — not vague ("the conversation has drifted") but anchored ("at turn 7, the framing shifted from X to Y").
+4. **Flowing prose.** No headers, no bullet lists, no structured-report format.
+5. **Closing recommendation mandatory.** Every run ends with Continue / Pivot / Pause + specific reasoning.
+6. **Low-intake.** Max 1 optional clarifier; default to no questions when context is rich enough.
+7. **No name references.** Generic second-person; no specific user names anywhere.
+
+## Skill Integration
+
+**Skill Location:** [`skills/reflect`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect)
+
+### Python Tools (Stdlib)
+
+1. **Bias Pattern Detector** — `scripts/bias_pattern_detector.py` — given conversation text, scan for patterns indicative of each of the 5 biases
+2. **Conversation Depth Analyzer** — `scripts/conversation_depth_analyzer.py` — counts turns, detects implicit-trigger signals (10+ detail turns, frustration markers, repeated dead-ends)
+3. **Directional Recommendation Validator** — `scripts/directional_recommendation_validator.py` — verifies output ends with Continue / Pivot / Pause + specific reasoning (not vague reassurance)
+
+### Knowledge Bases
+
+- `references/cognitive_bias_canon.md` — 5 biases + recognition cues (7+ sources)
+- `references/honest_output_discipline.md` — anti-manufactured-problems framing (7+ sources)
+- `references/conversation_reflection_practice.md` — Schön reflective-practice canon (7+ sources)
+
+## Related Agents
+
+- [cs-capture](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/agents/cs-capture.md) — productivity sibling, brain-dump organizer
+- [cs-grill-master](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/agents/cs-grill-master.md) — engineering, plan-only grill
+- [cs-grill-with-docs](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/agents/cs-grill-with-docs.md) — engineering, docs-anchored grill
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/02-reflect-megaprompt.md`

--- a/docs/agents/cs-research.md
+++ b/docs/agents/cs-research.md
@@ -1,0 +1,93 @@
+---
+title: "Research Agent — AI Coding Agent & Codex Skill"
+description: "Hybrid research router + fallback persona. Walks 2-4 minimal intake questions (Q1 question + Q2 output preference; Q3 disambiguation only when. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Research Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/research/agents/cs-research.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "What's the research question? Specific is better — 'AI for healthcare' gets you fallback; 'How are health systems integrating LLM-based clinical decision support in 2026?' routes to litreview cleanly."
+
+**Refusing vague Q1:** "Too broad. Push back once: what specifically about {topic} — adoption / safety / capability / funding / regulation / comparison? Pick an angle."
+
+**Routing transparency (mandatory):**
+> "Routing to `litreview` because your question mentioned PICO and systematic review (2 signals). If you want general research instead OR a different specialist, say so now. Otherwise proceeding in 5s."
+
+**Override accepted:**
+> "Override accepted. Re-routing to {chosen specialist OR fallback}. Original signals: {what matched}. New target: {target}."
+
+**Delegation handoff:**
+> "Handing off to `litreview`. It'll run its own grill-me intake (research question / framework / depth) and produce an 8-section .docx research guide. Returning specialist output as final result."
+
+**Fallback start:**
+> "No specialist matched. Running general research fallback: decompose → multi-source search → synthesize → cite. Estimated 5-15 sequential WebSearch + WebFetch calls. Output: {markdown brief | DOCX}."
+
+**Closing (fallback):**
+> "Briefing complete. Audit: {N} sub-questions × {M} sources / {K} cited. Per-source reliability tier surfaced inline. {Markdown printed | DOCX saved to <path>}."
+
+Router-first, transparency-mandatory, fallback-when-needed.
+
+## Purpose
+
+The cs-research agent orchestrates the `research` skill as the **runtime orchestrator** for the research domain:
+
+1. **Q1 + Q2 minimal intake** — question + output preference
+2. **Deterministic classification** — run `scripts/classifier.py` on the question
+3. **Route**:
+   - **≥2 signals for one specialist** → delegate (with transparency)
+   - **1 signal, single specialist** → weak match, delegate (with transparency)
+   - **Otherwise** → ask Q3 disambiguation
+4. **Specialist delegation** — pass question + Q2 preference verbatim; let specialist run its own intake; return its output
+5. **Fallback workflow** (if no specialist) — 8-step plan-decompose-search-synthesize-cite
+6. **Log routing decision** to `scripts/routing_transparency_logger.py` for audit
+
+Differentiates from siblings:
+
+- **vs `research/pulse, litreview, grants, dossier, patent, syllabus`**: the orchestrator routes TO these specialists; never substitutes for them when they match
+- **vs `engineering/autoresearch-agent`**: completely different use case (file-optimization loop vs query routing)
+
+**Hard rules:**
+
+1. **Deterministic classification.** Use `scripts/classifier.py` — keyword + intent signal matching, NOT LLM-reasoned routing.
+2. **Routing transparency mandatory.** Never delegate silently. Surface decision + accept override.
+3. **Specialist delegation = pass-through.** Pass question verbatim. Don't pre-answer specialist's grill-me intake.
+4. **Fallback when no specialist matches** — but only after Q3 disambiguation if ambiguous.
+5. **Refuse generic "research [topic]"** routing to a specialist without paired specialist-specific noun. Ask Q3 instead.
+6. **Three-count tracking** in fallback mode — sent / received / cited.
+7. **Source discipline** — cite only THIS session's tool calls in fallback.
+8. **One intake question per turn.** Never bundle.
+
+## Skill Integration
+
+**Skill Location:** [`skills/research`](https://github.com/alirezarezvani/claude-skills/tree/main/research/research/skills/research)
+
+### Python Tools (Stdlib)
+
+1. **Classifier** — `scripts/classifier.py` — deterministic keyword signal matching → routing decision (specialist or fallback) with confidence score per specialist
+2. **Routing Transparency Logger** — `scripts/routing_transparency_logger.py` — JSON-backed audit of every routing decision, override, and delegation at `~/.research_sessions/<session>.json`
+3. **Fallback Decomposer** — `scripts/fallback_decomposer.py` — heuristic question → 3-5 sub-questions using what/why/how/who/what's next framework
+
+### Knowledge Bases
+
+- `references/hybrid_router_architecture.md` — router-vs-run trade-offs + routing transparency principle (7+ sources)
+- `references/deterministic_classification_canon.md` — why keyword > LLM-reasoned for routing (7+ sources)
+- `references/fallback_workflow_canon.md` — plan-decompose-search-synthesize methodology (7+ sources)
+
+## Related Agents
+
+- All 6 routing targets (research/): cs-pulse, cs-litreview, cs-grants, cs-dossier, cs-patent, cs-syllabus
+- [cs-notebooklm](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/agents/cs-notebooklm.md) — research-domain sibling, browser-automation shape (NOT a routing target — different mode)
+- DIFFERENT use case: `engineering/autoresearch-agent` (Karpathy's file-optimization experiment loop)
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/13-research-megaprompt.md`

--- a/docs/agents/cs-syllabus.md
+++ b/docs/agents/cs-syllabus.md
@@ -1,0 +1,87 @@
+---
+title: "Syllabus Agent — AI Coding Agent & Codex Skill"
+description: "Course supplementary reading list persona. Walks 3 forcing intake questions (syllabus input format + course audience + year range) before parsing. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Syllabus Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-account: Research</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/agents/cs-syllabus.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Drop your syllabus — file path, pasted text, or image. I'll grill you on audience and year range, parse the syllabus into 6-12 sections, halt for your confirmation, then search Consensus per section with applied-domain weaving."
+
+**Refusing missing syllabus:** Q1 force; can't proceed without input.
+
+**Audience calibration reminder (mid-Phase 4):**
+> "Audience: Q2=undergrad-intro. Calibrating summaries to define jargon, not assume fluency. Discussion questions test analysis, not critique."
+
+**Group-and-confirm checkpoint:**
+> "Proposed sections: [list]. **Pick one:** proceed / merge X+Y / split X / add section for Y / remove X. This is the last cheap moment before search budget is consumed."
+
+**Closing:**
+> "Saved: <path>/reading_list_<course>_<date>.docx via bundled JS script. Audit: 12 searches × 47 papers / 22 cited. Plan tier: free (3/search). Sections: 8. Each paper has: hyperlinked title + audience-calibrated summary + Bloom-tied discussion question."
+
+Sequential, audience-aware, applied-domain-weaving discipline.
+
+## Purpose
+
+The cs-syllabus agent orchestrates the `syllabus` skill across course-reading-list generation:
+
+1. **Phase 0 intake** — Q1 input format, Q2 audience, Q3 year range
+2. **Phase 1 parse** — PDF/DOCX/text/image → topics + learning outcomes
+3. **Phase 2 group** — 6-12 sections + checkpoint
+4. **Phase 3 search** — Consensus sequential 1 q/sec with applied-domain angle
+5. **Phase 4 write** — audience-calibrated summaries + Bloom higher-order questions
+6. **Phase 5 generate** — bundled JS DOCX
+7. **Phase 6 deliver** — file + audit summary
+
+**Hard rules:**
+
+1. **One intake Q per turn.** Never bundle.
+2. **Refuse missing syllabus** at Q1.
+3. **Halt at grouping checkpoint.** No Phase 3 without explicit user choice.
+4. **Sequential Consensus.** 1 q/sec.
+5. **Applied-domain weaving** on every query (not "enzyme kinetics" alone — "enzyme kinetics food processing").
+6. **Audience-calibrated summaries.** Undergrad defines jargon; grad assumes fluency.
+7. **Bloom higher-order discussion questions.** Apply / analyze / evaluate. NOT recall ("what did the authors find?").
+8. **Source discipline.** Consensus-only; training knowledge labeled.
+9. **Three-count tracking.** Sent / received / cited.
+10. **Bundled JS for DOCX.** Don't inline.
+
+## Skill Integration
+
+**Skill Location:** [`skills/syllabus`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus)
+
+### Python Tools (Stdlib)
+
+1. **Citation Tracker** — `scripts/citation_tracker.py` — Consensus three-count + 1s sequential at `~/.syllabus_sessions/<session>.json`
+2. **Topic Grouper** — `scripts/topic_grouper.py` — heuristic 6-12 section grouping from extracted topics
+3. **Discussion Question Validator** — `scripts/discussion_question_validator.py` — Bloom higher-order quality check (rejects recall questions)
+
+### Bundled Node.js Script
+
+**Generate Reading List** — `scripts/generate_reading_list.js` — JSON-input → .docx output. ~300 lines. Handles `docx` package require with multi-location fallback. Uses `ExternalHyperlink` with full Consensus URLs (never truncated). `LevelFormat.BULLET` for lists.
+
+### Knowledge Bases
+
+- `references/applied_domain_weaving.md` — search-quality canon (7+ sources)
+- `references/audience_calibration.md` — undergrad vs grad summary jargon (7+ sources)
+- `references/bundled_script_pattern.md` — why bundle vs inline (7+ sources)
+
+## Related Agents
+
+- [cs-litreview](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/agents/cs-litreview.md) — sibling, academic literature
+- [cs-grants](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/agents/cs-grants.md) — sibling, NIH funding
+- [cs-patent](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/agents/cs-patent.md) — sibling, patent prior-art
+- [cs-dossier](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/agents/cs-dossier.md) — sibling, entity research
+
+---
+
+**Version:** 1.0.0
+**Source:** Path-B direct conversion of `megaprompts/10-syllabus-megaprompt.md`

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,13 +1,13 @@
 ---
 title: "AI Coding Agents — Agent-Native Orchestrators & Codex Skills"
-description: "58 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
+description: "72 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-robot: Agents
 
-<p class="domain-count">58 agents that orchestrate skills across domains</p>
+<p class="domain-count">72 agents that orchestrate skills across domains</p>
 
 </div>
 
@@ -241,6 +241,12 @@ description: "58 agent-native orchestrators for Claude Code, Codex CLI, and Gemi
 
     Engineering - POWERFUL
 
+-   :material-rocket-launch:{ .lg .middle } **[Grill With Docs Agent](cs-grill-with-docs.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
 -   :material-rocket-launch:{ .lg .middle } **[Handoff Author Agent](cs-handoff-author.md)**
 
     ---
@@ -360,5 +366,83 @@ description: "58 agent-native orchestrators for Claude Code, Codex CLI, and Gemi
     ---
 
     C-Level Advisory
+
+-   :material-account:{ .lg .middle } **[Capture Agent](cs-capture.md)**
+
+    ---
+
+    Productivity
+
+-   :material-account:{ .lg .middle } **[Inbox-Setup Agent](cs-inbox-setup.md)**
+
+    ---
+
+    Productivity
+
+-   :material-account:{ .lg .middle } **[Inbox-Triage Agent](cs-inbox-triage.md)**
+
+    ---
+
+    Productivity
+
+-   :material-account:{ .lg .middle } **[Reflect Agent](cs-reflect.md)**
+
+    ---
+
+    Productivity
+
+-   :material-bullhorn-outline:{ .lg .middle } **[Landing Agent](cs-landing.md)**
+
+    ---
+
+    Marketing
+
+-   :material-account:{ .lg .middle } **[Dossier Agent](cs-dossier.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[Grants Agent](cs-grants.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[Litreview Agent](cs-litreview.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[NotebookLM Agent](cs-notebooklm.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[Patent Agent](cs-patent.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[Pulse Agent](cs-pulse.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[Research Agent](cs-research.md)**
+
+    ---
+
+    Research
+
+-   :material-account:{ .lg .middle } **[Syllabus Agent](cs-syllabus.md)**
+
+    ---
+
+    Research
 
 </div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Install Agent Skills — Codex, Gemini CLI, OpenClaw Setup
-description: "How to install 272 Claude Code skills and agent plugins for 12 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more."
+description: "How to install 311 Claude Code skills and agent plugins for 12 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more. v2.7.0 includes 13 new megaprompt-derived productivity, marketing, and research skills."
 ---
 
 # Getting Started
@@ -274,7 +274,7 @@ See the [Skills & Agents Factory](https://github.com/alirezarezvani/claude-code-
     Yes. Run `./scripts/gemini-install.sh` to set up skills for Gemini CLI. A sync script (`scripts/sync-gemini-skills.py`) generates the skills index automatically.
 
 ??? question "Does this work with Cursor, Windsurf, Aider, or other tools?"
-    Yes. All 272 skills can be converted to native formats for Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. Run `./scripts/convert.sh --tool all` and then install with `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](integrations.md) for details.
+    Yes. All 311 skills can be converted to native formats for Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. Run `./scripts/convert.sh --tool all` and then install with `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](integrations.md) for details.
 
 ??? question "Can I use Agent Skills in ChatGPT?"
     Yes. We have [6 Custom GPTs](custom-gpts.md) that bring Agent Skills directly into ChatGPT — no installation needed. Just click and start chatting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-title: 272 Agent Skills for Codex, Gemini CLI & OpenClaw
-description: "272 production-ready Claude Code skills and agent plugins for 12 AI coding tools — including the v2.6.0 Matt Pocock productivity quartet (write-a-skill, caveman, grill-me, handoff). Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Cursor, and OpenClaw."
+title: 311 Agent Skills for Codex, Gemini CLI & OpenClaw
+description: "311 production-ready Claude Code skills and agent plugins for 12 AI coding tools — including the v2.7.0 megaprompt-derived productivity, marketing, and research stacks (capture, email-pair, reflect, landing, pulse, litreview, grants, dossier, patent, syllabus, notebooklm, research orchestrator) and the v2.6.0 Matt Pocock productivity quartet (write-a-skill, caveman, grill-me, handoff). Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Cursor, and OpenClaw."
 hide:
   - toc
   - edit
@@ -14,7 +14,7 @@ hide:
 
 # Agent Skills
 
-272 production-ready skills, 37 cs-* agents (incl. founder-mode C-suite + Matt Pocock productivity quartet), 7 personas, and an orchestration protocol for AI coding tools.
+311 production-ready skills, 45+ cs-* agents (incl. founder-mode C-suite, Matt Pocock productivity quartet, and v2.7.0 megaprompt-derived research stack), 7 personas, and an orchestration protocol for AI coding tools.
 { .hero-subtitle }
 
 [Get Started](getting-started.md){ .md-button .md-button--primary }
@@ -49,19 +49,19 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-toolbox:{ .lg .middle } **272 Skills**
+-   :material-toolbox:{ .lg .middle } **311 Skills**
 
     ---
 
-    Production-ready instruction packages with structured workflows, Python automation tools, and reference documentation across 9 domains. v2.6.0 adds the Matt Pocock productivity quartet under MIT.
+    Production-ready instruction packages with structured workflows, Python automation tools, and reference documentation across 12 domains. v2.7.0 adds 13 Path-B skills (productivity, marketing, research). v2.6.0 added the Matt Pocock productivity quartet under MIT.
 
     [:octicons-arrow-right-24: Browse skills](skills/index.md)
 
--   :material-robot:{ .lg .middle } **37 Agents**
+-   :material-robot:{ .lg .middle } **45+ Agents**
 
     ---
 
-    Multi-skill orchestrators that combine domain expertise for complex tasks — from engineering leads to financial analysts.
+    Multi-skill orchestrators that combine domain expertise for complex tasks — from engineering leads to financial analysts to research-pack routers.
 
     [:octicons-arrow-right-24: View agents](agents/index.md)
 

--- a/docs/skills/engineering/grill-with-docs.md
+++ b/docs/skills/engineering/grill-with-docs.md
@@ -1,0 +1,147 @@
+---
+title: "Grill with Docs — Agent Skill for Codex & OpenClaw"
+description: "Docs-anchored grilling session — challenges a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), and. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Grill with Docs
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-identifier: `grill-with-docs`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install engineering-advanced-skills</code>
+</div>
+
+
+> Derived from [Matt Pocock's grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) (MIT, © 2026 Matt Pocock). Matt's interview discipline + docs-anchored grilling rules preserved verbatim under MIT. Additions in this repo: 3 stdlib validators (CONTEXT.md linter, ADR scanner, glossary↔code consistency check), 3 in-depth references each citing 7+ authoritative sources, `cs-grill-with-docs` agent, `/cs:grill-with-docs` command. See [Wrapper additions](#wrapper-additions) below.
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>
+
+## Wrapper Additions
+
+The additions below are **not** part of Matt's upstream skill. They operationalize the upstream's rules into deterministic, stdlib-only validators that pair naturally with the interview loop.
+
+### Workflow (with wrapper tools)
+
+1. **Pre-flight (before the first question):**
+   - Run `scripts/context_md_linter.py CONTEXT.md` if a `CONTEXT.md` exists — confirms the glossary is well-formed before grilling against it.
+   - Run `scripts/adr_scanner.py docs/adr/` if `docs/adr/` exists — surfaces numbering gaps, malformed ADRs, status-frontmatter inconsistencies.
+   - Run `scripts/glossary_code_consistency.py --context CONTEXT.md --code src/` — flags defined-but-unused terms (dead glossary) and code-only common nouns that may need definitions. Use these flags as opening grill questions.
+
+2. **During the session (Matt's rules apply):**
+   - One question per turn, walking depth-first.
+   - When a term is sharpened: edit `CONTEXT.md` immediately; re-run `context_md_linter.py` if the edit is structural.
+   - When an ADR is warranted: write it under `docs/adr/`; re-run `adr_scanner.py` to confirm numbering.
+
+3. **Closing:**
+   - Final `glossary_code_consistency.py` run to confirm no new orphan terms were introduced.
+   - Summarize: terms added/refined, ADRs written, scenarios discussed, open items.
+
+### Tools (stdlib-only)
+
+| Tool | One-line role |
+|---|---|
+| `scripts/context_md_linter.py` | Validate `CONTEXT.md` against the CONTEXT-FORMAT.md structure. PASS/WARN/FAIL per rule. |
+| `scripts/adr_scanner.py` | Walk `docs/adr/`, check `NNNN-slug.md` pattern, numbering integrity, body completeness. |
+| `scripts/glossary_code_consistency.py` | Cross-reference bold terms in `CONTEXT.md` against codebase usage. Flag dead glossary + code-only common nouns. |
+
+### References (citations behind each rule)
+
+- [`references/ubiquitous_language.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/references/ubiquitous_language.md) — why a glossary belongs in source control (Evans, Vernon, Khononov, Wlaschin, Brandolini, Avram & Marinescu, Fowler)
+- [`references/adr_practice.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/references/adr_practice.md) — when an ADR earns its keep (Nygard, Tyree & Akerman, Zimmermann Y-statements, MADR, ThoughtWorks Radar, adr-tools, Backstage)
+- [`references/context_md_as_artifact.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/skills/grill-with-docs/references/context_md_as_artifact.md) — CONTEXT.md as living artifact (Khononov on language drift, Kernighan on naming, BoundedContext bliki, Confluent on data contracts, Brandolini on EventStorming glossary)
+
+### Companion
+
+- Agent: `cs-grill-with-docs` (see [`agents/cs-grill-with-docs.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/agents/cs-grill-with-docs.md))
+- Command: `/cs:grill-with-docs` (see [`commands/cs-grill-with-docs.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs/commands/cs-grill-with-docs.md))
+
+---
+
+**Version:** 1.0.0
+**Derived:** Matt Pocock's grill-with-docs (MIT) + this repo's wrapper

--- a/docs/skills/engineering/index.md
+++ b/docs/skills/engineering/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Engineering - POWERFUL Skills — Agent Skills & Codex Plugins"
-description: "70 engineering - powerful skills — advanced agent-native skill and Claude Code plugin for AI agent design, infrastructure, and automation. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+description: "71 engineering - powerful skills — advanced agent-native skill and Claude Code plugin for AI agent design, infrastructure, and automation. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-rocket-launch: Engineering - POWERFUL
 
-<p class="domain-count">70 skills in this domain</p>
+<p class="domain-count">71 skills in this domain</p>
 
 </div>
 

--- a/docs/skills/marketing/index.md
+++ b/docs/skills/marketing/index.md
@@ -1,0 +1,20 @@
+---
+title: "Marketing (Top-Level) Skills — Agent Skills & Codex Plugins"
+description: "1 marketing (top-level) skills — landing-page generator agent skill and Claude Code plugin for single-file HTML output with 4 design styles. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+---
+
+<div class="domain-header" markdown>
+
+# :material-web: Marketing (Top-Level)
+
+<p class="domain-count">1 skills in this domain</p>
+
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install all:</span> <code>claude /plugin install marketing-top-level-skills</code>
+</div>
+
+<div class="grid cards" markdown>
+
+</div>

--- a/docs/skills/marketing/landing.md
+++ b/docs/skills/marketing/landing.md
@@ -1,0 +1,351 @@
+---
+title: "Landing — Premium HTML Landing Page Generator — Agent Skill for Landing Pages"
+description: "Generates a premium single-page HTML landing page with 3D CSS animations, GSAP scroll effects, and mouse-parallax depth. Forcing intake (product +."
+---
+
+# Landing — Premium HTML Landing Page Generator
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-web: Marketing (Top-Level)</span>
+<span class="meta-badge">:material-identifier: `landing`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install marketing-top-level-skills</code>
+</div>
+
+
+> **Distinct from `product-team/skills/landing-page-generator/`.** That skill outputs Next.js TSX components optimized for conversion / lead-gen. THIS skill outputs a single self-contained `.html` file optimized for premium visual experience with GSAP animations. Pick by use case.
+
+Generate a polished, self-contained `.html` landing page from a text prompt or brief. The output is ONE HTML file: all CSS inline in `<style>`, all JS inline in `<script>`, only external dependencies being Google Fonts + GSAP via CDN. The page is visually distinctive, animated, and production-quality.
+
+## Invocation Triggers
+
+- "create a landing page"
+- "build a landing page"
+- "make a landing page for X"
+- "I need a web page for Y"
+- "promotional page"
+- "product page"
+- "one-pager"
+- "web presence"
+- "sales page"
+- "landing for X"
+
+## Delivery Mode
+
+In **Claude Code CLI**, write the file to disk at the specified path. In **Claude.ai web**, create an HTML artifact with the same content.
+
+## Phase 0: Grill-Me Intake (4 forcing questions, one at a time)
+
+Dependency-ordered. Each question carries explicit "why I'm asking". Stop condition: max 4.
+
+### Q1 (root) — Product / Service
+
+> **What's the product or service? Give me the name + a 1–2 sentence elevator pitch — what does it do, and who's it for?**
+>
+> *Why I'm asking:* The headline, subtext, and feature copy all derive from this. "App for productivity" produces generic boilerplate; "Async standup tool for remote engineering teams who hate Zoom" produces a landing page that converts.
+
+**Refuse mush.** If user gives just a name with no pitch, push back once: "What does it do? Who's it for?" If still no pitch after push-back, deliver with explicit "generic positioning" caveat.
+
+### Q2 (depends on Q1) — Audience Register
+
+> **Who's the audience? Pick one:**
+>
+> 1. **Technical buyers** (engineers, ops, security)
+> 2. **Business buyers** (PMs, execs, ops leaders)
+> 3. **Consumers** (general public, hobbyists)
+> 4. **Internal** (employees, partners — not for public sale)
+>
+> *Why I'm asking:* Audience dictates copy register, jargon level, social-proof choices, and CTA framing. Technical buyers want specifics; consumers want benefits; internal pages can skip persuasion.
+
+Forcing choice.
+
+### Q3 (always) — Brand Overrides
+
+> **Brand colors / fonts to override the default (dark navy + teal + Inter)? Provide as: primary HEX, accent HEX, optional bg HEX. Or say "default" if you want the polished default.**
+>
+> *Why I'm asking:* The default is intentionally beautiful, but matching your brand makes the page feel native to your existing site. Even just a primary color override goes a long way.
+
+Accept "default" or partial overrides (e.g., just primary). If only primary provided, derive accent algorithmically (lighten / darken).
+
+### Q4 (depends on Q1) — Tone
+
+> **Tone — pick one:**
+>
+> 1. **Professional** — confident, restrained, B2B-friendly
+> 2. **Playful** — warm, light, occasional humor
+> 3. **Authoritative** — expert, data-forward, trust-building
+> 4. **Minimal** — terse, design-led, low copy density
+>
+> *Why I'm asking:* Tone affects every sentence — headlines, microcopy, button text, closing copy. Picking upfront prevents tonal whiplash across sections.
+
+Forcing choice. **Recommended default:** professional if Q2 = technical/business; playful if Q2 = consumer; minimal if the product is design-led.
+
+**Stop condition:** After Q4, commit and generate. No follow-up questions during generation.
+
+## Content Extraction (with Fallback Strategy)
+
+From Q1's elevator pitch, derive:
+- **Hero headline** — punchy version of "what it does" (8–12 words)
+- **Hero subtext** — version of "who it's for + payoff" (1–2 sentences)
+- **3–6 feature bullets** — distilled from pitch + audience (Q2) + tone (Q4)
+- **CTA text** — action-oriented, matches tone
+- **Closing copy** — short, emotive, matches tone
+
+**Fallback when input is sparse:** invent compelling content from product-name semantics + audience register. Flag inferred content with a comment in the HTML source (`<!-- inferred: ... -->`). Don't stall waiting for more input.
+
+## Brand System Specification
+
+### Default Color Palette (Dark Navy + Teal)
+
+```css
+:root {
+  --navy:       #0A1628;
+  --navy-mid:   #0D1F38;
+  --teal:       #00D4AA;
+  --teal-glow:  rgba(0, 212, 170, 0.12);
+  --amber:      #F5A623;
+  --off-white:  #F7F7F2;
+  --text-muted: rgba(247, 247, 242, 0.68);
+  --card-bg:    rgba(0, 212, 170, 0.06);
+  --card-border:rgba(0, 212, 170, 0.15);
+}
+```
+
+### Override Pattern
+
+When Q3 provides custom brand values, the skill substitutes them into the `:root` block:
+
+```
+Brand override:
+- primary: #FF6B35    →  --navy / hero bg
+- accent:  #2EC4B6    →  --teal / CTA / highlights
+- bg:      #011627    →  --navy-mid / section bg
+- text:    #FDFFFC    →  --off-white
+```
+
+If only primary provided, derive accent algorithmically (lighten 15% for accent; darken 8% for navy-mid; convert to rgba at 0.12 alpha for glow). Use `scripts/brand_palette_validator.py` for the deterministic derivation.
+
+See [`references/brand_system_design.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/brand_system_design.md) for color theory + WCAG + algorithmic palette derivation canon.
+
+### Typography
+
+- **Font family:** Inter (via Google Fonts)
+- **Weight scale:** 400 (body), 500 (eyebrow), 600 (links), 700 (subtitle), 800 (H1 + H2)
+- **Size scale:**
+  - Hero H1: 68–82px
+  - Section H2: 52–62px
+  - Card titles: 22px
+  - Body: 17–19px
+  - Eyebrow: 13px (uppercase, letter-spaced)
+  - CTA button: 18px (500 weight)
+
+### Components (Must Specify CSS)
+
+- `.btn-primary` — CTA button with hover state (lift + brightness)
+- `.feature-card` — card with hover lift (translateY(-6px) + border-brighten)
+- `.eyebrow` — letter-spaced (0.2em) uppercase category label
+
+## Section 1: Hero
+
+- `min-height: 100vh`, flex-centered content
+- Optional eyebrow label above H1
+- H1 (68–82px, 800 weight)
+- Subtitle (17–19px, 1–2 sentences)
+- CTA button (.btn-primary)
+- Scroll-down indicator (animated chevron, CSS bounce)
+- **Depth layers** (mouse parallax):
+  - `.hero-shapes-back` — large blurred circles, absolute-positioned, low opacity
+  - `.hero-shapes-mid` — smaller shapes, sharper edges, higher opacity
+  - Content layer (H1 + subtitle) — moves subtly in same direction as mouse
+
+## Section 2: Features
+
+- 3 columns default (`repeat(3, 1fr)` grid)
+- Responsive:
+  - 2 columns at 900px breakpoint
+  - 1 column at 580px breakpoint
+- Each card:
+  - SVG icon (28px, stroke=var(--teal), no fill)
+  - Title (22px, 700 weight)
+  - Description (15–16px, --text-muted)
+- Hover state:
+  - `transform: translateY(-6px)`
+  - `border-color: var(--teal)` (brighten from --card-border)
+  - `transition: 0.3s ease`
+
+## Section 3: Closing CTA
+
+- Full-width, `background: var(--navy-mid)`
+- `padding: 120px 24px`, text-align: center
+- Large closing headline (52–62px, 800 weight)
+- Short subtext (--text-muted, 1–2 sentences)
+- CTA button with ambient radial-gradient glow behind it:
+  ```css
+  background: radial-gradient(circle, var(--teal-glow) 0%, transparent 70%);
+  ```
+
+## Animation Patterns
+
+See [`references/gsap_animation_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/gsap_animation_patterns.md) for the canon. Five patterns required:
+
+### 1. Hero Entrance (GSAP timeline)
+
+```js
+// MUST use gsap.set() FIRST to prevent FOUC
+gsap.set([".eyebrow", ".hero h1", ".hero .subtitle", ".btn-primary", ".scroll-down"], {
+  opacity: 0,
+  y: 30
+});
+
+const tl = gsap.timeline({ defaults: { ease: "power3.out" } });
+tl.to(".eyebrow", { opacity: 1, y: 0, duration: 0.6 })
+  .to(".hero h1", { opacity: 1, y: 0, duration: 0.8 }, "-=0.3")
+  .to(".hero .subtitle", { opacity: 1, y: 0, duration: 0.6 }, "-=0.5")
+  .to(".btn-primary", { opacity: 1, y: 0, duration: 0.5 }, "-=0.3")
+  .to(".scroll-down", { opacity: 1, y: 0, duration: 0.4 }, "-=0.2");
+```
+
+### 2. Mouse Parallax
+
+```js
+const hero = document.querySelector(".hero");
+hero.addEventListener("mousemove", (e) => {
+  const x = (e.clientX / window.innerWidth - 0.5) * 2;
+  const y = (e.clientY / window.innerHeight - 0.5) * 2;
+  gsap.to(".hero-shapes-back", { x: x * 45, y: y * 22, duration: 0.8 });
+  gsap.to(".hero-shapes-mid",  { x: x * 22, y: y * 11, duration: 0.8 });
+  gsap.to(".hero .container",  { x: x * 8,  y: y * 5,  duration: 0.8 });
+});
+```
+
+### 3. Scroll-Triggered Feature Cards
+
+```js
+gsap.set(".feature-card", { opacity: 0, y: 55, rotateX: 18 });
+
+ScrollTrigger.batch(".feature-card", {
+  start: "top 80%",
+  onEnter: batch => gsap.to(batch, {
+    opacity: 1, y: 0, rotateX: 0,
+    duration: 0.8,
+    stagger: 0.11,
+    ease: "power2.out"
+  })
+});
+```
+
+### 4. Floating Decorative Shapes (CSS keyframes — NOT GSAP)
+
+CSS handles ambient continuous motion (smoother, cheaper than GSAP for indefinite animations):
+
+```css
+@keyframes floatA {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  50%      { transform: translate(20px, -30px) rotate(8deg); }
+}
+@keyframes floatB { /* different duration + rotation */ }
+@keyframes floatC { /* different duration + rotation */ }
+
+.hero-shapes-back .shape-a { animation: floatA 12s ease-in-out infinite; }
+```
+
+### 5. Scroll Indicator (CSS bounce)
+
+```css
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(8px); }
+}
+.scroll-down { animation: bounce 2s ease-in-out infinite; }
+```
+
+## Required CDN Dependencies
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
+```
+
+NO other external CSS or JS files. All custom CSS in `<style>`, all custom JS in `<script>` blocks within the same HTML file.
+
+See [`references/single_file_html_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/single_file_html_discipline.md) for the inline-only rationale.
+
+## Layout Rules
+
+- **Container max-width:** 1200px, centered
+- **Section padding:** `120px 24px` (vertical 120, horizontal 24, scales down on mobile)
+- **Responsive breakpoints:**
+  - 900px → features grid 3-col → 2-col
+  - 580px → all grids → 1-col; H1 scales down to ~52px
+- **Viewport meta:** `<meta name="viewport" content="width=device-width, initial-scale=1">`
+
+## Output Spec
+
+- **Path:** `${OUTPUT_DIR}/<product-name-kebab>.html`
+- **Default `${OUTPUT_DIR}`:** `./landing-pages/`
+- **Filename:** lowercase kebab-case from product name ("Quill AI" → `quill-ai.html`). Use `scripts/kebab_slug_generator.py` for deterministic slug generation + duplicate detection.
+- **Self-contained:** all CSS in `<style>`, all JS in `<script>`, only Google Fonts + GSAP CDN external.
+
+## Validation (Post-Generation)
+
+Run `scripts/html_validator.py --file ${OUTPUT_DIR}/<slug>.html` after generation. Checks:
+
+- All 3 required sections present (`.hero`, `.features`, `.closing-cta`)
+- CDN deps present (Inter + GSAP + ScrollTrigger)
+- `gsap.set()` initial states precede any `gsap.timeline` or `gsap.to` (FOUC prevention)
+- Responsive breakpoints at 900px + 580px
+- No external `<link rel="stylesheet">` other than Google Fonts
+- No external `<script src=>` other than GSAP CDN
+- `<meta name="viewport">` present
+- All animated elements have initial-state declarations
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| Input is just a name with no context | Invent compelling content from name semantics + audience register; flag as `<!-- inferred -->` in HTML source |
+| Input file is large or PDF | Read fully before generating; don't truncate |
+| Brand colors insufficient (only 1 HEX provided) | Use as primary; derive secondary/accent algorithmically (lighten/darken via brand_palette_validator.py) |
+| Features count not specified | Default to 4 |
+| Output dir doesn't exist | Create it |
+| Existing file at output path | Append timestamp suffix or ask user (kebab_slug_generator.py flags duplicates) |
+| html_validator returns FAIL | Regenerate ONLY the failing sections in one targeted pass; do NOT abandon the file |
+
+## Portability
+
+- **Claude Code CLI:** Native — writes HTML file directly to filesystem.
+- **Claude.ai web:** Native — produces HTML as an artifact instead of file.
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/brand_palette_validator.py` | Validates HEX format, checks WCAG AA contrast, generates derived palette from primary (algorithmic lighten/darken). |
+| `scripts/kebab_slug_generator.py` | Product name → kebab-case filename + duplicate detection in output dir. |
+| `scripts/html_validator.py` | Post-generation structural check: 3 sections, CDN deps, gsap.set() initial states, responsive breakpoints, no external files. |
+
+## References
+
+- [`references/brand_system_design.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/brand_system_design.md) — color theory + WCAG + algorithmic palette derivation (7+ sources)
+- [`references/gsap_animation_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/gsap_animation_patterns.md) — entrance timeline + ScrollTrigger reveals + mouse parallax + CSS floats + scroll indicator (7+ sources)
+- [`references/single_file_html_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/marketing/landing/skills/landing/references/single_file_html_discipline.md) — why inline + CDN-only externals + accessibility minimums + no-build rationale (7+ sources)
+
+## Anti-Patterns To Reject
+
+- Hardcoded absolute paths in output directory
+- Single brand palette without override documentation
+- Outlining before writing — write in one pass
+- External CSS or JS files (must be inline; only Google Fonts + GSAP CDN allowed)
+- Skipping `gsap.set()` initial states (causes FOUC)
+- More than 6 features in default grid (becomes unscannable)
+- Brand-specific content references in the skill itself
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/04-landing-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/04-landing-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Distinct from `product-team/skills/landing-page-generator/`.

--- a/docs/skills/productivity/capture.md
+++ b/docs/skills/productivity/capture.md
@@ -1,0 +1,218 @@
+---
+title: "Capture — Brain-Dump Organizer — Agent Skill for Personal Productivity"
+description: "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Capture — Brain-Dump Organizer
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-lightning-bolt-outline: Productivity</span>
+<span class="meta-badge">:material-identifier: `capture`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/capture/skills/capture/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install productivity-skills</code>
+</div>
+
+
+A fast-to-action skill for transforming unstructured streams of mixed thoughts, tasks, and ideas into a clean four-section actionable system with zero information loss.
+
+## Invocation Triggers
+
+**Explicit phrases** (any of):
+- "brain dump"
+- "capture this"
+- "let me dump some ideas"
+- "I've got a bunch of thoughts"
+- "here's everything on my mind"
+- "idea dump"
+- "let me just get this out of my head"
+- "I need to organize my thoughts"
+- "here's what I'm thinking"
+
+**Implicit signals** (no phrase, but the intent is unmistakable):
+- User pastes or dictates a long unstructured block of mixed ideas, tasks, plans
+- Multiple unrelated thoughts in one message without organizing framing
+- A wall of bullet-y text covering 3+ unrelated topics
+
+When you detect an implicit trigger, run the skill. Do NOT ask "do you want me to organize this?" first — the dump itself IS the request.
+
+## Operating Principles (All Five Apply Always)
+
+1. **Capture everything.** Zero loss. Trivial items go in; the user prunes later. Never silently drop something because it "seemed unimportant".
+2. **Preserve voice.** If the user said "build something crazy with AI", do NOT restate as "Explore innovative AI-driven solutions." Keep the energy and the casual register. See `references/voice_preservation.md` for concrete anti-patterns.
+3. **Match output complexity to input.** A 5-task dump does NOT get forced into 4 elaborate sections. See `references/complexity_matching.md` and the Compressed Output Pattern below.
+4. **Be honest about ambiguity.** If you're unsure what something means, flag it. Don't guess silently.
+5. **No action without approval.** The ONLY immediate action is the organization itself. Every offer in Section 4 waits for the user's explicit pick.
+
+## Grill-Me Mid-Organization Clarifier
+
+Capture is fast-to-action by design. **No upfront intake.** The dump is enough — start organizing immediately.
+
+The grill-me discipline applies as a **single mid-organization clarifying question**, asked **only when** one item in the dump is genuinely ambiguous between *task* and *project*, AND the misclassification would meaningfully change the output:
+
+> **Quick clarification — one item in your dump could go either way. Is [X] a one-shot task or a multi-step project?**
+>
+> *Why I'm asking:* If I guess wrong on a borderline item I either bury a project as a task or inflate a task into a project that doesn't need the structure. One question per dump prevents that.
+
+**Stop condition:** Max 1 clarifying question per dump. After the answer (or if no clarification was needed), deliver the four (or compressed) sections.
+
+If the dump is unambiguous, skip the clarifier entirely.
+
+**Anti-pattern (do not do this):** asking 3 clarifying questions up front. That breaks the dump-and-organize flow that makes capture useful.
+
+## Section 1: Projects & Ideas
+
+Cluster related items into themed projects when natural clustering exists. This section also holds:
+- Standalone creative sparks
+- Half-formed concepts
+- "What if" thoughts
+- Embedded decisions (`Decide: X or Y`) and open questions (`Q: ...`) — kept WITHIN the relevant project, NOT extracted into a separate top-level category
+
+**Format per project:**
+
+```
+### {Project name in user's voice}
+
+- {component / sub-idea}
+- {component}
+- Q: {open question this project needs answered}
+- Decide: {decision this project requires}
+```
+
+Use the user's words for the project name. If the user wrote "ai dating app for ferrets", do NOT rename it to "AI-Powered Pet Companion Platform".
+
+## Section 2: Tasks
+
+Flat, scannable, action-oriented. Includes:
+- Explicit todos
+- Decisions framed as `Decide: ...`
+- Open questions framed as `Resolve: ...`
+
+If a task belongs to a project from Section 1, append `[Project: X]` to link it — but don't repeat the project's context.
+
+**Format:**
+
+```
+- {task in imperative voice}  [Project: X if related]
+- Decide: {decision}  [Project: X if related]
+- Resolve: {open question}
+- ...
+```
+
+## Section 3: Connections
+
+This is where the skill earns its keep — and where **fabrication is forbidden**.
+
+**Workflow:**
+
+1. **Inventory the workspace** — Glob for filename patterns matching dump keywords, Grep for content matches, read the top-level directory structure. Use `scripts/workspace_inventory.py` to do this deterministically.
+2. **Match dump items to existing content** — files / folders relating to dumped items, prior thinking in documents, in-progress projects with overlap.
+3. **Surface dependencies within the dump** — items that affect each other, themes, ordering implications.
+4. **Be honest about inaccessibility** — if you can't inspect the workspace (no filesystem available, MCP not connected), say so explicitly. Do NOT make up plausible-sounding connections.
+
+**Hard rule:** NEVER fabricate connections. Only surface ones actually found by Glob/Grep/Read. If no real connections exist:
+
+> **Connections:** No connections found — workspace inventory clean.
+
+If the workspace is inaccessible:
+
+> **Connections:** No workspace accessible from here. If you're running this from Claude Code or have a project with files attached, I can fill this in. Want to share where this work lives?
+
+See `references/workspace_detection.md` for the per-context detection-tactic catalog.
+
+## Section 4: How I Can Help
+
+**Concrete offers, not abstract possibilities.** Every offer specifies what would be produced AND where it would go.
+
+| ✅ Right pattern | ❌ Anti-pattern |
+|---|---|
+| "I can research Consensus MCP integration patterns and give you 3 options. Output: `docs/consensus-options.md`." | "You might want to look into integration approaches." |
+| "I can draft the Q3 launch plan as a 1-pager. Output: chat reply, then `docs/q3-launch.md` if you want it filed." | "Maybe think about Q3 planning." |
+| "I can scaffold the new auth module with the existing pattern from `src/users/`. Output: 4 files in `src/auth/`." | "We could explore auth options." |
+
+End with the directive question:
+
+> **Which of these should I tackle?**
+
+## Compressed Output Pattern
+
+When the dump has **5 or fewer items** and items are **unrelated** (no natural clustering), drop the 4-section format and use compressed:
+
+```
+## What I heard
+
+- {item}
+- {item}
+- {item}
+- ...
+
+## How I can help
+
+- {concrete offer with what + where}
+- {concrete offer with what + where}
+
+Which should I tackle?
+```
+
+The trigger is the `complexity_estimator.py` recommendation OR your judgment when no clusters exist. See `references/complexity_matching.md` for worked examples of when each format applies.
+
+## Workspace Detection Strategy
+
+| Context | Detection method |
+|---|---|
+| Claude Code CLI | Glob for files matching dump keywords; Grep for content matches; read top-level structure. Use `scripts/workspace_inventory.py`. |
+| Claude.ai with project | Check project knowledge files for thematic overlap. List file titles; surface matches by keyword. |
+| Connected tools (Notion, Drive, etc.) | Search via MCP if available. |
+| No accessible workspace | State the limitation explicitly; ask user about their setup; do NOT fabricate. |
+
+## Approval Gate
+
+After the four (or compressed) sections are delivered:
+
+- **Wait for the user's explicit pick** before doing anything else.
+- If the user says "go" without picking a specific offer: honor it, but explicitly note any items you weren't 100% sure about so they can correct.
+- The organization itself is the only auto-action. Every Section 4 offer requires green light.
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| Workspace inaccessible | State this; skip Section 3 or surface "no workspace accessible" + ask about setup |
+| Dump is very short (3-5 items) | Use compressed output; don't force 4 sections |
+| Items are highly ambiguous | Flag in output, ask up to 1 clarifier (or skip clarifier and surface ambiguity in delivery) |
+| Dump contains sensitive info | Acknowledge but don't echo verbatim if user asks for organization without quoting |
+| Conflicting items in the dump | Surface the conflict in Section 1 or 3 explicitly (`Conflict: X says A, Y says B`) |
+| User says "go" before approval | Honor it, but explicitly note items you weren't sure about |
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/workspace_inventory.py` | Glob+Grep helper for Section 3. `python workspace_inventory.py --root . --keywords "k1,k2"` returns matches by keyword + folder structure. |
+| `scripts/dump_classifier.py` | Regex-classifies each dump line into `task` / `decision` / `question` / `idea` / `project-component`. Heuristic — override with judgment. |
+| `scripts/complexity_estimator.py` | Counts items, detects clustering signal, recommends `format=full` or `format=compressed`. |
+
+## References
+
+- `references/workspace_detection.md` — context-specific detection tactics (CLI / web / MCP / inaccessible)
+- `references/voice_preservation.md` — corporate-speak anti-patterns with concrete examples
+- `references/complexity_matching.md` — compressed vs full output, worked examples
+
+## Anti-Patterns To Reject
+
+- Fabricating workspace connections that weren't actually Glob/Grep-verified
+- Dropping items deemed "trivial" — capture everything, let the user prune
+- Corporate-ifying the user's casual language
+- Forcing 4-section structure when input is small (5 simple tasks doesn't need it)
+- Acting on Section-4 offers immediately without approval
+- Splitting decisions/questions into a separate top-level category instead of embedding them in the relevant project
+- Vague Section-4 offers ("you might want to consider…")
+- Asking 3+ clarifying questions up front (breaks fast-to-action)
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/05-capture-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/05-capture-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Re-grill with `/cs:grill-with-docs` if drift between spec and implementation surfaces.

--- a/docs/skills/productivity/email-inbox-setup.md
+++ b/docs/skills/productivity/email-inbox-setup.md
@@ -1,0 +1,234 @@
+---
+title: "Inbox-Setup — Email Triage Onboarding — Agent Skill for Personal Productivity"
+description: "One-time setup skill that builds a personalized inbox triage knowledge base via interactive interview. Interviews the user about their email. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Inbox-Setup — Email Triage Onboarding
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-lightning-bolt-outline: Productivity</span>
+<span class="meta-badge">:material-identifier: `inbox-setup`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install productivity-skills</code>
+</div>
+
+
+> **Paired with `inbox-triage`.** This skill writes the 7-file knowledge base at `${WORKSPACE}/Email/` that `inbox-triage` reads on every run. The file contracts (names, sections, fields) MUST match between the two skills exactly. See [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/kb_file_contract.md).
+
+Run once (or re-run when business/priorities change). Interview the user about their email patterns, business context, reply style, and priorities. Generate the structured knowledge base in `${WORKSPACE}/Email/` that captures everything `inbox-triage` needs to process the inbox effectively.
+
+## Invocation Triggers
+
+- "set up my inbox"
+- "configure inbox triage"
+- "set up my email system"
+- "configure email triage"
+- "build my email knowledge base"
+- "initialize email management"
+- "set up inbox triage"
+- "onboard email triage"
+
+## Conduct Discipline
+
+**Do NOT generate all files at once.** Walk through the 8 sections one at a time. Each section commits its file(s) before moving on. Partial completion (e.g., user drops off mid-interview) still produces a usable partial KB.
+
+Grill-me discipline applies throughout:
+
+- **One question per turn.** Never bundle. Even across section boundaries.
+- **"Why I'm asking" on every question** — so users can answer well.
+- **Forcing format where possible.** Multi-choice > open-ended.
+- **Dependency-ordered.** Q2 depends on Q1; downstream sections depend on upstream.
+
+See [`references/grill_me_section_walk.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/grill_me_section_walk.md) for the 8-section discipline detail.
+
+## Knowledge Base Contract — Files To Produce
+
+Exactly these files at `${WORKSPACE}/Email/`:
+
+| File | Purpose | Required? |
+|---|---|---|
+| `email-taxonomy.md` | Classification system + report preferences | **Yes** |
+| `email-patterns.md` | Reply voice, tone, templates, hard rules | **Yes** |
+| `evaluation-framework.md` | Decision tree for opportunity emails | Only if user receives pitches/opportunities |
+| `rate-card.md` | Pricing, terms, negotiation posture | Only if user has pricing |
+| `blocklist.md` | Auto-skip senders + learned decline patterns | **Yes** (seeded, grows over time) |
+| `tracker.md` | Active follow-ups, overdue items, deadlines | **Yes** (starts mostly empty) |
+| `triage-log/` | Directory for per-run logs | **Yes** (created empty) |
+
+The contract is identical to what `inbox-triage` expects — see [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/kb_file_contract.md) for the full spec.
+
+## Stop Condition (Full Interview)
+
+~25–31 questions total across the 8 sections (depending on skip-logic). Hard ceiling: 35 questions including all sub-clarifications. Section 4 (Evaluation Framework) is skipped entirely when Section 1 surfaced no opportunity-email category, dropping the total by 6 questions and the rate-card file. After Section 8's confirmation + handoff message, intake is closed — **never re-open it**. To change preferences later, the user re-runs the skill (which detects existing files and asks per-file: replace / merge / skip). The grill-me one-at-a-time rule applies across section boundaries: do NOT batch questions even when moving from S{n} to S{n+1}.
+
+## Section 1: The Big Picture
+
+Six grill-me questions, one at a time:
+
+- **S1.Q1:** "What do you do? Give me your role and business in 1–2 sentences. *Why I'm asking:* Context shapes what email patterns to expect — a solo creator's inbox looks nothing like an enterprise PM's."
+- **S1.Q2:** "What dominates your inbox? Pick the top 1–2: sales pitches / client work / internal team / newsletters / customer support / financial / other. *Why I'm asking:* Dominant categories drive the taxonomy."
+- **S1.Q3:** "Rough volume split — e.g., '60% business inquiries, 20% ops, 20% noise'. *Why I'm asking:* The split tells me where to focus triage effort."
+- **S1.Q4:** "Which email address(es) should triage cover? *Why I'm asking:* If multiple, I'll set up per-address taxonomies."
+- **S1.Q5:** "Run frequency: once daily / 2x daily / 3x daily / on-demand only? *Why I'm asking:* Drives the default search window in triage (9h overlap for 2x/day)."
+- **S1.Q6:** "Anyone helping manage email — assistant, VA, team — or solo? *Why I'm asking:* Persona handling differs for delegated inboxes."
+
+**Action:** Build mental model. Do NOT write files yet. Note whether opportunity emails are a category (drives S4 skip-logic).
+
+## Section 2: Email Categories
+
+Propose 5–7 categories based on Section 1 — pre-recommend a subset, not the whole template menu:
+
+- New Opportunities
+- Active Conversations
+- Action Required
+- Financial
+- Important/Personal
+- Informational
+- Ignore/Low Priority
+
+Then three forcing questions, one at a time:
+
+- **S2.Q1:** "Here's my proposed taxonomy: [list]. Does this match your inbox reality — yes / mostly / no? *Why I'm asking:* If 'no', I need to redo the taxonomy before any other section makes sense."
+- **S2.Q2:** "Missing categories? List them. (Skip if none.) *Why I'm asking:* Missing categories produce uncategorized emails downstream, which hurts triage quality."
+- **S2.Q3:** "Which category takes the MOST time per email? *Why I'm asking:* That's where draft-reply effort needs to focus most."
+
+**Action:** Generate `email-taxonomy.md` with categories, signals (for each: trigger phrases / sender patterns / subject markers), and default actions per category.
+
+## Section 3: Reply Style & Voice
+
+Six grill-me questions plus the critical sample request:
+
+- **S3.Q1:** "Register: formal / casual / in-between? *Why I'm asking:* Calibrates default voice; we'll refine from samples next."
+- **S3.Q2:** "Three communication pet peeves — phrases you hate, openings you avoid. *Why I'm asking:* I treat these as forbidden tokens in drafts."
+- **S3.Q3:** "Phrases or sign-offs you always use — list as many as come to mind. *Why I'm asking:* These are your voice fingerprints."
+- **S3.Q4:** "Different persona for different contexts — e.g., assistant replies as you? *Why I'm asking:* Persona context changes pronoun + signature handling."
+- **S3.Q5:** "Typical reply length — one-liner / short paragraph / longer? *Why I'm asking:* Length is the easiest voice signal to get wrong."
+- **S3.Q6:** "Hard rules — never X / always Y? (E.g., never emojis, always reply within 24h, never take calls without context.) *Why I'm asking:* Hard rules are enforced as non-negotiable in every draft."
+
+### S3.SAMPLES (the critical highest-quality input)
+
+> **Paste 3–5 real sent emails from your inbox.**
+>
+> *Why I'm asking:* Self-description of voice is unreliable. Real samples are the best signal — I'll analyze them for voice patterns that supplement everything above. Use `scripts/voice_sample_analyzer.py` to extract patterns deterministically.
+
+If user runs a business: also ask about media kits, rate sheets, standard pitches, repeated replies.
+
+**Action:** Generate `email-patterns.md` with tone description (with do/don't examples), persona rules, templates, signatures, hard rules. See [`references/voice_calibration.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/voice_calibration.md) for the sample-extraction discipline.
+
+## Section 4: Evaluation Framework (Conditional)
+
+**Skip-logic:** only run this section if Section 1 surfaced opportunity emails as a meaningful inbox category. Otherwise jump straight to Section 5.
+
+Six grill-me questions, one at a time:
+
+- **S4.Q1:** "First thing you check when pitched something — give me your gut filter. *Why I'm asking:* That's the top of the decision tree."
+- **S4.Q2:** "Three instant deal-breakers — things that make you decline immediately. *Why I'm asking:* These become PASS-auto signals."
+- **S4.Q3:** "Three things that make you immediately interested. *Why I'm asking:* These become TAKE-IT signals."
+- **S4.Q4:** "Standard pricing / terms — or 'no fixed pricing' if you negotiate every time. *Why I'm asking:* If you have a rate card, I'll generate one; if not, I'll skip."
+- **S4.Q5:** "Negotiation posture: firm / flexible / depends on context? *Why I'm asking:* Drives draft tone on counter-offers."
+- **S4.Q6:** "VIP senders or organizations that always get engagement — list names or domains. *Why I'm asking:* VIP list bypasses normal PASS filters."
+
+**Action:** Generate `evaluation-framework.md` (decision tree + recommendation categories + VIP list) AND `rate-card.md` if pricing exists.
+
+## Section 5: Blocklist & Patterns
+
+Three grill-me questions, one at a time:
+
+- **S5.Q1:** "Senders or domains to always skip — list them. (Skip if none.) *Why I'm asking:* Auto-blocklist saves the most time per run."
+- **S5.Q2:** "Patterns in emails you always delete — e.g., 'unsubscribe' links from specific marketers, recruiter cold outreach, newsletters? *Why I'm asking:* Patterns let triage auto-skip variants without exact-match maintenance."
+- **S5.Q3:** "Specific companies / recruiters / newsletters wasting time — list any. *Why I'm asking:* These seed the blocklist; triage will add more as you override decisions."
+
+**Action:** Generate `blocklist.md` (auto-maintained by triage thereafter).
+
+## Section 6: Current State
+
+Three grill-me questions, one at a time:
+
+- **S6.Q1:** "Active threads you're tracking — list with one-line context each. (Skip if none.) *Why I'm asking:* These become tracker entries so triage knows existing context."
+- **S6.Q2:** "Overdue replies — anything you should have responded to but haven't? *Why I'm asking:* Triage flags these as priority every run until resolved."
+- **S6.Q3:** "Time-sensitive items with deadlines — list with dates. *Why I'm asking:* Tracker enforces deadlines and surfaces them as overdue at the right time."
+
+**Action:** Generate `tracker.md` with active follow-ups table, overdue section, resolved section (empty), update log (empty). Also create empty `triage-log/` directory.
+
+## Section 7: Report Preferences
+
+Three grill-me questions, one at a time:
+
+- **S7.Q1:** "Delivery format — pick one: email draft to self / file in workspace / chat summary only. *Why I'm asking:* The triage report goes here every run."
+- **S7.Q2:** "Detail level — pick one: 30-second scan / detailed breakdown / both (scan first, expand on request). *Why I'm asking:* Affects report length."
+- **S7.Q3:** "Anything always shown first — e.g., overdue payments, VIP messages? *Why I'm asking:* Custom 'top-of-report' rules surface what you care about above standard sections."
+
+**Action:** Save these preferences into `email-taxonomy.md` under a "Report Preferences" section.
+
+## Section 8: Confirmation & Handoff
+
+List every file created with one-sentence summary. Then:
+
+> Your triage system is ready. Run the **inbox-triage** skill to process your inbox. First runs need oversight — system learns from your edits and overrides.
+
+Remind: re-run this setup anytime business/pricing/priorities change.
+
+Run `scripts/kb_validator.py --workspace ${WORKSPACE}` to confirm the 7-file contract is satisfied before final handoff.
+
+## Privacy Boundary
+
+**Never persist passwords, full account numbers, SSNs, or other sensitive credentials in knowledge base files.** If the user volunteers such info during the interview, acknowledge it but don't store it; the relevant KB file gets `[stored separately by user]` in its place.
+
+## Re-Run Behavior
+
+Re-running on an existing setup:
+
+1. Detect `${WORKSPACE}/Email/`
+2. For each existing file, ask per-file: **replace / merge / skip**
+3. Walk only the sections whose files the user chose to update
+4. Skip sections whose files the user kept
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| Workspace inaccessible | Stop. Tell user where files would go and ask for permission/path |
+| User refuses to share samples | Use self-description; flag in patterns file that calibration may need iteration |
+| User says "skip this" mid-interview | Honor it; flag the gap in the file as `[needs follow-up]` |
+| Sensitive info volunteered | Acknowledge but don't persist; note in file as `[stored separately by user]` |
+| Re-run on existing setup | Detect existing files; ask user per-file: replace, merge, skip |
+| User has no pricing / opportunities | Skip Section 4 entirely; don't create empty files |
+
+## Portability
+
+- **Claude Code CLI:** Native — writes markdown files directly to filesystem.
+- **Claude.ai web:** Works with project files / artifacts. Document the alternate path: generate files as artifacts, instruct user to save to their workspace, or use connected file system if available.
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/kb_validator.py` | Validates the 7-file KB output (required files present, conditional files only if their sections ran, headers + structure correct). |
+| `scripts/section_progress_tracker.py` | JSON-backed walk state at `~/.inbox_setup_sessions/<session>.json`. Tracks active section, answered questions, committed files. |
+| `scripts/voice_sample_analyzer.py` | Extracts voice patterns from pasted sent-email samples — opening phrases, sign-offs, length distribution, register markers. |
+
+## References
+
+- [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/kb_file_contract.md) — the canonical 7-file contract (write perspective; mirror lives in `inbox-triage/references/`)
+- [`references/grill_me_section_walk.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/grill_me_section_walk.md) — 8-section discipline, skip-logic, commit-per-section
+- [`references/voice_calibration.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-setup/references/voice_calibration.md) — sample-based voice extraction theory + anti-patterns
+
+## Anti-Patterns To Reject
+
+- Generating all files at once instead of walking through sections
+- Asking all questions in one batch
+- Hardcoded provider references (Gmail-only thinking)
+- Persisting sensitive credentials in knowledge base
+- Skipping the "why this question matters" explanation
+- Skipping the sample-emails ask for voice (it's the highest-quality input)
+- Overwriting existing files without consent on re-run
+- Forcing creation of `rate-card.md` or `evaluation-framework.md` when they don't apply
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/06-inbox-setup-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/06-inbox-setup-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Paired with `inbox-triage`.

--- a/docs/skills/productivity/email-inbox-triage.md
+++ b/docs/skills/productivity/email-inbox-triage.md
@@ -1,0 +1,317 @@
+---
+title: "Inbox-Triage — Recurring Email Triage — Agent Skill for Personal Productivity"
+description: "Runs a full inbox triage using the knowledge base created by the 'inbox-setup' skill. Light-intake by design (most invocations skip questions and run. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Inbox-Triage — Recurring Email Triage
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-lightning-bolt-outline: Productivity</span>
+<span class="meta-badge">:material-identifier: `inbox-triage`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install productivity-skills</code>
+</div>
+
+
+> **Paired with `inbox-setup`.** This skill consumes the 7-file knowledge base that `inbox-setup` writes at `${WORKSPACE}/Email/`. The file contracts MUST match exactly. See [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/references/kb_file_contract.md) — this is the mirror of the setup-side contract, viewed from the read side.
+
+Run on a recurring schedule (1–3x daily) or on demand. Classify recent emails, research new senders, generate decision recommendations, draft replies (**NEVER SEND**), deliver a clean report, and update the knowledge base with what was learned this run.
+
+## Invocation Triggers
+
+- "triage my inbox"
+- "inbox triage"
+- "check my email"
+- "run email triage"
+- "process my inbox"
+- "what's new in my email"
+- "handle my email"
+- "email triage"
+
+## Prerequisites
+
+Required reads at start (fail-fast if missing):
+
+**Core (required):**
+- `${WORKSPACE}/Email/email-taxonomy.md` — classification + report preferences
+- `${WORKSPACE}/Email/email-patterns.md` — voice, persona, templates, hard rules
+
+**Optional core (read if exists):**
+- `${WORKSPACE}/Email/evaluation-framework.md`
+- `${WORKSPACE}/Email/rate-card.md`
+
+**Evolving (read AND update every run):**
+- `${WORKSPACE}/Email/blocklist.md`
+- `${WORKSPACE}/Email/tracker.md`
+
+**Output:**
+- `${WORKSPACE}/Email/triage-log/<YYYY-MM-DD>-<run-label>.md` — per-run log
+
+If any core required file is missing → **halt**, direct user to run `inbox-setup` first. Use `scripts/kb_reader.py` to perform the read + validation.
+
+## DRAFTS ONLY — Never Send
+
+> **This skill creates drafts. It NEVER sends.**
+
+This is the safety property that makes the skill safe to run automatically. Stated multiple times in this skill body. Non-negotiable.
+
+The `scripts/draft_safety_validator.py` enforces it post-run. Any send-shaped tool call in the action log fails validation. See [`references/drafts_only_safety.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/references/drafts_only_safety.md) for the full discipline canon.
+
+## Step 0: Grill-Me Intake (Light — 0–2 Optional Override Questions)
+
+Inbox-triage is **light-intake by design** — it runs on a recurring cadence with preferences pre-baked into the knowledge base from `inbox-setup`. The grill-me discipline here is asking ONLY the override questions that matter THIS run.
+
+### Q1 (optional, asked only when on-demand run is outside normal cadence)
+
+> **Override the default 9-hour search window? Pick: yes (specify hours) / no (use default).**
+>
+> *Why I'm asking:* If you're running on-demand outside your normal 2x/day cadence, you may want a wider window (24h after a long break) or narrower (2h for a quick check).
+
+Skip if cadence is normal.
+
+### Q2 (optional, asked only when user invokes with category-skip intent)
+
+> **Skip any categories this run? E.g., "skip newsletters", "skip financial".**
+>
+> *Why I'm asking:* Sometimes you just want to scan opportunities or just want to clear active threads. Category skip narrows the run scope.
+
+Skip if user gave no category-skip signal.
+
+**Stop condition:** Max 2 questions. Default invocations skip both questions and run with KB-default preferences. The skill is optimized for fast recurring execution; intake is the exception, not the norm.
+
+## Step 1: Determine Search Window
+
+Compute via current date math. Default lookback: **9 hours** (works for 2x/day cadence with slight overlap so emails between runs aren't missed).
+
+Use `scripts/search_window_calculator.py --cadence <CADENCE> --now <ISO>`:
+
+```
+now = current_datetime
+window_start = now - 9_hours   (default for 2x-daily)
+run_label = "Morning" if now.hour < 12 else "Afternoon" if now.hour < 17 else "Evening"
+```
+
+Cadence-to-default-window mapping (override via Q1):
+
+| Cadence (from email-taxonomy.md S1.Q5) | Default window |
+|---|---|
+| once daily | 26h |
+| 2x daily | 9h |
+| 3x daily | 6h |
+| on-demand only | 24h (asks Q1) |
+
+## Step 2: Email Search
+
+Two queries (provider-agnostic adapter pattern):
+
+- **Primary:** Inbox + sent after `window_start`
+- **Secondary:** Starred unread (catch flagged items missed in primary)
+
+Collect for each email: sender, subject, date, snippet, thread ID, labels.
+
+Provider adapter mapping:
+
+| Provider | Tool |
+|---|---|
+| Gmail | Gmail MCP |
+| Outlook / Microsoft 365 | Outlook MCP |
+| IMAP (Fastmail, ProtonMail, etc.) | IMAP MCP if available; halt otherwise |
+| (no email tool available) | Halt with clear message: "No email tool registered for this session." |
+
+## Step 3: Classification
+
+Apply the taxonomy from `email-taxonomy.md`. For **lowest-priority** category (newsletters / automation / spam): skip thread reads entirely — context cost not worth it. For everything else: read full thread.
+
+## Step 4: Sender Research
+
+For senders not in tracker / blocklist / prior logs:
+
+1. Check `blocklist.md` → if matched, auto-skip
+2. Check `tracker.md` → if known thread, note existing context
+3. For opportunity senders (per evaluation framework): web search for company legitimacy, social presence, intermediary status
+
+**Skip research entirely** for: known senders (in tracker), internal email, automated notifications, obvious low-priority.
+
+## Step 5: Recommendations
+
+For decision-required emails, apply the framework from `evaluation-framework.md`. Categorize:
+
+| Category | When | Output |
+|---|---|---|
+| **TAKE IT** | Meets criteria | Recommend engaging; draft reply (Step 6) |
+| **WORTH CONSIDERING** | Has potential, needs user judgment | Surface key context; draft for user to edit |
+| **PASS** | Doesn't meet criteria | Brief "why" (1–3 sentences); draft polite decline |
+| **FLAG FOR REVIEW** | Unusual; needs direct user decision | Surface fully; NO draft (user decides response shape) |
+
+Each: brief "why", relevant context, pricing/timeline comparison if applicable.
+
+**Skip Step 5 entirely if no `evaluation-framework.md` exists.**
+
+See [`references/triage_decision_framework.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/references/triage_decision_framework.md) for the framework canon.
+
+## Step 6: Drafts
+
+For every reasonable reply candidate, create a draft using `email-patterns.md` voice rules.
+
+**Draft for:** opportunity responses (TAKE IT / WORTH / PASS), active conversations needing reply, action items, important personal emails.
+
+**Do NOT draft for:**
+- Clearly no-response emails (newsletters, automation, FYI)
+- Threads where user already replied
+- Blocked senders (unless new info changes the calculus)
+
+**Mechanics:**
+
+- Draft only in the existing thread when possible (preserves context)
+- Set `to`, `subject` (`Re: [original]`)
+- **NEVER call any send operation. Only create drafts.**
+
+The draft body MUST honor:
+- Voice register from `email-patterns.md`
+- Forbidden tokens (S3.Q2 pet peeves)
+- Sign-off patterns
+- Persona context
+- Hard rules (S3.Q6 — non-negotiable)
+- Reply length per `email-patterns.md`
+
+If `evaluation-framework.md` exists, draft tone matches recommendation:
+- TAKE IT → engaged + concrete next step
+- WORTH → curious + 1-2 clarifying questions
+- PASS → polite decline + brief reason (no hedging promises)
+- FLAG → NO draft
+
+## Step 7: Report Delivery
+
+Honor user's preference from `email-taxonomy.md` "Report Preferences" section. Default: email draft to self with HTML.
+
+**Subject:** `Inbox Triage — [Day], [Month Date] ([Run Label])`
+
+**Sections (in order):**
+
+1. **Overview** — 2–3 sentences. What happened? Anything urgent?
+2. **Stats** — Counts: processed, drafts created, action needed, skipped.
+3. **Action Needed** — Overdue items, decisions, drafts to review, deadlines.
+4. **Quick Reference** — One line per email, alphabetical by sender. `**Sender** — one-sentence summary + recommendation`.
+5. **Detailed Cards** — Opportunities, active threads, flags. Each: sender / subject / category, recommendation + reasoning, key context. **NO draft text previews** (drafts are already in email client for user to read there).
+6. **Footer** — Generation timestamp + KB update summary.
+
+**Formatting (if HTML):**
+
+- **Inline CSS only** (Gmail strips `<style>`)
+- Color-coded by recommendation:
+  - green → TAKE IT
+  - amber → WORTH CONSIDERING
+  - red → PASS
+  - purple → FLAG FOR REVIEW
+  - blue → active conversation
+
+## Step 8: Knowledge Base Update
+
+**`blocklist.md`** (append new):
+
+- New declined senders + reason + date
+- New decline patterns from observed behavior (e.g., "all emails containing 'looking for backend engineers' from gmail addresses → cold recruiter pattern")
+- Remove entries if user has overridden them (user replied to a "blocked" sender → unblock)
+
+**`tracker.md`** (append + update):
+
+- New follow-ups for emails needing future action
+- Update existing follow-ups (deadline changed, status changed)
+- Mark resolved items complete
+- Flag overdue items
+- Remove resolved items older than 30 days
+- Add entry to update log
+
+**Learning patterns to observe over runs:**
+
+- Drafts sent as-is vs. edited vs. deleted → tone calibration signal
+- PASS recommendations user overrides → framework adjustment signal
+- Engaged vs. ignored emails → taxonomy refinement signal
+- New decline patterns → blocklist additions
+
+After 5+ runs, suggest KB improvements to user (e.g., "You always decline emails from X — add as auto-skip?").
+
+## Step 9: Internal Log
+
+Save to `${WORKSPACE}/Email/triage-log/[YYYY-MM-DD]-[run-label].md`:
+
+- Emails processed with classifications
+- Recommendations made
+- Drafts created (with IDs / thread refs)
+- KB updates made
+- Follow-ups added / resolved
+- Notable observations (patterns surfaced, edge cases handled)
+
+The log is the audit trail for `scripts/draft_safety_validator.py` to scan for send operations post-run.
+
+## Step 10: Empty Inbox Handling
+
+Even with zero new emails:
+
+1. Check `tracker.md` for items due today or overdue
+2. Generate minimal report: "No new actionable emails since last run"
+3. Flag any overdue items
+4. Escalate per tracker rules
+
+Skip Steps 3–6 entirely on empty inbox.
+
+## Critical Rules (Stated Multiple Times)
+
+1. **DRAFTS ONLY — NEVER SEND.** Non-negotiable. Stated again here.
+2. **Privacy.** No passwords / credentials in KB. Reference threads by ID for sensitive content.
+3. **Accuracy over speed.** When unsure, flag for review. A wrong auto-draft is worse than no draft.
+4. **Respect the KB.** Documented preferences are source of truth. Don't override with judgment.
+5. **Transparency.** Note every KB change in the triage log.
+6. **First runs need oversight.** Document this expectation for the user.
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| KB files missing | Halt; direct user to run `inbox-setup` |
+| Email tool unavailable | Halt with clear message about required tool |
+| Web search unavailable for sender research | Skip research step; note senders not researched |
+| Draft creation fails | Skip that draft; note in log; report continues |
+| Report delivery fails | Save report to file as fallback; notify user |
+| User has 100+ new emails | Stay within reasonable limits; flag volume; offer to focus on priority categories only |
+| Sender appears in both blocklist and tracker | Tracker wins (active conversation); note inconsistency in log |
+
+## Portability
+
+- **Claude Code CLI:** Native — uses Gmail / Outlook MCP, file tools for KB, web search for research.
+- **Claude.ai web:** Works when email MCP connector is connected (Gmail MCP available). Skill must check tool availability before assuming. If no email tool: halt with clear message.
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/kb_reader.py` | Reads + validates the 7-file KB. Returns parsed structure. Halts with explicit error if required files missing. |
+| `scripts/search_window_calculator.py` | Computes `window_start` from cadence + current time. Returns `run_label`. Honors Q1 override. |
+| `scripts/draft_safety_validator.py` | Post-run scan of the action log for any send-shaped tool call. FAILs if detected. The deterministic enforcement of the NEVER-SEND rule. |
+
+## References
+
+- [`references/kb_file_contract.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/references/kb_file_contract.md) — canonical 7-file contract (read perspective; mirrors `inbox-setup/references/kb_file_contract.md`)
+- [`references/triage_decision_framework.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/references/triage_decision_framework.md) — TAKE IT / WORTH / PASS / FLAG taxonomy
+- [`references/drafts_only_safety.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/email/skills/inbox-triage/references/drafts_only_safety.md) — the NEVER-SEND discipline canon
+
+## Anti-Patterns To Reject
+
+- **Sending emails** (drafts only — non-negotiable)
+- Operating without knowledge base files
+- Storing passwords / credentials in KB
+- Skipping the learning loop (KB updates) at end of run
+- Overriding user's documented preferences with own judgment
+- Reading lowest-priority threads (waste of context)
+- Including draft text previews in report (drafts are already in email client)
+- Provider lock-in without adapter pattern
+- Silently failing on missing tools
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/07-inbox-triage-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/07-inbox-triage-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Paired with `inbox-setup`.

--- a/docs/skills/productivity/index.md
+++ b/docs/skills/productivity/index.md
@@ -1,0 +1,20 @@
+---
+title: "Productivity Skills — Agent Skills & Codex Plugins"
+description: "4 productivity skills — personal productivity agent skill and Claude Code plugin for brain-dump capture, email triage, and reflection. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+---
+
+<div class="domain-header" markdown>
+
+# :material-lightning-bolt-outline: Productivity
+
+<p class="domain-count">4 skills in this domain</p>
+
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install all:</span> <code>claude /plugin install productivity-skills</code>
+</div>
+
+<div class="grid cards" markdown>
+
+</div>

--- a/docs/skills/productivity/reflect.md
+++ b/docs/skills/productivity/reflect.md
@@ -1,0 +1,188 @@
+---
+title: "Reflect — Mid-Conversation Reassessment — Agent Skill for Personal Productivity"
+description: "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Reflect — Mid-Conversation Reassessment
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-lightning-bolt-outline: Productivity</span>
+<span class="meta-badge">:material-identifier: `reflect`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install productivity-skills</code>
+</div>
+
+
+> **Portability:** Pure-reasoning skill. No external tools required. Works in Claude Code CLI + Claude.ai web natively. Most portable in the v2 collection.
+
+When invoked mid-conversation, this skill **pauses execution** and produces a frank reassessment of where the conversation has been heading. Output is **flowing analysis (no headers, conversational tone)** covering macro perspective, gap analysis, reflective inquiry, bias check, and contextual alignment. The skill ends with a clear directional recommendation: **continue, pivot, or pause to answer a specific question**.
+
+## Invocation Triggers
+
+**Explicit phrases:**
+
+- "reflect"
+- "take a step back" / "step back"
+- "zoom out"
+- "are we missing something"
+- "bigger picture"
+- "what are we missing"
+- "let's pause"
+- "sanity check this"
+- "are we on track"
+- "are we overthinking this"
+- "forest for the trees"
+
+**Implicit signals (no phrase needed):**
+
+- Conversation has gone 10+ turns deep on implementation details without strategic check-in
+- User shows signs of frustration or stuck-ness
+- Repeated dead-ends or pivots within a short span
+
+When you detect an implicit trigger, **don't auto-invoke** — ask the user if they want to step back. Implicit signals are a prompt to OFFER reflection, not to unilaterally run it.
+
+## Stop Directive (Before Reassessing)
+
+**Halt the current thread.** Don't continue execution of the in-progress task. Reflection is a pause, not a side-quest.
+
+This matters because:
+- Continuing detail work while "reflecting on the side" defeats the purpose — you'll over-weight the current direction
+- The user expects a clear break in cadence
+- The reassessment needs full attention to the conversation history
+
+## Grill-Me Optional Clarifier
+
+This skill is intentionally **low-intake** — most invocations should run the 5-dimension analysis immediately without questions. The grill-me discipline applies *only* when the invocation is ambiguous (e.g., user pastes "step back" at the start of a fresh conversation with no prior context to reassess).
+
+### Q1 (optional, asked only when context is too thin to reassess)
+
+> **What specifically should I reassess? Pick one:**
+>
+> 1. The goal — are we solving the right problem?
+> 2. The approach — is the path we're on the best one?
+> 3. The assumptions — what are we taking for granted?
+> 4. All of the above (default if you have time)
+>
+> *Why I'm asking:* I'm seeing limited prior context to reassess, so I want to focus the reflection rather than guess. If you'd rather I do all three, that's fine — say so.
+
+Forcing choice with default. **Asked only when context is genuinely thin; otherwise skip and run the full analysis on existing conversation.**
+
+**Stop condition:** One question max. If the user invokes mid-conversation with normal context, no questions are asked — the skill runs directly.
+
+## The 5-Dimension Analysis Framework
+
+Re-read the **full conversation from the original goal forward** — not just recent turns. The discipline that distinguishes real reflection from local-context summary.
+
+### 1. Macro Perspective
+
+- **Original goal:** What did the user actually start trying to do?
+- **Drift detection:** Has the conversation moved away from that goal? Toward something better or worse?
+- **Connection check:** How does current work connect to the larger objective?
+
+Anchor with specific evidence: "At turn 3 the goal was X; by turn 12 we're working on Y. Is Y a productive narrowing of X, or a drift away?"
+
+### 2. Gap Analysis
+
+- **Unverified assumptions** — what are we taking for granted that we haven't checked?
+- **Missing stakeholders / audiences / users** — who needs this beyond the immediate context?
+- **Skipped constraints** — technical, regulatory, resource limits not addressed
+- **Dismissed alternatives** — paths considered but rejected; revisit briefly
+- **External factors** — timing, market, dependencies not in scope
+
+### 3. Reflective Inquiry
+
+- Is the problem framed correctly?
+- Solving the right problem vs. an adjacent easier one?
+- Simpler path being overcomplicated?
+- Harder but more valuable path being avoided?
+- **Fresh-eyes perspective:** would someone else approach this differently?
+
+### 4. Bias Check
+
+Five biases — recognize each through specific conversation patterns:
+
+| Bias | Recognition cue |
+|---|---|
+| **Confirmation bias** | Evidence cited only supports the working hypothesis; counter-evidence absent or dismissed |
+| **Sunk cost fallacy** | "We've already invested X" / "we're far enough in to..." instead of fresh cost/benefit |
+| **Anchoring** | Stuck on first option mentioned; new options compared against it rather than evaluated independently |
+| **Complexity bias** | Adding features / steps / safeguards without specific justification for each |
+| **Recency bias** | Over-weighting last few turns; older but important context being ignored |
+
+For each detected bias: name it, cite the specific evidence, suggest a corrective move.
+
+See [`references/cognitive_bias_canon.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect/references/cognitive_bias_canon.md) for the full canon.
+
+### 5. Contextual Alignment
+
+- Does the direction serve the user's actual goals (as known from context)?
+- Are external factors being ignored?
+- Is this the best use of the user's time and energy right now?
+- Connection to other known projects or priorities?
+
+## Tone and Format Rules
+
+The skill must produce:
+
+- **Flowing prose** — no headers, no bullet lists, no structured-report formatting
+- **Tight but thorough** — neither a one-liner nor a wall of text
+- **Direct critique when warranted** — with specific evidence from the conversation
+- **Validation when warranted** — with specific reasoning for why the path is solid
+- **No vague reassurance** — "looks good!" without reasoning is rejected
+- **No manufactured problems** — when the path is genuinely solid, say so with specific reasons; don't invent issues
+
+See [`references/honest_output_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect/references/honest_output_discipline.md) for the anti-manufactured-problems framing.
+
+## Closing Recommendation (Mandatory)
+
+Every run ends with one of three directional recommendations:
+
+| Recommendation | When | Format |
+|---|---|---|
+| **Continue** | Path is solid | "Continue. {specific reasoning for why}." |
+| **Pivot to {X}** | Drift has occurred OR better path surfaced | "Pivot toward {X}, away from {what to drop}. {specific evidence}." |
+| **Pause for {Q}** | A specific question needs answering before continuing | "Pause for {Q}. Without answering this, the next step risks {specific cost}." |
+
+The closing is always specific — never "you should think more about this" or "consider your options."
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| Conversation is very short (no real context to reassess) | Acknowledge limitation, ask user what they want reassessed (Q1 fires) |
+| Current direction is genuinely solid | State this clearly with reasoning; don't manufacture problems |
+| User invokes mid-task with no clear question | Default to macro perspective + bias check; offer to dig deeper |
+| Implicit trigger seems possible but unclear | Don't invoke proactively; ask user if they want to step back |
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/bias_pattern_detector.py` | Scan conversation text for patterns indicative of each of the 5 biases |
+| `scripts/conversation_depth_analyzer.py` | Count turns + detect implicit-trigger signals (10+ detail turns, frustration markers) |
+| `scripts/directional_recommendation_validator.py` | Verify output ends with Continue / Pivot / Pause + specific reasoning |
+
+## References
+
+- [`references/cognitive_bias_canon.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect/references/cognitive_bias_canon.md) — 5 biases + recognition cues (7+ sources)
+- [`references/honest_output_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect/references/honest_output_discipline.md) — anti-manufactured-problems framing (7+ sources)
+- [`references/conversation_reflection_practice.md`](https://github.com/alirezarezvani/claude-skills/tree/main/productivity/reflect/skills/reflect/references/conversation_reflection_practice.md) — Schön reflective-practice canon (7+ sources)
+
+## Anti-Patterns To Reject
+
+- Hardcoded user names or specific domain references
+- Structured-report output (headers, bullet lists) when prose is required
+- Manufactured problems when things are actually fine
+- Vague reassurance ("looks good!") instead of specific reasoning
+- Reassessing only recent turns instead of the full conversation
+- Skipping the closing directional recommendation
+- Continuing the in-progress task while "reflecting on the side"
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/02-reflect-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/02-reflect-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Productivity light-prompt-flow sibling of capture.

--- a/docs/skills/ra-qm-team/compliance-team-eu-ai-act-eu-ai-act-specialist.md
+++ b/docs/skills/ra-qm-team/compliance-team-eu-ai-act-eu-ai-act-specialist.md
@@ -1,0 +1,206 @@
+---
+title: "EU AI Act Compliance Specialist — Agent Skill for Compliance"
+description: "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# EU AI Act Compliance Specialist
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-shield-check-outline: Regulatory & Quality</span>
+<span class="meta-badge">:material-identifier: `eu-ai-act-specialist`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install ra-qm-skills</code>
+</div>
+
+
+Article-cited operational skill for Regulation (EU) 2024/1689. **Three decisions, no executive AI strategy:**
+
+1. **What tier is this AI system?** — prohibited (Article 5) / high-risk (Article 6 + Annex III) / limited-risk transparency (Article 50) / minimal-risk
+2. **For high-risk systems, what's the conformity assessment route + documentation pack?** — Article 43 Module A vs Module H + Annex IV technical documentation
+3. **Per organizational role, what are the obligations?** — provider / deployer / importer / distributor / authorized representative matrix per Article 16, 22, 25, 26
+
+This skill is **NOT chief-ai-officer-advisor**. CAIO decides whether to ship the AI feature at all and accepts business risk. This skill operates the conformity work that turns "we'll ship it" into Article-compliant artefacts.
+
+This skill is **NOT a legal substitute**. The Act is binding regulation. For novel cases (Is this a GPAI model? Does Article 6(2) carve-out apply? Is fine-tuning a foundation model "substantial modification"?), engage qualified outside counsel. The skill cites Articles + Annexes and uses Commission/EDPB published interpretation but does not provide binding legal opinion.
+
+This skill is **NOT GDPR**. Many AI systems also trigger GDPR (training data, output processing). See `ra-qm-team/skills/gdpr-dsgvo-expert/` for DPIA + lawful basis work. The Acts interact (Recital 10, Article 10 for high-risk training data).
+
+## Keywords
+
+EU AI Act, EU AI Regulation, Regulation 2024/1689, AI Act, AI regulation Europe, high-risk AI, prohibited AI, Article 5 AI Act, Article 6 AI Act, Article 9 AI Act, Article 50 AI Act, Annex III, Annex IV, conformity assessment, CE marking AI, notified body AI, Module A, Module H, technical documentation AI, post-market monitoring AI, fundamental rights impact assessment, FRIA, GPAI, general-purpose AI model, systemic risk GPAI, AI Office, ENISA AI, EDPB AI, AI Act timeline, AI Act penalties, EU AI Act provider, EU AI Act deployer, EU AI Act importer, EU AI Act distributor, EU AI Act fines, AI literacy
+
+## Quick Start
+
+```bash
+# Decision A: Classify an AI system per the Act
+python scripts/ai_system_risk_classifier.py                       # embedded 5-system sample
+python scripts/ai_system_risk_classifier.py path/to/systems.json
+
+# Decision B: Conformity assessment plan for a high-risk system
+python scripts/conformity_assessment_planner.py                   # embedded high-risk sample
+python scripts/conformity_assessment_planner.py path/to/system.json
+
+# Decision C: Obligation tracker per organizational role
+python scripts/ai_act_obligation_tracker.py                       # embedded sample (provider + deployer)
+python scripts/ai_act_obligation_tracker.py path/to/roles.json
+```
+
+## Key Questions (ask these first)
+
+- **Does this AI system fall under Article 5 (prohibited practices)?** Social scoring, emotion recognition in workplace/education, manipulative subliminal techniques, real-time remote biometric identification in public — any of these are flat-out prohibited.
+- **Does it fall under Annex III (high-risk categories)?** 8 categories: biometrics, critical infrastructure, education, employment, essential services, law enforcement, migration, justice. Triggering Annex III triggers Article 6(2) — unless the Article 6(3) carve-outs apply.
+- **What organizational role does the company play?** Provider (placed on market), deployer (uses under own authority), importer (places third-country system on EU market), distributor (makes available in supply chain). Many companies are BOTH provider AND deployer simultaneously.
+- **Is this a general-purpose AI model?** GPAI has its own track (Articles 51–55) with stricter rules above 10²⁵ FLOPs training compute (Article 51 systemic risk).
+- **For high-risk: have we run Article 9 risk management AND Article 27 FRIA?** Article 9 is the lifecycle risk management; Article 27 is the Fundamental Rights Impact Assessment for public-sector deployers + essential services.
+- **What's the conformity assessment Module per Article 43?** Module A (internal control, possible for most Annex III systems) vs Module H (full QMS + notified body, required for biometrics + sometimes others).
+
+## Core Responsibilities
+
+### 1. AI System Risk Classification
+
+**The framework:** The Act takes a risk-based approach (Recital 26). Each AI system falls into exactly one of four tiers:
+
+| Tier | Source | Examples | Obligations |
+|---|---|---|---|
+| **Prohibited** | Article 5 | Social scoring; emotion recognition in workplace/education; subliminal manipulation; real-time public biometrics by law enforcement (with narrow exceptions) | Cannot be placed on market or used (penalties up to EUR 35M / 7% turnover) |
+| **High-risk** | Article 6 + Annex III; Article 6(1) + Annex I | CV-screening, credit scoring, biometric categorisation, safety components of regulated products | Articles 8–17 (provider) + Article 26 (deployer); conformity assessment; CE marking |
+| **Limited-risk (transparency)** | Article 50 | Chatbots, deepfakes, emotion recognition outside Article 5 contexts | Transparency disclosures to natural persons |
+| **Minimal-risk** | Default | Spam filters, video-game AI, inventory forecasters | None under the Act (voluntary codes of conduct, Article 95) |
+
+**Critical carve-outs (Article 6(3)):** an Annex III system is NOT high-risk if it (a) performs a narrow procedural task, (b) improves the result of previously completed human activity, (c) detects decision-making patterns without replacing human assessment, (d) performs a preparatory task. Caveat: profiling of natural persons is always Annex III high-risk regardless of carve-outs.
+
+**Run** `ai_system_risk_classifier.py` with system characteristics. The tool checks Article 5 prohibitions first, then Annex III categories, then Article 6(3) carve-outs, then Article 50 transparency, then minimal-risk default.
+
+See `references/eu_ai_act_titles.md` for the full Article-by-Article walkthrough.
+
+### 2. Conformity Assessment + Annex IV Technical Documentation
+
+**The framework (Article 43 + Annex VI/VII):** for high-risk AI systems, the provider must demonstrate conformity before placing on market. Two routes:
+
+- **Module A — Internal control** (Annex VI): provider self-assesses against the requirements. Applies to most Annex III systems where the provider has implemented harmonised standards.
+- **Module H — Full quality management system + technical documentation** (Annex VII): notified body involvement. Required for biometrics systems (Article 43(1)).
+
+**Required artifacts per Annex IV — Technical Documentation:**
+
+1. General description of the AI system (intended purpose, identification, version)
+2. Detailed description of system elements (architecture, training data, validation procedures)
+3. Information about monitoring, functioning and control
+4. Description of risk management system (Article 9)
+5. Description of changes after placing on market
+6. List of harmonised standards applied (or alternative)
+7. EU declaration of conformity (Article 47)
+8. Description of the post-market monitoring system (Article 72)
+
+**Run** `conformity_assessment_planner.py` to select the Module and produce the Annex IV checklist for a given high-risk system.
+
+See `references/high_risk_systems_annex_iii.md` for which systems require which conformity route.
+
+### 3. Per-Role Obligation Tracker
+
+**The framework (Articles 16, 22, 23, 24, 25, 26):** the Act distinguishes provider obligations (most) from downstream-actor obligations (deployer, importer, distributor, authorized representative). A single company can play multiple roles simultaneously.
+
+| Role | Primary Articles | Key obligations |
+|---|---|---|
+| **Provider** (Article 3(3)) | 8–17, 47, 49, 72 | Conformity assessment; CE marking; risk management; data governance; technical documentation; post-market monitoring; serious incident reporting (Article 73) |
+| **Deployer** (Article 3(4)) | 26 | Use according to instructions; human oversight; input data quality; record-keeping (Article 19); inform workers (Article 26(7)); FRIA if public-sector/essential-services (Article 27) |
+| **Importer** (Article 3(6)) | 23 | Verify conformity; affixed CE marking; technical documentation availability |
+| **Distributor** (Article 3(7)) | 24 | Verify CE marking + documentation before making available |
+| **Authorized representative** (Article 22) | 22 | Non-EU providers must appoint one; representative liable for provider obligations |
+
+**Important:** under Article 25, a deployer who substantially modifies a high-risk AI system, or places it on the market under their own name, becomes a **provider** and inherits provider obligations.
+
+**Run** `ai_act_obligation_tracker.py` with the roles JSON to produce a deadline-sorted obligation matrix.
+
+See `references/gpai_obligations.md` for the separate GPAI Articles 51–55 track.
+
+## Workflows
+
+### Workflow 1: AI System Intake Review (per system, ~2 hours)
+**Goal:** classify, identify obligations, scope the conformity work.
+
+```bash
+# 1. Document system characteristics: purpose, users, data, autonomy, deployment context
+# 2. Run classifier
+python scripts/ai_system_risk_classifier.py systems.json
+# 3. If high-risk: run planner
+python scripts/conformity_assessment_planner.py system.json
+# 4. Identify org roles played (provider / deployer / both)
+python scripts/ai_act_obligation_tracker.py roles.json
+# 5. Cross-check with GDPR DPIA (gdpr-dsgvo-expert) if personal data
+# 6. Cross-check with ISO 42001 AIMS evidence (compliance-team-iso42001)
+# 7. Output: classification memo + conformity plan + obligation list
+```
+
+### Workflow 2: Annex IV Technical Documentation Build (per high-risk system, 2–4 weeks)
+**Goal:** assemble the Annex IV pack before conformity assessment.
+
+```bash
+# 1. Run conformity assessment planner to get the checklist
+python scripts/conformity_assessment_planner.py system.json
+# 2. Assemble: system description, architecture, training data, validation, risk management
+# 3. Reference ISO 42001 evidence where it satisfies Annex IV items
+# 4. Reference ISO 27001 evidence for security controls
+# 5. Run Article 9 risk management lifecycle
+# 6. Sign EU declaration of conformity (Article 47) AFTER assessment passes
+# 7. Affix CE marking (Article 48)
+# 8. Register in EU database (Article 71) — high-risk Annex III systems
+```
+
+### Workflow 3: Pre-Deployment Obligation Audit (per system, before launch)
+**Goal:** confirm all active obligations are in place before EU placement.
+
+```bash
+# 1. Confirm classification still correct (re-run classifier if system changed)
+# 2. Confirm conformity assessment completed (if high-risk)
+# 3. Confirm transparency requirements (Article 50) — for chatbots, deepfakes, emotion detection
+# 4. Confirm post-market monitoring system (Article 72) is live
+# 5. Confirm serious-incident reporting procedure (Article 73) is documented
+# 6. For deployers: FRIA done (Article 27, if applicable); workers informed (Article 26(7))
+# 7. For GPAI: Articles 51-55 obligations met if applicable
+```
+
+### Workflow 4: Annual Compliance Refresh (per organization, yearly)
+**Goal:** re-verify classifications + obligations as the Act phases in.
+
+1. List all AI systems on or planned for EU market
+2. Run classifier for each — Article 5 prohibited list may expand via delegated acts
+3. Run obligation tracker — deadlines shift as Title III phases in (2025 → 2026 → 2027)
+4. For each high-risk system: verify post-market monitoring data flow + serious incident reporting capacity
+5. Update Annex IV technical documentation per Article 11 ongoing requirement
+6. Pair with ISO 42001 management review (Clause 9.3) if both operate
+
+## Output Standards
+
+```
+**Bottom Line:** [one sentence — classification + most-significant obligation]
+**Article Citation:** [Article + paragraph number; do not paraphrase without cite]
+**The Decision:** [one of: classify | conformity-route | obligation-scope]
+**The Evidence:** [Article + Annex references; classification confidence]
+**How to Act:** [3 concrete next steps with owner + deadline aligned to phasing]
+**Your Decision:** [the call for compliance officer or legal counsel — risk-class disputes, novel cases, GPAI threshold determinations]
+```
+
+## Adjacent Skills
+
+- [`skills/gdpr-dsgvo-expert`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/gdpr-dsgvo-expert) — GDPR DPIA + lawful basis (most AI systems also trigger GDPR)
+- [`ra-qm-team/compliance-team-iso42001`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001) — ISO 42001 AIMS (voluntary management system that satisfies parts of Article 17 QMS for providers)
+- [`skills/information-security-manager-iso27001`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/information-security-manager-iso27001) — ISO 27001 for cybersecurity requirements (Article 15)
+- [`skills/risk-management-specialist`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/risk-management-specialist) — ISO 14971 risk management (referenced for safety-component AI under Article 6(1))
+- [`skills/mdr-745-specialist`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/mdr-745-specialist) — MDR 2017/745 (medical-device AI overlap)
+- [`compliance-os`](https://github.com/alirezarezvani/claude-skills/tree/main/compliance-os) — Meta-orchestrator for multi-framework programs
+- [`c-level-advisor/chief-ai-officer-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor) — Executive AI strategy
+
+## References
+
+- [eu_ai_act_titles.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/references/eu_ai_act_titles.md) — Titles I–XII Article-by-Article walkthrough with deployer/provider/importer/distributor obligation breakdown
+- [high_risk_systems_annex_iii.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/references/high_risk_systems_annex_iii.md) — Annex III 8 categories detailed + Article 6(2)–(3) interaction + carve-out test
+- [gpai_obligations.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/references/gpai_obligations.md) — Articles 51–55 GPAI track + systemic-risk threshold + transparency rules + Code of Practice status
+- [cross_framework_mapping_ai_act.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/references/cross_framework_mapping_ai_act.md) — AI Act ↔ ISO 42001 ↔ NIST AI RMF ↔ GDPR control-level mapping
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready

--- a/docs/skills/ra-qm-team/compliance-team-iso42001-iso42001-specialist.md
+++ b/docs/skills/ra-qm-team/compliance-team-iso42001-iso42001-specialist.md
@@ -1,0 +1,197 @@
+---
+title: "ISO/IEC 42001 AI Management System Specialist — Agent Skill for Compliance"
+description: "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# ISO/IEC 42001 AI Management System Specialist
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-shield-check-outline: Regulatory & Quality</span>
+<span class="meta-badge">:material-identifier: `iso42001-specialist`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install ra-qm-skills</code>
+</div>
+
+
+Internal-audit-grade operating skill for ISO/IEC 42001:2023. **Three decisions, no executive AI strategy:**
+
+1. **Where are the AIMS gaps against Clauses 4–10?** — coverage scoring per clause + remediation priority
+2. **What's the AI risk register, and which controls treat each risk?** — Annex A.2–A.10 control mapping per ISO 23894 risk method
+3. **What's the Clause 9.2 internal audit plan?** — 12-month schedule with scope, frequency, auditor independence checks
+
+This skill is **NOT a chief-ai-officer-advisor replacement**. CAIO decides whether to build/buy a model and what business risk to accept. This skill operates the management-system discipline that captures those decisions in audit-ready evidence.
+
+This skill is **NOT an EU AI Act compliance skill**. ISO 42001 is a voluntary management-system standard; EU AI Act is binding product-safety regulation. They overlap (a high-risk AI system per Article 6(2) of the AI Act typically requires the QMS in Article 17, which ISO 42001 can satisfy in part) but the artefacts differ. See `compliance-team-eu-ai-act` for Article-level conformity assessment.
+
+This skill is **NOT a substitute for ISO 23894 + 38507**. 42001 is the management system; 23894 is the AI risk methodology that feeds Clause 6.1; 38507 is the governance lens. The `ai_risk_register_builder.py` tool implements the 23894 process; treat the references as the methodology bridge.
+
+## Keywords
+
+ISO 42001, ISO/IEC 42001:2023, AI Management System, AIMS, AI governance, AI risk management, ISO 23894, AI risk assessment, ISO 38507, AI compliance, AI audit, internal audit AI, Annex A controls, AI risk register, AI policy, AI impact assessment, conformity declaration, AI lifecycle, AI risk treatment, NIST AI RMF, NIST AI Risk Management Framework, ISACA AI audit, BSI AIC4, AI assurance, responsible AI, AI ethics governance, AI system inventory, third-party AI risk, AI vendor management, AI change management, AI incident management
+
+## Quick Start
+
+```bash
+# Decision A: AIMS gap analysis against Clauses 4-10
+python scripts/aims_gap_analyzer.py                           # embedded sample (mid-stage AI SaaS)
+python scripts/aims_gap_analyzer.py path/to/aims_evidence.json
+
+# Decision B: AI risk register + Annex A control mapping
+python scripts/ai_risk_register_builder.py                    # embedded 7-risk sample
+python scripts/ai_risk_register_builder.py path/to/risks.json
+
+# Decision C: Clause 9.2 internal audit 12-month plan
+python scripts/aims_audit_scheduler.py                        # embedded 4-domain sample
+python scripts/aims_audit_scheduler.py path/to/scope.json
+```
+
+## Key Questions (ask these first)
+
+- **Does the AIMS scope statement (Clause 4.3) name every AI system, including embedded models and third-party AI services?** If "AI features added by our SaaS vendors" is not in scope, the AIMS is incomplete.
+- **Does the AI policy (Clause 5.2) commit to lawful use AND beneficial purpose AND human oversight AND continual improvement?** Missing any of the four = nonconformity at certification.
+- **Has the AI risk assessment (Clause 6.1.2) been re-run since the last material model change?** Concept drift is not a one-time event.
+- **Who signs the AI impact assessment for high-impact systems (Annex A.5.4)?** If no signed accountability, the control is missing.
+- **What's the internal audit cadence (Clause 9.2)?** ISO management-system standards expect ≥ once per 3-year cycle per clause; mature programs do annual.
+- **Is there a documented procedure for AI incidents (Annex A.9.3)?** Untreated post-deployment monitoring is the #1 nonconformity in early adopters.
+
+## Core Responsibilities
+
+### 1. AIMS Gap Analysis (Clauses 4–10)
+
+**The framework:** ISO 42001 follows the Annex SL high-level structure shared with ISO 9001 / 27001 / 13485. Clauses 4–10 are the management-system requirements; Annex A controls A.1–A.10 are the AI-specific operational controls.
+
+| Clause | What it requires | Common gap |
+|---|---|---|
+| **4. Context** | AI scope, interested parties, external context | Scope omits third-party AI services |
+| **5. Leadership** | AI policy, roles, accountability | Policy treats "AI ethics" as marketing copy, not commitment |
+| **6. Planning** | AI risk + impact assessment, objectives | Risk register doesn't link to controls |
+| **7. Support** | Resources, competence, awareness, documented info | Competence requirements undefined for ML engineers |
+| **8. Operation** | Operational planning, AI system lifecycle | Lifecycle stages not mapped to Annex A controls |
+| **9. Performance** | Monitoring, internal audit, management review | Drift monitoring exists in code but not in management review inputs |
+| **10. Improvement** | Nonconformity, corrective action, continual improvement | CAPA loop separate from existing 13485/9001 CAPA — duplication |
+
+**Run** `aims_gap_analyzer.py` with an evidence inventory JSON to score each clause (full / partial / missing) and get a prioritized remediation list.
+
+See `references/iso42001_clauses.md` for the full clause-by-clause walkthrough with audit evidence expectations.
+
+### 2. AI Risk Register + Annex A Control Mapping
+
+**The framework:** Clause 6.1.2 requires AI risk assessment; Clause 6.1.3 requires risk treatment. Annex A provides 38 controls organized into 10 control categories (A.2–A.10). The risk register must show each identified risk linked to ≥ 1 control that treats it.
+
+**Annex A control categories (the 10):**
+
+| ID | Category | Example controls |
+|---|---|---|
+| **A.2** | AI policy | A.2.2 AI policy, A.2.3 alignment with other policies |
+| **A.3** | Internal organization | A.3.2 AI roles & responsibilities, A.3.3 reporting concerns |
+| **A.4** | Resources for AI systems | A.4.2 data resources, A.4.3 tooling, A.4.4 human resources |
+| **A.5** | Assessing impacts | A.5.2 AI system impact assessment, A.5.4 documentation of impact assessment |
+| **A.6** | AI system lifecycle | A.6.2.2 objectives, A.6.2.3 lifecycle phases, A.6.2.4 verification & validation |
+| **A.7** | Data for AI systems | A.7.2 data management, A.7.3 data quality, A.7.4 data provenance, A.7.5 data preparation |
+| **A.8** | Information for interested parties | A.8.2 system documentation, A.8.3 user information, A.8.4 communication of incidents |
+| **A.9** | Use of AI systems | A.9.2 intended use, A.9.3 monitoring of operation, A.9.4 logging of system events |
+| **A.10** | Third-party & customer relationships | A.10.2 supplier relationships, A.10.3 customer relationships |
+
+ISO/IEC 23894:2023 provides the AI-specific risk-management process (the methodology); 42001 Annex A provides the controls. The risk register is the bridge.
+
+**Run** `ai_risk_register_builder.py` with an identified-risks JSON to produce a structured register with mapped controls + residual-risk verdict per ISO 23894 risk-treatment options.
+
+See `references/aims_controls_annex_a.md` for the full 38-control catalogue with audit evidence per control.
+
+### 3. Clause 9.2 Internal Audit Plan
+
+**The framework:** Clause 9.2 requires "internal audits at planned intervals to provide information on whether the AIMS conforms to the organization's requirements and is effectively implemented and maintained." That's the management-system requirement; the **how often** and **how deep** are organizational choices.
+
+**Mature-program defaults:**
+
+- Cover every clause + every applicable Annex A control over a 3-year cycle (rolling)
+- Annual full-system audit covering Clauses 4, 5, 9, 10 (the "always relevant" clauses)
+- Quarterly or semi-annual deep dives on Clauses 6, 7, 8 by domain (per AI system or per lifecycle phase)
+- Auditor independence: nobody audits their own work; A.6 lifecycle owner cannot audit Clause 8 operation
+
+**Run** `aims_audit_scheduler.py` with a scope JSON (AI systems in scope, prior-year findings, certification cycle phase) to produce a 12-month plan with auditor assignments and independence checks.
+
+See `references/aims_implementation_guide.md` for the maturity model and rollout sequencing (year 1 establish, year 2 certify, year 3+ continual improvement).
+
+## Workflows
+
+### Workflow 1: AIMS Gap Closure for Certification (4–8 weeks)
+**Goal:** Identify gaps; prioritize remediation; close before stage 1 certification audit.
+
+```bash
+# 1. Inventory current AIMS evidence (policies, procedures, records)
+python scripts/aims_gap_analyzer.py aims_evidence.json
+# 2. Review gap matrix; group by clause
+# 3. For each gap, identify owner + due date (target: close before stage 1)
+# 4. Cross-check against ISO 27001 / 13485 existing artifacts — many can be reused
+# 5. Cross-check against EU AI Act obligations (use compliance-team-eu-ai-act)
+# 6. Output: prioritized remediation plan with owners + dates
+```
+
+### Workflow 2: AI Risk Register Build (1–2 weeks)
+**Goal:** Construct the Clause 6.1.2 risk register with full Annex A control coverage.
+
+```bash
+# 1. Run ISO 23894 risk identification across AI lifecycle (data, model, deployment, decommission)
+# 2. Capture each risk with: source, event, consequence, likelihood, impact
+python scripts/ai_risk_register_builder.py risks.json
+# 3. For each high/critical risk, confirm ≥ 1 Annex A control is selected as treatment
+# 4. Document residual risk acceptance with management signoff
+# 5. Cross-check with cs-caio-advisor on executive risk acceptance for "tolerate" decisions
+# 6. Log via management review (Clause 9.3)
+```
+
+### Workflow 3: Annual Internal Audit Plan (1 day)
+**Goal:** Produce the 12-month Clause 9.2 plan with auditor independence.
+
+```bash
+# 1. Pull last year's audit findings and certification cycle status (year 1/2/3)
+python scripts/aims_audit_scheduler.py audit_scope.json
+# 2. Confirm auditor independence per assignment
+# 3. Confirm coverage hits every clause and every applicable Annex A control over rolling 3 years
+# 4. Submit plan for management review approval (Clause 9.3 input)
+```
+
+### Workflow 4: Cross-Framework Reuse Mapping (per system onboarded)
+**Goal:** When adding a new AI system, map ISO 42001 evidence against existing 27001 + 13485 evidence to avoid duplication.
+
+1. Pull existing ISO 27001 Annex A controls + ISO 13485 procedures relevant to the system
+2. For each ISO 42001 Annex A control, identify whether an existing artifact already satisfies it (e.g., 27001 A.8.16 monitoring activities can extend to AI system monitoring)
+3. Add the AI-specific overlay only where the existing control doesn't cover it
+4. Document mapping in the AIMS scope statement (Clause 4.3)
+
+## Output Standards
+
+```
+**Bottom Line:** [one sentence — gap severity + the one thing to close first]
+**The Decision:** [one of: gap-closure | risk-treatment | audit-scope]
+**The Evidence:** [clause numbers + control IDs from the tool, not adjectives]
+**How to Act:** [3 concrete next steps with owners + dates]
+**Your Decision:** [the call only the compliance officer or CAIO can make — risk acceptance, scope expansion, certification readiness]
+```
+
+## Adjacent Skills
+
+- [`skills/information-security-manager-iso27001`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/information-security-manager-iso27001) — ISO 27001 ISMS implementation (many controls reusable for AIMS A.7 data controls)
+- [`skills/quality-manager-qms-iso13485`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/quality-manager-qms-iso13485) — ISO 13485 QMS (provides CAPA + management-review machinery the AIMS reuses)
+- [`skills/gdpr-dsgvo-expert`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/gdpr-dsgvo-expert) — GDPR DPIA process (input to AIMS A.5 impact assessment for personal-data systems)
+- [`skills/isms-audit-expert`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/isms-audit-expert) — ISO 27001 internal audit pattern (the audit scheduler mirrors this for AIMS)
+- [`skills/soc2-compliance`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/soc2-compliance) — SOC 2 trust services (reusable controls for AIMS A.10 third-party relationships)
+- [`ra-qm-team/compliance-team-eu-ai-act`](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act) — EU AI Act Article-level compliance (binding regulation companion to voluntary 42001)
+- [`compliance-os`](https://github.com/alirezarezvani/claude-skills/tree/main/compliance-os) — Meta-orchestrator for multi-framework programs (run AIMS as one framework among 9)
+- [`c-level-advisor/chief-ai-officer-advisor`](https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor) — Executive AI strategy (build-vs-buy, cost economics — different audience)
+
+## References
+
+- [iso42001_clauses.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/references/iso42001_clauses.md) — Clauses 4–10 walkthrough with audit evidence expectations, common gaps, and reusable artifacts from ISO 27001/13485
+- [aims_controls_annex_a.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/references/aims_controls_annex_a.md) — All 38 Annex A controls (A.2–A.10) with implementation guidance, audit evidence, and severity of failure
+- [aims_implementation_guide.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/references/aims_implementation_guide.md) — 3-year maturity model (establish → certify → continually improve), rollout sequencing, integration with existing ISMS/QMS programs
+- [cross_framework_mapping_ai.md](https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/references/cross_framework_mapping_ai.md) — ISO 42001 ↔ EU AI Act ↔ NIST AI RMF ↔ ISO 23894 ↔ ISO 38507 ↔ ISO 27001 control-level mapping with mapping-confidence ratings
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready

--- a/docs/skills/research/dossier.md
+++ b/docs/skills/research/dossier.md
@@ -1,0 +1,323 @@
+---
+title: "Dossier — Decision-Grade Entity Research — Agent Skill for Research Workflows"
+description: "Decision-grade entity research skill — produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Dossier — Decision-Grade Entity Research
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `dossier`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Portability:** Requires `WebSearch` + `WebFetch`, Node.js with `docx` package, and optionally `bash_tool` + `curl` for free APIs (SEC EDGAR, GitHub, ProPublica). BYOK MCPs (LinkedIn, Crunchbase, Apollo, Pitchbook, SimilarWeb) are optional enhancements. Works in Claude Code CLI natively.
+
+## Non-Generic Framing — The Differentiator
+
+This skill is **decision-grade entity research with hypothesis-testing**. It **refuses** to be "tell me about Microsoft". Every invocation forces the user to expose their hypothesis upfront (Q4) so the dossier *tests* it rather than confirms it.
+
+The use case shape:
+
+> "I'm pitching Microsoft Tuesday. My hypothesis is they're consolidating AI spend on their first-party Foundry platform. Validate or disprove, and give me three conversation hooks tied to what you find."
+
+**NOT:**
+
+> "Tell me about Microsoft."
+
+The forcing Q4 — the hypothesis question — is the non-generic anchor. Skip it and the skill produces a Wikipedia summary.
+
+See [`references/hypothesis_testing_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/references/hypothesis_testing_discipline.md) for the canon.
+
+## Agent Integrity Rules (Research-Pack Convention)
+
+Locked verbatim per PR #657 audit.
+
+- **Execution discipline.** Sequential search calls. WebSearch + WebFetch have looser rate limits than Consensus but still apply 1 q/sec etiquette. Confirm response received before next call.
+- **Source discipline.** Cite only sources returned by this session's tool calls. Wikipedia / training knowledge labeled `[Background — verify before quoting]` and excluded from primary findings count.
+- **Three-count tracking.** Queries sent / sources received / sources cited. Plus **per-tier breakdown** (primary / secondary / tertiary) unique to dossier. Surfaced in audit log.
+- **Retry policy.** On failure → wait 3s → retry once → log. After 3 consecutive failures: stop, alert user.
+- **Source reliability tier.** Each citation tagged primary (official, SEC, court records) / secondary (mainstream news, trade press) / tertiary (blogs, forums). DOCX surfaces tier on every flag.
+
+## Phase 1: Grill-Me Intake (6 forcing questions, one at a time)
+
+### Q1 (root) — Subject identity
+
+> **Who is the subject? Give me the exact name and, if a company, the website or LinkedIn URL. If a person, their LinkedIn URL or a unique identifier (company affiliation + role).**
+>
+> *Why I'm asking:* Disambiguation. There are 47 John Smiths. There are three companies called "Atlas". I need a specific entity to research.
+
+If user gives only a name, push for a second identifier. **Refuse to proceed on ambiguous names.**
+
+### Q2 (depends on Q1) — Subject type
+
+> **What kind of subject is this? Pick one: person / company / nonprofit / government org / other.**
+>
+> *Why I'm asking:* Different source matrices apply. For people I check LinkedIn, GitHub, Scholar, news; for companies I check SEC EDGAR (if public), Crunchbase, news, GitHub for tech orgs; for nonprofits I check Form 990s on ProPublica.
+
+Forcing choice. "Other" requires a one-line description.
+
+### Q3 (depends on Q2) — Purpose
+
+> **What are you preparing for? Pick one:**
+>
+> 1. Sales meeting / partnership pitch
+> 2. Investment diligence
+> 3. Acquisition diligence
+> 4. Journalism / due diligence
+> 5. Job interview prep
+> 6. Competitive intelligence
+> 7. Personal vetting (date, hire, business partner)
+> 8. Other (specify)
+>
+> *Why I'm asking:* The purpose dictates the angle, the depth, and the red-flag sensitivity. Sales prep needs conversation hooks. Investment diligence needs traction signals. Personal vetting needs careful sensitivity boundaries.
+
+### Q4 (depends on Q3) — **Hypothesis — MANDATORY**
+
+> **What's your hypothesis going in? What do you already believe about this subject, and what do you want to verify or disprove?**
+>
+> *Why I'm asking:* This is the critical question. A dossier that just confirms what you already think is worthless. By stating your hypothesis upfront, I can search for evidence that would *disprove* it as well as evidence that supports it — and give you a verdict you can actually use.
+>
+> Examples:
+> - "I believe Microsoft is consolidating AI spend on first-party Foundry. Verify or disprove."
+> - "I think the CEO is over their head — too much TAM talk, no traction. Test that."
+> - "I believe this nonprofit's overhead ratio is sketchy. Check the 990s."
+> - "I think this person is technical enough to handle a CTO role. Verify."
+
+**MANDATORY.** If user says "I don't have one", push back **once**: "Then guess. Commit to a position you can update later. The dossier needs a hypothesis to test, otherwise it's a generic profile and won't help you make a decision."
+
+If still refused: fall back to implicit hypothesis "what's the most surprising thing I could find?" and **flag the fallback in audit log**.
+
+This question is **the non-generic anchor**. Skip it and the skill becomes a Wikipedia summary.
+
+### Q5 (depends on Q3) — Depth
+
+> **Time horizon: 5-minute brief or 15-minute decision-grade dossier?**
+>
+> *Why I'm asking:* Brief mode caps at ~10 searches and skips the network + reputation passes. Decision-grade goes deeper on every section. Pick based on how much skin you have in this decision.
+
+Forcing choice.
+
+### Q6 (asked only if Q3 ∈ {journalism, personal vetting}) — Sensitivities
+
+> **Anything sensitive to exclude? E.g., personal medical, family details, political history, or specific topics off-limits?**
+>
+> *Why I'm asking:* Some research contexts have ethical constraints. I'd rather know upfront than surface something you'd never share.
+
+Skip for sales/investment/acquisition/competitive intel (low sensitivity); ask for journalism/personal vetting (high sensitivity).
+
+**Stop condition:** After Q6 (or earlier with dependency skips), commit and start Phase 2. Never re-open intake after Phase 2 begins.
+
+## Phase 2: Subject Disambiguation
+
+Before Phase 3, resolve the subject to a specific entity:
+
+- For people: confirm LinkedIn URL OR (employer + role + city)
+- For companies: confirm domain OR (legal name + incorporation jurisdiction)
+- For nonprofits: confirm EIN OR (legal name + state)
+- For government orgs: confirm official .gov URL
+
+If still ambiguous after Q1 push-back: **halt and re-ask Q1** with disambiguating identifiers. Refuse to proceed.
+
+## Phase 3: Source Matrix Selection
+
+Routed by Q2 subject type. See [`references/subject_type_source_matrix.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/references/subject_type_source_matrix.md) for the full canon.
+
+### Person
+
+- LinkedIn (manual fetch or LinkedIn MCP if BYOK)
+- Personal website
+- Twitter/X (rate-limited; degrade gracefully)
+- GitHub (if technical subject)
+- Google Scholar (if academic)
+- News (WebSearch + WebFetch)
+- Conference talk transcripts, podcasts (WebSearch)
+
+### Company
+
+- Official website (about, leadership, news, careers)
+- SEC EDGAR (free API; 10-Ks, 10-Qs, 8-Ks for public co's)
+- Crunchbase free tier (or Crunchbase MCP if BYOK)
+- News (WebSearch + WebFetch)
+- GitHub (for tech orgs)
+- Glassdoor + Comparably (sentiment; degrade gracefully if scraping blocked)
+- LinkedIn company page
+
+### Nonprofit
+
+- ProPublica Nonprofit Explorer (free; Form 990s)
+- Official website
+- News
+- GuideStar (if accessible)
+
+### Government org
+
+- Official .gov sites
+- News
+- ProPublica (for federal agencies)
+
+If a paid MCP is connected (Apollo, Pitchbook, SimilarWeb), use it but mark findings as **BYOK-sourced** in the audit log.
+
+## Phase 4: Hypothesis-Driven Search
+
+Every Phase 4 search MUST be classified as either:
+
+- **Supporting evidence** (confirms hypothesis), OR
+- **Disconfirming evidence** (would refute hypothesis)
+
+**≥30% of search budget allocated to disconfirming queries.** Enforced via `scripts/disconfirming_evidence_balance.py`.
+
+Example for hypothesis "Microsoft is consolidating AI spend on Foundry":
+
+- **Supporting:** "Microsoft Foundry adoption 2026", "Microsoft AI infrastructure consolidation"
+- **Disconfirming:** "Microsoft OpenAI deal renegotiation", "Microsoft AI vendor diversification", "Microsoft third-party model partnerships 2026"
+
+This is what makes the dossier **decision-grade** rather than confirmation-biased.
+
+For each search:
+- Record via `citation_tracker.py` with classification (supporting / disconfirming)
+- Apply source tier from `source_tier_classifier.py` to each result URL
+
+## Phase 5: 12-Month Activity Timeline
+
+Default 12-month window for activity timeline; deeper for foundational identity.
+
+Categories:
+- News (acquisitions, hires, departures, product launches)
+- Funding rounds / financial events
+- Controversies / legal events
+- Public statements / strategy shifts
+
+Reverse chronological. Each entry hyperlinked + tiered.
+
+## Phase 6: Network + Reputation Signals
+
+### Network
+
+- **Companies:** investors (in/out), customers (named), partners
+- **People:** co-founders, advisors, mentors, employers, board roles
+- **Nonprofits:** funders, board, leadership
+
+5-10 entries, ranked by **relevance to hypothesis**.
+
+### Reputation
+
+- Sentiment from news (recent 12 months)
+- Glassdoor for companies (overall rating + 3 representative reviews)
+- Peer mentions for people
+- Caveat: reputation data is noisy; tier accordingly
+
+## Phase 7: Red-Flag Pass
+
+Surface but don't sensationalize:
+
+- Litigation (court records → primary tier)
+- Regulatory actions (SEC, DOJ, agency actions → primary)
+- Unusual departures (key personnel exits within 90 days)
+- Financial signals (going-concern notes in 10-Ks → primary)
+- Reputation hits (sustained negative coverage → secondary)
+
+**Each flag tiered.** Tier shows up next to every flag in the DOCX.
+
+## Phase 8: Conversation Hook Generation
+
+3-5 specific hooks tied to **actual findings**, not generic talking points.
+
+See [`references/conversation_hook_quality.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/references/conversation_hook_quality.md) for the canon.
+
+| ❌ Generic | ✅ Finding-tied |
+|---|---|
+| "Ask about their roadmap" | "Mention their recent acquisition of [X] — it signals they're investing in vertical Y. Suggested framing: 'Saw the [X] announcement — how does that change your roadmap on Y?'" |
+| "Ask about hiring" | "Their VP Engineering left 3 weeks ago (LinkedIn). Suggested framing: 'I noticed [name] moved on — what's the eng leadership plan?'" |
+| "Talk about their values" | "They updated their pricing page last week (their official site). Suggested framing: 'Saw the pricing refresh — what drove that?'" |
+
+Each hook:
+- **The hook** (one sentence)
+- **The finding it's tied to** (with hyperlink + tier)
+- **Suggested framing** (verbatim phrasing user can adapt)
+
+## Phase 9: DOCX Generation (9 Sections)
+
+Via Node.js + `docx` library.
+
+1. **Executive Summary** — one paragraph: who they are + why they matter + **verdict on the hypothesis** (SUPPORTED / PARTIALLY SUPPORTED / DISPROVEN / INCONCLUSIVE) + 3 things-you-should-know bullets.
+2. **Identity Facts Table** — founded/born, location, size/stage, current role, key affiliations. All cells sourced; hover-text tier.
+3. **Hypothesis Test** — user's hypothesis stated verbatim. Supporting evidence (3-5 bullets with hyperlinked citations). Disconfirming evidence (3-5 bullets with hyperlinked citations). Verdict paragraph (2-3 sentences explaining the weight).
+4. **12-Month Activity Timeline** — News, funding, hires, departures, product launches, controversies. Reverse chronological. Each entry hyperlinked.
+5. **Network Signals** — Collaborators / investors / associates. 5-10 entries, ranked by relevance to hypothesis.
+6. **Reputation Signals** — Sentiment from news, Glassdoor for companies, peer mentions for people. Caveat: reputation data is noisy.
+7. **Red Flags + Hidden Patterns** — Litigation, regulatory actions, unusual departures, financial signals, reputation hits. Tiered.
+8. **Conversation Hooks** — 3-5 specific hooks tied to findings. Each: hook + finding + suggested framing.
+9. **Source Provenance + Audit Log** — Per-source list with tier. Search summary table (#, query, classification, sources returned, sources cited). Three counts + per-tier counts. Failed searches. BYOK-MCP usage flag.
+
+### Styling
+
+Arial 12pt body, navy headings (#1a3a5c), light blue table headers (#e8f0f8), red red-flag callout, green conversation-hook callout.
+
+### Hyperlink patterns
+
+```js
+new ExternalHyperlink({
+  link: "https://...",
+  children: [new TextRun({ text: title, style: "Hyperlink" })],
+});
+```
+
+## Phase 10: Deliver
+
+- Save: `<output-dir>/dossier_<entity-slug>_<YYYY-MM-DD>.docx`
+- Chat summary: file path + **verdict on hypothesis** + audit counts + tier breakdown + BYOK MCPs used (if any)
+- Validate: `python scripts/office/validate.py <docx>`
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/citation_tracker.py` | Three-count audit + supporting/disconfirming classification + source-tier tagging at `~/.dossier_sessions/<session>.json` |
+| `scripts/disconfirming_evidence_balance.py` | Verifies ≥30% of search budget allocated to disconfirming queries; warns if biased |
+| `scripts/source_tier_classifier.py` | URL → primary / secondary / tertiary classification via domain heuristics |
+
+## References
+
+- [`references/hypothesis_testing_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/references/hypothesis_testing_discipline.md) — ≥30% rule + decision-grade vs encyclopedic (7+ sources)
+- [`references/subject_type_source_matrix.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/references/subject_type_source_matrix.md) — person/company/nonprofit/gov source matrices (7+ sources)
+- [`references/conversation_hook_quality.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/dossier/skills/dossier/references/conversation_hook_quality.md) — finding-tied hook discipline (7+ sources)
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Subject name ambiguous | Refuse to proceed. Re-ask Q1 with disambiguating identifier. |
+| User refuses to state hypothesis | Push back once. If still refused, fall back to "what's the most surprising thing I could find?" implicit hypothesis. Flag in audit. |
+| Subject has zero public footprint | Surface explicitly. Suggest different name or early-stage. Don't fabricate. |
+| LinkedIn scrape blocked | Note in audit; fall back to WebSearch; suggest user verify manually. |
+| SEC EDGAR fails | Retry once. If still failing, note "public filings not retrieved" and continue. |
+| Sentiment data sparse | Mark reputation section as "limited public signal"; don't infer from training. |
+| Sensitive topic surfaces (Q6 exclusion) | Exclude from DOCX. Note in chat (not in DOCX) so user knows the exclusion was honored. |
+| 3 consecutive tool failures | Stop, alert user, share collected so far. |
+| DOCX generation fails | Save raw data as JSON fallback. |
+
+## Anti-Patterns To Reject
+
+- Producing a dossier without forcing Q4 hypothesis
+- Allocating <30% of search budget to disconfirming evidence
+- Batching intake questions
+- Accepting ambiguous subject names
+- Generic conversation hooks ("ask about their roadmap")
+- Sensationalizing red flags (tier them, don't editorialize)
+- Skipping the source-reliability tier on flags
+- Fabricating coverage when LinkedIn or scraping is blocked
+- Using BYOK-MCP data without flagging in audit log
+- Including sensitive topics user excluded in Q6
+- Confirmation-biased verdict ("SUPPORTED" without engaging with disconfirming evidence)
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/12-dossier-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/12-dossier-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Research-pack sibling, hypothesis-testing variant.

--- a/docs/skills/research/grants.md
+++ b/docs/skills/research/grants.md
@@ -1,0 +1,291 @@
+---
+title: "Grants — NIH Funding Intelligence — Agent Skill for Research Workflows"
+description: "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Grants — NIH Funding Intelligence
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `grants`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Portability:** Requires `bash_tool` (for RePORTER POST via curl), Node.js with `docx` package, and a Consensus MCP connection. Works in Claude Code CLI natively. In Claude.ai with Code Execution + Consensus MCP, the workflow is supported but slower.
+
+> **Scope: NIH-only.** Non-NIH funders (PCORI, DOD CDMRP, VA, foundations) are out of scope and flagged at intake.
+
+For a clinical researcher with a research idea, produce a strategic NIH funding overview as an editable `.docx`. Output covers research positioning analysis, institute mapping, targeted grant discovery, and strategic recommendations the researcher can edit, copy from, and share with their mentor.
+
+## Agent Integrity Rules (Research-Pack Convention)
+
+Inherited; locked verbatim per PR #657 audit.
+
+- **Execution discipline.** A step isn't complete until result is confirmed received. Consensus calls **sequential with 1+ sec pause**. RePORTER calls sequential.
+- **Data sourcing.** Count only what tool calls returned this session. Never supplement with training knowledge. Training knowledge labeled `[Not from Consensus/RePORTER — reference information]` and excluded from counts.
+- **Counts & attribution.** Queries sent / results shown / results cited — three separate numbers, never conflate. Every cited paper has retrievable URL from this session.
+- **Error handling.** On failure → wait 3s → retry once → log. After 3 consecutive failures across tools: stop, alert researcher, explain what's missing. Never silently skip.
+- **Transparency.** Audit Log section in the DOCX. Same standards in chat summary as in document.
+
+See [`references/reporter_post_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/references/reporter_post_patterns.md) for the RePORTER POST canon + plan-tier detection.
+
+## Phase 1: Grill-Me Intake (6 forcing questions, one at a time)
+
+### Q1 (root) — Research idea
+
+> **Describe the research idea in 2–3 sentences. What's the question, what's new, and what's the clinical relevance? Vague answers ("AI for healthcare", "biomarkers for disease X") will be rejected — push for specificity.**
+>
+> *Why I'm asking:* Five Consensus searches (established / stakes / current approaches / adjacent methods / gaps) depend on a precise research idea. Vague ideas produce vague gap quotes and useless positioning narrative.
+
+Refuse mush. Re-ask once with examples if user is too broad.
+
+### Q2 (depends on Q1) — Career stage
+
+> **Career stage — pick one:**
+>
+> 1. Pre-doctoral (PhD student, T32 trainee)
+> 2. Postdoctoral fellow (F32, K99 candidate)
+> 3. Early career (K-award candidate, first R01)
+> 4. Independent investigator (multiple R01s, established lab)
+> 5. Senior PI (R35, P-series, U01 leadership)
+>
+> *Why I'm asking:* Career stage filters mechanism recommendations. F-series for trainees, K-series for early career, R-series for independent. Picking the wrong stage produces unfundable mechanism suggestions.
+
+Forcing choice.
+
+### Q3 (depends on Q2) — Preliminary data status
+
+> **Preliminary data — pick one:**
+>
+> 1. None (de novo project, no pilot data yet)
+> 2. Pilot data (early findings, single-site)
+> 3. Strong preliminary (multi-experiment, ready for R01-scale)
+> 4. Validated and ready (multi-site, publication-ready)
+>
+> *Why I'm asking:* Prelim data status drives mechanism budget. No data → R03 / R21 pilot scope. Strong prelim → R01 / U01 multi-site scale. Mismatch produces uncompetitive applications.
+
+### Q4 (depends on Q2) — Environment
+
+> **Research environment — pick one:**
+>
+> 1. R01-eligible (research-intensive institution with NIH base funding)
+> 2. Mid-tier (regional academic medical center, modest NIH portfolio)
+> 3. Resource-constrained (smaller institution, minimal NIH base)
+> 4. Industry-collaborative (academic + industry partnership)
+>
+> *Why I'm asking:* Environment affects scope realism (multi-site U01 requires R01-eligible) and which mechanism categories are competitive (R15 specifically targets resource-constrained).
+
+### Q5 (depends on Q1) — Submission posture
+
+> **Submission posture — pick one:**
+>
+> 1. New application (first submission, no prior reviews)
+> 2. Resubmission (A1 with reviewer responses needed)
+> 3. Exploring (haven't decided yet whether to submit)
+>
+> *Why I'm asking:* Resubmissions need reviewer-response guidance in the DOCX (Section 7). New applications skip that. Exploring shifts emphasis to landscape over strategy.
+
+### Q6 (depends on Q1) — Known institute targets
+
+> **Are you already considering specific NIH institutes? List names (NCI / NHLBI / NIMH / NINDS / NIDDK / etc.) or say "no preference — find the right ones".**
+>
+> *Why I'm asking:* If you have an institute hypothesis, I'll validate it against RePORTER data. If not, I'll surface the top-3 institutes funding adjacent work from the institute-tally.
+
+Accept "no preference" as the common case.
+
+**Stop condition:** After Q6, commit and start Phase 2A. Never re-open intake after Phase 2A begins.
+
+## Phase 2A: Research Positioning (5 Consensus searches)
+
+Run sequentially at 1 q/sec. Each search corresponds to one positioning facet:
+
+1. **Established** — `"<research idea>" established evidence` — what's known
+2. **Stakes** — `"<topic>" mortality OR burden OR cost OR prevalence` — why it matters
+3. **Current Approaches** — `"<topic>" current treatment OR standard of care OR approach` — state of the art
+4. **Adjacent Methods** — `"<related technique>" applied to <topic>` — methodological possibilities
+5. **Gaps** — `"<topic>" limitations OR unanswered OR future directions OR challenge` — gap signals
+
+Use `scripts/citation_tracker.py --action record_consensus_search` for each. Plan-tier detected from first response.
+
+**Synthesis:** for each facet, extract 2-3 quotable findings (becomes Section 2 gap quotes). Draft Significance/Innovation language using "the field has established X (refs), but Y remains unanswered (refs)" pattern.
+
+## Phase 2B: Institute Mapping + Grant Discovery (RePORTER POST)
+
+RePORTER is **POST-only**. Use `bash_tool` + `curl` — never `web_fetch`.
+
+### Dynamic fiscal year window
+
+Compute at runtime via `scripts/fiscal_year_calculator.py`. Default: current FY + 3 prior. Federal FY starts Oct 1, so:
+
+```bash
+python ../scripts/fiscal_year_calculator.py --output json
+# Returns: {"current_fy": 2026, "window": [2023, 2024, 2025, 2026]}
+```
+
+### Narrow (AND) search — finds direct overlap
+
+```bash
+curl -X POST 'https://api.reporter.nih.gov/v2/projects/search' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "criteria": {
+      "fiscal_years": [2023, 2024, 2025, 2026],
+      "include_active_projects": true,
+      "advanced_text_search": {
+        "operator": "AND",
+        "search_field": "all",
+        "search_text": "<key term 1> <key term 2>"
+      }
+    },
+    "limit": 50,
+    "include_fields": ["project_num", "project_title", "agency_ic_admin", "study_section", "fiscal_year", "principal_investigators", "abstract_text"]
+  }'
+```
+
+### Broad (OR) search — finds adjacent work
+
+```bash
+curl -X POST 'https://api.reporter.nih.gov/v2/projects/search' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "criteria": {
+      "fiscal_years": [2023, 2024, 2025, 2026],
+      "advanced_text_search": {
+        "operator": "OR",
+        "search_field": "all",
+        "search_text": "<term> <synonym> <related concept>"
+      }
+    },
+    "limit": 50
+  }'
+```
+
+### Institute tally + study section ranking
+
+After RePORTER responses:
+- Tally `agency_ic_admin` (institute code: NCI, NHLBI, NIMH, etc.) → top-3 funding institutes
+- Tally `study_section` → top-2 study sections (where applications go for review)
+
+### NOSI discovery
+
+Parse RePORTER responses for `NOT-*` opportunity numbers. For each:
+
+```bash
+# NOSIs live at predictable URLs:
+# https://grants.nih.gov/grants/guide/notice-files/NOT-<INSTITUTE>-<YEAR>-<NUMBER>.html
+web_fetch <url>
+```
+
+If fetch fails: log `[NOSI {number} — fetch failed, not included]`, continue.
+
+## Mechanism Matching (Scope-Aware)
+
+NOT career stage alone. Career stage **+** project scope **+** prelim data drive recommendation.
+
+Use `scripts/mechanism_matcher.py`:
+
+```bash
+python ../scripts/mechanism_matcher.py \
+  --career-stage "early_career" \
+  --prelim-data "pilot" \
+  --environment "r01_eligible" \
+  --scope "single_site" \
+  --output json
+# Returns mechanism shortlist with rationale
+```
+
+See [`references/nih_mechanism_matching.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/references/nih_mechanism_matching.md) for the full matrix.
+
+## Phase 3: DOCX Generation
+
+9 sections via Node.js + `docx` library. See [`references/docx_9_sections.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/references/docx_9_sections.md) for full spec.
+
+1. **Executive Summary** — title + career stage + environment + 3-4 key findings bullets
+2. **Research Positioning** — 3-5 gap quotes (italicized, inline Consensus citations) + 2-3 paragraph positioning narrative + supporting evidence table
+3. **Target Institutes** — ranking table (institute, project count in window, % match to your idea) + 2-3 sentence interpretation
+4. **Grant Opportunities** — bold NOSI callout if any. Top-3 grants table with hyperlinked FOAs + per-grant scope/budget fit paragraph
+5. **Funded Overlap** — top-5 projects table (PI, project_num, IC, year, hyperlinked to RePORTER) + differentiation paragraph
+6. **Study Sections** — ranking table + best-match interpretation
+7. **Strategic Recommendations & Next Steps** — 3-4 numbered recs + **mandatory program officer rec** + submission timeline note + (if resubmission Q5=2) reviewer-response guidance + closing paragraph
+8. **References** — numbered bibliography, hyperlinked to Consensus
+9. **Audit Log** — Consensus searches table, plan-tier note, RePORTER searches table, NOSI fetches table, summary stats, tool constraints note, failed steps
+
+### Styling
+
+Arial 12pt body, navy headings (#1a3a5c), light blue table headers (#e8f0f8), amber NOSI callout. `ExternalHyperlink` patterns:
+- Paper citations: `https://consensus.app/papers/...`
+- FOA links: `https://grants.nih.gov/grants/guide/...`
+- RePORTER projects: `https://reporter.nih.gov/project-details/<id>`
+
+## Mandatory Program Officer Recommendation
+
+Always include in Section 7:
+
+> **Recommended next step: contact program officer at {top institute}.** Find their staff page at https://www.nih.gov/institutes-nih/list-nih-institutes-centers-offices → {institute} → Program Officers. Prepare: 1-page specific aims + your CV + 3 specific questions about fit. Email subject: "Pre-application inquiry: <topic>".
+
+This is the single most valuable advice for any applicant. Never skip.
+
+## Submission Timeline (Embedded in DOCX Section 7)
+
+| Mechanism | Standard receipt dates |
+|---|---|
+| R01, R21, R03 | Feb 5, Jun 5, Oct 5 |
+| K awards (K01, K08, K23, K99) | Feb 12, Jun 12, Oct 12 |
+| R34, R61/R33 | Feb 16, Jun 16, Oct 16 |
+| F31, F32 | Apr 8, Aug 8, Dec 8 |
+
+## Phase 4: Deliver
+
+- Save DOCX to `<output-dir>/grants_<topic-slug>_<YYYY-MM-DD>.docx`
+- Chat summary: file path + audit counts + plan tier + verdict on institute targets
+- Validate: `python scripts/office/validate.py <docx>`
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/citation_tracker.py` | Three-count audit (Consensus sent/shown/cited + RePORTER projects/cited) at `~/.grants_sessions/<session>.json` |
+| `scripts/fiscal_year_calculator.py` | Current FY + 3-prior window. Computed at runtime, never hardcoded. |
+| `scripts/mechanism_matcher.py` | Career stage × scope × prelim → mechanism recommendation shortlist |
+
+## References
+
+- [`references/nih_mechanism_matching.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/references/nih_mechanism_matching.md) — career stage × scope × prelim → mechanism canon (7+ sources)
+- [`references/reporter_post_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/references/reporter_post_patterns.md) — RePORTER curl POST templates + plan-tier detection (7+ sources)
+- [`references/docx_9_sections.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/grants/skills/grants/references/docx_9_sections.md) — 9-section .docx spec + technical requirements (7+ sources)
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Consensus rate-limit hit | Wait 3s, retry once, log; if still failing, alert researcher |
+| Consensus returns 0 for a facet | Surface explicitly; never fill with training knowledge |
+| Consensus plan-tier cap detected | Log tier, note in audit, surface to researcher |
+| RePORTER POST returns error | Retry once after 3s; if still failing, log and continue |
+| RePORTER returns <5 on narrow | Document; broad OR should compensate; surface low count |
+| NOSI fetch fails | Log `[NOSI {n} — fetch failed]`, continue |
+| 3 consecutive tool failures | Stop, alert researcher with what's missing |
+| DOCX generation fails | Save raw data as JSON fallback so researcher doesn't lose work |
+
+## Anti-Patterns To Reject
+
+- Parallelizing Consensus calls (will hit rate limit)
+- Using `web_fetch` for RePORTER (POST-only — `web_fetch` is GET)
+- Hardcoded fiscal year values
+- Mechanism recommendations based on career stage alone (must consider scope too)
+- Silently filling thin facet results with training knowledge
+- Skipping the audit log
+- Skipping the program officer recommendation
+- Conflating "papers found" with "papers shown" with "papers cited"
+- Fabricating NOSI details when fetch fails
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/08-grants-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/08-grants-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Research-pack sibling of pulse + litreview.

--- a/docs/skills/research/index.md
+++ b/docs/skills/research/index.md
@@ -1,0 +1,20 @@
+---
+title: "Research Skills — Agent Skills & Codex Plugins"
+description: "8 research skills — research orchestrator agent skill and Claude Code plugin for hybrid routing across pulse, litreview, grants, dossier, patent, syllabus, and notebooklm specialists. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+---
+
+<div class="domain-header" markdown>
+
+# :material-magnify: Research
+
+<p class="domain-count">8 skills in this domain</p>
+
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install all:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+<div class="grid cards" markdown>
+
+</div>

--- a/docs/skills/research/litreview.md
+++ b/docs/skills/research/litreview.md
@@ -1,0 +1,256 @@
+---
+title: "Litreview — Academic Literature Orientation — Agent Skill for Research Workflows"
+description: "Academic literature orientation skill that searches papers via Consensus, builds a strategic search plan using PICO (default) or SPIDER /. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Litreview — Academic Literature Orientation
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `litreview`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Portability:** Requires a Consensus MCP connection, Node.js with `docx` package for document generation, and (in CLI) `bash_tool`. Works in Claude Code CLI natively. In Claude.ai with Consensus MCP + Code Execution, the workflow is supported.
+
+Produce a **launching pad** — not a finished literature review, but an orientation document that gives a researcher entering an unfamiliar field everything they need to start reading and searching with confidence. Think: what a generous colleague who knows the field would tell you over coffee.
+
+## Agent Integrity Rules (Research-Pack Convention)
+
+Inherited from the research-pack convention; locked verbatim per PR #657's cross-skill consistency audit.
+
+- **Source discipline.** Only cite Consensus-returned papers from THIS session. Training knowledge labeled `[Not from Consensus — model knowledge]` and excluded from cited count. Sparse results stated explicitly, never silently filled.
+- **Counting discipline.** Three numbers tracked: searches executed / unique papers received (deduplicated) / papers cited. Every cited paper has a retrievable Consensus URL from this session. Use `scripts/citation_tracker.py` for deterministic counts.
+- **Tool constraints.** Consensus per-query cap depends on plan tier. **Detect at first search**, report at checkpoint. Rate limit is **1 query/sec** — sequential execution mandatory.
+- **Retry policy.** On failure → wait 3s → retry once → log. After 3 consecutive failures: stop, alert user, share what was collected.
+- **Plan-tier detection.** Parse first-search response for "Showing top 10" / "upgrade" → free tier (10/search). 20 returned → Pro (20/search). Calculate theoretical ceiling and surface at checkpoint so user can recalibrate.
+
+See [`references/search_budget_allocation.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/search_budget_allocation.md) for the sequential-execution rationale + plan-tier signals.
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Consensus rate-limit hit | Wait 3s, retry once, log outcome |
+| Search returns 0 results | Note explicitly; "either niche terminology or genuine gap"; never silently fill |
+| Plan-tier cap detected | Log tier; report at checkpoint; surface in audit |
+| 3 consecutive failures | Stop searching, alert user, share what's collected, ask how to proceed |
+| Sub-area returns thin results (<5 papers) | Flag in audit; suggest manual PubMed/Scholar supplementation |
+| User wants to adjust sub-areas | Update table, re-confirm before searching |
+| DOCX validation fails | Unpack XML, fix, repack |
+
+## Phase 0: Grill-Me Intake (3 forcing questions, one at a time)
+
+Each question carries explicit "why I'm asking". Stop condition: max 3 before Phase 1.
+
+### Q1 (root) — Research question specificity
+
+> **State the research question in 1–2 sentences. Specific is better — "How do LLMs perform on clinical reasoning tasks compared to physicians?" beats "AI in medicine". Vague questions produce vague reviews.**
+>
+> *Why I'm asking:* The reconnaissance search hinges on precise terminology. Vague questions produce thin recon results that don't yield a useful framework breakdown.
+
+**Refuse mush.** Re-ask once with examples if user is too broad. If still vague, deliver with explicit "broad-scope orientation, not depth review" caveat.
+
+### Q2 (depends on Q1) — Framework hint
+
+> **Framework — pick one or say "you pick":**
+>
+> 1. **PICO** (Population / Intervention / Comparison / Outcome — most clinical questions)
+> 2. **SPIDER** (Sample / Phenomenon / Design / Evaluation / Research-type — social/qualitative)
+> 3. **Decomposition** (Problem / Solution / Evaluation / Limitations — technology-focused)
+> 4. **Hybrid** (you pick which components from which framework)
+> 5. **You pick** — analyze Q1 and recommend
+>
+> *Why I'm asking:* PICO is the default for ~70% of clinical questions but maps poorly to qualitative work or technology evaluation. Picking upfront saves the recon search from suggesting a misaligned framework.
+
+Forcing choice with default ("you pick"). The skill surfaces its own framework recommendation after the recon search so user can override. Use `scripts/framework_recommender.py` for the heuristic.
+
+See [`references/framework_selection.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/framework_selection.md) for PICO / SPIDER / Decomposition canon.
+
+### Q3 (depends on Q1) — Tentative depth
+
+> **Tentative depth — pick one. Final confirmation comes after the framework breakdown:**
+>
+> 1. **Quick scan** (5 searches)
+> 2. **Standard review** (10 searches)
+> 3. **Deep dive** (20 searches)
+>
+> *Why I'm asking:* I ask this twice — once now to calibrate the recon search emphasis, once after the framework breakdown to confirm. Tentative answer affects which sub-areas to surface first; final answer drives search budget allocation.
+
+Forcing choice. **Re-asked** at the post-Phase-2 checkpoint after the user has seen the framework breakdown.
+
+**Stop condition:** 3 questions max before Phase 1. The post-Phase-2 checkpoint is its own grill-me moment (framework table + sub-area-adjustment + depth-reconfirmation).
+
+## Phase 1: Initial Reconnaissance
+
+**One broad Consensus search** to map themes, terminology, methodological distinctions.
+
+- Query: broad version of Q1 (terminology variants are okay; first search casts wide)
+- Record: `citation_tracker.py --action record_search --session NAME --query "..."`
+- Record received count: `citation_tracker.py --action record_papers_received --session NAME --count N`
+- **Detect plan tier** from response: "Showing top 10" / "upgrade" → free; 20 returned → Pro
+
+Synthesize for the checkpoint:
+- Themes that surfaced
+- Terminology variations (e.g., "LLM" vs "large language model" vs "GPT-style model")
+- Methodological distinctions (clinical trials vs benchmark eval vs case study)
+- Coverage gaps (sub-questions absent from recon results)
+
+## Phase 2: Framework Selection + Sub-area Generation
+
+Choose framework (from Q2 OR override based on recon):
+- **PICO** — most clinical questions (~70% default)
+- **SPIDER** — social / qualitative
+- **Decomposition** — technology focus (Problem / Solution / Evaluation / Limitations)
+- **Hybrid** — explicit cross-framework mapping
+
+Generate **4-5 sub-area questions** mapped to framework components. Each becomes a targeted Phase 3 search.
+
+## Checkpoint (grill-me forcing-options moment)
+
+After Phase 2, halt and present:
+
+### 3-4 sentence recon summary
+- What themes surfaced
+- Terminology landscape
+- Evidence landscape characterization
+
+### Framework breakdown table
+
+| Framework Component | How It Maps to This Topic | Proposed Sub-area to Explore |
+|---|---|---|
+| (Component 1) | ... | Sub-area 1 |
+| (Component 2) | ... | Sub-area 2 |
+| (Component 3) | ... | Sub-area 3 |
+| (Component 4) | ... | Sub-area 4 |
+| Cross-cutting theme | ... | Sub-area 5 |
+
+### Depth re-confirmation (forcing choice)
+
+Surface the **practical constraint**: detected plan tier + theoretical ceiling.
+
+- Quick scan (5 searches × ~10 results each = ~50 papers max)
+- Standard review (10 searches × ~10 = ~100 papers)
+- Deep dive (20 searches × ~10 = ~200 papers)
+
+### Sub-area forcing options
+
+- "Looks good — proceed with these sub-areas"
+- "Adjust: add sub-area on [X]"
+- "Adjust: remove and replace [Y] with [Z]"
+- "Restart with different framework"
+
+### Why I'm asking (the rationale)
+
+> A wrong framework or sub-area set wastes the search budget. This is the **last cheap moment** to correct course.
+
+**Wait for user response before Phase 3.** Refuse to start Phase 3 without explicit user choice.
+
+## Phase 3: Targeted Searches
+
+Sequential (1 query/sec), budget per depth tier. See [`references/search_budget_allocation.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/search_budget_allocation.md) for full canon.
+
+### Quick scan (5 searches)
+- 5 sub-area searches (one per sub-area)
+- Skip era-gated + review-specific
+
+### Standard review (10 searches)
+- 5 sub-area searches
+- 2 review article searches (top 2 sub-areas): `"systematic review [topic]"` / `"meta-analysis [topic]"`
+- 2 era-gated searches (most important sub-area): `year_max: 2015` + `year_min: 2021`
+- 1 follow-up on highest-cited paper using its key terms + `year_min` after publication
+
+### Deep dive (20 searches)
+- 5 sub-area searches
+- 5 review article searches (one per sub-area)
+- 4 era-gated searches (top 2 sub-areas, old + new each)
+- 3 follow-ups on top 3 highest-cited papers
+- 3 spare for emerging threads (surprising findings to chase)
+
+Throughout: 1 q/sec rate limit. Sequential. Confirm response before next call. Record each via `citation_tracker.py`.
+
+## Cross-Search Intelligence
+
+Three trackers across ALL search results — run `scripts/cross_search_aggregator.py --session NAME` after Phase 3 completes:
+
+1. **Repeat-hit papers** — same paper appearing in 3+ sub-area searches = likely foundational
+2. **Recurring authors** — same author in multiple searches = dominant research group; top 3-5 most frequent matter
+3. **Citation-per-year heuristic** — a 2023 paper with 150 citations >> 2008 paper with 150 citations. Use for seminal-work identification.
+
+These feed the "Start Here" + "Key Research Groups" + "Bibliography" DOCX sections.
+
+## Phase 4: DOCX Research Guide
+
+Generate via Node.js + `docx` library. 8 sections (see [`references/docx_8_sections.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/docx_8_sections.md) for full spec):
+
+1. **Topic Overview** — single tight paragraph (4-6 sentences)
+2. **Start Here — Priority Reading Order** — 5-7 papers ordered: best recent review → foundational → 2-3 frontier → gap/controversy. Each: hyperlinked title + authors/year + 1-sentence contribution + 1-sentence "what to look for"
+3. **How the Field Got Here** — chronological narrative (1-2 paragraphs) + timeline table (5-8 milestones: Year / Milestone / Significance) + terminology evolution note
+4. **Sub-area Guides** (one per sub-area, 4 parts each)
+   - 4a. What the Research Shows (2-3 sentence synthesis with inline citations)
+   - 4b. Key Papers (3-5 hyperlinked papers with citation count, year, 1-sentence importance)
+   - 4c. Key Search Terms (6-10 keywords, synonyms, MeSH, historical terms)
+   - 4d. Boolean Search Strings (2-3 ready-to-paste strings)
+5. **Key Research Groups** — top 3-5 authors/groups with affiliations, sub-area coverage, representative paper link (from cross-search aggregator)
+6. **Open Questions & Gaps** — three categories: methodological / population-context / conceptual-theoretical. Each gap explains *why it matters*.
+7. **Bibliography** — alphabetical by first author. Every entry has clickable "View on Consensus" link. Every inline citation matches a bibliography entry.
+8. **Audit Log** — search summary table (#, query, filters, papers returned, status), counts block, coverage notes including detected tier and theoretical ceiling
+
+### DOCX Technical Requirements
+
+Document the key `docx` library patterns:
+
+- Page: US Letter, 1-inch margins
+- Lists: `LevelFormat.BULLET` (never unicode bullets)
+- Hyperlinks: `ExternalHyperlink` with `style: "Hyperlink"`, full URL (never truncated)
+- Tables: dual widths (`columnWidths` + cell `width`), `ShadingType.CLEAR`
+- Validation step after save (`python scripts/office/validate.py output.docx`)
+
+Reference the **docx skill** for setup patterns and best practices.
+
+## Output
+
+```
+research_guide_<topic-slug>_<YYYY-MM-DD>.docx
+```
+
+Plus:
+- Chat summary block: "Saved: <path>. Audit: N searches × M unique papers / K cited. Plan tier: <tier>."
+- Audit log printed inline if user asks for it
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/citation_tracker.py` | JSON-backed three-count audit at `~/.litreview_sessions/<session>.json` |
+| `scripts/framework_recommender.py` | Heuristic PICO/SPIDER/Decomposition suggestion from research question |
+| `scripts/cross_search_aggregator.py` | Repeat-hits + recurring-authors + citation-per-year ranking after Phase 3 |
+
+## References
+
+- [`references/framework_selection.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/framework_selection.md) — PICO / SPIDER / Decomposition canon (7+ sources)
+- [`references/search_budget_allocation.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/search_budget_allocation.md) — depth tiers + cross-search intelligence + sequential execution rationale (7+ sources)
+- [`references/docx_8_sections.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/litreview/skills/litreview/references/docx_8_sections.md) — research guide DOCX spec + technical requirements (7+ sources)
+
+## Anti-Patterns To Reject
+
+- Parallelizing Consensus calls
+- Skipping the interactive checkpoint (running all searches without user confirmation)
+- Padding thin results with training knowledge
+- Defaulting to non-PICO framework without justification
+- Citing papers in chat that didn't come from Consensus this session
+- Hardcoding plan tier instead of detecting from first response
+- Skipping era-gated searches in standard/deep budgets
+- Skipping cross-search intelligence (repeat-hits, recurring authors)
+- Truncating Consensus URLs in hyperlinks
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/09-litreview-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/09-litreview-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Sibling of `pulse` (research-pack shape).

--- a/docs/skills/research/notebooklm.md
+++ b/docs/skills/research/notebooklm.md
@@ -1,0 +1,295 @@
+---
+title: "NotebookLM — Browser Automation — Agent Skill for Research Workflows"
+description: "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# NotebookLM — Browser Automation
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `notebooklm`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Requires:** A browser automation environment (Claude Code CLI with computer-use, Claude Chrome Extension, or equivalent). **Skill will gracefully fail in non-automation contexts with a clear "not supported" message.**
+
+> **Critical:** This skill is the only browser-automation skill in the v2 collection. It does NOT follow the research-pack Agent Integrity Rules convention. Different constraints apply (UI dynamics, async generation, login walls).
+
+## Step 0: Browser Context Setup (Mandatory)
+
+Before any other action, verify browser automation is available:
+
+1. Check whether browser-control tools are loaded in the harness (screenshot, click, find-element, navigate)
+2. If unavailable → **halt with clear message:** "This skill requires browser automation. Currently in {context}. Cannot proceed. Use Claude Code CLI with computer-use, Claude Chrome Extension, or equivalent."
+3. If available → take initial screenshot, navigate to https://notebooklm.google.com
+4. **Detect login wall via screenshot.** If login screen detected: halt with "Please log in to NotebookLM in the browser, then re-invoke this skill." **Never attempt to handle login automatically.**
+
+## Phase 0: Grill-Me Intake (Action-Routing)
+
+Up to 4 forcing questions, one at a time, dependency-ordered. Most invocations stop at Q3.
+
+### Q1 (root) — Action
+
+> **What do you want me to do? Pick one:**
+>
+> 1. **Read / extract** — ask a question of an existing notebook
+> 2. **Add a source** — push content (URL, text, file, Google Doc, or synthesized content) into a notebook
+> 3. **Generate a Studio output** — Audio Overview, Study Guide, Briefing Doc, Timeline, FAQ, Infographic, Slides, or Mind Map
+> 4. **Create a new notebook** — initialize with title + initial sources
+>
+> *Why I'm asking:* Each action takes a different path through the UI and requires different parameters. Naming the action upfront prevents wasted screenshots and lets me ask only the follow-up questions that apply.
+
+**Forcing choice.** If the user says "open NotebookLM" without specifying an action, **refuse to start** and re-ask Q1.
+
+### Q2 (depends on Q1) — Notebook identity
+
+> **Which notebook?** *(asked for actions 1, 2, 3 — not for "create new")*
+>
+> *Why I'm asking:* If you give me a name, I'll search the homepage; if you give me a URL, I'll navigate directly. Names that are ambiguous will get a disambiguation prompt with screenshots.
+
+For action 4 (create new): replace with "What's the title for the new notebook?"
+
+### Q3 (depends on Q1) — Action-specific parameter
+
+**Action 1 (read/extract):**
+> "What's the question to ask the notebook? Use natural phrasing — the notebook's chat handles it best."
+
+**Action 2 (add source):**
+> "What source type? Pick one:
+> 1. URL / website / YouTube link
+> 2. Copied text (paste here or point at content)
+> 3. File upload (provide absolute path)
+> 4. Google Doc (link)
+> 5. Synthesized content (I'll pre-process and add as 'Copied text')
+>
+> *Why I'm asking:* Each source type goes through a different sub-flow in the Add Source dialog. Picking upfront saves a step."
+
+**Action 3 (Studio output):**
+> "Which Studio output? Audio Overview / Study Guide / Briefing Doc / Timeline / FAQ / Table of Contents / Infographic / Slides / Mind Map. And: any custom-prompt direction? **Default prompts produce mediocre output — I always open the customization menu and write a detailed prompt.** Tell me the angle or audience.
+>
+> *Why I'm asking:* The output type sets the UI button to find. The custom prompt is mandatory for quality."
+
+**Action 4 (create new):**
+> "Initial sources? Provide URLs, file paths, or 'I'll add later'."
+
+### Q4 (depends on Q1 = action 3) — Studio custom prompt detail
+
+> **Tell me the angle, audience, and length for the Studio output. Examples:**
+>
+> - **Audio Overview:** "Two-host conversation for a non-technical executive, 8–10 min, focus on business implications not technical depth"
+> - **Infographic:** "Decision-tree style, action-oriented, 6 panels max, monochrome navy"
+> - **Study Guide:** "Undergrad-level, definitions + 3 practice questions per concept"
+>
+> *Why I'm asking:* This becomes the custom prompt. **Default Studio prompts produce mediocre output — specific direction produces sharp output.**
+
+**Asked only for Studio output generation (Q1=3). Skip otherwise.**
+
+**Stop condition:** After Q4 (or earlier with dependency skips), commit and start the action sequence.
+
+See [`references/studio_output_custom_prompts.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/studio_output_custom_prompts.md) for the canon.
+
+## Notebook Discovery
+
+For actions 1-3 (require existing notebook):
+
+1. Navigate to homepage → screenshot
+2. If user provided **URL** → navigate directly
+3. If user provided **name**:
+   - Use semantic find() to locate notebook card by visible title text
+   - If multiple matches → screenshot homepage, list options, ask user to specify
+   - If no match → ask user to provide URL or confirm spelling
+
+For action 4 (create new):
+1. Locate "New notebook" button on homepage
+2. Click → set title from Q2
+3. Add initial sources per Q3
+
+## Action 1: Read / Extract
+
+1. Open the notebook (notebook discovery above)
+2. Locate chat input (semantic find or screenshot coordinates)
+3. Type the question (use the user's natural phrasing from Q3)
+4. Submit (Enter or send button)
+5. **Wait 3–5 seconds**
+6. Screenshot the response area
+7. Extract and present in **clean format** (not raw chat dump)
+
+## Action 2: Add Sources
+
+Sub-flows per source type:
+
+| Type | UI flow |
+|---|---|
+| URL / Website / YouTube | Add Source → Link → paste URL |
+| Copied Text | Add Source → Copied text → paste content |
+| File Upload | Use file-upload tool with absolute path + input ref (never click native file picker) |
+| Google Doc | Add Source → Google Docs → Drive picker |
+| Synthesized content | Pre-process content elsewhere, then add as Copied text |
+
+**After every add:** wait for ingestion spinner, screenshot to confirm success.
+
+**Synthesized content pattern (powerful):** instead of asking NotebookLM to ingest a raw URL with potentially noisy content, pre-process the content (extract main article, strip nav/ads/comments), then add as "Copied text". Produces dramatically better summarization.
+
+## Action 3: Studio Outputs
+
+**All 9 output types supported:** Audio Overview, Study Guide, Briefing Doc, Timeline, FAQ, Table of Contents, Infographic, Slides, Mind Map.
+
+**Mandatory workflow:**
+
+1. Locate Studio panel (right side; may need toggle)
+2. Find the specific output button for the requested type
+3. **Open customization menu** (chevron/arrow next to button) — **NOT the main button**
+4. **Write detailed custom prompt** (from Q4)
+5. Confirm and submit
+6. **Do NOT wait for completion** — confirm generation started, notify user, return
+
+### Custom prompt examples (4 output types)
+
+**Audio Overview:**
+> "Two-host conversation between a researcher and an experienced practitioner. Audience: non-technical executive making a budget decision. Length: 8-10 minutes. Focus on business implications, not technical depth. Include one concrete example per major point. Acknowledge counter-arguments briefly."
+
+**Infographic:**
+> "Decision-tree style. Action-oriented (each panel ends with a decision or action). 6 panels max. Monochrome navy + amber highlight. Each panel has: title (4-6 words), 1-2 sentence body, decision/action line. No filler panels."
+
+**Study Guide:**
+> "Undergraduate-level (define every technical term). Structure: 6 concepts × 4 elements each (definition / why it matters / one worked example / 3 practice questions). Practice questions Bloom-higher-order (apply/analyze), not recall."
+
+**Slides (slide deck):**
+> "12 slides max. 1-2 sentences per slide body. Presenter notes per slide with: one concrete example + one likely audience objection + how to address it. No bullet points in slide bodies — prose only. End with one-slide call-to-action."
+
+See [`references/studio_output_custom_prompts.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/studio_output_custom_prompts.md) for more.
+
+## Action 4: Create New Notebook
+
+1. Navigate to homepage
+2. Click "New notebook"
+3. Set title from Q2
+4. Add initial sources from Q3 (use Action 2 sub-flows per source type)
+5. **Wait for auto-summary generation** (this one IS synchronous — usually completes in <30 sec)
+6. Screenshot final state
+
+## Critical Async Behavior
+
+> **Async output rule:** For Studio generations (especially **Audio Overview** — 5-10 min), DO NOT wait for completion. The user's session will time out.
+>
+> Workflow: Click Generate → confirm generation has started via screenshot → tell the user "Generation in progress — NotebookLM will notify you when ready" → **end the task.**
+
+This is the **fire-and-notify** pattern. Different from add-source and auto-summary (which are fast enough to wait).
+
+Use `scripts/async_action_classifier.py` to determine wait-or-notify per action:
+
+| Action | Wait? |
+|---|---|
+| Add Source (URL/text/file) | Yes — wait for ingestion spinner (~5-30s) |
+| Read/Extract (chat) | Yes — wait 3-5s for response |
+| Studio: Audio Overview | **No** — fire and notify (5-10 min) |
+| Studio: Infographic / Slides / Mind Map | **No** — fire and notify (2-5 min) |
+| Studio: Study Guide / Briefing Doc / FAQ | Yes — wait ~30-60s |
+| Create New Notebook | Yes — wait for auto-summary (<30s) |
+
+See [`references/async_action_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/async_action_discipline.md) for the canon.
+
+## Screenshot-First Discipline
+
+NotebookLM is a **dynamic SPA** where UI varies by:
+- Account tier (free vs Plus vs Enterprise)
+- Feature rollout (some Studio types not yet available to all users)
+- Recent UI changes (Google iterates the product frequently)
+
+**Every UI action must be preceded by a screenshot.** Reasons:
+
+1. Verify the UI matches expectations before acting
+2. Catch login walls early
+3. Detect unexpected layout changes
+4. Audit trail for debugging
+
+Use `screenshot()` (or equivalent in your browser-automation tool) before every meaningful UI interaction.
+
+See [`references/browser_automation_canon.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/browser_automation_canon.md) for the discipline.
+
+## find()-Before-Click
+
+Use **semantic element finders** before pixel coordinates wherever possible:
+
+- ✅ `find(text="Audio Overview")` → returns element regardless of position
+- ❌ `click(x=420, y=380)` → breaks when UI rearranges
+
+Semantic finders survive minor UI changes. Pixel coordinates do not.
+
+Only fall back to coordinates when:
+- Semantic find() returns nothing
+- Element has no stable text/aria-label/data-attribute
+- Visual position is the only reliable signal
+
+## Saving Outputs to Workspace
+
+For Read/Extract actions producing useful information:
+
+1. Extract chat response cleanly (strip UI chrome)
+2. Format readably (paragraphs, lists, code blocks as appropriate)
+3. If user requested → save to file (`${WORKSPACE}/notebooklm/<notebook-slug>-<action>-<date>.md`)
+4. Otherwise → return in chat as final summary
+
+For Studio outputs:
+1. NotebookLM hosts the output (Audio Overview is in-app, Infographic downloadable, etc.)
+2. Report the location (URL or in-app navigation path) to user
+3. Don't try to download/save Studio outputs to local workspace — that's NotebookLM's job
+
+## Reporting Back Format
+
+After completing any action:
+
+1. Take final screenshot if visually relevant
+2. Give **clean summary** (not raw chat dump):
+   - Notebook used (name)
+   - Action taken (specific)
+   - Result (1-2 sentences)
+   - For generated outputs: what was created + where it is + when ready
+3. For fire-and-notify actions: explicit "NotebookLM will notify you when ready"
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Browser automation unavailable | Fail fast with "this skill requires browser automation" message (Step 0 halt) |
+| Login wall detected | Stop. Tell user to log in. Don't attempt auto-login. |
+| Multiple notebooks match name | Screenshot homepage, list options, ask user to specify |
+| Source ingestion spinner stuck > 60s | Note timeout, ask user if they want to retry |
+| Studio button not found in panel | Scroll down or look for "Discover more"; if still missing, note feature may not be enabled for this account |
+| Chat response doesn't appear in 10s | Screenshot, check for error state, retry once |
+| Page layout changed unexpectedly | Screenshot, describe what's visible, ask user for guidance |
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/action_router.py` | Q1-Q4 answers → action plan + UI flow + required parameters |
+| `scripts/custom_prompt_template_generator.py` | Studio output type + audience + length → starter custom prompt |
+| `scripts/async_action_classifier.py` | Action name → wait-or-notify pattern (fire-and-notify for slow generations) |
+
+## References
+
+- [`references/browser_automation_canon.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/browser_automation_canon.md) — screenshot-first + find-before-click + tool-agnostic patterns (7+ sources)
+- [`references/studio_output_custom_prompts.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/studio_output_custom_prompts.md) — why defaults are mediocre + per-output-type templates (7+ sources)
+- [`references/async_action_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/notebooklm/skills/notebooklm/references/async_action_discipline.md) — fire-and-notify pattern for slow UI ops (7+ sources)
+
+## Anti-Patterns To Reject
+
+- Tool-specific tool names without abstraction (e.g., hardcoding "Claude Chrome Extension")
+- Synchronous waiting on Studio generations (especially Audio Overview)
+- Skipping screenshots between actions
+- Using pixel coordinates when semantic find() is available
+- Attempting to handle login flows automatically
+- Generating Studio outputs without opening customization menu
+- Using default Studio prompts (always write custom)
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/03-notebooklm-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/03-notebooklm-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Browser-automation shape — distinct from research-pack convention.

--- a/docs/skills/research/patent.md
+++ b/docs/skills/research/patent.md
@@ -1,0 +1,292 @@
+---
+title: "Patent — Prior-Art + Landscape Intelligence — Agent Skill for Research Workflows"
+description: "Patent prior-art and landscape intelligence skill — not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Patent — Prior-Art + Landscape Intelligence
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `patent`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Portability:** Requires `web_fetch` (Google Patents, Espacenet, USPTO), `WebSearch` (adjacent academic art), Node.js with `docx` package, and optionally Lens.org API key for citation-graph signals. Works in Claude Code CLI natively. In Claude.ai with web tools + Code Execution + BYOK Lens.org, the workflow is supported.
+
+> **Out of scope:** trademark, copyright, trade-secret. These are flagged at intake. Use a different skill or qualified counsel.
+
+> **Legal disclaimer:** This skill produces search signal, not legal advice. Verdicts are technical assessments. **Always consult a patent attorney before filing or licensing decisions.**
+
+## Non-Generic Framing — The Differentiator
+
+This skill is **prior-art + landscape intelligence**. It **refuses to be a bucket**. Every invocation commits to one of five sub-use-cases via the grill-me intake before any search runs. The chosen sub-use-case dictates the entire search strategy, ranking heuristics, and DOCX emphasis.
+
+| Sub-use-case | Search strategy | DOCX emphasis |
+|---|---|---|
+| **Novelty search** | Narrow + claims-text focused; pre-filing date irrelevant | Closest art + claim-differentiation |
+| **Freedom-to-operate** | Broad + active patents only; jurisdiction-filtered | FTO flags + claim-by-claim risk |
+| **Competitive landscape** | Breadth + filer tally + CPC trends | Filer map + investment hotspots |
+| **Acquisition diligence** | Specific assignee + portfolio scope + assignment chain | Portfolio table + ownership verification |
+| **Litigation prior-art** | Specific target patent + adjacent art before priority date | Knock-out candidates ranked by relevance |
+
+See [`references/sub_use_case_routing.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent/references/sub_use_case_routing.md) for the canon.
+
+## Agent Integrity Rules (Research-Pack Convention)
+
+Locked verbatim per PR #657 audit.
+
+- **Execution discipline.** Sequential search calls only. **1 query/sec rate limit.** Confirm response received before next call.
+- **Source discipline.** Cite only patents returned by THIS session's tool calls. Training knowledge labeled `[Not from search — reference information]` and excluded from counts.
+- **Three-count tracking.** Queries sent / patents received (shown) / patents cited. Surfaced in audit log.
+- **Retry policy.** On failure → wait 3s → retry once → log. After 3 consecutive failures across tools: stop, alert user, explain what's missing.
+- **Plan-tier detection.** Lens.org free tier = 1000 queries/month. Google Patents has no auth but rate-limits per IP. Detect and surface caps.
+
+## Phase 1: Grill-Me Intake (6 forcing questions, one at a time)
+
+### Q1 (root) — Invention description
+
+> **Describe the invention in 2–3 sentences. What does it do, and what's new about it?**
+>
+> *Why I'm asking:* Concept and keyword extraction depends entirely on a precise description. Vague descriptions ("AI for healthcare", "a better widget") will be rejected — push back and ask the user to specify what the invention does and what differentiates it from existing approaches.
+
+**Refuse mush.** If answer is generic, ask once more: "What does it do that existing systems don't?" Then commit (with caveat in DOCX).
+
+### Q2 (depends on Q1) — Sub-use-case commitment
+
+> **What's the purpose of this search? Pick one:**
+>
+> 1. Novelty search (am I novel enough to file)
+> 2. Freedom-to-operate (will I get sued if I ship)
+> 3. Competitive landscape (who else plays here)
+> 4. Acquisition diligence (does target really own X)
+> 5. Litigation prior-art hunting (kill a specific patent)
+>
+> *Why I'm asking:* Each path uses a fundamentally different search strategy. I'll **refuse to start without you picking one**.
+
+Forcing format. If user says "all of them", push for the primary purpose — secondary purposes can run as follow-up searches.
+
+### Q3 (asked only if Q2 ∈ {FTO, landscape, diligence}) — Jurisdictions
+
+> **Which jurisdictions matter? Pick all that apply: US / EP / CN / JP / KR / PCT / worldwide.**
+>
+> *Why I'm asking:* FTO only matters where you'll sell. Landscape changes radically by region. Diligence requires checking all jurisdictions where the target operates.
+
+Skip for novelty (priority date is jurisdictionally portable) and litigation (jurisdiction is set by the target patent).
+
+### Q4 (depends on Q1) — Known prior art
+
+> **Have you already seen prior art close to this? Cite a patent number or paper.**
+>
+> *Why I'm asking:* If you know one piece of art, I can search adjacent to it — much more precise than starting cold. If you don't, that's fine — just confirm.
+
+Anchoring. Accept "none" but ask if the user has seen *any* related work even informally.
+
+### Q5 (depends on Q2) — Risk tolerance
+
+> **Risk tolerance for this search: strict (one close hit means abandon the path) or signal-gathering (you want the lay of the land regardless)?**
+>
+> *Why I'm asking:* Strict mode ranks aggressively and surfaces verdict-grade hits; signal mode prioritizes breadth and visualizations.
+
+Asked for novelty and FTO; skipped for pure landscape (always signal-gathering by definition).
+
+### Q6 (asked only if Q2 ∈ {novelty, FTO}) — Attorney status
+
+> **Have you spoken to a patent attorney? This skill produces search signal, not legal advice. Confirm you understand this is for technical assessment only.**
+>
+> *Why I'm asking:* Novelty and FTO have legal consequences. The skill's verdict is signal-grade; legal positions require qualified counsel.
+
+**Triggers the legal-disclaimer footer in the DOCX.** Skipped for landscape and diligence (lower legal exposure).
+
+**Stop condition:** After Q6 (or earlier if dependency skips applied), commit and start Phase 2. Never re-open intake after Phase 2 begins.
+
+## Phase 2: Search Strategy Selection
+
+Deterministic from intake answers. Use `scripts/sub_use_case_router.py`:
+
+```bash
+python ../scripts/sub_use_case_router.py \
+  --sub-use-case novelty \
+  --jurisdictions "" \
+  --risk strict \
+  --known-art "US10000000B2"
+```
+
+Returns: query plan (5-8 queries) + ranking heuristic + DOCX emphasis flags.
+
+## Phase 3: Multi-Source Search (Sequential)
+
+### Source priority
+
+1. **Google Patents** (https://patents.google.com) — workhorse, no auth required, broad coverage
+2. **Espacenet** (https://worldwide.espacenet.com) — global coverage, good for non-US art
+3. **USPTO PPS** (https://ppubs.uspto.gov) — US deep dive
+4. **Lens.org** (https://www.lens.org) — citation graph, BYOK API key required
+
+### Per-sub-use-case query patterns
+
+**Novelty:**
+- 3 narrow queries on invention-specific terminology (Google Patents)
+- 2 broad concept queries with synonyms (Google Patents + Espacenet)
+- 1 CPC-class-restricted query if class identified from initial hits
+
+**FTO:**
+- Jurisdiction-filtered: only active patents (not expired, not abandoned)
+- Date filter: priority < today
+- Active-claim text extraction for each hit
+
+**Competitive landscape:**
+- Broader queries on the technology space
+- CPC class identification → tally top filers in that class
+- 10-year filing trend by year per top-5 filer
+
+**Acquisition diligence:**
+- Specific assignee searches (target company + subsidiaries + named inventors)
+- Assignment chain check (USPTO assignment recordation)
+- Family resolution for deduplication
+
+**Litigation prior-art:**
+- Target patent input required (number)
+- Priority date extraction
+- Search for art before priority date in same CPC classes
+- Adjacent-claim-language search
+
+### Sequential discipline
+
+1 q/sec across ALL sources combined. Tracked via `scripts/citation_tracker.py` with timestamp-enforced gap.
+
+## Phase 4: Claim Extraction + Relevance Scoring
+
+For each closest-art hit:
+- Pull **independent claim 1** (the broadest claim — primary anticipation/obviousness vehicle)
+- Pull **key dependent claims** (claims that add the inventive step)
+- Score relevance against invention description (overlap of claim language with Q1 terminology)
+
+Rank by score. Verdict per sub-use-case (NOVEL / POTENTIALLY NOVEL / NOT NOVEL for novelty; CLEAR / FLAGGED / HIGH RISK per jurisdiction for FTO).
+
+## Phase 5: Citation Graph + Family Resolution
+
+### Citation graph (Lens.org BYOK)
+
+If user provides Lens.org API key:
+- Foundational-patent identification (cited-by count > threshold, typically 50+)
+- Recent high-cite signals (citations in last 24 months as proxy for current activity)
+- Forward citations from target patent (litigation prior-art) or from closest art (novelty)
+
+If no Lens.org key: skip; note in audit log; recommend manual citation review on Google Patents.
+
+### Family resolution
+
+Same invention often filed in multiple jurisdictions (US + EP + JP + CN). Group by family ID or priority number to avoid double-counting. Use `scripts/family_resolver.py`:
+
+```bash
+python ../scripts/family_resolver.py --hits-file hits.json
+# Returns: deduplicated family list + family-member jurisdictions
+```
+
+## CPC/IPC Classification Awareness
+
+**Critical:** keyword search alone misses adjacent art. After initial search, extract the CPC/IPC classes from top 5 hits and run **one class-restricted query**. This consistently surfaces art that keyword search misses.
+
+See [`references/cpc_classification_canon.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent/references/cpc_classification_canon.md) for the canon.
+
+## Phase 6: DOCX Generation (8 Sections)
+
+Sub-use-case-dependent emphasis. Via Node.js + `docx` library.
+
+1. **Executive Summary + Verdict** — Sub-use-case banner + one-line verdict (NOVEL / FLAGGED / etc.) + 3-4 key findings + legal disclaimer footer
+2. **Closest Prior Art** — 5-10 patents in ranked order. Per hit: hyperlinked title + assignee + filing/priority dates + independent claim 1 text (italicized) + relevance score + relevance rationale (1-2 sentences)
+3. **Patent Landscape** — Top filers table (top 10 by count) + 10-year filing trend description + CPC class distribution table. Only for landscape and diligence; abbreviated otherwise.
+4. **Citation Graph Signals** — Foundational patents (if Lens-enabled) + recent high-cite activity. If Lens unavailable, note "manual review recommended" and skip table.
+5. **Geographic Coverage** — Filings by jurisdiction for top 10 hits. Only for FTO, landscape, diligence; skipped for novelty and litigation.
+6. **FTO Flags** (FTO only) — Active patents posing infringement risk. Per flag: hyperlinked patent + jurisdiction + relevant claims + risk level (HIGH/MEDIUM/LOW) + mitigation note.
+7. **Strategy + Recommendations** — Sub-use-case-specific:
+   - Novelty → claim differentiation suggestions
+   - FTO → design-around hints + jurisdiction strategy
+   - Landscape → who-to-watch list
+   - Diligence → red flags in portfolio
+   - Litigation → ranked knock-out candidates
+   - **Mandatory disclaimer to consult patent attorney** for any filing/licensing decision.
+8. **Audit Log** — Searches table (#, query, source, results, status), counts (sent/shown/cited), tool constraints (plan-tier notes), failed steps, attorney-consultation reminder
+
+### Styling
+
+Arial 12pt body, navy headings (#1a3a5c), light blue table headers (#e8f0f8), red FTO-flag callout. `ExternalHyperlink` patterns:
+- Google Patents: `https://patents.google.com/patent/[number]`
+- Espacenet: `https://worldwide.espacenet.com/patent/...`
+- USPTO: `https://patents.uspto.gov/patent/...`
+
+## Date Discipline
+
+Distinguish at every hit:
+- **Filing date** — when the application was first submitted
+- **Priority date** — earliest claim of priority (often earlier than filing)
+- **Publication date** — when the application became public (typically 18 months after priority)
+- **Grant date** — when the patent was granted (later than publication)
+
+Surface the **legally-relevant date** per sub-use-case:
+- Novelty → priority date (vs invention's anticipated filing date)
+- FTO → grant date + status (active vs expired)
+- Landscape → publication date (when public knowledge began)
+- Diligence → grant date + assignment date
+- Litigation → priority date of target patent (sets the prior-art cutoff)
+
+## Phase 7: Deliver
+
+- Save: `<output-dir>/patent_<invention-slug>_<sub-use-case>_<YYYY-MM-DD>.docx`
+- Chat summary: file path + sub-use-case + verdict + audit counts + plan-tier
+- Validate: `python scripts/office/validate.py <docx>`
+- Reminder: "Consult patent attorney before filing/licensing"
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/citation_tracker.py` | Multi-source three-count audit (Google Patents + Espacenet + USPTO + Lens.org) at `~/.patent_sessions/<session>.json` |
+| `scripts/family_resolver.py` | Group same-invention filings across jurisdictions by family ID / priority number |
+| `scripts/sub_use_case_router.py` | Deterministic search-strategy selection from intake answers |
+
+## References
+
+- [`references/sub_use_case_routing.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent/references/sub_use_case_routing.md) — 5-sub-use-case canon (7+ sources)
+- [`references/cpc_classification_canon.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent/references/cpc_classification_canon.md) — CPC/IPC class follow-up rationale (7+ sources)
+- [`references/legal_disclaimer_discipline.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/patent/skills/patent/references/legal_disclaimer_discipline.md) — when + why disclaimer mandatory (7+ sources)
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| User refuses to commit to sub-use-case | Refuse to proceed. Re-ask Q2 with examples. |
+| Invention description is generic | Reject answer. Re-ask Q1 with "what does it do that existing systems don't?" |
+| Google Patents rate-limits | Wait 3s, retry once. Fall back to Espacenet for that query. Log in audit. |
+| Lens.org key missing | Skip citation graph section, note "manual review recommended" in DOCX. |
+| Claim text extraction fails | Fall back to abstract; flag as "abstract-only" in relevance rationale. |
+| Family resolution incomplete | Note in audit; same-invention duplicates may appear; suggest manual deduplication. |
+| All searches return <3 hits | Surface explicitly as "either niche art or genuine gap"; never fabricate. |
+| 3 consecutive tool failures | Stop, alert user, explain what's missing. |
+| DOCX generation fails | Save raw data as JSON fallback so user doesn't lose work. |
+| Target patent number invalid (litigation) | Validate format before search; ask user to confirm. |
+
+## Anti-Patterns To Reject
+
+- Starting any search before user commits to a sub-use-case (refuses generic "patent help")
+- Batching all intake questions instead of one at a time
+- Accepting vague invention descriptions ("AI for healthcare")
+- Keyword-only search without CPC/IPC class follow-up
+- Treating family members as separate hits (must be deduplicated)
+- Confusing filing date with priority date with publication date
+- Skipping the legal disclaimer when sub-use-case has legal consequences
+- Reporting a verdict without claim-text evidence
+- Fabricating Lens.org citation data when key is absent
+- Suggesting design-arounds without acknowledging attorney review is required
+- Skipping the audit log
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/11-patent-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/11-patent-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Research-pack sibling, sub-use-case routing variant.

--- a/docs/skills/research/pulse.md
+++ b/docs/skills/research/pulse.md
@@ -1,0 +1,263 @@
+---
+title: "Pulse — Multi-Source Recency Research — Agent Skill for Research Workflows"
+description: "Multi-source recency research skill that takes the pulse of any topic across Reddit, Hacker News, the open web, and optionally X/Twitter within a. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Pulse — Multi-Source Recency Research
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `pulse`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/pulse/skills/pulse/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Portability:** Works in both Claude Code CLI and Claude.ai. The optional X/Twitter phase requires browser automation and is skipped automatically if unavailable.
+
+A recency-oriented research skill that synthesizes what people are saying about a topic across Reddit, Hacker News, the open web, and (optionally) X/Twitter — within a configurable time window. Output is a single coherent briefing with citations, engagement signals, and cross-platform pattern analysis. The skill captures the **current conversation**, not the canonical reference.
+
+## Invocation
+
+**Explicit trigger phrases:**
+- "pulse on [topic]"
+- "what's happening with [topic]"
+- "what are people saying about [topic]"
+- "current conversation about [topic]"
+- "take the pulse of [topic]"
+- "trending: [topic]"
+- "find me info on [topic]"
+
+Also covers: competitor research with recency flavor, trend discovery, tool comparisons, audience sentiment analysis.
+
+## Agent Integrity Rules (Research-Pack Convention)
+
+The following rules apply throughout the run. They are inherited from the research-pack convention and locked down by PR #657's cross-skill consistency audit.
+
+- **Execution discipline.** Phases 1–3 run in parallel (Reddit + HN + Web are independent). Within each phase, sequential calls only. **1 q/sec rate limit per platform.** Confirm response received before next call within the same phase.
+- **Source discipline.** Cite only sources returned by **this session's tool calls.** Training knowledge is labeled `[Background — not from search]` and excluded from primary findings count.
+- **Three-count tracking.** Queries sent / sources received (shown) / sources cited. Surfaced in the audit log inline in the synthesis section. Use `scripts/citation_tracker.py` for the deterministic count.
+- **Retry policy.** On failure → wait 3s → retry once → log. After **3 consecutive failures across all sources:** stop, alert user, share what was collected. Never deliver an empty file.
+- **Plan-tier detection.** Reddit + HN are unauthenticated public JSON APIs (rate-limited per IP, not per plan). Surface rate-limit signals from response headers when available; degrade gracefully otherwise.
+
+See `references/research_pack_conventions.md` for the canon and `references/parallel_execution_discipline.md` for the rate-limit rationale.
+
+## Phase 0: Grill-Me Intake (2–4 forcing questions, one at a time)
+
+Dependency-ordered. Each question carries explicit "why I'm asking". Stop condition: max 4.
+
+### Q1 (root) — Topic Specificity
+
+> **What's the topic? State it in 1–2 sentences — be specific. "AI" or "tech" will get you a vague survey; "self-hosted LLM deployment for small teams" or "Claude Code adoption among enterprise engineering orgs" will get you a useful answer.**
+>
+> *Why I'm asking:* Specificity dictates search quality. Vague topics produce vague briefings. If your topic is broad, I'd rather narrow it now than spend a search budget on noise.
+
+**Refuse mush.** If the user says "AI", push back once: "What about AI — adoption, safety, capability, regulation, or comparison? Pick an angle." If the user still won't narrow after one push-back, deliver with the explicit "vague topic — survey level, not depth" caveat.
+
+### Q2 (depends on Q1) — Angle
+
+> **What angle matters most? Pick one:**
+>
+> 1. **Trend** — what's accelerating or decelerating
+> 2. **Sentiment** — what people feel about it
+> 3. **Problems** — pain points and complaints
+> 4. **Opportunities** — gaps and unmet needs
+> 5. **Comparison** — how it stacks up against alternatives
+>
+> *Why I'm asking:* The angle dictates which sources weight more (Reddit for sentiment, HN for technical critique, Web for trend coverage) and how I rank the synthesis.
+
+Forcing choice. **Recommended default:** trend, unless the topic obviously calls for a different angle.
+
+### Q3 (always) — Time Window
+
+> **Time window: 7 / 14 / 30 / 60 / 90 days? Default is 30.**
+>
+> *Why I'm asking:* 7 days catches breaking conversation; 90 days catches sustained narrative shift. Pick based on how recent the news matters.
+
+Forcing choice with default.
+
+### Q4 (depends on Q1) — Platform Scope
+
+> **Any platform to skip? By default I'll cover Reddit + Hacker News + open web, plus X/Twitter if browser automation is available. Skip any you don't care about.**
+>
+> *Why I'm asking:* Skipping a platform saves search budget. Reddit dominates sentiment; HN dominates technical critique; Web dominates breadth; X dominates breaking conversation. Skip what doesn't fit your angle.
+
+Asked only if Q1 + Q2 suggest some platforms are clearly off-target (e.g., consumer sentiment topic → HN less useful). Otherwise default to "all platforms".
+
+**Stop condition:** After Q4 (or earlier with dependency skips), commit and start Phase 1. Max 4 questions, never bundle.
+
+## Pre-flight
+
+Before any phase fires:
+
+1. **Compute the time window** with `scripts/time_window_calculator.py --window <Nd>`. Get back the Unix timestamp for `created_at_i>` (HN) and the `t=` parameter (`hour|day|week|month|year|all`) for Reddit.
+2. **Generate the output slug** with `scripts/topic_slug_generator.py --topic "<topic>" --date $(date +%Y-%m-%d)`. Detect if `${RESEARCH_DIR}/pulse/<slug>-<date>.md` already exists; if yes, append `-v2` suffix or warn user.
+3. **Start the three-count audit log** with `scripts/citation_tracker.py --action start --session pulse-<date>-<slug>`. This file at `~/.pulse_sessions/<session>.json` persists across the run.
+
+## Phase 1: Reddit (parallel with HN + Web)
+
+**API:** `reddit.com/search.json` (unauthenticated, public JSON).
+
+**Queries (sequential within Reddit, 1 q/sec):**
+1. `sort=top&t=<window>&q=<topic>` — top posts in window
+2. `sort=new&t=<window>&q=<topic>` — new posts in window (catches breaking signal)
+3. For each of the top 3–5 posts by score: fetch the comments JSON (`<post-url>.json?limit=top`) for the top 10–20 comments.
+
+**Headers / rate limits.** Reddit rate-limits by IP, not plan. Throttle to 1 q/sec. If response has `X-Ratelimit-Remaining: 0` or returns 429, wait 3s, retry once. If still failing, fall back to subreddit-restricted search (`r/<topic-subreddit>/search.json`) or `?raw_json=1`.
+
+**Record each query:** `citation_tracker.py --action record_sent --session NAME --query "..."`.
+**Record received counts:** `citation_tracker.py --action record_received --session NAME --count N`.
+
+## Phase 2: Hacker News (parallel with Reddit + Web)
+
+**API:** Algolia HN search (`hn.algolia.com/api/v1/`).
+
+**Queries (sequential within HN, 1 q/sec):**
+1. `search?query=<topic>&numericFilters=created_at_i><timestamp>&tags=story` — stories in window
+2. `search?query=<topic>&numericFilters=created_at_i><timestamp>&tags=comment` — comments in window (catches discussion signal)
+
+**Failure handling.** If HN returns empty: broaden the query (remove uncommon nouns); if still empty, drop the timestamp filter as last resort and label results "outside window".
+
+**HN bias note.** HN skews technical / builder. Surface this in synthesis: "HN's voice is implementation-oriented; consumer sentiment will be under-represented here."
+
+## Phase 3: Web Search (parallel with Reddit + HN)
+
+**Tools:** Available web search + fetch (e.g., `WebSearch` + `WebFetch`).
+
+**Query strategy (sequential within Web, 1 q/sec):**
+1. **Trusted publishers** — `"<topic>" site:nytimes.com OR site:wsj.com OR site:wired.com OR site:theverge.com OR site:techcrunch.com after:<date>`
+2. **Recent reviews** — `"<topic>" review <year>` or `"<topic>" "honest review" after:<date>`
+3. **Honest-opinion sources** — `"<topic>" problems OR complaints OR "worth it" after:<date>`
+
+Fetch the top 3–5 URLs per query. Truncate at the body, skip cookie/nav markup.
+
+**Citation discipline.** Every claim in the Web section must trace to a fetched URL. Do NOT cite from snippets alone; fetch first.
+
+## Phase 4: X/Twitter (sequential, optional)
+
+Run last. Reasons:
+- Most likely to fail / require browser automation
+- X content overlaps significantly with Reddit/HN — so it adds delta, not primary signal
+
+**Interface (in priority order):**
+1. **Grok** if available in the harness
+2. **X API** if authenticated
+3. **Browser automation** if the harness supports it (Claude Code CLI with `playwright` or similar)
+4. **Skip with note** if none of the above available
+
+**Documented behavior:**
+> If Phase 4 is skipped: include the section header `## X/Twitter` with body `Skipped — [reason: no browser automation / no Grok / no X API]`. Do NOT pretend to have data.
+
+## Synthesis (Cross-Platform Patterns)
+
+After Phases 1–4 complete (or Phase 4 skipped), produce the synthesis:
+
+1. **Consensus signals** — points where 3+ platforms agree (highest confidence). Tag each with cited source URLs.
+2. **Controversy signals** — points where platforms disagree. Note who says what.
+3. **Pain points** — recurring complaints across sources (esp. Reddit + Web).
+4. **Excitement signals** — recurring enthusiasm (esp. HN + X if available).
+5. **Emerging trends** — first-time mentions in newest posts but absent from older ones (compare `sort=new` vs `sort=top`).
+6. **Gaps** — what's notably absent that you'd expect to find.
+
+For each pattern, **cite the source URLs** that support it. Use `citation_tracker.py --action record_cited --session NAME --url "..."` per citation.
+
+See `references/cross_platform_synthesis.md` for detection heuristics.
+
+## Output
+
+Save to file AND paste in chat:
+
+**File:** `${RESEARCH_DIR}/pulse/<topic-slug>-<YYYY-MM-DD>.md` (path from `topic_slug_generator.py`).
+
+**Format:**
+
+```markdown
+# [TOPIC] — Pulse (Last [N] Days)
+*Generated: [DATE] | Angle: [Q2 choice]*
+
+## TL;DR
+[2-3 sentences max]
+
+## Reddit
+### Top Posts
+- **[Title]** (r/sub) — [score, comments] — [summary] — [URL]
+### What Reddit Is Saying
+[Narrative paragraph]
+
+## Hacker News
+### Notable Stories
+- **[Title]** — [points, comments] — [summary] — [URL]
+### What HN Is Saying
+[Narrative paragraph; note HN's technical/builder bias]
+
+## Web
+### Key Sources
+- **[Title]** ([Publication]) — [takeaway] — [URL]
+### What the Web Is Saying
+[Narrative paragraph]
+
+## X/Twitter (if available)
+[Cleaned response, with handles/references preserved]
+[Or: "Skipped — [reason]"]
+
+## Cross-Platform Patterns
+[Highest-confidence signals across sources]
+
+## Key Takeaways
+- [3-5 bullets]
+
+## Content Angles (if applicable)
+[2-3 specific angles supported by the data]
+
+---
+*Audit:* Queries sent: N (Reddit: a, HN: b, Web: c, X: d|skipped).
+Sources received: M. Sources cited: K. Training knowledge: 0 ([Background] excluded from count).
+```
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Topic is too vague (Q1) | Refuse to start. Re-ask Q1 once with examples. After 1 push-back, deliver with "vague topic" caveat. |
+| Reddit blocks / rate-limits | Try `?raw_json=1` or fall back to subreddit-restricted search. Honor 3s-retry. |
+| HN returns empty | Broaden query, drop timestamp filter as last resort, label results "outside window". |
+| Web search returns nothing useful | Note in output; don't fabricate sources. |
+| Browser automation unavailable | Skip Phase 4 with documented note. |
+| WebFetch times out | Use what loaded, mark the source as "truncated". |
+| 3 consecutive failures across sources | Stop. Return what was collected with explicit "stopped early" note. Do NOT deliver empty file. |
+| All sources fail | Return error with diagnostic info. Do NOT deliver empty file. |
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/time_window_calculator.py` | Compute Unix timestamps + Reddit `t=` parameter from window string (`30d`, `7d`, etc.). Deterministic from `datetime.now()`. |
+| `scripts/citation_tracker.py` | JSON-backed three-count audit log (sent / received / cited) at `~/.pulse_sessions/<session>.json`. |
+| `scripts/topic_slug_generator.py` | Filesystem-safe slug + duplicate-date detection for output paths. |
+
+## References
+
+- `references/research_pack_conventions.md` — Agent Integrity Rules canon (7+ sources: Google SRE, Reddit API docs, Algolia HN docs, exponential-backoff literature, citation discipline)
+- `references/cross_platform_synthesis.md` — consensus / controversy / pain detection across platforms (7+ sources)
+- `references/parallel_execution_discipline.md` — 1 q/sec rationale + plan-tier signals (7+ sources)
+
+## Anti-Patterns To Reject
+
+- Starting any search before the user commits to topic specificity (Q1)
+- Batching intake questions instead of one at a time
+- Hardcoded URLs that won't survive API changes (note format, explain may evolve)
+- Specific person / brand references in the skill body
+- Tight coupling to one X/Twitter interface
+- Missing fallback behavior on source failure
+- "Just use [specific tool]" without explaining what the tool does
+- Citing training knowledge in the cited count
+- Fabricating sources to fill out a section
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/01-pulse-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/01-pulse-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Re-grill with `/cs:grill-with-docs` if drift between spec and implementation surfaces.

--- a/docs/skills/research/research.md
+++ b/docs/skills/research/research.md
@@ -1,0 +1,330 @@
+---
+title: "Research — Hybrid Router + Fallback — Agent Skill for Research Workflows"
+description: "Default entry point for any research request — a hybrid router that classifies the question deterministically and either delegates to a specialist. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Research — Hybrid Router + Fallback
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `research`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/research/skills/research/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+**The runtime orchestrator for the research domain.** Architecture C: deterministic classification → specialist delegation OR own plan-decompose-search-synthesize-cite workflow.
+
+## Portability
+
+Requires `WebSearch` + `WebFetch` for the fallback workflow; specialist skills (`pulse`, `grants`, `litreview`, `syllabus`, `patent`, `dossier`) must be present for delegation to work. Node.js with `docx` package required if Q2 = document mode. Works in Claude Code CLI natively. In Claude.ai with web tools + Code Execution, the workflow is supported.
+
+## Distinct From `engineering/autoresearch-agent`
+
+These two skills share the word "research" but serve **completely different use cases**:
+
+- **`research/research/`** (this skill) — research-query router + fallback workflow ("Research X")
+- **`engineering/autoresearch-agent/`** — Karpathy's autonomous file-optimization experiment loop ("Make this code faster")
+
+No overlap. They coexist.
+
+## Hybrid Architecture (C)
+
+Every invocation produces one of three outcomes:
+
+1. **Delegation** — Classified as specialist-domain. Routes there. User sees the specialist's output.
+2. **Fallback execution** — Classified as general research. Runs own plan → search → synthesize workflow.
+3. **Clarification request** — Classification ambiguous. Asks one forcing question to disambiguate, then routes.
+
+The skill **never silently runs its fallback** when a specialist would have done better. **Routing transparency** is what makes the hybrid architecture trustworthy.
+
+## Specialist Registry
+
+| Specialist | Routing signals | Domain |
+|---|---|---|
+| `pulse` | reddit / hn / x / buzz / sentiment / trending / "what's people saying" / "pulse on" / "take the pulse" / "current conversation" | Multi-source recency research |
+| `grants` | NIH / grant / R01 / K-award / RePORTER / NOSI / "grants for" / FDA / "study section" / "principal investigator" | NIH grant-funding intelligence |
+| `litreview` | literature review / PICO / SPIDER / systematic review / "review papers on" / meta-analysis | Academic literature orientation |
+| `syllabus` | syllabus / course outline / curriculum / "reading list" / "for my class" / "for my students" | Course supplementary reading |
+| `patent` | prior art / FTO / freedom to operate / patent / "patent landscape" / invention / novelty search / "ip landscape" | Patent prior-art + landscape |
+| `dossier` | "dossier on" / "due diligence" / "background check" / "prep me for" / "competitor research" / "investor diligence" / "interview prep" / "background on" | Decision-grade entity research |
+
+## Agent Integrity Rules
+
+This skill obeys the research-pack convention:
+
+- **Execution discipline (fallback only)**: Sequential searches. 1 q/sec rate limit. Confirm response received before next call.
+- **Source discipline**: Cite only sources returned by this session's tool calls. Training knowledge labeled `[Background — not from search]` and excluded from counts.
+- **Three-count tracking (fallback only)**: Queries sent / sources received / sources cited.
+- **Retry policy**: On failure → wait 3s → retry once → log. After 3 consecutive failures: stop, alert user.
+- **Plan-tier detection**: If delegated to Consensus-using specialist, that specialist handles detection. In fallback mode, surface any rate-limit signals.
+- **Routing discipline**: Never delegate silently. Always state the decision + accept override.
+
+## Phase 1: Grill-Me Intake (2–4 Questions)
+
+Intake is intentionally minimal — the goal is to route fast, not to interrogate. One question per turn.
+
+### Q1 (always) — Research question
+
+> **What's the research question? State it in 1–2 sentences. Specific is better than broad — "AI for healthcare" gets you a vague survey; "How are health systems integrating LLM-based clinical decision support in 2026?" gets you a useful answer.**
+>
+> *Why I'm asking:* Specificity dictates classification accuracy and search precision. A vague question routes to fallback; a specific question often matches a specialist cleanly.
+
+**Refuse mush.** If user says "research AI", push back once: "What about AI specifically — adoption, safety, capability, funding, regulation, comparison? Pick an angle."
+
+### Q2 (always) — Output preference
+
+> **What output do you want? Pick one:**
+> 1. Quick chat briefing (5-min read, markdown in chat)
+> 2. Standalone document (.docx with citations, shareable)
+>
+> *Why I'm asking:* Document mode triggers deeper search budgets and full audit logs. Chat mode optimizes for fast delivery.
+
+Forcing choice.
+
+### Q3 (asked only if classification ambiguous — ≤1 signal) — Domain disambiguation
+
+> **Quick clarification — pick the closest match:**
+> 1. Academic literature (papers, peer-reviewed)
+> 2. Industry / trends (what's the buzz, news, sentiment)
+> 3. Specific entity (a company, person, organization)
+> 4. Technology / patents (prior art, IP landscape)
+> 5. Grant funding (NIH, foundations)
+> 6. Course material (syllabus or curriculum)
+> 7. None of the above — run general research
+>
+> *Why I'm asking:* I couldn't classify confidently from your question alone. This routes you to the right specialist or confirms general-research fallback.
+
+**Skip if Q1 + Q2 produced clear specialist match (≥2 signals).**
+
+### Q4 (asked only if Q3 was needed AND user picked "none of the above") — General-research scope
+
+> **For general research, what's your time horizon — quick scan (5 searches) or thorough (15 searches)?**
+>
+> *Why I'm asking:* General research has no specialist budget; you pick it. Quick is good for "what's the lay of the land". Thorough is for "I'll make a decision based on this".
+
+Skip if a specialist took over.
+
+**Stop condition:** After Q4 (or earlier if dependency skips applied), commit and start Phase 2. **Most invocations exit intake after Q1 + Q2.**
+
+## Phase 2: Deterministic Classification
+
+This is **deterministic, not LLM-reasoned** — for speed, debuggability, and consistency.
+
+```python
+SIGNALS = {
+  pulse:    ["reddit", "hn", "hacker news", "x.com", "twitter", "buzz",
+             "sentiment", "trending", "what are people saying",
+             "what's happening", "the conversation around",
+             "pulse on", "take the pulse", "current conversation"],
+  grants:   ["nih", "grant", "grants for", "r01", "r21", "k-award", "reporter",
+             "nosi", "funding", "fda", "study section", "principal investigator"],
+  litreview:["literature review", "lit review", "litreview", "pico", "spider",
+             "systematic review", "review papers on", "research papers on",
+             "papers about", "meta-analysis"],
+  syllabus: ["syllabus", "course outline", "curriculum", "reading list",
+             "for my class", "for my students", "course material"],
+  patent:   ["prior art", "fto", "freedom to operate", "patent",
+             "patent landscape", "invention", "novelty search",
+             "patent search", "ip landscape"],
+  dossier:  ["dossier on", "due diligence", "background check",
+             "prep me for", "competitor research", "investor diligence",
+             "interview prep", "research my competitor", "background on"]
+}
+
+# Signals are case-insensitive literal phrases (multi-word substring match).
+# Bracketed placeholders (e.g., "research [company]") are intentionally NOT
+# signals — they over-trigger on generic "research X" queries that should
+# fall back to general research, not auto-route to dossier. Specific phrases
+# pair the verb with the noun ("dossier on", "background on") and route reliably.
+
+For each specialist S:
+  score[S] = count of SIGNALS[S] phrases matched in question (case-insensitive substring)
+
+if max(score) >= 2:
+  route_to = argmax(score)                                  # high confidence
+elif max(score) == 1 and only one specialist has score 1:
+  route_to = that specialist                                # weak match, single specialist
+else:
+  route_to = "fallback"                                     # ambiguous or no match — ask Q3
+```
+
+**Implementation:** `scripts/classifier.py --question "..."` returns the routing decision + matched signals + per-specialist scores. Use it; don't re-implement.
+
+## Phase 3a: Specialist Delegation (≥2 signals OR single weak match)
+
+When delegating:
+
+1. Pass the user's question **verbatim** plus the output preference (Q2)
+2. **Let the specialist run its own grill-me intake** — do NOT pre-answer specialist questions
+3. Return specialist output as the user-visible result
+4. Tag the result with `[Delegated to: research → {specialist}]` in the chat output so the user knows what skill produced it
+5. Tag the audit log via `scripts/routing_transparency_logger.py --action record_delegation`
+
+## Phase 3b: Own Fallback Workflow
+
+If routing produced no specialist match, run the 8-step fallback.
+
+### Step 1: Decompose
+
+Break the research question into 3–5 sub-questions. Use the framework: what / why / how / who / what's next. Show the decomposition to the user before searching. Use `scripts/fallback_decomposer.py --question "..."` for a deterministic starting point.
+
+### Step 2: Source Selection
+
+For each sub-question, choose source(s) deterministically:
+
+- **Recency-sensitive** → WebSearch + WebFetch + (optionally Reddit/HN if signal)
+- **Technical specs / docs** → WebSearch + WebFetch
+- **Academic** → Consensus MCP if connected; otherwise WebSearch with `scholar.google.com` site filter
+- **Data / numbers** → WebSearch for sources; then WebFetch for primary documents
+- **Person / company entity-level** → consider routing to `dossier` (offer override)
+
+### Step 3: Search
+
+Sequential per sub-question. 1 q/sec etiquette. Per source: 2–4 queries, broad-to-narrow.
+
+### Step 4: Read + Extract
+
+For each result that looks high-signal: WebFetch and extract the relevant section. Note the source URL.
+
+### Step 5: Synthesize
+
+Per sub-question: 2–4 paragraphs answering it with inline citations. Surface disagreement when sources disagree.
+
+### Step 6: Cross-Cutting Patterns
+
+After per-sub-question synthesis: 1–2 paragraphs of patterns across sub-questions — consensus, controversy, gaps.
+
+### Step 7: Output
+
+Markdown brief by default (Q2 choice). DOCX if user picked document mode.
+
+### Step 8: Audit Log
+
+Three-count summary (sent / received / cited) + per-source list with reliability tier (primary / secondary / tertiary).
+
+## Routing Transparency Protocol (Mandatory)
+
+After classification, the skill **always**:
+
+1. **States the decision** in one sentence: "Routing to `litreview` because you mentioned PICO and meta-analysis (2 signals)."
+2. **Offers override**: "If you want general research instead OR a different specialist, say so now. Otherwise proceeding in 5 seconds."
+3. **Waits 1 turn** for confirmation (or auto-proceeds after 5s in interactive contexts).
+4. **If user overrides** → accept, re-route, log the override via `routing_transparency_logger.py --action record_override`.
+
+**Never delegates silently.** This is the trust-building property that makes the hybrid pattern work.
+
+## Output Format
+
+### Markdown brief (Q2 = quick chat briefing)
+
+```markdown
+# [Research Question] — Briefing
+*Generated: [DATE] | Routed: [delegated specialist | fallback]*
+
+## TL;DR
+[2-3 sentences]
+
+## Findings
+### [Sub-question 1]
+[2-4 paragraphs with inline citations]
+
+### [Sub-question 2]
+...
+
+## Cross-Cutting Patterns
+[1-2 paragraphs]
+
+## Sources
+[Numbered list with hyperlinks, reliability tier per source]
+
+## Audit
+[Three counts + per-source tier + failures]
+```
+
+### DOCX (Q2 = standalone document)
+
+Use the standard research-pack DOCX patterns: Arial 12pt, navy headings, blue table headers, hyperlinked sources, mandatory audit log section. Reference the `docx` skill for setup.
+
+## Audit Log Requirement (Fallback Mode)
+
+```
+Queries sent:        N
+Sources received:    M
+Sources cited:       K
+Failures:            F (3-consecutive-failures triggered: yes/no)
+Per-source tier:     [URL — primary | secondary | tertiary]
+Routing decision:    fallback (no specialist matched)
+Sub-questions:       [list]
+```
+
+All routing decisions + overrides also logged to `~/.research_sessions/<session>.json` via `routing_transparency_logger.py`.
+
+## Failure Modes
+
+| Failure | Behavior |
+|---|---|
+| Classification ambiguous (≤1 signal) | Ask Q3 (domain disambiguation). |
+| Specialist delegation fails | Note in chat. Offer to retry or fall back to general research. |
+| User overrides routing | Accept. Re-route to chosen specialist or fallback. Log the override. |
+| Fallback search returns thin results | Surface explicitly. Suggest the question may be too niche or too new. Do not fabricate. |
+| 3 consecutive tool failures in fallback | Stop, alert user, share what was collected. |
+| Question is non-research (e.g., "write me code") | Decline politely. Suggest the user invoke an appropriate skill. |
+| Sub-question can't be answered | Note in synthesis as "limited public signal on this"; don't omit silently. |
+| Output format mismatch | Honor Q2 preference; if format unavailable, fall back to markdown with note. |
+| Specialist skill missing from environment | Skip it in classification scoring; route to fallback or next-best specialist. |
+
+## Anti-Patterns Rejected
+
+- LLM-reasoned classification (must be deterministic keyword + intent matching)
+- Silent delegation (always surface routing decision)
+- Refusing to route to a specialist when ≥2 signals match
+- Routing to a specialist when classification is genuinely ambiguous (≤1 signal across all)
+- Pre-answering the specialist's grill-me intake (let it run its own)
+- Running fallback when a specialist would clearly do better
+- Fabricating sources in fallback when search is thin
+- Skipping audit log in fallback mode
+- Treating "dossier on [company]" as fallback when `dossier` is the right specialist (the verb-noun-paired phrase, not the generic "research X" form, is what routes)
+- Treating "what are people saying about X" as fallback when `pulse` is the right specialist
+- Auto-routing generic "research [topic]" queries to a specialist when the user hasn't paired the verb with a specialist-specific noun (e.g., "research Microsoft" alone is ambiguous — could be dossier or general; ask Q3 instead of guessing)
+
+## Tooling
+
+### Python (stdlib only)
+
+- **`scripts/classifier.py`** — Deterministic SIGNALS matching → routing decision + per-specialist score + matched phrases. `--question "..." --output json`.
+- **`scripts/routing_transparency_logger.py`** — JSON-backed audit log at `~/.research_sessions/<session>.json`. Records every routing decision, override, and delegation handoff.
+- **`scripts/fallback_decomposer.py`** — Heuristic question → 3–5 sub-questions using what / why / how / who / what's next framework.
+
+### Reference Docs (each cites 7+ authoritative sources)
+
+- **`references/hybrid_router_architecture.md`** — router-vs-run trade-offs + routing transparency principle
+- **`references/deterministic_classification_canon.md`** — why keyword > LLM-reasoned for routing
+- **`references/fallback_workflow_canon.md`** — plan-decompose-search-synthesize methodology
+
+## Dependencies
+
+- **`WebSearch`** + **`WebFetch`** — Required for fallback workflow
+- **Specialist skills** — Required for delegation: `pulse`, `grants`, `litreview`, `syllabus`, `patent`, `dossier`. If a specialist is missing, the router skips it in classification and routes to fallback instead.
+- **Node.js `docx` library** — Required if user picks document output (Q2 = standalone)
+- **Consensus MCP** — Optional; used in fallback if academic sub-questions surface
+
+## Trigger Phrases
+
+- "research [topic]"
+- "look into [topic]"
+- "what do we know about [topic]"
+- "investigate [topic]"
+- "find me information on [topic]"
+- "do some research on [topic]"
+- "I need to understand [topic]"
+- Any research request that doesn't obviously match a more-specific specialist
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/13-research-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/13-research-megaprompt.md)
+**Build pattern:** Path B (direct conversion)

--- a/docs/skills/research/syllabus.md
+++ b/docs/skills/research/syllabus.md
@@ -1,0 +1,298 @@
+---
+title: "Syllabus — Course Supplementary Reading List — Agent Skill for Research Workflows"
+description: "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format +. Agent skill for Claude Code, Codex CLI, Gemini CLI, OpenClaw."
+---
+
+# Syllabus — Course Supplementary Reading List
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-magnify: Research</span>
+<span class="meta-badge">:material-identifier: `syllabus`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install research-skills</code>
+</div>
+
+
+> **Portability:** Requires a Consensus MCP connection, Node.js with `docx` package, and file reading capability for the syllabus. Works in Claude Code CLI natively. In Claude.ai with Consensus MCP + Code Execution + file upload, the workflow is supported.
+
+For an instructor or student with a course syllabus, produce a professional supplementary reading list as `.docx` containing recent peer-reviewed papers per course section.
+
+## Architectural Pattern: Bundled Script
+
+This skill uses a **bundled JavaScript helper script** for DOCX generation rather than inlining the 300+ lines of layout code:
+
+- DOCX generation logic is reusable + complex
+- Better separation of concerns: skill = orchestration + intelligence; script = mechanical document assembly
+- Token-efficient: skill doesn't re-derive layout each run
+- Easier to maintain and version
+
+The bundled script is at `scripts/generate_reading_list.js`. The skill orchestrates the pipeline + invokes the script with JSON input.
+
+## Agent Integrity Rules (Research-Pack Convention)
+
+Locked verbatim per PR #657 audit.
+
+- **Only use what Consensus returns.** Every paper title, author, journal, year, URL must come from this session's tool calls. Training-knowledge papers labeled `[Not from Consensus — model knowledge]` and excluded.
+- **Confirm before moving on.** A search isn't complete until response received and inspected.
+- **Track three counts.** Queries sent / papers received / papers cited. Surface in audit summary.
+- **Surface gaps, don't fill them.** Section with one paper + note about limited results > section padded with fabrications.
+
+## Phase 0: Grill-Me Intake (3 forcing questions)
+
+### Q1 (root) — Syllabus input
+
+> **Provide the syllabus — pick one:**
+>
+> 1. File path (PDF, DOCX, text) — I'll read it
+> 2. Pasted content — paste below
+> 3. Image of a printed syllabus — attach the image
+>
+> *Why I'm asking:* Each format needs a different reader (PDF / DOCX parser / vision). Picking upfront prevents wasted attempts.
+
+Forcing choice. Refuse to start without a syllabus.
+
+### Q2 (depends on Q1) — Course audience
+
+> **Course audience — pick one:**
+>
+> 1. Undergraduate (intro level)
+> 2. Undergraduate (advanced / upper division)
+> 3. Graduate (Masters / early PhD)
+> 4. Graduate (doctoral / advanced)
+> 5. Professional / continuing education
+> 6. Mixed
+>
+> *Why I'm asking:* Audience dictates summary jargon level and discussion-question complexity. Undergrad summaries define every term; grad summaries assume technical fluency. Discussion questions for undergrads test analysis; for grads test critique and extension.
+
+See [`references/audience_calibration.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/references/audience_calibration.md) for the canon.
+
+### Q3 (depends on Q1) — Year range
+
+> **Year range for papers — pick one:**
+>
+> 1. Last 1 year (most recent only)
+> 2. Last 2 years (default — recent + a year of context)
+> 3. Last 5 years (broader, includes foundational recent work)
+>
+> *Why I'm asking:* Reading lists go stale fast. 1-year filters keep things fresh; 5-year filters surface foundational recent work that's already standard. Drives the year_min parameter on every Consensus search.
+
+Forcing choice with default (last 2 years).
+
+**Stop condition:** 3 questions max before Phase 1. The post-Phase-2 group-and-confirm checkpoint is its own grill-me moment.
+
+## Phase 1: Parse the Syllabus
+
+Per Q1 input format:
+
+- **PDF**: use PDF reader; extract text
+- **DOCX**: use pandoc or DOCX parser; extract text
+- **Text/pasted**: read directly
+- **Image**: use vision; extract text
+
+From extracted text:
+1. Course title + instructor + term
+2. Topic list (lecture titles, week-by-week breakdown, etc.)
+3. Learning outcomes (if explicit; if missing, infer 3-5 from description)
+
+Mark inferred learning outcomes as `[inferred]` in the DOCX.
+
+## Phase 2: Group Topics + Confirm with User
+
+### Group via topic_grouper.py
+
+Use `scripts/topic_grouper.py` to cluster related topics into 6-12 sections. Heuristic: closely-related topics merge; cross-cutting topics get their own section.
+
+### Group-and-Confirm Checkpoint (Forcing Options)
+
+After grouping, present:
+
+> **Proposed sections: [list with item counts]. Pick one:**
+>
+> 1. "Looks good — proceed with these sections"
+> 2. "Merge sections [X] and [Y]"
+> 3. "Split section [X] into two"
+> 4. "Add a section for [topic]"
+> 5. "Remove section [X]"
+>
+> *Why I'm asking:* Grouping drives search allocation. Wrong grouping wastes the search budget on bad clusters. This is the **last cheap moment** to correct course before searches consume Consensus calls.
+
+**Refuse to start Phase 3 without explicit user choice.**
+
+## Phase 3: Search Consensus per Section
+
+Sequential, 1 q/sec. 1-2 queries per section.
+
+### Applied-Domain Weaving (Critical)
+
+Don't just search the topic — **search the topic + applied domain**:
+
+| ❌ Generic | ✅ Applied-domain |
+|---|---|
+| "enzyme kinetics" | "enzyme kinetics food processing applications" |
+| "machine learning" | "machine learning clinical decision support" |
+| "thermodynamics" | "thermodynamics renewable energy systems" |
+| "social network analysis" | "social network analysis public health interventions" |
+
+Boosts paper relevance dramatically. See [`references/applied_domain_weaving.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/references/applied_domain_weaving.md) for the canon.
+
+### Per-Section Pattern
+
+```
+For each section:
+  1. Construct query: "{topic-keywords} {applied-domain-angle}" + year_min from Q3
+  2. Submit to Consensus (sequential, 1 q/sec gap enforced by citation_tracker)
+  3. Receive results
+  4. (If thin) submit one fallback query without applied-domain angle
+  5. Select 1-3 papers per section (15-25 total across all sections)
+```
+
+### Selection Priorities
+
+1. **Relevance** — paper directly addresses the section topic
+2. **Reviews / meta-analyses** — synthesize the field
+3. **Citation count** — established work
+4. **Applied-domain connection** — tied to the course's domain (e.g., engineering vs theory)
+
+## Phase 4: Write Summaries + Discussion Questions
+
+### Summary writing
+
+Per paper:
+- Plain language (calibrated to audience from Q2)
+- 2-3 sentences
+- Define jargon if undergraduate audience; assume fluency if graduate
+
+### Quality bars
+
+| ✅ Good summary | ❌ Bad summary |
+|---|---|
+| "This review maps how different diets — Mediterranean, Nordic, vegetarian — reshape the types of fat molecules circulating in your blood, with implications for heart disease risk." | "This paper reviews lipidomic profiles across dietary interventions and their cardiometabolic implications." |
+
+### Discussion question writing
+
+Per paper:
+- Bloom **higher-order** (apply / analyze / evaluate)
+- Tied to a specific course learning outcome
+- Promotes discussion, not just recall
+
+| ✅ Good question | ❌ Bad question |
+|---|---|
+| "If dietary fat quality can reshape your lipoprotein lipidome, what does this suggest about the biochemical basis for dietary guidelines recommending unsaturated over saturated fats?" | "What did the authors find?" (Just recall) |
+
+Use `scripts/discussion_question_validator.py` to flag recall-only questions.
+
+## Phase 5: Generate .docx via Bundled Script
+
+```bash
+node ../scripts/generate_reading_list.js \
+  --input /tmp/syllabus_data.json \
+  --output /path/to/reading_list_<course>_<date>.docx
+```
+
+The script accepts JSON with this schema:
+
+```json
+{
+  "courseTitle": "string",
+  "courseSubtitle": "string",
+  "generatedDate": "string",
+  "yearRange": "string",
+  "introText": "string",
+  "learningOutcomes": ["string", ...],
+  "sections": [
+    {
+      "heading": "string",
+      "papers": [
+        {
+          "title": "string",
+          "authors": "string",
+          "journal": "string",
+          "year": number,
+          "url": "string",
+          "summary": "string",
+          "question": "string"
+        }
+      ]
+    }
+  ],
+  "auditLog": {
+    "totalQueriesSent": number,
+    "totalPapersReceived": number,
+    "totalPapersCited": number,
+    "toolConstraints": "string",
+    "searchDetails": [
+      {
+        "section": "string",
+        "query": "string",
+        "papersReturned": number,
+        "papersSelected": number,
+        "status": "string"
+      }
+    ],
+    "failures": []
+  }
+}
+```
+
+The script handles:
+- `docx` package require with multi-location fallback
+- Title page, intro with Consensus link, learning outcomes box, numbered papers per section
+- `ExternalHyperlink` with full Consensus URLs (never truncated)
+- `LevelFormat.BULLET` for lists (not unicode bullets)
+- Footer with generation metadata
+- Input validation (missing fields → graceful error)
+
+See [`references/bundled_script_pattern.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/references/bundled_script_pattern.md) for why bundled vs inline.
+
+## Phase 6: Deliver
+
+- File path
+- Audit summary in chat: "Saved {file}. {N} sections × {M} papers / {K} cited. Plan tier: {tier}."
+- Validate: `python scripts/office/validate.py <docx>`
+
+## Tooling
+
+| Script | Role |
+|---|---|
+| `scripts/citation_tracker.py` | Consensus three-count audit + 1s sequential discipline at `~/.syllabus_sessions/<session>.json` |
+| `scripts/topic_grouper.py` | Heuristic 6-12 section grouping from extracted topics |
+| `scripts/discussion_question_validator.py` | Bloom higher-order quality check; flags recall-only questions |
+| `scripts/generate_reading_list.js` | **Bundled Node.js DOCX generator** — JSON input → .docx output |
+
+## References
+
+- [`references/applied_domain_weaving.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/references/applied_domain_weaving.md) — search-quality canon (7+ sources)
+- [`references/audience_calibration.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/references/audience_calibration.md) — undergrad vs grad summary jargon (7+ sources)
+- [`references/bundled_script_pattern.md`](https://github.com/alirezarezvani/claude-skills/tree/main/research/syllabus/skills/syllabus/references/bundled_script_pattern.md) — why bundle vs inline (7+ sources)
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Consensus rate-limit hit | Wait 3s, retry once, log |
+| Search returns 0 for a section | Note section as "limited results — consider manual supplementation" |
+| 3 consecutive failures | Stop, alert user, share collected so far |
+| `docx` package not installed | Script attempts `npm install`; if still failing, fail with clear message |
+| DOCX validation fails | Unpack XML, log issue, ask user to retry |
+| Syllabus format unsupported | List supported formats, ask user to convert |
+| Learning outcomes can't be extracted | Infer 3-5 from course description; mark as inferred in document |
+
+## Anti-Patterns To Reject
+
+- Parallelizing Consensus calls (rate limit)
+- Searching topics without applied-domain angle (poor relevance)
+- Padding sections with fabricated entries when Consensus returns thin
+- Generic discussion questions ("What did the authors find?")
+- Jargon-heavy summaries unsuitable for the course's audience level
+- Skipping the group-and-confirm step (wastes searches)
+- Truncating Consensus URLs in hyperlinks
+- Inlining 300 lines of docx-generation JavaScript in the skill body (use bundled script)
+
+---
+
+**Version:** 1.0.0
+**Source spec:** [`megaprompts/10-syllabus-megaprompt.md`](https://github.com/alirezarezvani/claude-skills/tree/main/megaprompts/10-syllabus-megaprompt.md)
+**Build pattern:** Path B (direct conversion). Bundled-JS-DOCX-generator variant.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Claude Code Skills & Agent Plugins
 site_url: https://alirezarezvani.github.io/claude-skills/
-site_description: "272 production-ready skills, 37 cs-* agents (incl. founder-mode C-suite: GC, CDO, CAIO, CCO, VPE + Matt Pocock-derived productivity quartet: skill-author, caveman, grill-master, handoff), 7 personas, 25 /cs:* slash commands, and an orchestration protocol for 12 AI coding tools."
+site_description: "311 production-ready skills, 45+ cs-* agents (incl. founder-mode C-suite: GC, CDO, CAIO, CCO, VPE + Matt Pocock-derived productivity quartet: skill-author, caveman, grill-master, handoff + v2.7.0 megaprompt-derived research stack), 7 personas, 59+ /cs:* slash commands, and an orchestration protocol for 12 AI coding tools. v2.7.0 adds 13 new skills across productivity (capture, email pair, reflect), marketing (landing), and research (pulse, litreview, grants, dossier, patent, syllabus, notebooklm + research orchestrator)."
 site_author: Alireza Rezvani
 repo_url: https://github.com/alirezarezvani/claude-skills
 repo_name: alirezarezvani/claude-skills
@@ -418,6 +418,25 @@ nav:
       - "Business Investment Advisor": skills/finance/business-investment-advisor.md
       - "Financial Analyst": skills/finance/financial-analyst.md
       - "SaaS Metrics Coach": skills/finance/saas-metrics-coach.md
+    - Productivity:
+      - Overview: skills/productivity/index.md
+      - "Capture (Brain-Dump-to-Action)": skills/productivity/capture.md
+      - "Inbox Setup (KB Builder)": skills/productivity/email-inbox-setup.md
+      - "Inbox Triage (Drafts-Only)": skills/productivity/email-inbox-triage.md
+      - "Reflect (Light-Prompt Journal)": skills/productivity/reflect.md
+    - Marketing (Landing Pages):
+      - Overview: skills/marketing/index.md
+      - "Landing Page Generator (HTML)": skills/marketing/landing.md
+    - Research:
+      - Overview: skills/research/index.md
+      - "Research Orchestrator (Hybrid Router)": skills/research/research.md
+      - "Pulse (Recency + Sentiment)": skills/research/pulse.md
+      - "LitReview (Academic)": skills/research/litreview.md
+      - "Grants (NIH)": skills/research/grants.md
+      - "Dossier (Entity Research)": skills/research/dossier.md
+      - "Patent (Prior Art + IP Landscape)": skills/research/patent.md
+      - "Syllabus (Course Reading List)": skills/research/syllabus.md
+      - "NotebookLM (Browser Automation)": skills/research/notebooklm.md
   - Plugins:
     - Overview: plugins/index.md
   - Personas:

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -19,6 +19,9 @@ DOMAINS = {
     "ra-qm-team": ("Regulatory & Quality", 7, ":material-shield-check-outline:", "ra-qm-skills"),
     "business-growth": ("Business & Growth", 8, ":material-trending-up:", "business-growth-skills"),
     "finance": ("Finance", 9, ":material-calculator-variant:", "finance-skills"),
+    "productivity": ("Productivity", 10, ":material-lightning-bolt-outline:", "productivity-skills"),
+    "marketing": ("Marketing (Top-Level)", 11, ":material-web:", "marketing-top-level-skills"),
+    "research": ("Research", 12, ":material-magnify:", "research-skills"),
 }
 
 # Skills to skip (nested assets, samples, etc.)
@@ -191,6 +194,9 @@ DOMAIN_SEO_SUFFIX = {
     "ra-qm-team": "Agent Skill for Compliance",
     "business-growth": "Agent Skill for Growth",
     "finance": "Agent Skill for Finance",
+    "productivity": "Agent Skill for Personal Productivity",
+    "marketing": "Agent Skill for Landing Pages",
+    "research": "Agent Skill for Research Workflows",
 }
 
 # Domain-specific description context for pages without frontmatter descriptions
@@ -204,6 +210,9 @@ DOMAIN_SEO_CONTEXT = {
     "ra-qm-team": "regulatory and quality management agent skill for ISO 13485, MDR, FDA, and GDPR compliance",
     "business-growth": "business growth agent skill and Claude Code plugin for customer success, sales, and revenue ops",
     "finance": "finance agent skill and Claude Code plugin for DCF valuation, budgeting, and SaaS metrics",
+    "productivity": "personal productivity agent skill and Claude Code plugin for brain-dump capture, email triage, and reflection",
+    "marketing": "landing-page generator agent skill and Claude Code plugin for single-file HTML output with 4 design styles",
+    "research": "research orchestrator agent skill and Claude Code plugin for hybrid routing across pulse, litreview, grants, dossier, patent, syllabus, and notebooklm specialists",
 }
 
 


### PR DESCRIPTION
## Summary

**v2.7.0 documentation + cross-platform sync update.** Comprehensive sync across MkDocs, GitHub Pages, README, CLAUDE.md, marketplace metadata, and Codex/Gemini CLI registries.

Required for v2.7.0 release because PR #673 only updated CLAUDE.md + CHANGELOG — the broader doc surface (README, docs/, mkdocs.yml, cross-platform sync) still referenced 272 skills / 9 domains. This PR fixes that.

## Step-by-step (per `update-docs` skill 7-step pipeline)

### Step 1: Inventory
13 new skills + 13 new agents + 13 new commands shipped in v2.7.0 across 3 new top-level domain folders (`productivity/`, `marketing/`, `research/`).

### Step 2: Cross-platform CLI sync
| Platform | Before | After |
|---|---|---|
| Codex (`.codex/skills-index.json`) | 290 entries | 303 entries |
| Gemini (`.gemini/skills-index.json`) | 351 items | 353 items (grill-with-docs added) |
| OpenClaw | uses same dir structure, no separate sync needed |

### Step 3: Marketplace
- Top-level `description` updated (272 → 311 skills, 9 → 12 domains)
- `metadata.version` bumped 2.6.1 → 2.7.0

### Step 4: Documentation file updates
- **CLAUDE.md**: Current Scope line updated
- **README.md**: hero count, all 4 badge counts, Skills Overview table (+ 3 new domain rows: Productivity, Marketing top-level, Research)
- **docs/index.md**: hero subtitle, meta description, "What's Inside" grid cards
- **docs/getting-started.md**: meta description, FAQ count references
- **mkdocs.yml**: `site_description`, nav (3 new domain sections with 13 new skill page entries)

### Step 5: GitHub Pages regeneration
Extended `scripts/generate-docs.py`:
- `DOMAINS` dict: added `productivity`, `marketing`, `research` entries (with material icon + plugin name)
- `DOMAIN_SEO_SUFFIX`: added 3 new domain title suffixes
- `DOMAIN_SEO_CONTEXT`: added 3 new domain meta descriptions

| Generator output | Before | After |
|---|---|---|
| Skill pages | 281 (9 domains) | **294 (12 domains)** |
| Agent pages | 59 | **72** |
| Command pages | 33 | 33 |
| Total | 373 | **399** |

**MkDocs build: PASSED** (16.03s, 448 HTML pages, 0 errors).

### Step 6: Consistency verification
| Check | Result |
|---|---|
| Skill count consistency across 5 core doc files | all reference 311 |
| Path validation (55 marketplace sources) | all exist on disk |
| New script verification (3 orchestrator scripts) | all `--help` pass |
| Frontmatter check (13 new SKILL.md files) | 13/13 valid YAML |
| Stale "272" references remaining | 0 |

## Files changed
- **48 files modified/created**
- 6,426 insertions, 44 deletions
- 21 new doc pages (14 agent pages + 7 skill pages for new domains)

## Known minor

3 unrelated pre-existing duplicate-path symlinks (`.codex/skills/review`, `.codex/skills/run`, `.codex/skills/status`) flipped target during this codex sync. These are skill-name collisions across multiple repo folders (e.g., `review` exists in both `engineering-team/playwright-pro/skills/` AND `engineering-team/self-improving-agent/skills/`). The sync script now picks one consistent canonical path. Same churn would happen on any sync run — not a regression from this PR.

## Test plan

- [x] Cross-platform sync verified (Codex 303, Gemini 353)
- [x] All 55 marketplace.json source paths valid
- [x] All 13 new SKILL.md files have valid frontmatter
- [x] MkDocs build passes without errors
- [x] All 5 core doc files reference 311 skills (consistency check clean)
- [x] generate-docs.py emits pages for all 12 domains
- [ ] CI lint + tests + docs gate (will run on this PR)
- [ ] CI security scan (will run)
- [ ] CI claude-review (will run)

## Sequencing note

This PR targets `dev`. Once merged, it joins the dev → main release PR #674 (which already has the v2.7.0 release prep from PR #673). After this lands in dev, PR #674 will automatically pick up these doc changes on next sync.

https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw)_