### PR TITLE
Fix link to Skills & Agents Factory in documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,7 +249,7 @@ my-skill/
   assets/        # Templates (optional)
 ```
 
-See the [Skills & Agents Factory](https://github.com/alirezarezvani/claude-code-skills-agents-factory) for a complete guide.
+See the [Skills & Agents Factory]((https://github.com/alirezarezvani/claude-code-skill-factory)) for a complete guide.
 
 <hr class="section-divider">
 


### PR DESCRIPTION
## Summary

<!-- What does this PR add or change? -->

## Checklist

- [ ] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [ ] Scripts (if any) run with `--help` without errors
- [ ] No hardcoded API keys, tokens, or secrets
- [ ] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

<!-- How did you verify this works? -->
