### PR TITLE
fix(plugin.json): schema-valid skills field + fix .gemini symlinks (was #713)

### DIFF
--- a/.gemini/skills-index.json
+++ b/.gemini/skills-index.json
@@ -1266,7 +1266,7 @@
     {
       "name": "run",
       "category": "engineering-advanced",
-      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
+      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
     },
     {
       "name": "runbook-generator",
@@ -1331,7 +1331,7 @@
     {
       "name": "skills-run",
       "category": "engineering-advanced",
-      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
+      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
     },
     {
       "name": "skills-slo-architect",
@@ -1341,7 +1341,7 @@
     {
       "name": "skills-status",
       "category": "engineering-advanced",
-      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
+      "description": "Show experiment dashboard with results, active loops, and progress."
     },
     {
       "name": "slo-architect",
@@ -1371,7 +1371,7 @@
     {
       "name": "status",
       "category": "engineering-advanced",
-      "description": "Show experiment dashboard with results, active loops, and progress."
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
     },
     {
       "name": "tc-tracker",

--- a/.gemini/skills/chaos-engineering/SKILL.md
+++ b/.gemini/skills/chaos-engineering/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/chaos-engineering/SKILL.md
+../../../engineering/chaos-engineering/skills/chaos-engineering/SKILL.md

--- a/.gemini/skills/chief-ai-officer-advisor/SKILL.md
+++ b/.gemini/skills/chief-ai-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/chief-ai-officer-advisor/SKILL.md
+../../../c-level-advisor/chief-ai-officer-advisor/skills/chief-ai-officer-advisor/SKILL.md

--- a/.gemini/skills/chief-customer-officer-advisor/SKILL.md
+++ b/.gemini/skills/chief-customer-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/chief-customer-officer-advisor/SKILL.md
+../../../c-level-advisor/chief-customer-officer-advisor/skills/chief-customer-officer-advisor/SKILL.md

--- a/.gemini/skills/chief-data-officer-advisor/SKILL.md
+++ b/.gemini/skills/chief-data-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/chief-data-officer-advisor/SKILL.md
+../../../c-level-advisor/chief-data-officer-advisor/skills/chief-data-officer-advisor/SKILL.md

--- a/.gemini/skills/eu-ai-act-specialist/SKILL.md
+++ b/.gemini/skills/eu-ai-act-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/skills/eu-ai-act-specialist/SKILL.md
+../../../ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/SKILL.md

--- a/.gemini/skills/feature-flags-architect/SKILL.md
+++ b/.gemini/skills/feature-flags-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/feature-flags-architect/SKILL.md
+../../../engineering/feature-flags-architect/skills/feature-flags-architect/SKILL.md

--- a/.gemini/skills/general-counsel-advisor/SKILL.md
+++ b/.gemini/skills/general-counsel-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/general-counsel-advisor/SKILL.md
+../../../c-level-advisor/general-counsel-advisor/skills/general-counsel-advisor/SKILL.md

--- a/.gemini/skills/iso42001-specialist/SKILL.md
+++ b/.gemini/skills/iso42001-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/skills/iso42001-specialist/SKILL.md
+../../../ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/SKILL.md

--- a/.gemini/skills/kubernetes-operator/SKILL.md
+++ b/.gemini/skills/kubernetes-operator/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/kubernetes-operator/SKILL.md
+../../../engineering/kubernetes-operator/skills/kubernetes-operator/SKILL.md

--- a/.gemini/skills/run/SKILL.md
+++ b/.gemini/skills/run/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/autoresearch-agent/skills/run/SKILL.md
+../../../engineering/agenthub/skills/run/SKILL.md

--- a/.gemini/skills/skills-chaos-engineering/SKILL.md
+++ b/.gemini/skills/skills-chaos-engineering/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/chaos-engineering/skills/chaos-engineering/SKILL.md
+../../../engineering/skills/chaos-engineering/SKILL.md

--- a/.gemini/skills/skills-chief-ai-officer-advisor/SKILL.md
+++ b/.gemini/skills/skills-chief-ai-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/chief-ai-officer-advisor/skills/chief-ai-officer-advisor/SKILL.md
+../../../c-level-advisor/skills/chief-ai-officer-advisor/SKILL.md

--- a/.gemini/skills/skills-chief-customer-officer-advisor/SKILL.md
+++ b/.gemini/skills/skills-chief-customer-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/chief-customer-officer-advisor/skills/chief-customer-officer-advisor/SKILL.md
+../../../c-level-advisor/skills/chief-customer-officer-advisor/SKILL.md

--- a/.gemini/skills/skills-chief-data-officer-advisor/SKILL.md
+++ b/.gemini/skills/skills-chief-data-officer-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/chief-data-officer-advisor/skills/chief-data-officer-advisor/SKILL.md
+../../../c-level-advisor/skills/chief-data-officer-advisor/SKILL.md

--- a/.gemini/skills/skills-eu-ai-act-specialist/SKILL.md
+++ b/.gemini/skills/skills-eu-ai-act-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist/SKILL.md
+../../../ra-qm-team/skills/eu-ai-act-specialist/SKILL.md

--- a/.gemini/skills/skills-feature-flags-architect/SKILL.md
+++ b/.gemini/skills/skills-feature-flags-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/feature-flags-architect/skills/feature-flags-architect/SKILL.md
+../../../engineering/skills/feature-flags-architect/SKILL.md

--- a/.gemini/skills/skills-general-counsel-advisor/SKILL.md
+++ b/.gemini/skills/skills-general-counsel-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/general-counsel-advisor/skills/general-counsel-advisor/SKILL.md
+../../../c-level-advisor/skills/general-counsel-advisor/SKILL.md

--- a/.gemini/skills/skills-iso42001-specialist/SKILL.md
+++ b/.gemini/skills/skills-iso42001-specialist/SKILL.md
@@ -1,1 +1,1 @@
-../../../ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist/SKILL.md
+../../../ra-qm-team/skills/iso42001-specialist/SKILL.md

--- a/.gemini/skills/skills-kubernetes-operator/SKILL.md
+++ b/.gemini/skills/skills-kubernetes-operator/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/kubernetes-operator/skills/kubernetes-operator/SKILL.md
+../../../engineering/skills/kubernetes-operator/SKILL.md

--- a/.gemini/skills/skills-run/SKILL.md
+++ b/.gemini/skills/skills-run/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/agenthub/skills/run/SKILL.md
+../../../engineering/autoresearch-agent/skills/run/SKILL.md

--- a/.gemini/skills/skills-slo-architect/SKILL.md
+++ b/.gemini/skills/skills-slo-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/slo-architect/skills/slo-architect/SKILL.md
+../../../engineering/skills/slo-architect/SKILL.md

--- a/.gemini/skills/skills-status/SKILL.md
+++ b/.gemini/skills/skills-status/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/agenthub/skills/status/SKILL.md
+../../../engineering/autoresearch-agent/skills/status/SKILL.md

--- a/.gemini/skills/skills-vpe-advisor/SKILL.md
+++ b/.gemini/skills/skills-vpe-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/vpe-advisor/skills/vpe-advisor/SKILL.md
+../../../c-level-advisor/skills/vpe-advisor/SKILL.md

--- a/.gemini/skills/slo-architect/SKILL.md
+++ b/.gemini/skills/slo-architect/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/skills/slo-architect/SKILL.md
+../../../engineering/slo-architect/skills/slo-architect/SKILL.md

--- a/.gemini/skills/status/SKILL.md
+++ b/.gemini/skills/status/SKILL.md
@@ -1,1 +1,1 @@
-../../../engineering/autoresearch-agent/skills/status/SKILL.md
+../../../engineering/agenthub/skills/status/SKILL.md

--- a/.gemini/skills/vpe-advisor/SKILL.md
+++ b/.gemini/skills/vpe-advisor/SKILL.md
@@ -1,1 +1,1 @@
-../../../c-level-advisor/skills/vpe-advisor/SKILL.md
+../../../c-level-advisor/vpe-advisor/skills/vpe-advisor/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # IDE and OS
 .vscode
 .DS_Store
-
+venv
 # Environment files
 .env
 .env.*

--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
+++ b/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-customer-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-data-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
+++ b/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/general-counsel-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vpe-advisor",
-  "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification), eng hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes), eng team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references: DORA framework, eng hiring funnel, eng team structure (Conway's Law), production discipline (on-call, incidents, deployment, SLOs). Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill — VPE owns how the team ships, CTO owns what to build.",
+  "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification), eng hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes), eng team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references: DORA framework, eng hiring funnel, eng team structure (Conway's Law), production discipline (on-call, incidents, deployment, SLOs). Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill \u2014 VPE owns how the team ships, CTO owns what to build.",
   "version": "1.0.0",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/vpe-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/a11y-audit/.claude-plugin/plugin.json
+++ b/engineering-team/a11y-audit/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
+++ b/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
@@ -8,6 +8,8 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills",
+  "skills": [
+    "./skills"
+  ],
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/google-workspace-cli"
 }

--- a/engineering-team/playwright-pro/.claude-plugin/plugin.json
+++ b/engineering-team/playwright-pro/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/playwright-pro",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -8,6 +8,8 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills",
+  "skills": [
+    "./skills"
+  ],
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent"
 }

--- a/engineering-team/snowflake-development/.claude-plugin/plugin.json
+++ b/engineering-team/snowflake-development/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/snowflake-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/agenthub/.claude-plugin/plugin.json
+++ b/engineering/agenthub/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/agenthub",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/autoresearch-agent/.claude-plugin/plugin.json
+++ b/engineering/autoresearch-agent/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/autoresearch-agent",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/behuman/.claude-plugin/plugin.json
+++ b/engineering/behuman/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "behuman",
-  "description": "Self-Mirror consciousness loop for human-like AI responses. Adds inner dialogue (Self → Mirror → Conscious Response) to make AI output feel authentic, not robotic. Zero dependencies — pure prompt technique.",
+  "description": "Self-Mirror consciousness loop for human-like AI responses. Adds inner dialogue (Self \u2192 Mirror \u2192 Conscious Response) to make AI output feel authentic, not robotic. Zero dependencies \u2014 pure prompt technique.",
   "version": "2.2.2",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/behuman",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/chaos-engineering/.claude-plugin/plugin.json
+++ b/engineering/chaos-engineering/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/chaos-engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/code-tour/.claude-plugin/plugin.json
+++ b/engineering/code-tour/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-tour",
-  "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Supports 10 developer personas (vibecoder, new joiner, architect, security reviewer, etc.), all CodeTour step types, and SMIG description formula.",
+  "description": "Create CodeTour .tour files \u2014 persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Supports 10 developer personas (vibecoder, new joiner, architect, security reviewer, etc.), all CodeTour step types, and SMIG description formula.",
   "version": "2.2.2",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/code-tour",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/data-quality-auditor/.claude-plugin/plugin.json
+++ b/engineering/data-quality-auditor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/data-quality-auditor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/demo-video/.claude-plugin/plugin.json
+++ b/engineering/demo-video/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/docker-development/.claude-plugin/plugin.json
+++ b/engineering/docker-development/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/docker-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/feature-flags-architect/.claude-plugin/plugin.json
+++ b/engineering/feature-flags-architect/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/feature-flags-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/helm-chart-builder/.claude-plugin/plugin.json
+++ b/engineering/helm-chart-builder/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-chart-builder",
-  "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing.",
+  "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw \u2014 chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing.",
   "version": "2.2.2",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/helm-chart-builder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/karpathy-coder/.claude-plugin/plugin.json
+++ b/engineering/karpathy-coder/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/kubernetes-operator/.claude-plugin/plugin.json
+++ b/engineering/kubernetes-operator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes-operator",
-  "description": "End-to-end Kubernetes Operator discipline: CRD design, reconcile-loop patterns, and OperatorHub Capability Levels. Ships CRD validator, reconcile-loop linter, and capability auditor (3 stdlib Python tools), 4 references on the operator pattern + CRD design + reconcile patterns + framework comparison (controller-runtime/kubebuilder/operator-sdk/metacontroller/KOPF), CRD + Go controller skeletons, and /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
+  "description": "End-to-end Kubernetes Operator discipline: CRD design, reconcile-loop patterns, and OperatorHub Capability Levels. Ships CRD validator, reconcile-loop linter, and capability auditor (3 stdlib Python tools), 4 references on the operator pattern + CRD design + reconcile patterns + framework comparison (controller-runtime/kubebuilder/operator-sdk/metacontroller/KOPF), CRD + Go controller skeletons, and /operator-audit slash command. NOT a generic k8s skill \u2014 specifically the Operator pattern.",
   "version": "2.4.0",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/kubernetes-operator",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
+++ b/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-cost-optimizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/llm-wiki/.claude-plugin/plugin.json
+++ b/engineering/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "description": "Turn Claude Code + Obsidian into a second brain. The LLM incrementally ingests sources into a persistent, interlinked markdown wiki — building entity/concept/source pages, flagging contradictions, maintaining an index and log. Knowledge compounds instead of being re-derived by RAG on every query. Inspired by Karpathy's LLM Wiki gist. Ships SKILL, 3 sub-agents, 5 slash commands, 8 Python tools (stdlib only), full vault templates, and cross-tool compatibility (Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI).",
+  "description": "Turn Claude Code + Obsidian into a second brain. The LLM incrementally ingests sources into a persistent, interlinked markdown wiki \u2014 building entity/concept/source pages, flagging contradictions, maintaining an index and log. Knowledge compounds instead of being re-derived by RAG on every query. Inspired by Karpathy's LLM Wiki gist. Ships SKILL, 3 sub-agents, 5 slash commands, 8 Python tools (stdlib only), full vault templates, and cross-tool compatibility (Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI).",
   "version": "2.3.2",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/prompt-governance/.claude-plugin/plugin.json
+++ b/engineering/prompt-governance/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/prompt-governance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/slo-architect/.claude-plugin/plugin.json
+++ b/engineering/slo-architect/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/statistical-analyst/.claude-plugin/plugin.json
+++ b/engineering/statistical-analyst/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/statistical-analyst",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/terraform-patterns/.claude-plugin/plugin.json
+++ b/engineering/terraform-patterns/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/terraform-patterns",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/finance/business-investment-advisor/.claude-plugin/plugin.json
+++ b/finance/business-investment-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance/business-investment-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
+++ b/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/video-content-strategist",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/agile-product-owner/.claude-plugin/plugin.json
+++ b/product-team/agile-product-owner/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/apple-hig-expert/.claude-plugin/plugin.json
+++ b/product-team/apple-hig-expert/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/code-to-prd/.claude-plugin/plugin.json
+++ b/product-team/code-to-prd/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/code-to-prd",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/research-summarizer/.claude-plugin/plugin.json
+++ b/product-team/research-summarizer/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/research-summarizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compliance-team-eu-ai-act",
-  "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance specialist for compliance teams. Three deterministic tools: AI system risk classifier (Article 5 prohibited / Article 6 + Annex III high-risk / Article 50 limited-risk / minimal-risk per the binding regulation), conformity assessment planner (Article 43 Module A vs Module H + notified-body routing + Annex IV technical documentation checklist), obligation tracker (provider/deployer/importer/distributor obligations matrix per Title III Chapter 3 + GPAI obligations per Articles 51-55). 4 in-depth references: Titles I-XII Article-by-Article walkthrough, Annex III 8 high-risk categories with Article 6(2) carve-outs, GPAI obligations including systemic-risk threshold, cross-framework mapping to ISO 42001 + NIST AI RMF + GDPR. Stdlib-only. Built for compliance officers executing Article-level conformity work — not for executive AI strategy (see chief-ai-officer-advisor for that).",
+  "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance specialist for compliance teams. Three deterministic tools: AI system risk classifier (Article 5 prohibited / Article 6 + Annex III high-risk / Article 50 limited-risk / minimal-risk per the binding regulation), conformity assessment planner (Article 43 Module A vs Module H + notified-body routing + Annex IV technical documentation checklist), obligation tracker (provider/deployer/importer/distributor obligations matrix per Title III Chapter 3 + GPAI obligations per Articles 51-55). 4 in-depth references: Titles I-XII Article-by-Article walkthrough, Annex III 8 high-risk categories with Article 6(2) carve-outs, GPAI obligations including systemic-risk threshold, cross-framework mapping to ISO 42001 + NIST AI RMF + GDPR. Stdlib-only. Built for compliance officers executing Article-level conformity work \u2014 not for executive AI strategy (see chief-ai-officer-advisor for that).",
   "version": "1.0.0",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }

--- a/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compliance-team-iso42001",
-  "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams: AIMS gap analyzer (Clauses 4-10 coverage scoring + remediation priority), AI risk register builder (Annex A 38 controls + risk-to-treatment map per ISO 23894), AIMS audit scheduler (Clause 9.2 internal audit cadence + 12-month plan + auditor independence checks). 4 in-depth references: ISO 42001 Clauses 4-10 walkthrough, Annex A controls A.1-A.10, AIMS implementation maturity model, cross-framework mapping (42001 ↔ EU AI Act ↔ NIST AI RMF ↔ ISO 23894). Stdlib-only. Standalone-installable; also bundled in ra-qm-skills. Built for compliance officers running internal AIMS audits, not for executive AI strategy decisions (see chief-ai-officer-advisor for those).",
+  "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams: AIMS gap analyzer (Clauses 4-10 coverage scoring + remediation priority), AI risk register builder (Annex A 38 controls + risk-to-treatment map per ISO 23894), AIMS audit scheduler (Clause 9.2 internal audit cadence + 12-month plan + auditor independence checks). 4 in-depth references: ISO 42001 Clauses 4-10 walkthrough, Annex A controls A.1-A.10, AIMS implementation maturity model, cross-framework mapping (42001 \u2194 EU AI Act \u2194 NIST AI RMF \u2194 ISO 23894). Stdlib-only. Standalone-installable; also bundled in ra-qm-skills. Built for compliance officers running internal AIMS audits, not for executive AI strategy decisions (see chief-ai-officer-advisor for those).",
   "version": "1.0.0",
   "author": {
     "name": "Alireza Rezvani",
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": [
+    "./skills"
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes the `plugin.json` schema for Claude Code compatibility and corrects broken `.gemini/` skill symlinks.

**Problem:** Most `plugin.json` files declared `"skills": "skills"` (string), which Claude Code's plugin loader rejects with `Validation errors: skills: Invalid input` — every bundle install fails:

```
[ERROR] installPluginFromMarketplace failed for engineering-advanced-skills@claude-code-skills:
Validation errors: skills: Invalid input
```

**Fix:**
- `plugin.json` — change `"skills": "skills"` → `"skills": ["./skills"]` (array form required by the Claude Code plugin schema). Affects `business-growth`, `c-level-advisor`, and other bundles in this PR.
- `.gemini/skills/*/SKILL.md` symlinks — repoint from `<bundle>/skills/<skill>/SKILL.md` to `<bundle>/<skill>/skills/<skill>/SKILL.md` (actual location after the per-skill nesting refactor). 27 symlinks fixed.
- `.gemini/skills-index.json` — correct 4 swapped descriptions (`run` ↔ `skills-run`, `status` ↔ `skills-status`).
- `.gitignore` — minor cleanup.

## Type of Change

- [x] Bug fix
- [x] Infrastructure / CI

## Testing

Verified locally against Claude Code 2.1.145:

- **Before:** `/plugin install engineering-advanced-skills@claude-code-skills` fails with `Validation errors: skills: Invalid input`.
- **After:** install succeeds for all umbrella bundles (engineering-advanced-skills, engineering-skills, c-level-skills, c-level-agents, marketing-skills, product-skills, pm-skills, pw, business-operations-skills, commercial-skills).

## Checklist

- [x] Target branch is `dev`
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies
- [x] Follows existing directory structure

---
Supersedes #713 (auto-closed because it targeted `main`). Same head commit, rebased onto current `dev`.