### PR TITLE
fix(engineering-team): make inspect-assets.py --help work without Pillow

### DIFF
--- a/engineering-team/skills/epic-design/SKILL.md
+++ b/engineering-team/skills/epic-design/SKILL.md
@@ -65,6 +65,7 @@ Before writing a single line of code, do ALL of the following in order.
 ### B. Inspect every uploaded image asset
 
 Run `scripts/inspect-assets.py` on every image the user has provided.
+> **Optional runtime dependency:** `pip install Pillow` — required for image analysis, not for `--help`.
 For each image, determine:
 
 1. **Format** — JPEG never has a real alpha channel. PNG may have a fake one.

--- a/engineering-team/skills/epic-design/scripts/inspect-assets.py
+++ b/engineering-team/skills/epic-design/scripts/inspect-assets.py
@@ -15,17 +15,18 @@ The AI reads this output and uses it to inform the user.
 The script NEVER modifies images — inspect only.
 """
 
+import argparse
+import json
 import sys
 import os
 
-try:
-    from PIL import Image
-except ImportError:
-    print("PIL not found. Install with: pip install Pillow")
-    sys.exit(1)
-
 
 def analyse_image(path):
+    try:
+        from PIL import Image
+    except ImportError:
+        print("Error: Pillow not installed. Install with: pip install Pillow")
+        sys.exit(2)
     result = {
         "path": path,
         "filename": os.path.basename(path),
@@ -234,21 +235,35 @@ def collect_paths(args):
     return paths
 
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2 or sys.argv[1] in ('-h', '--help'):
-        print("\nUsage:")
-        print("  python scripts/inspect-assets.py image.png")
-        print("  python scripts/inspect-assets.py image1.jpg image2.png")
-        print("  python scripts/inspect-assets.py path/to/folder/\n")
-        if len(sys.argv) < 2:
-            sys.exit(1)
-        else:
-            sys.exit(0)
+def main():
+    parser = argparse.ArgumentParser(
+        description="2.5D Asset Inspector — checks images for background type, "
+        "transparency, and depth-level recommendations."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Image files or directories to inspect",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    args = parser.parse_args()
 
-    paths = collect_paths(sys.argv[1:])
+    paths = collect_paths(args.paths)
     if not paths:
         print("No valid image files found.")
         sys.exit(1)
 
     results = [analyse_image(p) for p in paths]
-    print_report(results)
+
+    if args.json:
+        print(json.dumps(results, indent=2, default=str))
+    else:
+        print_report(results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- What: Lazy-import PIL inside `analyse_image()` so `--help` works without Pillow; add proper argparse with `--json` output support.
- Why: `inspect-assets.py` was the only 1 of 409 Python tools failing `--help` due to a module-level PIL import. This restores 409/409 `--help` compliance.

## Changes
- Moved `from PIL import Image` from module top-level into `analyse_image()` (lazy import)
- Replaced manual `sys.argv` help handling with `argparse.ArgumentParser`
- Added `--json` flag for structured output (per project conventions)
- Updated SKILL.md to document Pillow as optional runtime dependency

## Acceptance Criteria (from #653)
- [x] `python3 inspect-assets.py --help` exits 0 and shows argparse help WITHOUT Pillow
- [x] `python3 inspect-assets.py <image>` exits with install instructions if Pillow missing
- [x] Pillow noted as optional runtime dep in SKILL.md
- [x] `script_tester.py` confirms: argparse ✓, help text ✓, JSON output ✓

## Checklist
- [x] Targets dev branch
- [x] SKILL.md frontmatter: name + description only (no changes to frontmatter)
- [x] Scripts pass --help
- [x] Scripts use stdlib only (PIL is optional runtime dep, not required for --help)
- [x] Scripts support --json output
- [x] No modifications to .codex/, .gemini/, marketplace.json
- [x] No 3rd party links added
- [x] Clean diff — single commit, no merge history

Fixes #653