### PR TITLE
fix(engineering): prefix skills path with "./" in plugin.json

### DIFF
--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": "./skills"
 }


### PR DESCRIPTION
## Bug Description

  The `engineering-advanced-skills` plugin fails to install via Claude Code's plugin system with:

  Validation errors: skills: Invalid input

  ## Root Cause

  Claude Code's internal Zod schema validates the `"skills"` field with `z.string().startsWith("./")`. The current value `"skills": "skills"` (without the `./` prefix) fails this validation on v2.1.144.

  ## Fix

  ```diff
  -  "skills": "skills"
  +  "skills": "./skills"

  Verification

  $ claude plugin validate ./engineering
  # Before: ✘ skills: Invalid input
  # After:  ✔ Validation passed

  Tested on Claude Code v2.1.144. The superpowers plugin (official, v5.1.0) omits the field entirely and relies on auto-discovery — "./skills" also works and is explicit.

  Note

  This fix only addresses engineering/.claude-plugin/plugin.json. Other sub-plugins in this repo have the same issue but are left untouched to keep the diff minimal. A follow-up PR could fix all 68 manifests and update
  scripts/check_plugin_json.py + CLAUDE.md which currently reject the "./" prefix based on outdated information (issue #686 may have been fixed upstream in Claude Code between v2.1.133 and v2.1.144).