### PR TITLE
fix(plugin.json): drop "./" prefix from skills field to clear /doctor warning (#686)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,9 +299,9 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
    - `source` (object) — provenance metadata for skills built via Path-B megaprompt conversion. Recommended shape: `{spec: "megaprompts/NN-name.md", build_pattern: "...", distinct_from: "..."}`. Used by all 13 v2 megaprompt-derived skills (productivity/, marketing/, research/).
    - `attribution` (object) — credit metadata for skills derived from external MIT-licensed work. Used by `engineering/caveman`, `engineering/grill-me`, `engineering/grill-with-docs` (Matt Pocock derivatives).
 
-   No other extras. The `skills` value depends on the plugin layout (Claude Code v2.1.107+ rejects bare `"./"`):
+   No other extras. The `skills` value depends on the plugin layout (Claude Code v2.1.107+ rejects bare `"./"`, and v2.1.133+ rejects `"./skills"` with a "Path escapes plugin directory" warning — drop the `./` prefix):
    - Single-skill plugin (SKILL.md at root): `"skills": ["./"]` (array form required).
-   - Plugin with `./skills/` subdir: `"skills": "./skills"`.
+   - Plugin with `skills/` subdir: `"skills": "skills"` (no `./` prefix — see issue #686).
    - Multi-skill domain plugin (skills are subfolders at root): `"skills": ["./sub1", "./sub2", ...]` (explicit list, omit `"./"` to avoid namespace collision with the index SKILL.md).
 6. **Version follows repo versioning.** ClawHub package versions must match the repo release version (currently v2.7.0+).
 

--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
+++ b/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-customer-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-data-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
+++ b/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/general-counsel-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/vpe-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering-team/a11y-audit/.claude-plugin/plugin.json
+++ b/engineering-team/a11y-audit/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
+++ b/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
@@ -8,6 +8,6 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills",
+  "skills": "skills",
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/google-workspace-cli"
 }

--- a/engineering-team/playwright-pro/.claude-plugin/plugin.json
+++ b/engineering-team/playwright-pro/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/playwright-pro",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -8,6 +8,6 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills",
+  "skills": "skills",
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent"
 }

--- a/engineering-team/snowflake-development/.claude-plugin/plugin.json
+++ b/engineering-team/snowflake-development/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/snowflake-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/agenthub/.claude-plugin/plugin.json
+++ b/engineering/agenthub/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/agenthub",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/autoresearch-agent/.claude-plugin/plugin.json
+++ b/engineering/autoresearch-agent/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/autoresearch-agent",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/behuman/.claude-plugin/plugin.json
+++ b/engineering/behuman/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/behuman",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/chaos-engineering/.claude-plugin/plugin.json
+++ b/engineering/chaos-engineering/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/chaos-engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/code-tour/.claude-plugin/plugin.json
+++ b/engineering/code-tour/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/code-tour",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/data-quality-auditor/.claude-plugin/plugin.json
+++ b/engineering/data-quality-auditor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/data-quality-auditor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/demo-video/.claude-plugin/plugin.json
+++ b/engineering/demo-video/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/docker-development/.claude-plugin/plugin.json
+++ b/engineering/docker-development/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/docker-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/feature-flags-architect/.claude-plugin/plugin.json
+++ b/engineering/feature-flags-architect/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/feature-flags-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/helm-chart-builder/.claude-plugin/plugin.json
+++ b/engineering/helm-chart-builder/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/helm-chart-builder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/karpathy-coder/.claude-plugin/plugin.json
+++ b/engineering/karpathy-coder/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/kubernetes-operator/.claude-plugin/plugin.json
+++ b/engineering/kubernetes-operator/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/kubernetes-operator",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
+++ b/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-cost-optimizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/llm-wiki/.claude-plugin/plugin.json
+++ b/engineering/llm-wiki/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/prompt-governance/.claude-plugin/plugin.json
+++ b/engineering/prompt-governance/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/prompt-governance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/slo-architect/.claude-plugin/plugin.json
+++ b/engineering/slo-architect/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/statistical-analyst/.claude-plugin/plugin.json
+++ b/engineering/statistical-analyst/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/statistical-analyst",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/engineering/terraform-patterns/.claude-plugin/plugin.json
+++ b/engineering/terraform-patterns/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/terraform-patterns",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/finance/business-investment-advisor/.claude-plugin/plugin.json
+++ b/finance/business-investment-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance/business-investment-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
+++ b/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/video-content-strategist",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/product-team/agile-product-owner/.claude-plugin/plugin.json
+++ b/product-team/agile-product-owner/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/product-team/apple-hig-expert/.claude-plugin/plugin.json
+++ b/product-team/apple-hig-expert/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/product-team/code-to-prd/.claude-plugin/plugin.json
+++ b/product-team/code-to-prd/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/code-to-prd",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/product-team/research-summarizer/.claude-plugin/plugin.json
+++ b/product-team/research-summarizer/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/research-summarizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }

--- a/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": "skills"
 }


### PR DESCRIPTION
## Summary

Fixes #686 — Claude Code `/doctor` rejects `"skills": "./skills"` in all marketplace plugin.json files with a "Path escapes plugin directory" warning, preventing skills from loading.

- Replaced `"skills": "./skills"` with `"skills": "skills"` across **47 plugin.json files** (the 9 main domain plugins called out in the bug, plus all 38 sibling sub-plugins exposed in the marketplace, since they share the same manifest pattern and would hit the same validator bug).
- Updated `CLAUDE.md` ClawHub publishing constraints section to document the new convention, the Claude Code 2.1.133+ behavior, and reference the issue.

## Why

`./skills` and `skills` resolve to the same path inside the plugin root, but Claude Code's plugin validator (≥2.1.133) treats the leading `./` as a path-escape attempt and silently drops the skill registration. The upstream docs example already uses `"skills": "skills"` (no prefix), so this is the safer, more broadly compatible spelling — works on every CC version plus Codex, Gemini CLI, etc.

## Test plan

- [x] All 47 plugin.json files still parse as valid JSON (`json.load` over the full tree — clean).
- [x] No remaining `"skills": "./skills"` matches anywhere in the repo (`grep -r` clean).
- [ ] After merge: run `/doctor` in Claude Code with these plugins installed — expect zero "Path escapes plugin directory" warnings.
- [ ] After merge: confirm skills under each plugin's `skills/` directory now load and are listed.

Closes #686.

https://claude.ai/code/session_018tVmuJqtHY7Z6zB54nrorC

---
_Generated by [Claude Code](https://claude.ai/code/session_018tVmuJqtHY7Z6zB54nrorC)_