### PR TITLE
release(v2.7.1): hotfix — plugins page accurate counts (28 → 55)

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Agent Plugin Marketplace — Codex & OpenClaw Plugins"
-description: "28 installable agent plugins for Claude Code, Codex CLI, Gemini CLI, and OpenClaw. One-command install for engineering, marketing, product, compliance, and finance skill bundles."
+description: "55 installable agent plugins for Claude Code, Codex CLI, Gemini CLI, and OpenClaw. 9 domain bundles + 46 standalone packages covering engineering, marketing, product, c-level, compliance, finance, productivity, and research. One-command install for any skill bundle."
 ---
 
 <div class="skills-hero" markdown>
 
 # Plugins & Marketplace
 
-**28 installable plugins** — domain bundles and standalone packages distributed via Claude Code plugin registry and ClawHub.
+**55 installable plugins** — 9 domain bundles + 46 standalone packages distributed via Claude Code plugin registry and ClawHub.
 
 <p class="skills-hero-sub">Install entire skill domains or individual tools with a single command. Compatible with Claude Code, OpenAI Codex, Gemini CLI, and OpenClaw.</p>
 
@@ -19,19 +19,19 @@ description: "28 installable agent plugins for Claude Code, Codex CLI, Gemini CL
 
 <div class="grid cards" markdown>
 
--   :material-puzzle-outline:{ .lg .middle } **28 Plugins**
+-   :material-puzzle-outline:{ .lg .middle } **55 Plugins**
 
     ---
 
-    9 domain bundles + 10 standalone packages
+    9 domain bundles + 46 standalone packages
 
--   :material-domain:{ .lg .middle } **9 Domains**
+-   :material-domain:{ .lg .middle } **12 Domains**
 
     ---
 
-    Engineering, Marketing, Product, C-Level, PM, RA/QM, Business, Finance
+    Engineering (Core + POWERFUL), Marketing, Product, C-Level, PM, RA/QM, Business, Finance, Productivity ✨v2.7.0, Marketing-top-level ✨v2.7.0, Research ✨v2.7.0
 
--   :material-toolbox-outline:{ .lg .middle } **177 Skills**
+-   :material-toolbox-outline:{ .lg .middle } **311 Skills**
 
     ---
 
@@ -41,7 +41,7 @@ description: "28 installable agent plugins for Claude Code, Codex CLI, Gemini CL
 
     ---
 
-    Claude Code, Codex CLI, Gemini CLI, OpenClaw
+    Claude Code, OpenAI Codex, Gemini CLI, OpenClaw — single repo, all platforms
 
 </div>
 
@@ -52,26 +52,27 @@ description: "28 installable agent plugins for Claude Code, Codex CLI, Gemini CL
 === "Claude Code"
 
     ```bash
-    # Install a domain bundle
-    claude /plugin install marketing-skills
+    # Add the marketplace
+    /plugin marketplace add alirezarezvani/claude-skills
 
-    # Install a standalone plugin
-    claude /plugin install pw
+    # Install a domain bundle
+    /plugin install engineering-skills@claude-code-skills
+
+    # Or install a standalone plugin (v2.7.0 example)
+    /plugin install research-orchestrator@claude-code-skills
     ```
 
-=== "Codex CLI"
+=== "OpenAI Codex"
 
     ```bash
-    # Clone the repository
     git clone https://github.com/alirezarezvani/claude-skills.git
-
-    # Symlinks are pre-configured in .codex/skills/
+    cd claude-skills
+    ./scripts/codex-install.sh
     ```
 
 === "Gemini CLI"
 
     ```bash
-    # Clone and run the sync script
     git clone https://github.com/alirezarezvani/claude-skills.git
     cd claude-skills
     python3 scripts/sync-gemini-skills.py --verbose
@@ -90,35 +91,36 @@ description: "28 installable agent plugins for Claude Code, Codex CLI, Gemini CL
 ```mermaid
 graph TB
     subgraph Registry["Plugin Registry"]
-        MP["marketplace.json<br/>28 plugins"]
+        MP["marketplace.json<br/>55 plugins"]
     end
 
     subgraph Bundles["Domain Bundles (9)"]
-        B1["engineering-skills<br/>24 skills"]
-        B2["engineering-advanced-skills<br/>25 skills"]
-        B3["marketing-skills<br/>43 skills"]
+        B1["engineering-skills<br/>32 skills"]
+        B2["engineering-advanced-skills<br/>40+ skills"]
+        B3["marketing-skills<br/>44 skills"]
         B4["c-level-skills<br/>28 skills"]
-        B5["ra-qm-skills<br/>12 skills"]
-        B6["product-skills<br/>12 skills"]
-        B7["pm-skills<br/>6 skills"]
-        B8["business-growth-skills<br/>4 skills"]
-        B9["finance-skills<br/>2 skills"]
+        B5["ra-qm-skills<br/>14 skills"]
+        B6["product-skills<br/>13 skills"]
+        B7["pm-skills<br/>9 skills"]
+        B8["business-growth-skills<br/>5 skills"]
+        B9["finance-skills<br/>3 skills"]
     end
 
-    subgraph Standalone["Standalone Plugins (10)"]
-        S1["pw<br/>Playwright Pro"]
+    subgraph V270["v2.7.0 New Plugins"]
+        V1["12 standalone:<br/>3 productivity, 1 marketing,<br/>8 research (incl. orchestrator)"]
+    end
+
+    subgraph Standalone["Other Standalone (46 total)"]
+        S1["pw<br/>(Playwright Pro)"]
         S2["self-improving-agent"]
-        S3["google-workspace-cli"]
-        S4["executive-mentor"]
-        S5["content-creator"]
-        S6["demand-gen"]
-        S7["fullstack-engineer"]
-        S8["aws-architect"]
-        S9["product-manager"]
-        S10["skill-security-auditor"]
+        S3["agenthub, llm-wiki, slo-architect"]
+        S4["caveman, grill-me, handoff,<br/>write-a-skill"]
+        S5["chaos-engineering, kubernetes-operator,<br/>feature-flags-architect"]
+        S6["...29 more"]
     end
 
     MP --> Bundles
+    MP --> V270
     MP --> Standalone
 ```
 
@@ -128,17 +130,31 @@ graph TB
 
 Domain bundles install an entire skill domain with all its tools, references, and assets. Use these when you want comprehensive coverage for a functional area.
 
-### :material-code-braces: Engineering — Core
+### :material-trending-up: Business & Growth
 
 | | |
 |---|---|
-| **Plugin** | `engineering-skills` |
-| **Skills** | 24 |
-| **Install** | `claude /plugin install engineering-skills` |
+| **Plugin** | `business-growth-skills` |
+| **Skills** | 5 |
+| **Install** | `claude /plugin install business-growth-skills` |
 
-Architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright Pro (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI.
+Customer success manager, sales engineer, revenue operations, contract & proposal writer, BizDev toolkit.
 
-[:octicons-arrow-right-24: Browse skills](../skills/engineering-team/index.md)
+[:octicons-arrow-right-24: Browse skills](../skills/business-growth/index.md)
+
+---
+
+### :material-shield-check-outline: Regulatory & Quality
+
+| | |
+|---|---|
+| **Plugin** | `ra-qm-skills` |
+| **Skills** | 14 |
+| **Install** | `claude /plugin install ra-qm-skills` |
+
+ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, EU AI Act, ISO 42001, CAPA management, risk management, clinical evaluation for HealthTech/MedTech.
+
+[:octicons-arrow-right-24: Browse skills](../skills/ra-qm-team/index.md)
 
 ---
 
@@ -147,26 +163,40 @@ Architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data en
 | | |
 |---|---|
 | **Plugin** | `engineering-advanced-skills` |
-| **Skills** | 25 |
+| **Skills** | 40+ |
 | **Install** | `claude /plugin install engineering-advanced-skills` |
 
-Agent designer, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler.
+Agent designer, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, AgentHub, llm-wiki, slo-architect, chaos-engineering, kubernetes-operator, feature-flags-architect, ship-gate, plus the 4 Matt Pocock skills (write-a-skill, caveman, grill-me, handoff).
 
 [:octicons-arrow-right-24: Browse skills](../skills/engineering/index.md)
 
 ---
 
-### :material-bullhorn-outline: Marketing
+### :material-code-braces: Engineering — Core
 
 | | |
 |---|---|
-| **Plugin** | `marketing-skills` |
-| **Skills** | 43 |
-| **Install** | `claude /plugin install marketing-skills` |
+| **Plugin** | `engineering-skills` |
+| **Skills** | 32 |
+| **Install** | `claude /plugin install engineering-skills` |
 
-Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs across 7 specialist pods.
+Architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright Pro (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit, 6-skill security suite.
 
-[:octicons-arrow-right-24: Browse skills](../skills/marketing-skill/index.md)
+[:octicons-arrow-right-24: Browse skills](../skills/engineering-team/index.md)
+
+---
+
+### :material-calculator-variant: Finance
+
+| | |
+|---|---|
+| **Plugin** | `finance-skills` |
+| **Skills** | 3 |
+| **Install** | `claude /plugin install finance-skills` |
+
+Financial analyst (DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR), business investment advisor.
+
+[:octicons-arrow-right-24: Browse skills](../skills/finance/index.md)
 
 ---
 
@@ -178,23 +208,23 @@ Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitt
 | **Skills** | 28 |
 | **Install** | `claude /plugin install c-level-skills` |
 
-Virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO), executive mentor, founder coach, board meetings, decision logger, scenario war room, competitive intel, M&A playbook, culture frameworks.
+Full C-suite (10 roles: CEO, CTO, CFO, COO, CPO, CMO, CRO, CISO, CHRO, GC, CDO, CAIO, CCO, VPE), executive mentor, founder coach, board meetings, decision logger, scenario war room, competitive intel, M&A playbook, culture frameworks.
 
 [:octicons-arrow-right-24: Browse skills](../skills/c-level-advisor/index.md)
 
 ---
 
-### :material-shield-check-outline: Regulatory & Quality
+### :material-bullhorn-outline: Marketing
 
 | | |
 |---|---|
-| **Plugin** | `ra-qm-skills` |
-| **Skills** | 12 |
-| **Install** | `claude /plugin install ra-qm-skills` |
+| **Plugin** | `marketing-skills` |
+| **Skills** | 44 |
+| **Install** | `claude /plugin install marketing-skills` |
 
-ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation for HealthTech/MedTech.
+Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs across 7 specialist pods.
 
-[:octicons-arrow-right-24: Browse skills](../skills/ra-qm-team/index.md)
+[:octicons-arrow-right-24: Browse skills](../skills/marketing-skill/index.md)
 
 ---
 
@@ -203,10 +233,10 @@ ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA ma
 | | |
 |---|---|
 | **Plugin** | `product-skills` |
-| **Skills** | 12 |
+| **Skills** | 13 |
 | **Install** | `claude /plugin install product-skills` |
 
-Product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator. 13 Python tools.
+Product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, apple-hig-expert.
 
 [:octicons-arrow-right-24: Browse skills](../skills/product-team/index.md)
 
@@ -217,156 +247,90 @@ Product manager toolkit (RICE, PRDs), agile product owner, product strategist, U
 | | |
 |---|---|
 | **Plugin** | `pm-skills` |
-| **Skills** | 6 |
+| **Skills** | 9 |
 | **Install** | `claude /plugin install pm-skills` |
 
-Senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator. 12 Python tools with Atlassian MCP integration.
+Senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator. 12 Python tools with bundled Atlassian Remote MCP integration.
 
 [:octicons-arrow-right-24: Browse skills](../skills/project-management/index.md)
 
 ---
 
-### :material-trending-up: Business & Growth
+## v2.7.0 Standalone Plugins ✨
 
-| | |
-|---|---|
-| **Plugin** | `business-growth-skills` |
-| **Skills** | 4 |
-| **Install** | `claude /plugin install business-growth-skills` |
+Thirteen new Path-B megaprompt-derived skills shipped in v2.7.0 across three new top-level domain folders.
 
-Customer success manager, sales engineer, revenue operations, contract & proposal writer.
+### Productivity (3 plugins)
 
-[:octicons-arrow-right-24: Browse skills](../skills/business-growth/index.md)
+| Plugin | Skills | Install |
+|---|:-:|---|
+| `capture-skill` | 1 | `claude /plugin install capture-skill` — brain-dump-to-action workspace |
+| `email-pair` | 2 | `claude /plugin install email-pair` — paired inbox-setup + inbox-triage with 7-file KB contract |
+| `reflect-skill` | 1 | `claude /plugin install reflect-skill` — light-prompt journal sibling of capture |
+
+### Marketing (top-level — 1 plugin)
+
+| Plugin | Skills | Install |
+|---|:-:|---|
+| `landing` | 1 | `claude /plugin install landing` — single-file HTML landing-page generator (4 design styles, GSAP, brand palette validator) |
+
+### Research (8 plugins)
+
+| Plugin | Skills | Install |
+|---|:-:|---|
+| `research-orchestrator` | 1 | `claude /plugin install research-orchestrator` — **hybrid router + fallback**. Classifies + routes to 6 specialists or runs own workflow. |
+| `pulse` | 1 | `claude /plugin install pulse` — multi-source recency research (Reddit/HN/X/web) |
+| `litreview` | 1 | `claude /plugin install litreview` — academic literature (PICO/SPIDER frameworks) |
+| `grants` | 1 | `claude /plugin install grants` — NIH grant-funding intelligence |
+| `dossier` | 1 | `claude /plugin install dossier` — decision-grade entity research |
+| `patent` | 1 | `claude /plugin install patent` — patent prior-art + IP landscape |
+| `syllabus` | 1 | `claude /plugin install syllabus` — course supplementary reading (bundled DOCX generator) |
+| `notebooklm` | 1 | `claude /plugin install notebooklm` — Google NotebookLM browser automation |
 
 ---
 
-### :material-calculator-variant: Finance
-
-| | |
-|---|---|
-| **Plugin** | `finance-skills` |
-| **Skills** | 2 |
-| **Install** | `claude /plugin install finance-skills` |
-
-Financial analyst (ratio analysis, DCF valuation, budgeting, forecasting) and SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR). 7 Python tools.
-
-[:octicons-arrow-right-24: Browse skills](../skills/finance/index.md)
-
----
-
-## Standalone Plugins
+## Other Standalone Plugins
 
 Standalone plugins install individual skills or toolkits. Use these when you need a specific capability without the full domain bundle.
 
-<div class="grid cards" markdown>
 
--   :material-test-tube:{ .lg .middle } **Playwright Pro** `pw`
+| Plugin | Category | Source |
+|---|---|---|
+| `apple-hig-expert` | design | `./product-team/apple-hig-expert` |
+| `a11y-audit` | development | `./engineering-team/a11y-audit` |
+| `agenthub` | development | `./engineering/agenthub` |
+| `autoresearch-agent` | development | `./engineering/autoresearch-agent` |
+| `caveman` | development | `./engineering/caveman` |
+| `chaos-engineering` | development | `./engineering/chaos-engineering` |
+| `code-tour` | development | `./engineering/code-tour` |
+| `data-quality-auditor` | development | `./engineering/data-quality-auditor` |
+| `demo-video` | development | `./engineering/demo-video` |
+| `docker-development` | development | `./engineering/docker-development` |
+| `feature-flags-architect` | development | `./engineering/feature-flags-architect` |
+| `google-workspace-cli` | development | `./engineering-team/google-workspace-cli` |
+| `grill-me` | development | `./engineering/grill-me` |
+| `handoff` | development | `./engineering/handoff` |
+| `helm-chart-builder` | development | `./engineering/helm-chart-builder` |
+| `karpathy-coder` | development | `./engineering/karpathy-coder` |
+| `kubernetes-operator` | development | `./engineering/kubernetes-operator` |
+| `pw` | development | `./engineering-team/playwright-pro` |
+| `self-improving-agent` | development | `./engineering-team/self-improving-agent` |
+| `slo-architect` | development | `./engineering/slo-architect` |
+| `statistical-analyst` | development | `./engineering/statistical-analyst` |
+| `terraform-patterns` | development | `./engineering/terraform-patterns` |
+| `write-a-skill` | development | `./engineering/write-a-skill` |
+| `llm-wiki` | knowledge | `./engineering/llm-wiki` |
+| `c-level-agents` | leadership | `./c-level-advisor/c-level-agents` |
+| `chief-ai-officer-advisor` | leadership | `./c-level-advisor/chief-ai-officer-advisor` |
+| `chief-customer-officer-advisor` | leadership | `./c-level-advisor/chief-customer-officer-advisor` |
+| `chief-data-officer-advisor` | leadership | `./c-level-advisor/chief-data-officer-advisor` |
+| `executive-mentor` | leadership | `./c-level-advisor/executive-mentor` |
+| `general-counsel-advisor` | leadership | `./c-level-advisor/general-counsel-advisor` |
+| `vpe-advisor` | leadership | `./c-level-advisor/vpe-advisor` |
+| `agile-product-owner` | product | `./product-team/agile-product-owner` |
+| `code-to-prd` | product | `./product-team/code-to-prd` |
+| `research-summarizer` | product | `./product-team/research-summarizer` |
 
-    ---
-
-    Production-grade Playwright testing toolkit. 9 sub-skills, 3 agents, 55 templates, TestRail + BrowserStack MCP.
-
-    ```bash
-    claude /plugin install pw
-    ```
-
-    **Slash commands:** `/pw:generate`, `/pw:fix`, `/pw:review`, `/pw:migrate`, `/pw:coverage`, `/pw:init`, `/pw:report`, `/pw:testrail`, `/pw:browserstack`
-
--   :material-brain:{ .lg .middle } **Self-Improving Agent** `self-improving-agent`
-
-    ---
-
-    Auto-memory curation, learning promotion, and pattern extraction into reusable skills.
-
-    ```bash
-    claude /plugin install self-improving-agent
-    ```
-
-    **Slash commands:** `/si:review`, `/si:promote`, `/si:extract`, `/si:status`, `/si:remember`
-
--   :fontawesome-brands-google:{ .lg .middle } **Google Workspace CLI** `google-workspace-cli`
-
-    ---
-
-    Gmail, Drive, Sheets, Calendar, Docs, Chat, Tasks via the `gws` CLI. 5 Python tools, 43 recipes, 10 persona bundles.
-
-    ```bash
-    claude /plugin install google-workspace-cli
-    ```
-
--   :material-account-supervisor:{ .lg .middle } **Executive Mentor** `executive-mentor`
-
-    ---
-
-    Adversarial thinking partner for founders. Pre-mortem, board prep, hard calls, stress tests, postmortems.
-
-    ```bash
-    claude /plugin install executive-mentor
-    ```
-
-    **Slash commands:** `/em:challenge`, `/em:board-prep`, `/em:hard-call`, `/em:stress-test`, `/em:postmortem`
-
--   :material-pencil:{ .lg .middle } **Content Creator** `content-creator`
-
-    ---
-
-    SEO-optimized content with brand voice analysis, content frameworks, and social media templates.
-
-    ```bash
-    claude /plugin install content-creator
-    ```
-
--   :material-magnet:{ .lg .middle } **Demand Gen** `demand-gen`
-
-    ---
-
-    Multi-channel demand generation, paid media optimization, SEO strategy, and partnership programs.
-
-    ```bash
-    claude /plugin install demand-gen
-    ```
-
--   :material-layers-triple:{ .lg .middle } **Fullstack Engineer** `fullstack-engineer`
-
-    ---
-
-    Full-stack engineering with React, Node, databases, and deployment patterns.
-
-    ```bash
-    claude /plugin install fullstack-engineer
-    ```
-
--   :fontawesome-brands-aws:{ .lg .middle } **AWS Architect** `aws-architect`
-
-    ---
-
-    AWS serverless architecture with IaC templates, cost optimization, and CI/CD pipelines.
-
-    ```bash
-    claude /plugin install aws-architect
-    ```
-
--   :material-clipboard-text:{ .lg .middle } **Product Manager** `product-manager`
-
-    ---
-
-    RICE scoring, customer interview analysis, and PRD generation toolkit.
-
-    ```bash
-    claude /plugin install product-manager
-    ```
-
--   :material-shield-lock:{ .lg .middle } **Skill Security Auditor** `skill-security-auditor`
-
-    ---
-
-    Security scanner for AI agent skills. Detects malicious patterns, prompt injection, data exfiltration, and unsafe file operations.
-
-    ```bash
-    claude /plugin install skill-security-auditor
-    ```
-
-</div>
 
 ---
 
@@ -378,33 +342,22 @@ Every plugin follows the same minimal schema for maximum portability:
 {
   "name": "plugin-name",
   "description": "What it does",
-  "version": "2.1.2",
+  "version": "2.7.0",
   "author": { "name": "Author Name" },
   "homepage": "https://...",
   "repository": "https://...",
   "license": "MIT",
-  "skills": "./"
+  "skills": ["./skills/<name>"]
 }
 ```
 
+Two approved extension fields permitted (per CLAUDE.md ClawHub rule #5):
+
+- **`source`** (object) — provenance metadata for Path-B megaprompt-derived skills. Used by all 13 v2.7.0 skills (productivity, marketing, research).
+- **`attribution`** (object) — credit metadata for MIT-licensed external derivatives. Used by `caveman`, `grill-me`, `grill-with-docs`.
+
 !!! info "ClawHub Registry"
     Plugins are distributed via [ClawHub](https://clawhub.com) as the public registry. The `cs-` prefix is used only when a slug is already taken by another publisher — repo folder names remain unchanged.
-
-### Directory Layout
-
-```
-domain-name/
-├── .claude-plugin/
-│   └── plugin.json        # Plugin metadata
-├── skill-a/
-│   ├── SKILL.md           # Skill instructions
-│   ├── scripts/           # Python CLI tools
-│   ├── references/        # Knowledge bases
-│   └── assets/            # Templates
-├── skill-b/
-│   └── ...
-└── CLAUDE.md              # Domain instructions
-```
 
 ---
 
@@ -418,49 +371,91 @@ domain-name/
 | **OpenClaw** | :material-check: | :material-check: | :material-close: | :material-close: |
 
 !!! tip "Full feature support"
-    Slash commands (like `/pw:generate`) and agent spawning (like `cs-engineering-lead`) are Claude Code features. On other platforms, the underlying skills and Python tools work — just without the command/agent wrappers.
+    Slash commands (like `/cs:research`, `/pw:generate`) and agent spawning (like `cs-research`) are Claude Code features. On other platforms, the underlying skills and Python tools work — just without the command/agent wrappers.
 
 ---
 
-## All Plugins at a Glance
+## All 55 Plugins at a Glance
 
-| Plugin | Type | Skills | Category | Keywords |
-|--------|------|:------:|----------|----------|
-| `marketing-skills` | Bundle | 43 | Marketing | content, seo, cro, growth, social |
-| `c-level-skills` | Bundle | 28 | Leadership | ceo, cto, strategy, advisory |
-| `engineering-advanced-skills` | Bundle | 25 | Development | agent, rag, database, ci-cd, mcp |
-| `engineering-skills` | Bundle | 24 | Development | architecture, devops, ai, ml |
-| `ra-qm-skills` | Bundle | 12 | Compliance | iso-13485, mdr, fda, gdpr |
-| `product-skills` | Bundle | 12 | Product | pm, agile, ux, saas, analytics, experimentation, discovery, roadmap |
-| `pm-skills` | Bundle | 6 | PM | scrum, jira, confluence |
-| `business-growth-skills` | Bundle | 4 | Business | sales, revenue, customer-success |
-| `finance-skills` | Bundle | 2 | Finance | dcf, valuation, saas-metrics |
-| `pw` | Standalone | 9 | Development | playwright, e2e, testing |
-| `self-improving-agent` | Standalone | 5 | Development | memory, auto-memory |
-| `google-workspace-cli` | Standalone | 1 | Development | gmail, drive, sheets, calendar |
-| `executive-mentor` | Standalone | 5 | Leadership | pre-mortem, board-prep |
-| `content-creator` | Standalone | 1 | Marketing | seo, brand-voice |
-| `demand-gen` | Standalone | 1 | Marketing | paid-media, acquisition |
-| `fullstack-engineer` | Standalone | 1 | Development | react, node |
-| `aws-architect` | Standalone | 1 | Development | aws, serverless, cloud |
-| `product-manager` | Standalone | 1 | Product | rice, prd |
-| `skill-security-auditor` | Standalone | 1 | Development | security, audit |
+| Plugin | Type | Category | Source |
+|---|---|---|---|
+| `business-growth-skills` | Bundle | business-growth | `./business-growth` |
+| `ra-qm-skills` | Bundle | compliance | `./ra-qm-team` |
+| `engineering-advanced-skills` | Bundle | development | `./engineering` |
+| `engineering-skills` | Bundle | development | `./engineering-team` |
+| `finance-skills` | Bundle | finance | `./finance` |
+| `c-level-skills` | Bundle | leadership | `./c-level-advisor` |
+| `marketing-skills` | Bundle | marketing | `./marketing-skill` |
+| `product-skills` | Bundle | product | `./product-team` |
+| `pm-skills` | Bundle | project-management | `./project-management` |
+| `apple-hig-expert` | Standalone | design | `./product-team/apple-hig-expert` |
+| `a11y-audit` | Standalone | development | `./engineering-team/a11y-audit` |
+| `agenthub` | Standalone | development | `./engineering/agenthub` |
+| `autoresearch-agent` | Standalone | development | `./engineering/autoresearch-agent` |
+| `caveman` | Standalone | development | `./engineering/caveman` |
+| `chaos-engineering` | Standalone | development | `./engineering/chaos-engineering` |
+| `code-tour` | Standalone | development | `./engineering/code-tour` |
+| `data-quality-auditor` | Standalone | development | `./engineering/data-quality-auditor` |
+| `demo-video` | Standalone | development | `./engineering/demo-video` |
+| `docker-development` | Standalone | development | `./engineering/docker-development` |
+| `feature-flags-architect` | Standalone | development | `./engineering/feature-flags-architect` |
+| `google-workspace-cli` | Standalone | development | `./engineering-team/google-workspace-cli` |
+| `grill-me` | Standalone | development | `./engineering/grill-me` |
+| `handoff` | Standalone | development | `./engineering/handoff` |
+| `helm-chart-builder` | Standalone | development | `./engineering/helm-chart-builder` |
+| `karpathy-coder` | Standalone | development | `./engineering/karpathy-coder` |
+| `kubernetes-operator` | Standalone | development | `./engineering/kubernetes-operator` |
+| `pw` | Standalone | development | `./engineering-team/playwright-pro` |
+| `self-improving-agent` | Standalone | development | `./engineering-team/self-improving-agent` |
+| `slo-architect` | Standalone | development | `./engineering/slo-architect` |
+| `statistical-analyst` | Standalone | development | `./engineering/statistical-analyst` |
+| `terraform-patterns` | Standalone | development | `./engineering/terraform-patterns` |
+| `write-a-skill` | Standalone | development | `./engineering/write-a-skill` |
+| `llm-wiki` | Standalone | knowledge | `./engineering/llm-wiki` |
+| `c-level-agents` | Standalone | leadership | `./c-level-advisor/c-level-agents` |
+| `chief-ai-officer-advisor` | Standalone | leadership | `./c-level-advisor/chief-ai-officer-advisor` |
+| `chief-customer-officer-advisor` | Standalone | leadership | `./c-level-advisor/chief-customer-officer-advisor` |
+| `chief-data-officer-advisor` | Standalone | leadership | `./c-level-advisor/chief-data-officer-advisor` |
+| `executive-mentor` | Standalone | leadership | `./c-level-advisor/executive-mentor` |
+| `general-counsel-advisor` | Standalone | leadership | `./c-level-advisor/general-counsel-advisor` |
+| `vpe-advisor` | Standalone | leadership | `./c-level-advisor/vpe-advisor` |
+| `landing` ✨ | Standalone | marketing | `./marketing/landing` |
+| `agile-product-owner` | Standalone | product | `./product-team/agile-product-owner` |
+| `code-to-prd` | Standalone | product | `./product-team/code-to-prd` |
+| `research-summarizer` | Standalone | product | `./product-team/research-summarizer` |
+| `capture-skill` ✨ | Standalone | productivity | `./productivity/capture` |
+| `email-pair` ✨ | Standalone | productivity | `./productivity/email` |
+| `reflect-skill` ✨ | Standalone | productivity | `./productivity/reflect` |
+| `dossier` ✨ | Standalone | research | `./research/dossier` |
+| `grants` ✨ | Standalone | research | `./research/grants` |
+| `litreview` ✨ | Standalone | research | `./research/litreview` |
+| `notebooklm` ✨ | Standalone | research | `./research/notebooklm` |
+| `patent` ✨ | Standalone | research | `./research/patent` |
+| `pulse` ✨ | Standalone | research | `./research/pulse` |
+| `research-orchestrator` ✨ | Standalone | research | `./research/research` |
+| `syllabus` ✨ | Standalone | research | `./research/syllabus` |
 
 ---
 
 ## FAQ
 
 ??? question "What's the difference between a bundle and a standalone plugin?"
-    **Bundles** install all skills in a domain (e.g., `marketing-skills` installs all 43 marketing skills). **Standalone** plugins install a single skill or toolkit (e.g., `pw` installs just Playwright Pro). Standalone plugins are subsets of their parent bundle — installing both is safe but redundant.
+    **Bundles** install all skills in a domain (e.g., `marketing-skills` installs all 44 marketing skills). **Standalone** plugins install a single skill or toolkit (e.g., `pulse` installs just the recency-research skill). Standalone plugins are subsets of their parent bundle when applicable — installing both is safe but redundant.
+
+??? question "What are the v2.7.0 plugins?"
+    Twelve new plugins covering 13 skills shipped in v2.7.0 across three new top-level domains: **productivity** (capture-skill, email-pair, reflect-skill), **marketing** top-level (landing), and **research** (research-orchestrator + 7 specialists: pulse, litreview, grants, dossier, patent, syllabus, notebooklm). All Path-B converted from `megaprompts/01-13`.
+
+??? question "What is the research orchestrator?"
+    `research-orchestrator` is a **hybrid router + fallback** that classifies any research question deterministically and either delegates to one of 6 specialists (pulse, litreview, grants, dossier, patent, syllabus, notebooklm) at ≥2-signal confidence, OR runs its own 8-step plan-decompose-search-synthesize-cite workflow when no specialist matches. Routing transparency is mandatory — it never delegates silently. Distinct from `engineering/autoresearch-agent` (Karpathy's file-optimization loop).
 
 ??? question "Can I install multiple plugins?"
     Yes. Plugins are designed to coexist without conflicts. Each skill is self-contained with no cross-dependencies.
 
 ??? question "Do plugins require API keys or paid services?"
-    No. All Python tools use stdlib only. Some skills reference external services (AWS, Google Workspace, Stripe) but follow a BYOK (bring-your-own-key) pattern — you use your own accounts.
+    No. All Python tools use stdlib only. Some skills reference external services (AWS, Google Workspace, Stripe, NIH RePORTER, Reddit/HN APIs) but follow a BYOK (bring-your-own-key) pattern — you use your own accounts.
 
 ??? question "How do I update plugins?"
-    Re-run the install command. Plugins follow semantic versioning aligned with the repository releases (currently v2.1.2).
+    Re-run the install command. Plugins follow semantic versioning aligned with the repository releases (currently v2.7.0).
 
 ??? question "What is ClawHub?"
     [ClawHub](https://clawhub.com) is the public registry for Claude Code plugins. Think of it like npm for AI agent skills. The `cs-` prefix is used only when a plugin slug conflicts with another publisher.


### PR DESCRIPTION
## v2.7.1 hotfix — plugins page accurate counts

**Single fix:** `docs/plugins/index.md` was showing v2.1.x-era counts (28 plugins, 9 domains, 177 skills) on the live github.io site. PR #675's docs sweep missed this file. PR #676 fixed it in `dev`. This release PR pushes the fix to `main` so github.io rebuilds with the accurate numbers.

## Scope

2 commits, 1 file changed, +226 / −231 lines:

| Commit | Description |
|---|---|
| `1872ed0` | `fix(docs): plugins page — refresh stale counts to v2.7.0 reality` |
| `c71b51a` | Merge PR #676 |

## What the page now shows

| Field | Before (live) | After (this PR) |
|---|---|---|
| Hero / at-a-glance | 28 plugins | **55 plugins** |
| Domain count | 9 | **12** |
| Total skills | 177 | **311** |
| Plugin Structure example | v2.1.2 | **v2.7.0** |
| Standalone plugin list | Hardcoded 10 (5 obsolete) | All 46 standalones from marketplace.json |
| v2.7.0 callout section | absent | **NEW** — lists all 12 new plugins with install commands |
| All-plugins table | 19 rows | **55 rows** (auto from marketplace.json) |
| Architecture mermaid | 28 plugins | 55 plugins + v2.7.0 subgraph |
| FAQ entries | 6 | 8 (added: "What are the v2.7.0 plugins?" + "What is the research orchestrator?") |

## After merge

GitHub Pages workflow rebuilds → https://alirezarezvani.github.io/claude-skills/plugins/ shows 55 plugins / 12 domains / 311 skills within ~2 minutes.

## Test plan

- [ ] CI lint + tests + docs gate passes
- [ ] After merge: github.io `/plugins` page shows updated counts
- [ ] After merge: All 12 v2.7.0 plugins visible in the new "v2.7.0 Standalone Plugins ✨" section

https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEUmeuYhmnxVFq7EZM8ZSw)_