### PR TITLE
fix(engineering): resolve 3 decision-engine bugs flagged on PR #718

### DIFF
--- a/engineering-team/skills/senior-backend/scripts/backend_decision_engine.py
+++ b/engineering-team/skills/senior-backend/scripts/backend_decision_engine.py
@@ -153,15 +153,24 @@ def score_profile(profile: dict[str, Any], inputs: Inputs) -> Match:
             inputs.needs_admin_panel == c["admin_panel_needed"],
             weight=1.0,
         )
-    # Language preference soft-match
-    stack_keys = list(profile.keys())
-    stack_lang_hits = sum(
-        1 for k in stack_keys
-        if k.startswith("stack") and inputs.language_preference.lower() in json.dumps(profile.get(k, {})).lower()
-    )
-    base_stack = profile.get("stack", {})
-    if inputs.language_preference and (stack_lang_hits or inputs.language_preference.lower() in json.dumps(base_stack).lower()):
-        check(f"stack-language matches '{inputs.language_preference}'", True, weight=1.0)
+    # Language preference — match only against fields that explicitly name a language:
+    # profile_name, stack.language, stack.runtime. The previous substring search over
+    # the entire serialized profile false-matched e.g. "go" against "django"/"mongo".
+    if inputs.language_preference:
+        lang = inputs.language_preference.lower()
+        stack = profile.get("stack", {})
+        language_fields = [
+            name.lower(),
+            str(stack.get("language", "")).lower(),
+            str(stack.get("runtime", "")).lower(),
+        ]
+        # Token-level match: split on '-' and check exact membership so "go" doesn't
+        # match "mongo" but still matches "go-or-rust-microservice".
+        tokens: set[str] = set()
+        for field in language_fields:
+            tokens.update(field.replace("_", "-").split("-"))
+        if lang in tokens:
+            check(f"stack-language matches '{inputs.language_preference}'", True, weight=1.0)
 
     score = w_matched / w_total if w_total > 0 else 0.0
     return Match(

--- a/engineering-team/skills/senior-frontend/scripts/frontend_decision_engine.py
+++ b/engineering-team/skills/senior-frontend/scripts/frontend_decision_engine.py
@@ -58,9 +58,11 @@ class Inputs:
                 f"mobile-4g primary with LCP target {self.lcp_target_ms}ms: "
                 "target is too loose for the device class. Tighten to < 2500ms (Web Vitals 'good')."
             )
-        if self.team_size >= 4 and self.team_size <= 10 and self.read_write_ratio >= 50:
-            # Hint: marketing-site shape but with a real team
-            pass
+        if self.primary_device == "mobile-4g" and self.inp_target_ms > 300:
+            kills.append(
+                f"mobile-4g primary with INP target {self.inp_target_ms}ms: "
+                "target is too loose for the device class. Tighten to < 200ms (Web Vitals 'good')."
+            )
         if self.team_size < 1:
             kills.append("team_size < 1 makes no sense.")
         return kills


### PR DESCRIPTION
## Summary

Addresses the three blocking bugs flagged by claude[bot] in the code review on PR #718. Each bug could silently produce incorrect recommendations.

## Bugs fixed

### 1. `backend_decision_engine.py` — fragile language-preference matching (HIGH)

The previous code serialized the entire profile dict to JSON and ran a substring search:

```python
inputs.language_preference.lower() in json.dumps(profile.get(k, {})).lower()
```

`--language-preference=go` false-matched against `"django"`, `"mongo"`, `"django-orm"`, etc.

**Fix:** scope the match to the three fields that explicitly name a language (`profile_name`, `stack.language`, `stack.runtime`), tokenize on `-`, and check exact-token membership.

**Verified:**
| Input | Matched profiles | Should match |
|---|---|---|
| `go` | go-or-rust-microservice | ✅ only that one |
| `python` | django-monolith, fastapi-python | ✅ both legitimate |
| `typescript` | node-express | ✅ only that one |

### 2. `frontend_decision_engine.py` — dead `pass` kill-criterion (MEDIUM)

```python
if self.team_size >= 4 and self.team_size <= 10 and self.read_write_ratio >= 50:
    # Hint: marketing-site shape but with a real team
    pass
```

A `pass` inside a conditional that's supposed to add a kill message is a no-op. The intent comment doesn't explain what the kill should have said. Removed (no kill message to fall back on).

### 3. `frontend_decision_engine.py` — unused `inp_target_ms` field (MEDIUM)

`inp_target_ms` was declared on `Inputs`, exposed via `--inp-target-ms`, and threaded through `main()`, but no kill criterion or constraint consulted it.

**Fix:** wired it into a kill check that mirrors the existing LCP check:

```python
if self.primary_device == "mobile-4g" and self.inp_target_ms > 300:
    kills.append(
        f"mobile-4g primary with INP target {self.inp_target_ms}ms: "
        "target is too loose for the device class. Tighten to < 200ms (Web Vitals 'good')."
    )
```

300ms is the "needs improvement" threshold and 200ms the "good" threshold from Web Vitals.

## What was NOT touched

The bot's review also flagged 6 lower-severity items (asymmetric cadence matching, variable-naming inconsistency, missing SKILL.md tool reference, missing "Forcing-question library" section header, specialist routing order, fork contract). Those are polish — handling them in a follow-up keeps this PR surgical.

The bot's "stale CLAUDE.md" claim is incorrect: PR #715 already rewrote that section. The bot was likely reading the cumulative diff.

## Verification

- `backend_decision_engine.py --sample` → exit 0
- `frontend_decision_engine.py --sample` → exit 0
- `fullstack_decision_engine.py --sample` → exit 0 (untouched)
- All three language-preference test cases verified end-to-end

## Test plan

- [ ] CI quality gate passes
- [ ] Once merged, PR #718 (`dev → main`) refreshes with these fixes included


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkUYmjodSKSmaBgbNkg3zx)_