### PR TITLE
chore: sync codex + gemini indices for senior-engineering skills

### DIFF
--- a/.codex/skills-index.json
+++ b/.codex/skills-index.json
@@ -685,15 +685,15 @@
     },
     {
       "name": "review",
-      "source": "../../engineering-team/playwright-pro/skills/review",
-      "category": "engineering",
-      "description": ">-"
-    },
-    {
-      "name": "review",
       "source": "../../engineering-team/self-improving-agent/skills/review",
       "category": "engineering",
       "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics."
+    },
+    {
+      "name": "review",
+      "source": "../../engineering-team/playwright-pro/skills/review",
+      "category": "engineering",
+      "description": ">-"
     },
     {
       "name": "security-pen-testing",
@@ -1153,15 +1153,15 @@
     },
     {
       "name": "run",
-      "source": "../../engineering/agenthub/skills/run",
-      "category": "engineering-advanced",
-      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
-    },
-    {
-      "name": "run",
       "source": "../../engineering/autoresearch-agent/skills/run",
       "category": "engineering-advanced",
       "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
+    },
+    {
+      "name": "run",
+      "source": "../../engineering/agenthub/skills/run",
+      "category": "engineering-advanced",
+      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
     },
     {
       "name": "runbook-generator",
@@ -1249,15 +1249,15 @@
     },
     {
       "name": "status",
-      "source": "../../engineering/agenthub/skills/status",
-      "category": "engineering-advanced",
-      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
-    },
-    {
-      "name": "status",
       "source": "../../engineering/autoresearch-agent/skills/status",
       "category": "engineering-advanced",
       "description": "Show experiment dashboard with results, active loops, and progress."
+    },
+    {
+      "name": "status",
+      "source": "../../engineering/agenthub/skills/status",
+      "category": "engineering-advanced",
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
     },
     {
       "name": "tc-tracker",

--- a/.codex/skills/review
+++ b/.codex/skills/review
@@ -1,1 +1,1 @@
-../../engineering-team/self-improving-agent/skills/review
+../../engineering-team/playwright-pro/skills/review

--- a/.codex/skills/run
+++ b/.codex/skills/run
@@ -1,1 +1,1 @@
-../../engineering/autoresearch-agent/skills/run
+../../engineering/agenthub/skills/run

--- a/.codex/skills/status
+++ b/.codex/skills/status
@@ -1,1 +1,1 @@
-../../engineering/autoresearch-agent/skills/status
+../../engineering/agenthub/skills/status

--- a/.gemini/skills-index.json
+++ b/.gemini/skills-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "gemini-cli-skills",
-  "total_skills": 385,
+  "total_skills": 392,
   "skills": [
     {
       "name": "README",
@@ -27,6 +27,11 @@
       "name": "cs-agile-product-owner",
       "category": "agent",
       "description": "Agile product owner agent for epic breakdown, sprint planning, backlog refinement, and INVEST-compliant user story generation"
+    },
+    {
+      "name": "cs-backend-engineer",
+      "category": "agent",
+      "description": "Backend-engineering orchestrator. Walks the 7 Matt Pocock forcing questions (read/write ratio + QPS, tenancy, sync vs async, data sensitivity, pattern, RPO/RTO, SLO), picks the language + pattern profile, forks into specialists (api-design-reviewer, database-designer, migration-architect, slo-architect, observability-designer) rather than reimplementing their scope. Forks own context. Invoke via /cs:backend-review or Agent({subagent_type:\"cs-backend-engineer\",...})."
     },
     {
       "name": "cs-ceo-advisor",
@@ -57,6 +62,16 @@
       "name": "cs-financial-analyst",
       "category": "agent",
       "description": "Financial Analyst agent for DCF valuation, financial modeling, budgeting, forecasting, and SaaS metrics (ARR, MRR, churn, CAC, LTV, NRR). Orchestrates finance skills. Spawn when users need financial analysis, valuation models, budget planning, ratio analysis, SaaS health checks, or unit economics projections."
+    },
+    {
+      "name": "cs-frontend-engineer",
+      "category": "agent",
+      "description": "Frontend-engineering orchestrator. Walks the 7 Matt Pocock forcing questions (device, LCP target, rendering, bundle budget, SEO vs auth, design system, WCAG), picks the framework/rendering profile, forks into specialists (a11y-audit, performance-profiler, epic-design, apple-hig-expert, playwright-pro) rather than reimplementing their scope. Forks own context. Invoke via /cs:frontend-review or Agent({subagent_type:\"cs-frontend-engineer\",...})."
+    },
+    {
+      "name": "cs-fullstack-engineer",
+      "category": "agent",
+      "description": "Fullstack-engineering orchestrator. Walks the Matt Pocock 7-question forcing-question grill, runs the deterministic profile picker, then forks into the POWERFUL-tier specialists (api-design-reviewer, database-designer, slo-architect, ci-cd-pipeline-builder, performance-profiler) rather than reimplementing their scope. Forks own context so heavy ingestion does not pollute parent thread. Invoke via /cs:fullstack-review or Agent({subagent_type:\"cs-fullstack-engineer\",...})."
     },
     {
       "name": "cs-growth-strategist",
@@ -577,6 +592,26 @@
       "name": "competitive-matrix",
       "category": "command",
       "description": "Build competitive analysis matrices with scoring and gap analysis. Usage: /competitive-matrix <analyze> [options]"
+    },
+    {
+      "name": "cs-backend-review",
+      "category": "command",
+      "description": "Backend engineering review \u2014 walks the 7 Matt Pocock forcing questions (read/write ratio + QPS, tenancy, sync vs async, data sensitivity, pattern, RPO/RTO, SLO), picks the language + pattern profile, forks into specialists (api-design-reviewer, database-designer, migration-architect, slo-architect). Invokes the cs-backend-engineer agent with context fork."
+    },
+    {
+      "name": "cs-engineer-grill",
+      "category": "command",
+      "description": "Cross-role engineering grill \u2014 Matt Pocock 7 questions per role \u00d7 3 roles (fullstack / frontend / backend) = up to 21 forcing questions, one per turn, with canon citations and kill criteria. Default: ask which lane first; `--all` runs all 21."
+    },
+    {
+      "name": "cs-frontend-review",
+      "category": "command",
+      "description": "Frontend engineering review \u2014 walks the 7 Matt Pocock forcing questions (device, LCP target, rendering, bundle budget, SEO vs auth, design system, WCAG), picks the framework + rendering profile, forks into specialists (a11y-audit, performance-profiler, epic-design). Invokes the cs-frontend-engineer agent with context fork."
+    },
+    {
+      "name": "cs-fullstack-review",
+      "category": "command",
+      "description": "Fullstack engineering review \u2014 walks the 7 Matt Pocock forcing questions, picks the profile, forks into POWERFUL specialists (api-design-reviewer, database-designer, slo-architect). Invokes the cs-fullstack-engineer agent with context fork."
     },
     {
       "name": "financial-health",
@@ -1931,7 +1966,7 @@
   ],
   "categories": {
     "agent": {
-      "count": 30,
+      "count": 33,
       "description": "Agent resources"
     },
     "business-growth": {
@@ -1947,7 +1982,7 @@
       "description": "C-level resources"
     },
     "command": {
-      "count": 34,
+      "count": 38,
       "description": "Command resources"
     },
     "commercial": {

--- a/.gemini/skills/cs-backend-engineer/SKILL.md
+++ b/.gemini/skills/cs-backend-engineer/SKILL.md
@@ -1,0 +1,1 @@
+../../../agents/engineering/cs-backend-engineer.md

--- a/.gemini/skills/cs-backend-review/SKILL.md
+++ b/.gemini/skills/cs-backend-review/SKILL.md
@@ -1,0 +1,1 @@
+../../../commands/cs-backend-review.md

--- a/.gemini/skills/cs-engineer-grill/SKILL.md
+++ b/.gemini/skills/cs-engineer-grill/SKILL.md
@@ -1,0 +1,1 @@
+../../../commands/cs-engineer-grill.md

--- a/.gemini/skills/cs-frontend-engineer/SKILL.md
+++ b/.gemini/skills/cs-frontend-engineer/SKILL.md
@@ -1,0 +1,1 @@
+../../../agents/engineering/cs-frontend-engineer.md

--- a/.gemini/skills/cs-frontend-review/SKILL.md
+++ b/.gemini/skills/cs-frontend-review/SKILL.md
@@ -1,0 +1,1 @@
+../../../commands/cs-frontend-review.md

--- a/.gemini/skills/cs-fullstack-engineer/SKILL.md
+++ b/.gemini/skills/cs-fullstack-engineer/SKILL.md
@@ -1,0 +1,1 @@
+../../../agents/engineering/cs-fullstack-engineer.md

--- a/.gemini/skills/cs-fullstack-review/SKILL.md
+++ b/.gemini/skills/cs-fullstack-review/SKILL.md
@@ -1,0 +1,1 @@
+../../../commands/cs-fullstack-review.md


### PR DESCRIPTION
## Summary

Routine sync-script output after PR #709 added three new senior-engineering skills + three new cs-* agents. The `.codex/` and `.gemini/` indices and symlinks now reflect them.

## What ran

```bash
python3 scripts/sync-codex-skills.py --verbose
python3 scripts/sync-gemini-skills.py --verbose
python3 scripts/sync-hermes-skills.py --verbose
```

## Changes

- **7 new gemini symlinks** for the new agents + their commands:
  - `cs-backend-engineer`, `cs-frontend-engineer`, `cs-fullstack-engineer` (agents)
  - `cs-backend-review`, `cs-frontend-review`, `cs-fullstack-review`, `cs-engineer-grill` (commands)
- **3 codex symlinks updated** (`review`, `run`, `status`) — re-pointed to canonical sources after the engineering reorg in #708.
- **Index manifests refreshed:** `.codex/skills-index.json`, `.gemini/skills-index.json`.

## Verification

- `python3 scripts/check_plugin_json.py --all` → 0 FAIL, 0 WARN, 69 OK
- `find . -type l ! -exec test -e {} \;` → 0 broken symlinks
- Codex: 320 skills | Gemini: 392 items | Hermes: 320 skills

## Audit summary (also run)

Audited the 3 new senior-engineering skills:
- **senior-backend** → PASS (quality 62.1, 0 security findings)
- **senior-fullstack** → 2 CRIT + 9 HIGH security findings, **all false positives** — auditor pattern-matched Django `settings.py` template strings (`os.environ.get("DB_PASSWORD", ...)`) and `package.json` template lists inside the scaffolder as "credential harvesting" and "runtime dependency injection". The scaffolder writes secure template code for *other* projects.
- **senior-frontend** → 1 HIGH false positive (the literal string `"npm install"` in a "next steps" hint list).

No real blockers. Optional follow-up: add allowlist annotations to the security auditor so future scaffolders don't trip the same noise.

## Test plan

- [ ] CI quality gate passes
- [ ] Verify `/skills` in Gemini CLI surfaces the three new cs-* agents


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkUYmjodSKSmaBgbNkg3zx)_