### PR TITLE
fix(plugin-schema): migrate to "./"-prefixed skills field per live Claude Code spec

### DIFF
--- a/.gemini/skills/business-growth-bundle/SKILL.md
+++ b/.gemini/skills/business-growth-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../business-growth/SKILL.md

--- a/.gemini/skills/c-level-advisor-bundle/SKILL.md
+++ b/.gemini/skills/c-level-advisor-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../c-level-advisor/SKILL.md

--- a/.gemini/skills/c-level-advisor-main/SKILL.md
+++ b/.gemini/skills/c-level-advisor-main/SKILL.md
@@ -1,1 +1,0 @@
-../../../c-level-advisor/SKILL.md

--- a/.gemini/skills/engineering-bundle/SKILL.md
+++ b/.gemini/skills/engineering-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../engineering/SKILL.md

--- a/.gemini/skills/engineering-main/SKILL.md
+++ b/.gemini/skills/engineering-main/SKILL.md
@@ -1,1 +1,0 @@
-../../../engineering/SKILL.md

--- a/.gemini/skills/engineering-team-bundle/SKILL.md
+++ b/.gemini/skills/engineering-team-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../engineering-team/SKILL.md

--- a/.gemini/skills/finance-bundle/SKILL.md
+++ b/.gemini/skills/finance-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../finance/SKILL.md

--- a/.gemini/skills/marketing-bundle/SKILL.md
+++ b/.gemini/skills/marketing-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../marketing-skill/SKILL.md

--- a/.gemini/skills/marketing-skill-bundle/SKILL.md
+++ b/.gemini/skills/marketing-skill-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../marketing-skill/SKILL.md

--- a/.gemini/skills/playwright-pro/SKILL.md
+++ b/.gemini/skills/playwright-pro/SKILL.md
@@ -1,1 +1,0 @@
-../../../engineering-team/playwright-pro/SKILL.md

--- a/.gemini/skills/product-bundle/SKILL.md
+++ b/.gemini/skills/product-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../product-team/SKILL.md

--- a/.gemini/skills/product-team-bundle/SKILL.md
+++ b/.gemini/skills/product-team-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../product-team/SKILL.md

--- a/.gemini/skills/project-management-bundle/SKILL.md
+++ b/.gemini/skills/project-management-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../project-management/SKILL.md

--- a/.gemini/skills/ra-qm-team-bundle/SKILL.md
+++ b/.gemini/skills/ra-qm-team-bundle/SKILL.md
@@ -1,1 +1,0 @@
-../../../ra-qm-team/SKILL.md

--- a/.gemini/skills/ra-qm-team-main/SKILL.md
+++ b/.gemini/skills/ra-qm-team-main/SKILL.md
@@ -1,1 +1,0 @@
-../../../ra-qm-team/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,12 +333,18 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
    - `source` (object) — provenance metadata for skills built via Path-B megaprompt conversion. Recommended shape: `{spec: "megaprompts/NN-name.md", build_pattern: "...", distinct_from: "..."}`. Used by all 13 v2 megaprompt-derived skills (productivity/, marketing/, research/).
    - `attribution` (object) — credit metadata for skills derived from external MIT-licensed work. Used by `engineering/caveman`, `engineering/grill-me`, `engineering/grill-with-docs` (Matt Pocock derivatives).
 
-   No other extras. The `skills` value depends on the plugin layout (Claude Code v2.1.107+ rejects bare `"./"`, and v2.1.133+ rejects `"./skills"` with a "Path escapes plugin directory" warning — drop the `./` prefix):
-   - Single-skill plugin (SKILL.md at root): `"skills": ["./"]` (array form required).
-   - Plugin with `skills/` subdir: `"skills": "skills"` (no `./` prefix — see issue #686).
-   - Multi-skill domain plugin (skills are subfolders at root): `"skills": ["./sub1", "./sub2", ...]` (explicit list, omit `"./"` to avoid namespace collision with the index SKILL.md).
+   No other extras. The `skills` value depends on the plugin layout. Per the live Claude Code plugin spec ([plugins-reference](https://code.claude.com/docs/en/plugins-reference)), **all paths must be relative to the plugin root and start with `./`**. CC 2.1.144+ returns `Validation errors: skills: Invalid input` on a bare string without the prefix.
 
-   **Enforcement:** `scripts/check_plugin_json.py --all` runs in `ci-quality-gate.yml` on every PR and blocks merge on any violation. It actively rejects the `"./"` (issue #539) and `"./skills"` (issue #686) regressions. When CC tightens its path validator again in the future, update both the validator's `_check_skills_string` rules and this section together — they must move in lockstep.
+   **Canonical forms (CC 2.1.144+):**
+   - Single-skill plugin (SKILL.md at root): `"skills": ["./"]` (array form required).
+   - Plugin with `skills/` subdir: `"skills": "./skills"` or `"skills": ["./skills"]`.
+   - Multi-skill domain plugin (skills are subfolders at root): `"skills": ["./sub1", "./sub2", ...]` (explicit list).
+
+   **Legacy form (still tolerated by the validator):** `"skills": "skills"` (bare subdir name, no `./`). Older versions of CC accepted this; current CC rejects it. The repo has been fully migrated to the canonical form — the validator keeps WARN-level tolerance for the legacy literal as a safety net against accidental regressions in copied templates. Do **not** use this form in new manifests.
+
+   **Historical regressions (now reversed upstream):** The `./` prefix was briefly forbidden between CC v2.1.107 and v2.1.144 (issues #539, #686). That window is closed; the `./` prefix is required again. Do **not** reintroduce the bare-string form for new manifests.
+
+   **Enforcement:** `scripts/check_plugin_json.py --all` runs in `ci-quality-gate.yml` on every PR. It hard-fails on any non-`./`-prefixed string that isn't the legacy `"skills"` literal, on empty strings/arrays, and on non-string array entries. When CC tightens its path validator again in the future, update both the validator (`_check_skills_string` / `_check_skills_array`) and this section together — they must move in lockstep.
 6. **Version follows repo versioning.** ClawHub package versions must match the repo release version (currently v2.7.0+).
 
 ## Anti-Patterns to Avoid

--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
+++ b/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-customer-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-data-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
+++ b/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/general-counsel-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/vpe-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering-team/a11y-audit/.claude-plugin/plugin.json
+++ b/engineering-team/a11y-audit/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
+++ b/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
@@ -8,6 +8,6 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills",
+  "skills": ["./skills"],
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/google-workspace-cli"
 }

--- a/engineering-team/playwright-pro/.claude-plugin/plugin.json
+++ b/engineering-team/playwright-pro/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/playwright-pro",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -8,6 +8,6 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills",
+  "skills": ["./skills"],
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent"
 }

--- a/engineering-team/snowflake-development/.claude-plugin/plugin.json
+++ b/engineering-team/snowflake-development/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/snowflake-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/agenthub/.claude-plugin/plugin.json
+++ b/engineering/agenthub/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/agenthub",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/autoresearch-agent/.claude-plugin/plugin.json
+++ b/engineering/autoresearch-agent/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/autoresearch-agent",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/behuman/.claude-plugin/plugin.json
+++ b/engineering/behuman/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/behuman",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/chaos-engineering/.claude-plugin/plugin.json
+++ b/engineering/chaos-engineering/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/chaos-engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/code-tour/.claude-plugin/plugin.json
+++ b/engineering/code-tour/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/code-tour",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/data-quality-auditor/.claude-plugin/plugin.json
+++ b/engineering/data-quality-auditor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/data-quality-auditor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/demo-video/.claude-plugin/plugin.json
+++ b/engineering/demo-video/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/docker-development/.claude-plugin/plugin.json
+++ b/engineering/docker-development/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/docker-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/feature-flags-architect/.claude-plugin/plugin.json
+++ b/engineering/feature-flags-architect/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/feature-flags-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/helm-chart-builder/.claude-plugin/plugin.json
+++ b/engineering/helm-chart-builder/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/helm-chart-builder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/karpathy-coder/.claude-plugin/plugin.json
+++ b/engineering/karpathy-coder/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/kubernetes-operator/.claude-plugin/plugin.json
+++ b/engineering/kubernetes-operator/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/kubernetes-operator",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
+++ b/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-cost-optimizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/llm-wiki/.claude-plugin/plugin.json
+++ b/engineering/llm-wiki/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/prompt-governance/.claude-plugin/plugin.json
+++ b/engineering/prompt-governance/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/prompt-governance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/slo-architect/.claude-plugin/plugin.json
+++ b/engineering/slo-architect/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/statistical-analyst/.claude-plugin/plugin.json
+++ b/engineering/statistical-analyst/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/statistical-analyst",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/engineering/terraform-patterns/.claude-plugin/plugin.json
+++ b/engineering/terraform-patterns/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/terraform-patterns",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/finance/business-investment-advisor/.claude-plugin/plugin.json
+++ b/finance/business-investment-advisor/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance/business-investment-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
+++ b/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/video-content-strategist",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/product-team/agile-product-owner/.claude-plugin/plugin.json
+++ b/product-team/agile-product-owner/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/product-team/apple-hig-expert/.claude-plugin/plugin.json
+++ b/product-team/apple-hig-expert/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/product-team/code-to-prd/.claude-plugin/plugin.json
+++ b/product-team/code-to-prd/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/code-to-prd",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/product-team/research-summarizer/.claude-plugin/plugin.json
+++ b/product-team/research-summarizer/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/research-summarizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": "skills"
+  "skills": ["./skills"]
 }

--- a/scripts/check_plugin_json.py
+++ b/scripts/check_plugin_json.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate plugin.json files against the strict ClawHub schema.
+"""Validate plugin.json files against the ClawHub schema.
 
 Required fields (exactly these 8):
   name, description, version, author{name,url}, homepage, repository, license, skills
@@ -7,16 +7,25 @@ Required fields (exactly these 8):
 Two approved extension fields (documented in CLAUDE.md, stripped at ClawHub-publish):
   source, attribution
 
-skills layouts (Claude Code tightens its path validator regularly — be explicit):
-  - Single-skill plugin (SKILL.md at root):       "skills": ["./"]   (array form)
-  - Plugin with skills/ subdir:                   "skills": "skills" (NO "./" prefix — #686)
-  - Multi-skill domain plugin (subfolders at root):
-                                                   "skills": ["./sub1", "./sub2", ...]
+skills layouts — per the live Claude Code plugin spec
+(https://code.claude.com/docs/en/plugins-reference), "All paths must be
+relative to the plugin root and start with ./". CC 2.1.145 returns
+`Validation errors: skills: Invalid input` on a bare string without "./".
+Legacy bare-string form is still accepted by this validator during the
+migration window, but emits a WARN line.
 
-REJECTED forms and why:
-  - "skills": "./"     — Claude Code v2.1.107+ rejects ("Path escapes plugin directory")
-  - "skills": "./skills" — Claude Code v2.1.133+ rejects (issue #686)
-  - Any string starting with "./" (lifted out of array context)
+  CANONICAL (post-CC 2.1.144):
+    - Single-skill plugin (SKILL.md at root):      "skills": ["./"]
+    - Plugin with skills/ subdir:                  "skills": "./skills"  (or ["./skills"])
+    - Multi-skill domain plugin (subfolders):      "skills": ["./sub1", "./sub2", ...]
+
+  LEGACY (pre-migration, still passes with WARN):
+    - "skills": "skills"  (bare subdir name, no "./" prefix)
+
+  REJECTED:
+    - Empty string / empty array
+    - Non-string array entries
+    - Strings that are neither "skills"-style legacy nor "./"-prefixed
 """
 import argparse
 import json
@@ -73,15 +82,21 @@ def _check_author(data):
     return errors
 
 
+_LEGACY_SKILLS_VALUES = {"skills"}
+
+
 def _check_skills_string(s):
-    if s in ("./", ""):
-        return ['skills: bare "./" is rejected by Claude Code v2.1.107+; '
-                'use ["./"] (array) for single-skill at root, or "skills" for subdir layout']
+    if s == "":
+        return ["skills: empty string"]
+    if s == "./":
+        return ['skills: bare "./" must be wrapped in an array — use ["./"] for single-skill plugins']
     if s.startswith("./"):
-        return [f'skills: {s!r} starts with "./" — Claude Code v2.1.133+ rejects this as '
-                f'"Path escapes plugin directory" (issue #686). Drop the "./" prefix: '
-                f'"{s[2:]}". (For single-skill plugins, use ["./"] in an array instead.)']
-    return []
+        return []
+    if s in _LEGACY_SKILLS_VALUES:
+        return [f'WARN skills: legacy bare {s!r} — Claude Code 2.1.144+ requires the "./" prefix '
+                f'per the plugin spec. Migrate to "./{s}" or ["./{s}"].']
+    return [f'skills: {s!r} must start with "./" (Claude Code plugin spec: "All paths must be '
+            f'relative to the plugin root and start with ./")']
 
 
 def _check_skills_array(s):
@@ -91,6 +106,13 @@ def _check_skills_array(s):
     for entry in s:
         if not isinstance(entry, str):
             errors.append(f"skills: entries must be strings, got {entry!r}")
+            continue
+        if entry == "":
+            errors.append("skills: array contains empty string")
+            continue
+        if not entry.startswith("./"):
+            errors.append(f'skills: array entry {entry!r} must start with "./" '
+                          f'(Claude Code plugin spec)')
     return errors
 
 
@@ -135,16 +157,28 @@ def main():
 
     targets = find_all() if args.all else [args.path]
     failed = 0
+    warned = 0
     for t in targets:
-        errs = validate(t)
+        msgs = validate(t)
         rel = os.path.relpath(t, REPO)
-        if errs:
+        hard = [m for m in msgs if not m.startswith("WARN ")]
+        soft = [m for m in msgs if m.startswith("WARN ")]
+        if hard:
             failed += 1
             print(f"FAIL {rel}")
-            for e in errs:
+            for e in hard:
                 print(f"  - {e}")
+            for w in soft:
+                print(f"  - {w[5:]}")
+        elif soft:
+            warned += 1
+            print(f"WARN {rel}")
+            for w in soft:
+                print(f"  - {w[5:]}")
         else:
             print(f"OK   {rel}")
+    if warned:
+        print(f"\n{warned} file(s) passed with warnings (legacy schema)", file=sys.stderr)
     if failed:
         print(f"\n{failed} file(s) failed validation", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Resolves both **#712** and **#714**.

Claude Code's plugin spec ([plugins-reference](https://code.claude.com/docs/en/plugins-reference)) requires *"All paths must be relative to the plugin root and start with `./`"*. CC 2.1.144+ rejects the bare `"skills"` form with `Validation errors: skills: Invalid input`, breaking plugin installs from this repo.

The two competing PRs each captured part of the fix:
- **#712** (`"./skills"` string form) — spec-correct, would have failed CI due to the stale validator.
- **#714** (`["./skills"]` array form) — also spec-correct, passed CI only by accident (the array path of `_check_skills_string` was never reached).

Both author premises were correct. The repo's own `CLAUDE.md` §5 and `scripts/check_plugin_json.py` had the rule **inverted** — they were enforcing the v2.1.107→v2.1.133 regression window that has since been reversed upstream (issues #539, #686 are closed). This PR realigns the docs + validator with the live spec and migrates every manifest.

## Changes

- **47 `plugin.json` manifests** migrated from `"skills": "skills"` → `["./skills"]`.
- **`scripts/check_plugin_json.py`** rewritten to enforce the live spec:
  - Hard-fails on non-`./`-prefixed strings (except the legacy `"skills"` literal).
  - Hard-fails on empty strings/arrays and non-string array entries.
  - Emits `WARN` (non-fatal) on the legacy `"skills"` literal as a safety net against copied templates. The repo is fully migrated so `WARN` count is currently 0.
- **`CLAUDE.md` §5** rewritten with the live spec, current canonical forms, and historical context.
- **15 stale broken symlinks under `.gemini/skills/`** removed. These were orphaned from older domain reorgs that `sync-gemini-skills.py` never pruned (its cleanup block is commented out). No live skill is affected — the targets they pointed to no longer exist (e.g. `engineering/SKILL.md`, `finance/SKILL.md`).

## Verification

- `python scripts/check_plugin_json.py --all` → **0 FAIL, 0 WARN, 69 OK, exit 0**
- `pytest tests/` → **2103 passed, 1 warning (unrelated escape sequence)**
- `find . -type l ! -exec test -e {} \; -print` → **0 broken symlinks** (was 15)
- Validator test matrix:
  - `["./"]`, `["./skills"]`, `"./skills"`, `["./sub1","./sub2"]` → all PASS
  - bare `"./"`, empty array, non-string entries, plain `"my-skills"` → all FAIL with clear messages
  - legacy `"skills"` → WARN only (CI-passing)

## What this does **not** do

- Does **not** rename any skill folder or change the directory layout — the repo is the source of truth, only the `skills` field inside `.claude-plugin/plugin.json` changes.
- Does **not** fix the root-cause sync-script bug (the commented-out cleanup pass in `scripts/sync-gemini-skills.py`). Worth a separate small PR; leaving as-is here to keep the diff focused.

## Test plan

- [ ] CI quality gate passes
- [ ] Spot-install one of the migrated plugins in CC 2.1.144+ (e.g. `marketing-skills`) and confirm no `Invalid input` error
- [ ] Optionally close #712 and #714 as superseded


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkUYmjodSKSmaBgbNkg3zx)_