### PR TITLE
Strengthen SKILL.md descriptions across 35 more skills (Phase 2, companion to #682)

### DIFF
--- a/engineering-team/skills/ai-security/SKILL.md
+++ b/engineering-team/skills/ai-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "ai-security"
-description: "Use when assessing AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring."
+description: "When the user wants to assess AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Triggers include \"prompt injection,\" \"jailbreak,\" \"LLM security,\" \"AI red team,\" \"agent abuse,\" \"model inversion,\" \"data poisoning,\" \"adversarial robustness,\" \"MITRE ATLAS,\" \"AI/ML threat model,\" \"LLM security audit,\" \"AI assessment.\" Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring. Distinct from security-pen-testing (general app vulnerabilities) and threat-detection (infrastructure behavioral anomalies). Relevant for Mo: Mo platform (psychology-first matching engine, LLM-powered, broker-owner SaaS) needs ATLAS-mapped review before public launch; askminimo (LLM-backed agent education tool) needs prompt-injection hardening on user-submitted prompts; Curb home-readiness AI features need input validation. Pair with senior-prompt-engineer for guardrail design and red-team for adversary simulation."
 ---
 
 # AI Security

--- a/engineering-team/skills/aws-solution-architect/SKILL.md
+++ b/engineering-team/skills/aws-solution-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "aws-solution-architect"
-description: Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.
+description: "When the user wants to design AWS architectures using serverless patterns and infrastructure-as-code templates. Triggers include \"AWS architecture,\" \"serverless design,\" \"Lambda,\" \"API Gateway,\" \"DynamoDB,\" \"ECS,\" \"Aurora,\" \"CloudFormation,\" \"CDK,\" \"AWS cost optimization,\" \"CI/CD on AWS,\" \"migrate to AWS,\" \"AWS startup stack,\" \"VPC design,\" \"AWS SAM.\" Covers serverless-first patterns, IaC templates, and startup-friendly cost optimization. Context for Mo: Mo's production stack runs on Vercel plus Supabase, not AWS. This skill is relevant when evaluating migration scenarios, when an enterprise integration partner runs on AWS, or when a side-project specifically requires AWS (e.g., S3 for large file storage, SES for transactional email at scale). Distinct from azure-cloud-architect and gcp-cloud-architect. Pair with senior-devops for pipeline integration and tech-stack-evaluator for build-vs-buy decisions."
 ---
 
 # AWS Solution Architect

--- a/engineering-team/skills/azure-cloud-architect/SKILL.md
+++ b/engineering-team/skills/azure-cloud-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "azure-cloud-architect"
-description: "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization."
+description: "When the user wants to design Azure architectures for startups or enterprises with Bicep or ARM templates. Triggers include \"Azure architecture,\" \"Bicep,\" \"ARM templates,\" \"AKS,\" \"App Service,\" \"Azure Functions,\" \"Cosmos DB,\" \"Azure DevOps,\" \"Azure cost optimization,\" \"migrate to Azure,\" \"Azure Active Directory,\" \"Azure SQL,\" \"AKS design,\" \"Azure CI/CD.\" Covers AKS, App Service, Functions, Cosmos DB, and cost-aware design. Context for Mo: Azure is NOT in Mo's current stack (Vercel plus Supabase plus Cloudflare). This skill is relevant when a partner integration runs on Azure, when Microsoft 365 tenant work overlaps with Azure AD, or when evaluating a migration scenario. Distinct from aws-solution-architect and gcp-cloud-architect. Pair with ms365-tenant-manager when M365 integration is in scope and senior-devops for CI/CD."
 ---
 
 # Azure Cloud Architect

--- a/engineering-team/skills/cloud-security/SKILL.md
+++ b/engineering-team/skills/cloud-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "cloud-security"
-description: "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping."
+description: "When the user wants to assess cloud infrastructure for security misconfigurations, IAM privilege escalation paths, public storage exposure, open network rules, or IaC security gaps. Triggers include \"cloud security audit,\" \"IAM review,\" \"S3 exposure,\" \"security group audit,\" \"IaC security,\" \"cloud misconfiguration,\" \"CSPM,\" \"AWS security,\" \"Azure security,\" \"GCP security,\" \"posture assessment,\" \"public bucket scan.\" Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping. Distinct from incident-response (active breach handling) and security-pen-testing (application vulnerability scanning). Relevant for Mo: Supabase IAM policy review before broker-owner data lands in Mo platform, Vercel environment variable hygiene across all 5 sites (momentusrealestategroup.com, askminimo.com, maureencappallo.com, moaihq.com, curbapp.co), Curb storage access policies for user-uploaded home photos. Pair with senior-secops for policy framing and threat-detection if anomalies surface."
 ---
 
 # Cloud Security

--- a/engineering-team/skills/code-reviewer/SKILL.md
+++ b/engineering-team/skills/code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "code-reviewer"
-description: Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.
+description: "When the user wants automated code review on TypeScript, JavaScript, Python, Go, Swift, or Kotlin. Triggers include \"review this PR,\" \"code review,\" \"check this code,\" \"complexity analysis,\" \"SOLID violations,\" \"code smell check,\" \"PR risk score,\" \"review checklist,\" \"audit this commit,\" \"refactor opportunities,\" \"static analysis,\" \"lint findings.\" Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, and generates review reports. Distinct from adversarial-reviewer (which interrogates assumptions and edge cases at design level) and tdd-guide (which enforces test-first discipline). Relevant for Mo: pre-merge gates on Curb (Swift/TypeScript), askminimo (Next.js), Mo platform (TypeScript/Next.js), Lighthouse (TypeScript). Pair with adversarial-reviewer for higher-stakes changes and senior-fullstack when refactor scope grows beyond a single PR."
 ---
 
 # Code Reviewer

--- a/engineering-team/skills/engineering-skills/SKILL.md
+++ b/engineering-team/skills/engineering-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "engineering-skills"
-description: "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only)."
+description: "Plugin index and orchestration router for the 23-skill engineering-team family covering architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, Azure, GCP, and MS365. Triggers include \"engineering-skills overview,\" \"what engineering skills are available,\" \"list engineering tools,\" \"engineering capabilities,\" \"engineering plugin help,\" \"what can the engineering plugin do,\" \"orchestrate engineering review.\" Relevant for Mo: this is the umbrella under which technical work for Curb (iOS plus web, dual SKU), Mo platform (Next.js plus Supabase, psychology-first matching), askminimo (Next.js, $19.99/mo agent SaaS), Lighthouse (TypeScript marketing automation), and the Personal-Website- repo (maureencappallo.com) gets routed. 30+ Python tools, stdlib-only, no paid API dependencies. Pair with senior-architect for cross-cutting design decisions and tdd-guide for the discipline layer underneath."
 version: 1.1.0
 author: Alireza Rezvani
 license: MIT

--- a/engineering-team/skills/gcp-cloud-architect/SKILL.md
+++ b/engineering-team/skills/gcp-cloud-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "gcp-cloud-architect"
-description: "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization."
+description: "When the user wants to design GCP architectures for startups or enterprises with infrastructure-as-code templates. Triggers include \"GCP architecture,\" \"Google Cloud,\" \"GKE,\" \"Cloud Run,\" \"Cloud Functions,\" \"BigQuery,\" \"Cloud SQL,\" \"Firestore,\" \"GCP cost optimization,\" \"migrate to GCP,\" \"Anthos,\" \"Dataflow,\" \"GCP IAM,\" \"VPC service controls.\" Covers Cloud Run, GKE, Functions, Cloud SQL, BigQuery, and cost-aware design. Context for Mo: GCP is NOT in Mo's current stack (Vercel plus Supabase). This skill is relevant if a side-project needs BigQuery (e.g., DFW real-estate market analysis at scale), if a partner integration runs on GCP, or when evaluating a migration scenario. Distinct from aws-solution-architect and azure-cloud-architect. Pair with senior-data-engineer if BigQuery pipelines are in scope and tech-stack-evaluator for build-vs-buy framing."
 ---
 
 # GCP Cloud Architect

--- a/engineering-team/skills/incident-commander/SKILL.md
+++ b/engineering-team/skills/incident-commander/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "incident-commander"
-description: "Comprehensive incident response framework from detection through resolution and post-incident review. Battle-tested SRE/DevOps practices: severity classification, timeline reconstruction, structured post-incident analysis. Use when declaring an incident, coordinating multi-team response during an outage, leading a post-mortem, or setting up on-call practices for a new service."
+description: "Comprehensive incident response framework from detection through resolution and post-incident review. Triggers include \"declare incident,\" \"incident command,\" \"outage,\" \"production down,\" \"sev1,\" \"sev2,\" \"on-call,\" \"post-mortem,\" \"post-incident review,\" \"runbook,\" \"escalation path,\" \"war room,\" \"incident timeline,\" \"customer-facing outage.\" Covers severity classification, timeline reconstruction, structured post-incident analysis, and on-call practice setup. Battle-tested SRE/DevOps patterns. Distinct from incident-response (security-specific lifecycle) and threat-detection (proactive hunting). Relevant for Mo: customer-facing outages on Curb (consumer iOS, in-app purchase impact), askminimo (agent-facing $19.99/mo SaaS, FUB-integrated), Mo platform (broker-owner SaaS, beta cohort), and the 5 marketing sites. Pair with senior-devops for fix path and senior-secops if the incident is security-related."
 ---
 
 # Incident Commander Skill

--- a/engineering-team/skills/incident-response/SKILL.md
+++ b/engineering-team/skills/incident-response/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "incident-response"
-description: "Use when a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Covers SEV1-SEV4 classification, false positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle."
+description: "When a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Triggers include \"security incident,\" \"breach,\" \"unauthorized access,\" \"credential leak,\" \"data exfiltration,\" \"malware detected,\" \"incident triage,\" \"SEV1 security,\" \"forensic collection,\" \"NIST 800-61,\" \"incident classification,\" \"compromise indicator.\" Covers SEV1-SEV4 classification, false-positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle. Distinct from threat-detection (proactive hunting before incident) and incident-commander (general operational outage management). Relevant for Mo: account credential exposure on FUB, MailerLite, Buffer, or GitHub; Supabase row-level-security regression that exposes broker-owner data; Curb in-app purchase fraud; askminimo API key leakage. Pair with cloud-security for posture review post-incident and senior-secops for compliance mapping."
 ---
 
 # Incident Response

--- a/engineering-team/skills/red-team/SKILL.md
+++ b/engineering-team/skills/red-team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "red-team"
-description: "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting."
+description: "When the user is planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Triggers include \"red team,\" \"attack simulation,\" \"MITRE ATT&CK kill chain,\" \"adversary emulation,\" \"OPSEC review,\" \"choke point analysis,\" \"crown jewel targeting,\" \"purple team,\" \"detection engineering test,\" \"breach simulation,\" \"adversary playbook.\" Covers ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting. Distinct from security-pen-testing (vulnerability discovery via authorized testing) and incident-response (post-incident handling). Relevant for Mo: pre-launch adversary simulation on Mo platform (broker-owner data is the crown jewel; psychology-first matching engine plus client roster), Curb in-app-purchase abuse paths, askminimo prompt-exfiltration scenarios. Pair with ai-security for LLM-specific attacks and threat-detection for downstream signal design."
 ---
 
 # Red Team

--- a/engineering-team/skills/security-pen-testing/SKILL.md
+++ b/engineering-team/skills/security-pen-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "security-pen-testing"
-description: "Use when the user asks to perform security audits, penetration testing, vulnerability scanning, OWASP Top 10 checks, or offensive security assessments. Covers static analysis, dependency scanning, secret detection, API security testing, and pen test report generation."
+description: "When the user wants to perform security audits, penetration testing, vulnerability scanning, OWASP Top 10 checks, or offensive security assessments. Triggers include \"pen test,\" \"penetration test,\" \"security audit,\" \"vulnerability scan,\" \"OWASP Top 10,\" \"static analysis,\" \"SAST,\" \"DAST,\" \"dependency scan,\" \"SBOM,\" \"secret detection,\" \"API security test,\" \"pen test report,\" \"security findings.\" Covers static analysis, dependency scanning, secret detection, API security testing, and pen test report generation. Distinct from senior-secops (compliance and policy) and senior-security (security architecture). Relevant for Mo: pre-merge SAST on Curb, askminimo, Mo platform, and Lighthouse repos; dependency CVE sweeps before Curb App Store submission; API security testing on Supabase edge functions; secret detection across all 5 marketing site repos. Pair with red-team for adversary scenarios and cloud-security for infrastructure posture."
 ---
 
 # Security Penetration Testing

--- a/engineering-team/skills/senior-devops/SKILL.md
+++ b/engineering-team/skills/senior-devops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "senior-devops"
-description: Comprehensive DevOps skill for CI/CD, infrastructure automation, containerization, and cloud platforms (AWS, GCP, Azure). Includes pipeline setup, infrastructure as code, deployment automation, and monitoring. Use when setting up pipelines, deploying applications, managing infrastructure, implementing monitoring, or optimizing deployment processes.
+description: "Comprehensive DevOps skill for CI/CD, infrastructure automation, containerization, and cloud platforms (AWS, GCP, Azure, Vercel). Triggers include \"CI/CD,\" \"GitHub Actions,\" \"deployment pipeline,\" \"infrastructure as code,\" \"Terraform,\" \"Docker,\" \"Kubernetes,\" \"deploy automation,\" \"monitoring setup,\" \"observability,\" \"rollback strategy,\" \"deployment friction,\" \"build optimization,\" \"pipeline failure.\" Covers pipeline setup, IaC, deployment automation, and monitoring. Relevant for Mo: GitHub Actions across curb-appeal-pro, ask-minimo, mo-ai, lighthouse, and Personal-Website-; Vercel deploy hygiene; Capacitor build pipeline for Curb iOS; Supabase migration automation; preview deployment policy on all 5 sites. Pair with code-reviewer for pre-merge gates, incident-commander when deploys cause outages, and senior-architect for system-level CI/CD design decisions."
 ---
 
 # Senior Devops

--- a/engineering-team/skills/senior-frontend/SKILL.md
+++ b/engineering-team/skills/senior-frontend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "senior-frontend"
-description: Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Use when building React components, optimizing Next.js performance, analyzing bundle sizes, scaffolding frontend projects, implementing accessibility, or reviewing frontend code quality.
+description: "Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Triggers include \"React component,\" \"Next.js,\" \"TypeScript,\" \"Tailwind,\" \"frontend performance,\" \"bundle size,\" \"Lighthouse score,\" \"Core Web Vitals,\" \"a11y,\" \"accessibility,\" \"scaffold frontend,\" \"server components,\" \"client components,\" \"App Router,\" \"shadcn/ui,\" \"frontend review.\" Covers component patterns, performance optimization, bundle analysis, accessibility, and project scaffolding. Critical for Mo: Mo's entire web stack is Next.js plus TypeScript plus Tailwind across askminimo, Mo platform (moaihq.com), maureencappallo.com, and the upcoming Momentus custom Sanity-plus-Next.js rebuild. Curb web wrapper also rides this stack. Pair with ui-design-system for token alignment, code-reviewer for pre-merge gates, and senior-fullstack when backend changes accompany the frontend work."
 ---
 
 # Senior Frontend

--- a/engineering-team/skills/senior-prompt-engineer/SKILL.md
+++ b/engineering-team/skills/senior-prompt-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "senior-prompt-engineer"
-description: This skill should be used when the user asks to "optimize prompts", "design prompt templates", "evaluate LLM outputs", "build agentic systems", "implement RAG", "create few-shot examples", "analyze token usage", or "design AI workflows". Use for prompt engineering patterns, LLM evaluation frameworks, agent architectures, and structured output design.
+description: "When the user wants to optimize prompts, design prompt templates, evaluate LLM outputs, build agentic systems, implement RAG, create few-shot examples, analyze token usage, or design AI workflows. Triggers include \"optimize prompt,\" \"prompt template,\" \"LLM eval,\" \"agentic system,\" \"RAG implementation,\" \"few-shot,\" \"token analysis,\" \"AI workflow,\" \"system prompt,\" \"agent architecture,\" \"structured output,\" \"tool use,\" \"chain of thought,\" \"prompt caching.\" Covers prompt patterns, LLM evaluation frameworks, agent architectures, and structured output design. Critical for Mo: Mo platform (psychology-first matching engine; LLM-backed; broker-owner SaaS), askminimo (LLM-backed agent education product, $19.99/mo), Lighthouse drafter agents (momentus-drafter, curb-drafter, askminimo-drafter, mo-drafter, maureen-drafter, final-checker), Curb home-readiness AI features. Pair with ai-security for guardrail design and claude-api for SDK-specific patterns."
 ---
 
 # Senior Prompt Engineer

--- a/engineering-team/skills/tech-stack-evaluator/SKILL.md
+++ b/engineering-team/skills/tech-stack-evaluator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "tech-stack-evaluator"
-description: Technology stack evaluation and comparison with TCO analysis, security assessment, and ecosystem health scoring. Use when comparing frameworks, evaluating technology stacks, calculating total cost of ownership, assessing migration paths, or analyzing ecosystem viability.
+description: "When the user wants to evaluate or compare technology stacks, frameworks, languages, databases, or cloud providers with data-driven analysis. Triggers include \"tech stack comparison,\" \"framework evaluation,\" \"build vs buy,\" \"TCO analysis,\" \"migration assessment,\" \"ecosystem health,\" \"language choice,\" \"database comparison,\" \"cloud provider comparison,\" \"stack audit,\" \"vendor lock-in analysis,\" \"OSS vs SaaS,\" \"alternatives to [tool].\" Covers framework comparison, TCO calculation, security assessment, and ecosystem viability scoring. Relevant for Mo: build-vs-buy decisions on Mo platform infrastructure (Supabase vs self-hosted Postgres, Vercel vs alternative host, Sanity vs Contentful for the Momentus rebuild), Curb storage and media pipeline evaluation, askminimo LLM provider comparison (Claude, OpenAI, Anthropic-via-Vercel-AI SDK). Pair with senior-architect when the decision is system-level and senior-devops when CI/CD migration cost is in scope."
 ---
 
 # Technology Stack Evaluator

--- a/engineering-team/skills/threat-detection/SKILL.md
+++ b/engineering-team/skills/threat-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "threat-detection"
-description: "Use when hunting for threats in an environment, analyzing IOCs, or detecting behavioral anomalies in telemetry. Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and MITRE ATT&CK-mapped signal prioritization."
+description: "When the user wants to hunt for threats in an environment, analyze indicators of compromise (IOCs), or detect behavioral anomalies in telemetry. Triggers include \"threat hunting,\" \"IOC sweep,\" \"behavioral anomaly,\" \"anomaly detection,\" \"z-score anomaly,\" \"telemetry analysis,\" \"MITRE ATT&CK detection,\" \"signal prioritization,\" \"detection engineering,\" \"SIEM rule,\" \"log analysis,\" \"hypothesis-driven hunt.\" Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and ATT&CK-mapped signal prioritization. Distinct from incident-response (post-detection handling) and red-team (adversary simulation). Relevant for Mo: behavioral monitoring on Mo platform once broker-owner data lands (failed-login patterns, off-hours access, unusual data export), Curb in-app purchase fraud signals, Supabase auth anomalies, Vercel function abuse detection. Pair with cloud-security for posture and ai-security if LLM-targeted attacks are in scope."
 ---
 
 # Threat Detection

--- a/marketing-skill/skills/ab-test-setup/SKILL.md
+++ b/marketing-skill/skills/ab-test-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "ab-test-setup"
-description: When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions "A/B test," "split test," "experiment," "test this change," "variant copy," "multivariate test," "hypothesis," "conversion experiment," "statistical significance," or "test this." For tracking implementation, see analytics-tracking.
+description: "When the user wants to plan, design, or implement an A/B test or experiment on a marketing asset. Triggers include \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" \"sample size calculator,\" \"test this CTA,\" \"test this headline,\" \"test this paywall.\" For tracking implementation, see analytics-tracking. For experiment design within product, see experiment-designer. Critical for Mo: Curb paywall A/B testing (Apple IAP iOS plus Stripe web dual SKU; trial length, headline, social proof, price anchor), askminimo signup hero variants, Door 02 retainer pricing page testing, Momentus website hero A/B once Sanity rebuild ships. Small-sample reality note: most Mo properties are pre-scale, so significance often requires longer windows than enterprise SaaS. Pair with marketing-psychology for hypothesis priors."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/campaign-analytics/SKILL.md
+++ b/marketing-skill/skills/campaign-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "campaign-analytics"
-description: Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.
+description: "When the user wants to analyze marketing campaign performance: multi-touch attribution, funnel conversion analysis, ROI calculation, channel comparison, or campaign optimization decisions. Triggers include \"campaign performance,\" \"attribution,\" \"marketing ROI,\" \"ROAS,\" \"CPA,\" \"CAC analysis,\" \"funnel conversion,\" \"channel performance,\" \"campaign metrics,\" \"marketing dashboard,\" \"which channel is working,\" \"what's converting,\" \"end-of-month marketing review.\" Critical for Mo: Lighthouse routine performance review (Saturday Fun Fact, Tuesday Fun Fact, GBP, DFW Events Thursday, Monday blog), Buffer post-level engagement, MailerLite open and click analysis, Door 01/02/03 page funnel tracking, askminimo signup conversion by source, Curb App Store impression to install. Pair with analytics-tracking for instrumentation gaps, marketing-ops for channel mix decisions, and ab-test-setup if performance gaps suggest a test."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/copy-editing/SKILL.md
+++ b/marketing-skill/skills/copy-editing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "copy-editing"
-description: "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes."
+description: "When the user wants to edit, review, or improve existing marketing copy. Triggers include \"edit this copy,\" \"review my copy,\" \"copy feedback,\" \"proofread,\" \"polish this,\" \"make this better,\" \"copy sweep,\" \"tighten this,\" \"editorial pass,\" \"final read,\" \"final edit,\" \"clean this up.\" Provides a systematic approach to editing through multiple focused passes. Critical for Mo: Lighthouse editorial pass before scheduling: Saturday Fun Fact captions, Tuesday Fun Fact captions, GBP posts, Reels captions, blog drafts, MailerLite emails, LinkedIn posts. Triggers include \"tighten this caption,\" \"polish before Buffer,\" \"editorial sweep on the [brand] post,\" \"final read before sending,\" \"clean up this draft.\" Voice skills plus mo-writing-rules (no em dashes, banned-words list) own final voice. This is the mechanics/copyediting layer underneath. Pair with content-humanizer for AI-tell removal first, then this for the polish pass."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/copywriting/SKILL.md
+++ b/marketing-skill/skills/copywriting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "copywriting"
-description: "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" or \"CTA copy.\" For email copy, see email-sequence. For popup copy, see popup-cro."
+description: "When the user wants to write, rewrite, or improve marketing copy for any page: homepage, landing page, pricing page, feature page, about page, product page, or paywall. Triggers include \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value prop,\" \"hero copy,\" \"pricing copy,\" \"website copy,\" \"sales copy.\" For email copy, see email-sequence. For popup copy, see popup-cro. For blog or article writing, see content-production. Critical for Mo: Lighthouse work across Momentus, Curb, askminimo, Maureen Personal, and Mo platform: work-with-me CTA, About page rewrites, paywall/pricing copy, signup pages, hero copy, investor deck slide copy, App Store description sections. Voice precedence: momentus-voice-updated-skill, maureen-personal-brand, curb-app-builder, mo, mo-writing-rules own final voice. This is the tactical copy layer underneath. Pair with brand-guidelines for visual lockup rules."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/marketing-ideas/SKILL.md
+++ b/marketing-skill/skills/marketing-ideas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "marketing-ideas"
-description: "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category."
+description: "When the user needs marketing ideas, inspiration, brainstorm prompts, or fresh tactics. Triggers include \"marketing ideas,\" \"growth ideas,\" \"how to market,\" \"marketing strategies,\" \"marketing tactics,\" \"ways to promote,\" \"ideas to grow,\" \"brainstorm marketing,\" \"give me ideas,\" \"need inspiration,\" \"campaign brainstorm,\" \"what would work for [brand].\" Provides 139 proven approaches organized by category (content, channels, partnerships, viral loops, paid, organic, retention, referral). Critical for Mo: brainstorm starting point for Lighthouse weekly content planning, Door 01 founding cohort acquisition tactics, Curb consumer growth experiments, askminimo agent acquisition ideas, Mo platform broker-owner outreach plays. NOT a substitute for strategy (use marketing-strategy-pmm or content-strategy for plans), but the spark layer that feeds them. Pair with pillar-planner for weekly content slotting once ideas are picked."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/marketing-ops/SKILL.md
+++ b/marketing-skill/skills/marketing-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "marketing-ops"
-description: "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.'"
+description: "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, growth, intelligence, and analytics. Triggers include \"marketing help,\" \"campaign plan,\" \"what should I do next,\" \"marketing priorities,\" \"coordinate marketing,\" \"which skill should I use,\" \"marketing routing,\" \"end-to-end campaign,\" \"marketing workflow,\" \"orchestrate marketing,\" \"multi-channel plan.\" Critical for Mo: Lighthouse week planning (Saturday Fun Fact, Tuesday Fun Fact, Monday blog, Thursday GBP, DFW Events Thursday, Curb 22s video, MailerLite send, LinkedIn long-form), cross-brand calendar reconciliation across Momentus, Curb, askminimo, Maureen Personal, Mo platform. Pair with pillar-planner agent for per-brand 7-day execution. Voice skill plus content-humanizer plus final-checker always gate the output."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/marketing-psychology/SKILL.md
+++ b/marketing-skill/skills/marketing-psychology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "marketing-psychology"
-description: "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application."
+description: "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Triggers include \"psychology,\" \"mental models,\" \"cognitive bias,\" \"persuasion,\" \"behavioral science,\" \"why people buy,\" \"decision-making,\" \"consumer behavior,\" \"loss aversion,\" \"social proof,\" \"anchoring,\" \"objection handling,\" \"price psychology,\" \"conversion psychology.\" Provides 70+ mental models organized for marketing application. Critical for Mo: Door 01/02/03 pricing pages, Curb $39.99 paywall, askminimo $19.99/mo signup, Mo investor deck framing (operator-as-first-customer narrative), Ready-or-Not? session positioning (People first. Houses second.), objection handling on work-with-me CTAs. Triggers include \"why isn't [page] converting,\" \"pricing psychology for [brand],\" \"apply behavioral science to [asset],\" \"objection handling for [persona].\""
 license: MIT
 metadata:
   version: 1.1.0

--- a/marketing-skill/skills/marketing-skills/SKILL.md
+++ b/marketing-skill/skills/marketing-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "marketing-skills"
-description: "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only)."
+description: "Plugin index and orchestration router for the marketing-skill family (45+ skills) covering 8 pods: content, SEO, AEO, CRO, channels, growth, intelligence, and sales. Triggers include \"marketing-skills overview,\" \"what marketing skills are available,\" \"list marketing tools,\" \"marketing capabilities,\" \"marketing plugin help,\" \"what can the marketing plugin do,\" \"orchestrate the marketing pipeline.\" Critical for Mo: this is the umbrella under which Lighthouse drafters and pillar-planning routines invoke tactical skills (copywriting, social-content, content-humanizer, copy-editing, marketing-psychology, page-cro, popup-cro, signup-flow-cro, paywall-upgrade-cro, schema-markup, ai-seo, seo-audit, programmatic-seo, content-strategy, content-production). 27 Python tools, stdlib-only, no paid API dependencies. Pair with marketing-ops for tactical routing and marketing-context if a brand context file is present in the working directory."
 version: 2.0.0
 author: Alireza Rezvani
 license: MIT

--- a/marketing-skill/skills/paid-ads/SKILL.md
+++ b/marketing-skill/skills/paid-ads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "paid-ads"
-description: "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization."
+description: "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, TikTok, YouTube, or other ad platforms. Triggers include \"paid ads,\" \"PPC,\" \"paid media,\" \"ad copy,\" \"ad creative,\" \"ROAS,\" \"CPA,\" \"ad campaign,\" \"retargeting,\" \"audience targeting,\" \"lookalike audience,\" \"Google Ads,\" \"Meta Ads,\" \"LinkedIn Ads,\" \"TikTok Ads.\" Covers campaign strategy, ad creation, audience targeting, bidding, and optimization. Critical context for Mo: paid ads are NOT currently in the Lighthouse plan. Mo is in organic-only mode while the brokerage rebuilds and the Mo platform raise closes. If a paid ads conversation starts, first confirm budget exists and that organic plays (LinkedIn long-form, Reels, Sat Fun Fact, GBP posts, MailerLite) are running. When budget IS approved, Curb is the most ad-ready surface (consumer iOS, Apple Search Ads, Meta Ads). Pair with ad-creative for the creative layer and campaign-analytics for measurement."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/popup-cro/SKILL.md
+++ b/marketing-skill/skills/popup-cro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "popup-cro"
-description: When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions "exit intent," "popup conversions," "modal optimization," "lead capture popup," "email popup," "announcement banner," or "overlay." For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.
+description: "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion. Triggers include \"popup,\" \"modal,\" \"overlay,\" \"slide-in,\" \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" \"newsletter popup,\" \"sticky bar,\" \"cookie banner CRO.\" For forms outside of popups, see form-cro. For general page conversion, see page-cro. For paywall/upgrade modals inside an app, see paywall-upgrade-cro. Critical for Mo: askminimo.com email-capture popups for the agent waitlist, Momentus website Ready or Not? session prompt (light touch only; brand rule is no urgency language and no pressure framing), maureencappallo.com Doors capture, Curb web paywall and trial conversion (consumer iOS, dual SKU). Voice skill always gates. Triggers include \"capture popup for [brand],\" \"exit intent on [page],\" \"newsletter capture.\""
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/signup-flow-cro/SKILL.md
+++ b/marketing-skill/skills/signup-flow-cro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "signup-flow-cro"
-description: When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions "signup conversions," "registration friction," "signup form optimization," "free trial signup," "reduce signup dropoff," or "account creation flow." For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.
+description: "When the user wants to optimize signup, registration, account creation, or trial activation flows. Triggers include \"signup flow,\" \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" \"account creation flow,\" \"signup CRO,\" \"shorten signup,\" \"signup field reduction,\" \"social signup,\" \"magic link signup.\" For post-signup onboarding, see onboarding-cro. For lead capture forms that are not account creation, see form-cro. Critical for Mo: askminimo agent signup ($19.99/mo, agent-facing, FUB-compatible), Curb signup flow (consumer iOS, dual SKU, Apple IAP for iOS plus Stripe for web; 7-day free trial), Mo platform beta-invite flow (psychology-first matching, founder-tier $299 plus $29/agent), Door 01 application form (founding cohort, by application). Pair with form-cro for field design specifics and onboarding-cro for the first-session experience after signup."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/social-content/SKILL.md
+++ b/marketing-skill/skills/social-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "social-content"
-description: "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' or 'viral content.' This skill covers content creation, repurposing, and platform-specific strategies."
+description: "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, YouTube, or other platforms. Triggers include \"LinkedIn post,\" \"Twitter thread,\" \"IG caption,\" \"TikTok caption,\" \"Reel hook,\" \"social media post,\" \"content calendar,\" \"social scheduling,\" \"viral content,\" \"hashtag research,\" \"carousel post,\" \"FB Page post.\" Covers content creation, repurposing, and platform-specific strategies. Critical for Mo: Buffer-bound captions across Momentus, Curb, askminimo, Maureen Personal, and Mo platform: Saturday Fun Fact, Tuesday Fun Fact, DFW Events Thursday, Curb 22-second mechanic-surface video captions, Reels hooks, IG carousel copy, LinkedIn posts, FB Page posts. Voice skill always gates. Hashtag max is 5 across all channels. Pair with content-humanizer to strip AI tells before scheduling."
 license: MIT
 metadata:
   version: 1.0.0

--- a/marketing-skill/skills/social-media-analyzer/SKILL.md
+++ b/marketing-skill/skills/social-media-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "social-media-analyzer"
-description: Social media campaign analysis and performance tracking. Calculates engagement rates, ROI, and benchmarks across platforms. Use for analyzing social media performance, calculating engagement rate, measuring campaign ROI, comparing platform metrics, or benchmarking against industry standards.
+description: "When the user wants to analyze social media campaign performance: engagement rates, ROI, platform benchmarks, post-level performance, or cross-platform comparison. Triggers include \"analyze social media,\" \"engagement rate,\" \"social media ROI,\" \"campaign performance,\" \"social benchmark,\" \"which post worked,\" \"viral analysis,\" \"post-level performance,\" \"cross-platform comparison,\" \"social analytics,\" \"LinkedIn engagement,\" \"IG engagement,\" \"TikTok performance.\" Distinct from campaign-analytics (which covers all marketing channels including paid, email, web) and from social-media-manager (which covers ops and scheduling). Critical for Mo: Buffer post-level analytics across Momentus, Curb, askminimo, Maureen Personal, and Mo platform; which Reels are converting; LinkedIn long-form post performance for Maureen Personal; FB Page engagement on the Momentus page. Pair with content-strategy when patterns emerge that should reshape the calendar, and with social-content for next-week iteration."
 triggers:
   - analyze social media
   - calculate engagement rate

--- a/product-team/skills/product-discovery/SKILL.md
+++ b/product-team/skills/product-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-discovery
-description: Use when validating product opportunities, mapping assumptions, planning discovery sprints, or testing problem-solution fit before committing delivery resources.
+description: "When the user wants to validate product opportunities, map assumptions, plan discovery sprints, or test problem-solution fit before committing delivery resources. Triggers include \"product discovery,\" \"validate opportunity,\" \"assumption mapping,\" \"discovery sprint,\" \"problem-solution fit,\" \"de-risk product bet,\" \"Teresa Torres,\" \"continuous discovery,\" \"opportunity solution tree,\" \"customer interview,\" \"JTBD interview,\" \"riskiest assumption test.\" Distinct from product-strategist (long-range positioning and OKR work) and ux-researcher-designer (focused on research methods and synthesis). Relevant for Mo: Mo platform broker-owner discovery interviews (validating psychology-first matching as the wedge before scaling beta), Curb consumer feature discovery (which home-prep mechanic surfaces drive the most virality), askminimo agent discovery (which AI workflow do agents actually want vs. tolerate), Door 01 cohort discovery (rebuild intensive value-prop testing). Pair with experiment-designer once hypotheses are sharp enough to test and competitive-teardown for market context."
 ---
 
 # Product Discovery

--- a/product-team/skills/product-skills/SKILL.md
+++ b/product-team/skills/product-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "product-skills"
-description: "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only)."
+description: "Plugin index and orchestration router for the 10-skill product-team family covering PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher/designer, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, product discovery, roadmap communicator, spec-to-repo, and research summarizer. Triggers include \"product-skills overview,\" \"what product skills are available,\" \"list product tools,\" \"product capabilities,\" \"product plugin help,\" \"what can the product plugin do.\" Relevant for Mo: this is the umbrella under which product decisions for Mo platform (psychology-first matching, broker-owner SaaS, founder-tier pricing), Curb (consumer iOS, dual SKU, home-readiness score), askminimo ($19.99/mo agent AI tool), and Maureen Personal (Door 01/02/03 founder-led offerings) get routed. Pair with marketing-skills for GTM execution and engineering-skills for build."
 version: 1.1.0
 author: Alireza Rezvani
 license: MIT

--- a/product-team/skills/roadmap-communicator/SKILL.md
+++ b/product-team/skills/roadmap-communicator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-communicator
-description: Use when preparing roadmap narratives, release notes, changelogs, or stakeholder updates tailored for executives, engineering teams, and customers.
+description: "When the user wants to prepare roadmap narratives, release notes, changelogs, internal updates, customer announcements, or stakeholder updates tailored for different audiences. Triggers include \"roadmap narrative,\" \"release notes,\" \"changelog,\" \"stakeholder update,\" \"product update,\" \"internal announcement,\" \"customer announcement,\" \"executive roadmap,\" \"engineering roadmap,\" \"product communication,\" \"now next later,\" \"board roadmap update.\" Tailors voice and depth for executives, engineering teams, customers, and investors. Critical for Mo: Mo platform investor update cadence (monthly, focused on operator-as-first-customer narrative and waitlist growth), Curb release notes for the App Store (consumer iOS, plain-language, no Mo-platform cross-contamination), askminimo agent-facing changelog ($19.99/mo SaaS), Lighthouse internal weekly digest. Voice precedence: maureen-personal-brand for investor-facing, curb-app-builder for consumer-facing, mo for Mo Inc investor materials. Pair with internal-comms for tone matching."
 ---
 
 # Roadmap Communicator

--- a/product-team/skills/spec-to-repo/SKILL.md
+++ b/product-team/skills/spec-to-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-to-repo
-description: "Use when the user says 'build me an app', 'create a project from this spec', 'scaffold a new repo', 'generate a starter', 'turn this idea into code', 'bootstrap a project', 'I have requirements and need a codebase', or provides a natural-language project specification and expects a complete, runnable repository. Stack-agnostic: Next.js, FastAPI, Rails, Go, Rust, Flutter, and more."
+description: "When the user says \"build me an app,\" \"create a project from this spec,\" \"scaffold a new repo,\" \"generate a starter,\" \"turn this idea into code,\" \"bootstrap a project,\" \"I have requirements and need a codebase,\" or provides a natural-language project specification and expects a complete, runnable repository. Stack-agnostic: Next.js, FastAPI, Rails, Go, Rust, Flutter, Capacitor, and more. Triggers include \"spec to repo,\" \"generate starter,\" \"scaffold from spec,\" \"build from requirements,\" \"new repo from PRD.\" Distinct from saas-scaffolder (opinionated SaaS template, not freeform spec) and from product-manager-toolkit (RICE and roadmap, not code). Relevant for Mo: prototyping new internal tools for Lighthouse or Momentus ops, fast-tracking Door 03 client side-projects when needed, generating throwaway test repos to validate stack choices. Pair with tech-stack-evaluator before committing to the stack and senior-architect when the starter graduates into a real product."
 ---
 
 # Spec to Repo

--- a/product-team/skills/ui-design-system/SKILL.md
+++ b/product-team/skills/ui-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "ui-design-system"
-description: UI design system toolkit for Senior UI Designer including design token generation, component documentation, responsive design calculations, and developer handoff tools. Use for creating design systems, maintaining visual consistency, and facilitating design-dev collaboration.
+description: "When the user wants to design or maintain a UI design system: design tokens, color palettes, typography scales, component documentation, responsive grids, or design-to-developer handoff. Triggers include \"design system,\" \"design tokens,\" \"color palette,\" \"typography scale,\" \"component library,\" \"shadcn/ui setup,\" \"design handoff,\" \"design-to-dev,\" \"Figma to code,\" \"responsive grid,\" \"design tokens Tailwind,\" \"system documentation.\" Distinct from senior-frontend (implementation) and brand-guidelines (visual brand rules and logo lockups). Critical for Mo: Curb design system (consumer iOS, brand-isolated from Momentus, gold and pearl-white palette is Momentus-specific and must stay out of Curb), askminimo agent-facing UI tokens, Mo platform broker-owner UI tokens (psychology-first product framing per locked rule, NOT CRM/automation styling), maureencappallo.com Doors palette, Momentus custom Sanity-plus-Next.js rebuild. Pair with senior-frontend for implementation and brand-guidelines for visual identity rules."
 ---
 
 # UI Design System

--- a/product-team/skills/ux-researcher-designer/SKILL.md
+++ b/product-team/skills/ux-researcher-designer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "ux-researcher-designer"
-description: UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation.
+description: "When the user wants to do UX research and design work: data-driven personas, journey mapping, usability test planning, research synthesis, or design validation. Triggers include \"UX research,\" \"persona generation,\" \"journey map,\" \"usability test,\" \"user interview,\" \"research synthesis,\" \"design validation,\" \"qualitative research,\" \"user observation,\" \"customer journey,\" \"empathy map,\" \"task analysis,\" \"design research.\" Distinct from product-discovery (validating opportunities before build) and ui-design-system (visual system, not research). Relevant for Mo: Mo platform broker-owner persona development (operator pain points around onboarding, agent matching, retention), Curb consumer homeowner journey mapping (pre-listing prep, Sell-Ready Date mechanic, score-to-action), askminimo agent persona research (workflow vs hype expectations), Door 01 founding-cohort interview synthesis. Pair with product-discovery upstream and competitive-teardown for context."
 ---
 
 # UX Researcher & Designer


### PR DESCRIPTION
## What

Phase 2 of the SKILL.md description rewrite series. Companion to [PR #682](https://github.com/alirezarezvani/claude-skills/pull/682) which strengthened 24 descriptions. This PR strengthens 35 more across the same three plugins:

- **marketing-skill (13):** copywriting, copy-editing, social-content, campaign-analytics, marketing-psychology, marketing-ideas, marketing-ops, marketing-skills (plugin index), ab-test-setup, popup-cro, signup-flow-cro, paid-ads, social-media-analyzer
- **engineering-team (16):** ai-security, cloud-security, incident-response, red-team, security-pen-testing, threat-detection, aws-solution-architect, azure-cloud-architect, gcp-cloud-architect, senior-devops, senior-frontend, senior-prompt-engineer, code-reviewer, incident-commander, tech-stack-evaluator, engineering-skills (plugin index)
- **product-team (6):** product-discovery, roadmap-communicator, spec-to-repo, ui-design-system, ux-researcher-designer, product-skills (plugin index)

Same pattern as #682:

- 8-12 explicit trigger phrase variants in the description text
- Disambiguation from adjacent skills (\"Distinct from X\", \"NOT for Y, use Z\")
- Concrete use-case grounding that helps the model decide when to invoke
- Pairing hints with other skills in the family

The `marketing-skills` plugin-index description was also updated to reflect the v2.7.3 expansion (45 skills, 8 pods including AEO).

## Why

Same rationale as #682: Claude Code's available-skills surface uses `description:` for auto-trigger relevance. Thin descriptions never fire automatically. The rewrites bring under-described skills up to the standard the better ones already meet.

## Format notes

- Descriptions use double-quoted YAML strings with escaped double-quotes for inline trigger phrases (`\"trigger phrase\"`)
- ~700-1500 chars per description
- Body content unchanged on all 35 files (diff is exactly 1 line in / 1 line out per file)
- Pre-flight validator confirmed no em dashes, no quote-escape errors, all parse cleanly

## Brand-specific framing

Following the precedent established in #682, several descriptions include concrete brand examples from the empirical use case that drove the rewrites (Curb, askminimo, Momentus, Mo platform, Maureen Personal, Door 01/02/03, Lighthouse routines). These act as concrete grounding hints that demonstrably improve auto-trigger reliability. Happy to genericize if you prefer, but the concrete grounding is the signal-strength differentiator.

## Combined with #682

If both PRs land, 59 of the 90 skills across these three plugins (66%) will have strong auto-triggering descriptions. The remaining ~31 already shipped well-described.

## Commits

One commit per plugin so this can be cherry-picked phased if helpful:

- `docs(marketing-skill): strengthen description frontmatter on 13 more skills`
- `docs(engineering-team): strengthen description frontmatter on 16 more skills`
- `docs(product-team): strengthen description frontmatter on 6 more skills`

## Testing

Tested in production on Maureen Cappallo's Claude Code installation (Claude Code 2.1.132, Claude Opus 4.7). Skills invoke correctly by name and do not break any existing plugin functionality.