### PR TITLE
fix the syntax of skill to match Claude

### DIFF
--- a/.gemini/skills-index.json
+++ b/.gemini/skills-index.json
@@ -1266,7 +1266,7 @@
     {
       "name": "run",
       "category": "engineering-advanced",
-      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
+      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
     },
     {
       "name": "runbook-generator",
@@ -1331,7 +1331,7 @@
     {
       "name": "skills-run",
       "category": "engineering-advanced",
-      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
+      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
     },
     {
       "name": "skills-slo-architect",
@@ -1341,7 +1341,7 @@
     {
       "name": "skills-status",
       "category": "engineering-advanced",
-      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
+      "description": "Show experiment dashboard with results, active loops, and progress."
     },
     {
       "name": "slo-architect",
@@ -1371,7 +1371,7 @@
     {
       "name": "status",
       "category": "engineering-advanced",
-      "description": "Show experiment dashboard with results, active loops, and progress."
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
     },
     {
       "name": "tc-tracker",

--- a/.gemini/skills/chaos-engineering/SKILL.md
+++ b/.gemini/skills/chaos-engineering/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/chaos-engineering/SKILL.md
+../../../engineering/chaos-engineering/skills/chaos-engineering/SKILL.md

--- a/.gemini/skills/chief-ai-officer-advisor/SKILL.md
+++ b/.gemini/skills/chief-ai-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/chief-ai-officer-advisor/SKILL.md
+../../../c-level-advisor/chief-ai-officer-advisor/skills/chief-ai-officer-advisor/SKILL.md

--- a/.gemini/skills/chief-customer-officer-advisor/SKILL.md
+++ b/.gemini/skills/chief-customer-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/chief-customer-officer-advisor/SKILL.md
+../../../c-level-advisor/chief-customer-officer-advisor/skills/chief-customer-officer-advisor/SKILL.md

--- a/.gemini/skills/chief-data-officer-advisor/SKILL.md
+++ b/.gemini/skills/chief-data-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/chief-data-officer-advisor/SKILL.md
+../../../c-level-advisor/chief-data-officer-advisor/skills/chief-data-officer-advisor/SKILL.md

--- a/.gemini/skills/eu-ai-act-specialist/SKILL.md
+++ b/.gemini/skills/eu-ai-act-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/skills/eu-ai-act-specialist/SKILL.md
+../../../ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/SKILL.md

--- a/.gemini/skills/feature-flags-architect/SKILL.md
+++ b/.gemini/skills/feature-flags-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/feature-flags-architect/SKILL.md
+../../../engineering/feature-flags-architect/skills/feature-flags-architect/SKILL.md

--- a/.gemini/skills/general-counsel-advisor/SKILL.md
+++ b/.gemini/skills/general-counsel-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/general-counsel-advisor/SKILL.md
+../../../c-level-advisor/general-counsel-advisor/skills/general-counsel-advisor/SKILL.md

--- a/.gemini/skills/iso42001-specialist/SKILL.md
+++ b/.gemini/skills/iso42001-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/skills/iso42001-specialist/SKILL.md
+../../../ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/SKILL.md

--- a/.gemini/skills/kubernetes-operator/SKILL.md
+++ b/.gemini/skills/kubernetes-operator/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/kubernetes-operator/SKILL.md
+../../../engineering/kubernetes-operator/skills/kubernetes-operator/SKILL.md

--- a/.gemini/skills/run/SKILL.md
+++ b/.gemini/skills/run/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/autoresearch-agent/skills/run/SKILL.md
+../../../engineering/agenthub/skills/run/SKILL.md

--- a/.gemini/skills/skills-chaos-engineering/SKILL.md
+++ b/.gemini/skills/skills-chaos-engineering/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/chaos-engineering/skills/chaos-engineering/SKILL.md
+../../../engineering/skills/chaos-engineering/SKILL.md

--- a/.gemini/skills/skills-chief-ai-officer-advisor/SKILL.md
+++ b/.gemini/skills/skills-chief-ai-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/chief-ai-officer-advisor/skills/chief-ai-officer-advisor/SKILL.md
+../../../c-level-advisor/skills/chief-ai-officer-advisor/SKILL.md

--- a/.gemini/skills/skills-chief-customer-officer-advisor/SKILL.md
+++ b/.gemini/skills/skills-chief-customer-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/chief-customer-officer-advisor/skills/chief-customer-officer-advisor/SKILL.md
+../../../c-level-advisor/skills/chief-customer-officer-advisor/SKILL.md

--- a/.gemini/skills/skills-chief-data-officer-advisor/SKILL.md
+++ b/.gemini/skills/skills-chief-data-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/chief-data-officer-advisor/skills/chief-data-officer-advisor/SKILL.md
+../../../c-level-advisor/skills/chief-data-officer-advisor/SKILL.md

--- a/.gemini/skills/skills-eu-ai-act-specialist/SKILL.md
+++ b/.gemini/skills/skills-eu-ai-act-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/SKILL.md
+../../../ra-qm-team/skills/eu-ai-act-specialist/SKILL.md

--- a/.gemini/skills/skills-feature-flags-architect/SKILL.md
+++ b/.gemini/skills/skills-feature-flags-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/feature-flags-architect/skills/feature-flags-architect/SKILL.md
+../../../engineering/skills/feature-flags-architect/SKILL.md

--- a/.gemini/skills/skills-general-counsel-advisor/SKILL.md
+++ b/.gemini/skills/skills-general-counsel-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/general-counsel-advisor/skills/general-counsel-advisor/SKILL.md
+../../../c-level-advisor/skills/general-counsel-advisor/SKILL.md

--- a/.gemini/skills/skills-iso42001-specialist/SKILL.md
+++ b/.gemini/skills/skills-iso42001-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/SKILL.md
+../../../ra-qm-team/skills/iso42001-specialist/SKILL.md

--- a/.gemini/skills/skills-kubernetes-operator/SKILL.md
+++ b/.gemini/skills/skills-kubernetes-operator/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/kubernetes-operator/skills/kubernetes-operator/SKILL.md
+../../../engineering/skills/kubernetes-operator/SKILL.md

--- a/.gemini/skills/skills-run/SKILL.md
+++ b/.gemini/skills/skills-run/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/agenthub/skills/run/SKILL.md
+../../../engineering/autoresearch-agent/skills/run/SKILL.md

--- a/.gemini/skills/skills-slo-architect/SKILL.md
+++ b/.gemini/skills/skills-slo-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/slo-architect/skills/slo-architect/SKILL.md
+../../../engineering/skills/slo-architect/SKILL.md

--- a/.gemini/skills/skills-status/SKILL.md
+++ b/.gemini/skills/skills-status/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/agenthub/skills/status/SKILL.md
+../../../engineering/autoresearch-agent/skills/status/SKILL.md

--- a/.gemini/skills/skills-vpe-advisor/SKILL.md
+++ b/.gemini/skills/skills-vpe-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/vpe-advisor/skills/vpe-advisor/SKILL.md
+../../../c-level-advisor/skills/vpe-advisor/SKILL.md

--- a/.gemini/skills/slo-architect/SKILL.md
+++ b/.gemini/skills/slo-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/slo-architect/SKILL.md
+../../../engineering/slo-architect/skills/slo-architect/SKILL.md

--- a/.gemini/skills/status/SKILL.md
+++ b/.gemini/skills/status/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/autoresearch-agent/skills/status/SKILL.md
+../../../engineering/agenthub/skills/status/SKILL.md

--- a/.gemini/skills/vpe-advisor/SKILL.md
+++ b/.gemini/skills/vpe-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/vpe-advisor/SKILL.md
+../../../c-level-advisor/vpe-advisor/skills/vpe-advisor/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # IDE and OS
 .vscode
 .DS_Store
-
+venv
 # Environment files
 .env
 .env.*

--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
+++ b/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-customer-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-data-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
+++ b/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/general-counsel-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vpe-advisor",
-  "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification), eng hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes), eng team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references: DORA framework, eng hiring funnel, eng team structure (Conway's Law), production discipline (on-call, incidents, deployment, SLOs). Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill — VPE owns how the team ships, CTO owns what to build.",
+  "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification), eng hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes), eng team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references: DORA framework, eng hiring funnel, eng team structure (Conway's Law), production discipline (on-call, incidents, deployment, SLOs). Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill \u2014 VPE owns how the team ships, CTO owns what to build.",
   "version": "1.0.0",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/vpe-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/a11y-audit/.claude-plugin/plugin.json
+++ b/engineering-team/a11y-audit/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes the `plugin.json` schema for Claude Code compatibility and corrects broken `.gemini/` skill symlinks.

**Problem:** Most `plugin.json` files declared `"skills": "skills"` (string), which Claude Code's plugin loader rejects with `Validation errors: skills: Invalid input` — every bundle install fails:

```
[ERROR] installPluginFromMarketplace failed for engineering-advanced-skills@claude-code-skills:
Validation errors: skills: Invalid input
```

**Fix:**
- `plugin.json` — change `"skills": "skills"` → `"skills": ["./skills"]` (array form required by the Claude Code plugin schema). Affects `business-growth`, `c-level-advisor`, and other bundles in this PR.
- `.gemini/skills/*/SKILL.md` symlinks — repoint from `<bundle>/skills/<skill>/SKILL.md` to `<bundle>/<skill>/skills/<skill>/SKILL.md` (actual location after the per-skill nesting refactor). 27 symlinks fixed.
- `.gemini/skills-index.json` — correct 4 swapped descriptions (`run` ↔ `skills-run`, `status` ↔ `skills-status`).
- `.gitignore` — minor cleanup.

## Type of Change

- [x] Bug fix
- [x] Infrastructure / CI

## Testing

Verified locally against Claude Code 2.1.145:

- **Before:** `/plugin install engineering-advanced-skills@claude-code-skills` fails with `Validation errors: skills: Invalid input`.
- **After:** install succeeds for all umbrella bundles (engineering-advanced-skills, engineering-skills, c-level-skills, c-level-agents, marketing-skills, product-skills, pm-skills, pw, business-operations-skills, commercial-skills).

## Checklist

- [x] Target branch is `dev`
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies
- [x] Follows existing directory structure