### PR TITLE
feat(productivity/handoff): v1.1 — SessionEnd hook + self-check fidelity script + --refresh flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -973,8 +973,8 @@
     {
       "name": "handoff",
       "source": "./productivity/handoff",
-      "description": "Compact the current conversation into a handoff document for another agent to pick up. Configurable save location (no project clutter), redaction enforcement, SessionStart auto-load, mtime-guarded cleanup. Inspired by Matt Pocock's handoff (MIT).",
-      "version": "2.7.4",
+      "description": "Compact the current conversation into a handoff document for another agent to pick up. Configurable save location, redaction enforcement, SessionStart auto-load + SessionEnd reminder, self-check fidelity script, --refresh flag, mtime-guarded cleanup. Inspired by Matt Pocock's handoff (MIT).",
+      "version": "2.7.5",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -984,6 +984,8 @@
         "session-continuity",
         "redaction",
         "session-start-hook",
+        "session-end-hook",
+        "self-check",
         "matt-pocock"
       ],
       "category": "productivity"

--- a/productivity/handoff/.claude-plugin/plugin.json
+++ b/productivity/handoff/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handoff",
   "description": "Compact the current conversation into a handoff document for another agent to pick up. Save to a user-configured location (OS temp, home folder, or per-project .handoff/), redact secrets before write, suggest skills for the next session, and auto-load the latest handoff on the next SessionStart. First-run setup asks where to save so the project folder never gets cluttered. Use when the user says 'hand this off', 'handoff doc', 'summarize this for a new session', 'compact this conversation', 'I'm ending this session', or any variation signaling intent to pass work to a fresh agent.",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/productivity/handoff/README.md
+++ b/productivity/handoff/README.md
@@ -16,6 +16,14 @@ A productivity-shaped handoff skill. Configurable save location (no project clut
 | 4 | **Redaction linter** | Operationalizes Matt's redaction sentence with regex + whitelist marker + strict/warn modes. |
 | 5 | **mtime-guarded cleanup** | Auto-cleanup never deletes a handoff the user edited as a working surface. |
 
+## v1.1 additions
+
+| Feature | Why |
+|---|---|
+| **SessionEnd reminder hook** | Pairs with SessionStart. If a session ends without a recent handoff, prints a one-line reminder so the user doesn't lose context for next time. Disable with `HANDOFF_SESSIONEND=0`. |
+| **Self-check script** (`handoff_self_check.py`) | Operationalizes the mandatory checklist. Flags empty Goal, State bullets that reference no artifact, missing Open decisions when git is dirty, too few/many Skills, inline content in Artifacts. Runs before the redaction linter. |
+| **`--refresh` flag** on the template generator | Reuses the most recent handoff instead of creating a new file. Keeps the save location uncluttered when work continues past the original handoff. |
+
 ## Install
 
 This plugin lives at `productivity/handoff/`. Enable through your plugin manager. On first invocation of `/cs:handoff`, the skill will prompt:

--- a/productivity/handoff/commands/cs-handoff.md
+++ b/productivity/handoff/commands/cs-handoff.md
@@ -28,8 +28,19 @@ The argument (if provided) becomes the **Goal of next session** verbatim. Withou
 4. **Generate scaffold.** `python3 ${CLAUDE_PLUGIN_ROOT}/skills/handoff/scripts/handoff_template_generator.py --goal "<goal>"`. Capture the printed path.
 5. **Fill the five sections.** Goal / State of play / Open decisions / Skills to use / Artifacts. Reference artifacts; do not duplicate them.
 6. **Recommend skills.** `python3 ${CLAUDE_PLUGIN_ROOT}/skills/handoff/scripts/skill_recommender.py --goal "<goal>"`. Pick 3-5 max. Edit the auto-list.
-7. **Run the redaction linter.** `python3 ${CLAUDE_PLUGIN_ROOT}/skills/handoff/scripts/redaction_linter.py <path>`. Strict mode by default — resolve findings before save. Use `<!-- handoff:allow secret -->` for true false positives.
-8. **Save and report path.** Print the final path so the user can open it.
+7. **Run the self-check.** `python3 ${CLAUDE_PLUGIN_ROOT}/skills/handoff/scripts/handoff_self_check.py <path>`. Fixes fidelity gaps (empty Goal, State bullets without artifacts, missing Decisions when git is dirty, too few/many Skills, inline content in Artifacts). Strict mode by default — resolve findings before save.
+8. **Run the redaction linter.** `python3 ${CLAUDE_PLUGIN_ROOT}/skills/handoff/scripts/redaction_linter.py <path>`. Strict mode by default — resolve findings before save. Use `<!-- handoff:allow secret -->` for true false positives.
+9. **Save and report path.** Print the final path so the user can open it.
+
+## Refreshing an existing handoff
+
+When work continues past the original handoff, pass `--refresh` to the generator instead of creating a new file:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/handoff/scripts/handoff_template_generator.py --refresh --goal "<updated goal>"
+```
+
+The script returns the path of the most recent handoff; edit it in place. Re-run the self-check and redaction linter after editing.
 
 ## What you do NOT do
 

--- a/productivity/handoff/hooks/hooks.json
+++ b/productivity/handoff/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "SessionStart hook for the handoff skill. On a new session, scans the configured save location for the most recent handoff (within the retention window) and surfaces it to the agent as <handoff_from_previous_session> data. Disable per-session with HANDOFF_SESSIONSTART=0.",
+  "description": "SessionStart and SessionEnd hooks for the handoff skill. SessionStart surfaces the latest handoff (within retention window) as <handoff_from_previous_session> data. SessionEnd reminds the user to write a handoff if none exists from the last 30 minutes. Disable per-session with HANDOFF_SESSIONSTART=0 or HANDOFF_SESSIONEND=0.",
   "hooks": {
     "SessionStart": [
       {
@@ -7,6 +7,16 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
           }
         ]
       }

--- a/productivity/handoff/hooks/session_end.py
+++ b/productivity/handoff/hooks/session_end.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""SessionEnd hook for the handoff skill.
+
+When a session ends, checks whether a recent handoff exists in the
+configured save location. If none does (or the most recent is older than
+the staleness threshold), prints a one-line reminder so the user
+remembers to write one before context is lost.
+
+Cannot block session end and cannot prompt interactively — the reminder
+is printed to stdout, which Claude Code surfaces in the session log.
+
+Disable per-session with HANDOFF_SESSIONEND=0.
+
+Stdlib-only.
+"""
+
+import datetime as dt
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+SKILL_SCRIPTS = (
+    Path(__file__).resolve().parent.parent / "skills" / "handoff" / "scripts"
+)
+sys.path.insert(0, str(SKILL_SCRIPTS))
+
+try:
+    import config_loader  # type: ignore
+except ImportError:
+    sys.exit(0)
+
+
+HANDOFF_TOKENS = ("handoff-", "handoff_", "handoff.md")
+STALE_AFTER_MINUTES = 30  # If no handoff in this window, remind.
+
+
+def _disabled() -> bool:
+    return os.environ.get("HANDOFF_SESSIONEND", "1") == "0"
+
+
+def _candidate_dirs(config: dict) -> list[Path]:
+    save = config.get("save_location", {})
+    mode = save.get("mode", "temp")
+    raw_path = save.get("path")
+    dirs: list[Path] = []
+    if mode == "temp":
+        dirs.append(Path(tempfile.gettempdir()))
+    elif raw_path:
+        dirs.append(Path(raw_path))
+    proj = Path.cwd() / ".handoff"
+    if proj.exists() and proj not in dirs:
+        dirs.append(proj)
+    return [d for d in dirs if d.exists()]
+
+
+def _looks_like_handoff(p: Path) -> bool:
+    name = p.name.lower()
+    return name.endswith(".md") and any(t in name for t in HANDOFF_TOKENS)
+
+
+def _latest_mtime(config: dict) -> dt.datetime | None:
+    latest: float | None = None
+    for d in _candidate_dirs(config):
+        try:
+            for entry in d.iterdir():
+                if not entry.is_file() or not _looks_like_handoff(entry):
+                    continue
+                try:
+                    mtime = entry.stat().st_mtime
+                except OSError:
+                    continue
+                if latest is None or mtime > latest:
+                    latest = mtime
+        except OSError:
+            continue
+    if latest is None:
+        return None
+    return dt.datetime.utcfromtimestamp(latest)
+
+
+def _remind() -> None:
+    print("=" * 60)
+    print("Session ending — no recent handoff detected.")
+    print()
+    print("Want to capture state for next time? In a future session, run:")
+    print("  /cs:handoff \"<what the next session should do>\"")
+    print()
+    print("Disable this reminder: HANDOFF_SESSIONEND=0")
+    print("=" * 60)
+
+
+def main() -> int:
+    if _disabled():
+        return 0
+    try:
+        config = config_loader.load_config()
+    except Exception:
+        return 0
+    try:
+        latest = _latest_mtime(config)
+    except Exception:
+        return 0
+    now = dt.datetime.utcnow()
+    stale_cutoff = now - dt.timedelta(minutes=STALE_AFTER_MINUTES)
+    if latest is None or latest < stale_cutoff:
+        try:
+            _remind()
+        except Exception:
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/productivity/handoff/skills/handoff/SKILL.md
+++ b/productivity/handoff/skills/handoff/SKILL.md
@@ -108,13 +108,32 @@ When the plugin is installed, a `SessionStart` hook scans the configured save lo
 
 Disable per-session with `HANDOFF_SESSIONSTART=0`.
 
+## SessionEnd Reminder
+
+A paired `SessionEnd` hook checks whether a recent handoff exists when the session is ending. If none does (or the most recent is older than 30 minutes), it prints a one-line reminder so the user is prompted to write one before context is lost.
+
+The hook cannot prompt interactively or block session end — it surfaces text in the session log.
+
+Disable per-session with `HANDOFF_SESSIONEND=0`.
+
+## Refreshing an Existing Handoff
+
+When work continues past the original handoff time, refresh in place instead of creating a new file:
+
+```bash
+python3 scripts/handoff_template_generator.py --refresh --goal "<updated goal>"
+```
+
+Prints the path of the most recent handoff. The agent edits it directly. Keeps the save location uncluttered and ensures the SessionStart hook always loads the up-to-date version.
+
 ## Tools
 
 | Tool | Purpose |
 |---|---|
 | `setup.py` | First-run Q&A — save location, retention, redaction strictness, git-context, recommender scope. |
-| `handoff_template_generator.py` | Writes the 5-section scaffold at the configured path. |
+| `handoff_template_generator.py` | Writes the 5-section scaffold at the configured path. `--refresh` reuses the most recent handoff instead of creating a new file. |
 | `redaction_linter.py` | Scans the draft for secrets/PII before save. Exit 1 on findings in strict mode. |
+| `handoff_self_check.py` | Fidelity check — flags empty Goal, State bullets without artifacts, missing Decisions when git is dirty, too few/many Skills, inline content in Artifacts. Run before the linter. |
 | `skill_recommender.py` | Suggests 3-5 skills for the next session based on goal text + repo scan. |
 | `cleanup.py` | Deletes scaffolds older than the retention window. mtime-guarded — never deletes a handoff the user edited. |
 | `config_loader.py` | Shared helper: read project config → global config → defaults. |

--- a/productivity/handoff/skills/handoff/scripts/handoff_self_check.py
+++ b/productivity/handoff/skills/handoff/scripts/handoff_self_check.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Self-check for handoff drafts — operationalizes handoff_prompt.md.
+
+Reads a draft handoff and flags fidelity issues the agent might have
+left behind when free-handing the summary. Complements the redaction
+linter (which finds secrets) by finding structural / fidelity gaps.
+
+Checks:
+  1. All 5 sections present (Goal, State, Decisions, Skills, Artifacts).
+  2. Goal section is not empty / placeholder.
+  3. State of play has at least one Done or In-flight bullet that
+     references an artifact (commit hash, PR/issue number, or path).
+  4. Open decisions: if the git repo has uncommitted changes or recent
+     commits, expect at least one decision OR an explicit "- None.".
+  5. Skills to use: 3-5 entries, each with a one-line "why".
+  6. Artifacts: every bullet looks like a path or URL, no inline bodies.
+
+Exit codes:
+  0 — clean (or warn mode with findings)
+  1 — findings in strict mode (default)
+  2 — usage / IO error
+
+Stdlib-only.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SECTION_HEADERS = [
+    "Goal of next session",
+    "State of play",
+    "Open decisions",
+    "Skills to use",
+    "Artifacts",
+]
+
+PLACEHOLDER_PATTERNS = [
+    r"_<!--.*-->_",
+    r"<!--.*-->",
+    r"^\s*\.\.\.\s*$",
+    r"^\s*TODO\s*$",
+    r"^\s*\?\?\?\s*$",
+]
+
+ARTIFACT_HINTS = re.compile(
+    r"(\b[a-f0-9]{7,40}\b"             # git commit hash
+    r"|#\d+"                            # PR/issue number
+    r"|\bPR\s+\d+\b|\bissue\s+\d+\b"
+    r"|https?://"
+    r"|\b[\w./-]+\.(?:py|md|ts|tsx|js|jsx|json|yaml|yml|toml|sql|sh)\b"
+    r"|`[^`]+\.[a-z]+`"
+    r")",
+    re.IGNORECASE,
+)
+
+URL_OR_PATH = re.compile(
+    r"^[\s\-*]*"
+    r"(?:[A-Za-z][\w\s-]{0,30}:\s*)?"   # optional label like "PR:" or "Branch:"
+    r"(?:https?://\S+|[\w./-]+\.\w+|`[^`]+`|/[\w./-]+|\S+/\S+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class Finding:
+    severity: str  # high | medium | low
+    code: str
+    message: str
+    suggestion: str
+    line_hint: int | None = None
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, severity: str, code: str, message: str, suggestion: str, line: int | None = None) -> None:
+        self.findings.append(Finding(severity, code, message, suggestion, line))
+
+    def by_severity(self) -> dict[str, int]:
+        counts = {"high": 0, "medium": 0, "low": 0}
+        for f in self.findings:
+            counts[f.severity] = counts.get(f.severity, 0) + 1
+        return counts
+
+
+def _strip_frontmatter(text: str) -> str:
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    return text[end + 4:].lstrip("\n")
+
+
+def _split_sections(text: str) -> dict[str, str]:
+    body = _strip_frontmatter(text)
+    sections: dict[str, str] = {}
+    current_header: str | None = None
+    current_lines: list[str] = []
+    for line in body.splitlines():
+        m = re.match(r"^##\s+(.+?)\s*$", line)
+        if m:
+            if current_header is not None:
+                sections[current_header] = "\n".join(current_lines).strip()
+            current_header = m.group(1).strip()
+            current_lines = []
+        else:
+            if current_header is not None:
+                current_lines.append(line)
+    if current_header is not None:
+        sections[current_header] = "\n".join(current_lines).strip()
+    return sections
+
+
+def _is_placeholder(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return True
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.fullmatch(pattern, stripped, re.IGNORECASE):
+            return True
+    # Section content that is ONLY placeholder comment(s)
+    non_placeholder = re.sub(r"_?<!--.*?-->_?", "", stripped, flags=re.DOTALL).strip()
+    return not non_placeholder
+
+
+def _bullet_lines(section: str) -> list[str]:
+    out = []
+    for line in section.splitlines():
+        line = line.rstrip()
+        if re.match(r"^\s*[-*+]\s+", line):
+            out.append(line)
+    return out
+
+
+def _git_state(cwd: Path) -> dict[str, int]:
+    state = {"dirty": 0, "recent_commits": 0, "in_repo": 0}
+
+    def run(cmd: list[str]) -> str | None:
+        try:
+            r = subprocess.run(
+                cmd, cwd=str(cwd), check=False,
+                capture_output=True, text=True, timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return r.stdout if r.returncode == 0 else None
+
+    if run(["git", "rev-parse", "--is-inside-work-tree"]):
+        state["in_repo"] = 1
+        status = run(["git", "status", "--porcelain"]) or ""
+        state["dirty"] = sum(1 for ln in status.splitlines() if ln.strip())
+        log = run(["git", "log", "--since=1.day.ago", "--oneline"]) or ""
+        state["recent_commits"] = sum(1 for ln in log.splitlines() if ln.strip())
+    return state
+
+
+def check(text: str, cwd: Path | None = None) -> Report:
+    report = Report()
+    sections = _split_sections(text)
+
+    # Check 1: all 5 sections present
+    for header in SECTION_HEADERS:
+        if header not in sections:
+            report.add(
+                "high", "MISSING_SECTION",
+                f"Section missing: '## {header}'",
+                f"Add a `## {header}` section. See references/handoff_structure.md.",
+            )
+
+    # Check 2: Goal section is not empty/placeholder
+    goal = sections.get("Goal of next session", "")
+    if _is_placeholder(goal):
+        report.add(
+            "high", "EMPTY_GOAL",
+            "Goal section is empty or placeholder text.",
+            "Write one sentence describing what the next session must accomplish.",
+        )
+
+    # Check 3: State of play references an artifact
+    state_text = sections.get("State of play", "")
+    if _is_placeholder(state_text):
+        report.add(
+            "high", "EMPTY_STATE",
+            "State of play is empty or placeholder text.",
+            "List what's done/in-flight/blocked. Each bullet references a commit, PR, file path, or issue.",
+        )
+    else:
+        bullets = _bullet_lines(state_text)
+        substantive = [b for b in bullets if not _is_placeholder(b)]
+        with_artifact = [b for b in substantive if ARTIFACT_HINTS.search(b)]
+        if substantive and not with_artifact:
+            report.add(
+                "high", "STATE_NO_ARTIFACT",
+                "State of play bullets do not reference any artifact (commit hash, PR/issue number, file path).",
+                "For every bullet, name the artifact that proves it. See handoff_prompt.md Step 2.",
+            )
+
+    # Check 4: Open decisions vs git context
+    decisions_text = sections.get("Open decisions", "")
+    has_decisions = (
+        not _is_placeholder(decisions_text)
+        and "none." not in decisions_text.lower()[:30]
+    )
+    if cwd is not None:
+        gs = _git_state(cwd)
+        if gs["in_repo"] and (gs["dirty"] > 0 or gs["recent_commits"] > 1) and not has_decisions:
+            report.add(
+                "medium", "MISSING_DECISIONS",
+                f"Repo has {gs['dirty']} dirty file(s) and {gs['recent_commits']} commit(s) today, but Open decisions is empty.",
+                "Either list the decisions that surfaced during this work, or write '- None.' explicitly.",
+            )
+
+    # Check 5: Skills to use — 3 to 5 entries
+    skills_text = sections.get("Skills to use", "")
+    skill_bullets = _bullet_lines(skills_text)
+    substantive_skills = [b for b in skill_bullets if not _is_placeholder(b)]
+    n = len(substantive_skills)
+    if n == 0:
+        report.add(
+            "medium", "NO_SKILLS",
+            "Skills to use section has no entries.",
+            "Run scripts/skill_recommender.py and pick 3-5 skills. Each with a one-line 'why'.",
+        )
+    elif n > 5:
+        report.add(
+            "medium", "TOO_MANY_SKILLS",
+            f"{n} skills listed. Hard cap is 5.",
+            "Trim to the 3-5 skills the next session actually needs. See handoff_prompt.md Step 4.",
+        )
+    elif n < 3:
+        report.add(
+            "low", "FEW_SKILLS",
+            f"Only {n} skill(s) listed. Minimum recommended is 3.",
+            "Consider adding a review or verifier skill.",
+        )
+    # Each skill should have a 'why' (em-dash or hyphen + explanation)
+    for b in substantive_skills:
+        if not re.search(r"[-—–]\s+\S+", b.split("**", 2)[-1] if "**" in b else b):
+            report.add(
+                "low", "SKILL_NO_WHY",
+                f"Skill bullet has no '— why' explanation: {b.strip()[:60]}",
+                "Format: `- skill-name — one-line why this session needs it`",
+            )
+            break  # only flag once
+
+    # Check 6: Artifacts — only paths/URLs, no inline bodies
+    artifacts_text = sections.get("Artifacts", "")
+    if not _is_placeholder(artifacts_text):
+        artifact_bullets = _bullet_lines(artifacts_text)
+        for line in artifact_bullets:
+            if _is_placeholder(line):
+                continue
+            # If bullet is very long (>200 chars) it likely embeds content
+            if len(line) > 200:
+                report.add(
+                    "medium", "ARTIFACT_INLINE_BODY",
+                    f"Artifact bullet is suspiciously long ({len(line)} chars) — likely embedded content.",
+                    "Replace inline content with a path/URL. See deduplication_discipline.md.",
+                )
+                break
+
+    return report
+
+
+def _format_human(report: Report, mode: str, path: Path) -> str:
+    if not report.findings:
+        return f"OK: handoff passes self-check ({path})."
+    lines = [f"Found {len(report.findings)} fidelity issue(s) in {path}:", ""]
+    for f in report.findings:
+        lines.append(f"  [{f.severity}] {f.code}: {f.message}")
+        lines.append(f"    fix: {f.suggestion}")
+        lines.append("")
+    counts = report.by_severity()
+    lines.append(f"Severity counts: high={counts['high']} medium={counts['medium']} low={counts['low']}")
+    if mode == "strict":
+        lines.append("Mode: STRICT — save is blocked until findings are resolved.")
+    else:
+        lines.append("Mode: WARN — save proceeds; review findings before sharing.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Self-check a handoff draft for fidelity issues.",
+        epilog="Pairs with redaction_linter.py: this finds structural gaps, that finds secrets.",
+    )
+    parser.add_argument("file", nargs="?", help="Path to the handoff markdown file.")
+    parser.add_argument(
+        "--mode",
+        choices=["strict", "warn"],
+        default="strict",
+        help="strict: exit 1 on high-severity findings; warn: always exit 0.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of human output.")
+    parser.add_argument("--sample", action="store_true", help="Run against a built-in bad fixture and exit.")
+    parser.add_argument(
+        "--no-git", action="store_true",
+        help="Skip git context probing (Check 4 becomes a no-op).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        fixture = """---
+goal: ""
+---
+
+# Handoff
+
+## Goal of next session
+
+_<!-- one sentence: what the next session must accomplish -->_
+
+## State of play
+
+- Done: implemented the feature
+- In flight: testing
+- Blocked: nothing
+
+## Open decisions
+
+_<!-- What must the next agent decide before continuing? -->_
+
+## Skills to use
+
+- code-review
+- handoff
+- security-scan
+- update-docs
+- skill-tester
+- review
+- something-else
+
+## Artifacts
+
+- _<!-- e.g. PR: https://github.com/org/repo/pull/123 -->_
+"""
+        report = check(fixture, cwd=None)
+        if args.json:
+            print(json.dumps({
+                "findings": [
+                    {"severity": f.severity, "code": f.code, "message": f.message, "suggestion": f.suggestion}
+                    for f in report.findings
+                ],
+                "counts": report.by_severity(),
+            }, indent=2))
+        else:
+            print(_format_human(report, args.mode, Path("<sample>")))
+        return 1 if report.findings and args.mode == "strict" else 0
+
+    if not args.file:
+        parser.error("file is required unless --sample is used.")
+
+    path = Path(args.file)
+    if not path.exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        return 2
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading {path}: {exc}", file=sys.stderr)
+        return 2
+
+    cwd = None if args.no_git else Path.cwd()
+    report = check(text, cwd=cwd)
+
+    if args.json:
+        print(json.dumps({
+            "file": str(path),
+            "mode": args.mode,
+            "findings": [
+                {"severity": f.severity, "code": f.code, "message": f.message, "suggestion": f.suggestion}
+                for f in report.findings
+            ],
+            "counts": report.by_severity(),
+        }, indent=2))
+    else:
+        print(_format_human(report, args.mode, path))
+
+    if not report.findings:
+        return 0
+    if args.mode == "strict":
+        return 1 if any(f.severity == "high" for f in report.findings) else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/productivity/handoff/skills/handoff/scripts/handoff_template_generator.py
+++ b/productivity/handoff/skills/handoff/scripts/handoff_template_generator.py
@@ -61,6 +61,46 @@ def _git_context(cwd: Path) -> str | None:
     return "\n".join(lines)
 
 
+HANDOFF_FILENAME_TOKENS = ("handoff-", "handoff_", "handoff.md")
+
+
+def _save_dirs(config: dict) -> list[Path]:
+    """Directories where existing handoffs might live, in lookup order."""
+    save = config.get("save_location", {})
+    mode = save.get("mode", "temp")
+    raw_path = save.get("path")
+    dirs: list[Path] = []
+    if mode == "temp":
+        dirs.append(Path(tempfile.gettempdir()))
+    elif raw_path:
+        dirs.append(Path(raw_path))
+    proj = Path.cwd() / ".handoff"
+    if proj.exists() and proj not in dirs:
+        dirs.append(proj)
+    return [d for d in dirs if d.exists()]
+
+
+def _find_latest_handoff(config: dict) -> Path | None:
+    latest: tuple[float, Path] | None = None
+    for d in _save_dirs(config):
+        try:
+            for entry in d.iterdir():
+                if not entry.is_file() or not entry.name.lower().endswith(".md"):
+                    continue
+                name = entry.name.lower()
+                if not any(t in name for t in HANDOFF_FILENAME_TOKENS):
+                    continue
+                try:
+                    mtime = entry.stat().st_mtime
+                except OSError:
+                    continue
+                if latest is None or mtime > latest[0]:
+                    latest = (mtime, entry)
+        except OSError:
+            continue
+    return latest[1] if latest else None
+
+
 def _resolve_save_path(config: dict, goal: str, now: dt.datetime) -> Path:
     save = config.get("save_location", {})
     mode = save.get("mode", "temp")
@@ -165,11 +205,27 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip git context even if enabled in config.",
     )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Reuse the most recent handoff in the configured location instead of creating a new file. The agent edits it in place.",
+    )
     args = parser.parse_args(argv)
 
     config = config_loader.load_config()
     now = dt.datetime.utcnow()
     goal = args.goal.strip()
+
+    if args.refresh and not args.sample:
+        existing = _find_latest_handoff(config)
+        if existing is not None:
+            if args.print_path_only:
+                print(str(existing))
+            else:
+                print(f"Refresh: reusing existing handoff at {existing}")
+                print("Edit the file in place to reflect the current state.")
+            return 0
+        # Fall through to creating a new one — refresh becomes create-if-missing.
 
     git_block: str | None = None
     if not args.no_git and config.get("include_git_context", True):


### PR DESCRIPTION
## Summary

Follow-up to #724. Ships the three improvements judged most impactful in the v1.1 design review.

### 1. SessionEnd hook (`hooks/session_end.py`)

Pairs with the SessionStart hook from v1.0. When a session ends with no handoff in the last 30 minutes, prints a one-line reminder so the user doesn't lose context for next time.

- Cannot prompt interactively or block session end (Claude Code hook constraint) — surfaces text via stdout.
- Reads the same config as SessionStart, scans the same save locations.
- Disable per-session with `HANDOFF_SESSIONEND=0`.
- `hooks/hooks.json` updated to wire both `SessionStart` and `SessionEnd`.

### 2. `handoff_self_check.py` — fidelity script

Operationalizes `references/handoff_prompt.md`. Was the deferred answer to weakness W3 (agent free-hands the summary; nothing verifies fidelity). 6 checks, stdlib-only:

| # | Check | Severity |
|---|---|---|
| 1 | All 5 sections present (Goal / State / Decisions / Skills / Artifacts) | high |
| 2 | Goal section is non-empty and non-placeholder | high |
| 3 | State-of-play bullets reference at least one artifact (commit hash, PR/issue number, file path, URL) | high |
| 4 | Open decisions section is non-empty (or explicit "- None.") when git is dirty / has recent commits | medium |
| 5 | Skills to use: 3-5 entries, hard cap enforced; each with a `— why` explanation | medium / low |
| 6 | Artifacts contain only paths/URLs, no inline content | medium |

Strict mode exits 1 only on **high-severity** findings (so medium issues warn without blocking). `--sample` fixture has 3 planted issues (2 high + 1 medium) and exits 1. The canonical `assets/example_handoff.md` passes clean (exit 0).

`/cs:handoff` command updated to run the self-check between scaffold-fill and the redaction linter.

### 3. `--refresh` flag on `handoff_template_generator.py`

Reuses the most recent handoff in the configured save location instead of creating a new file. Falls through to create-if-missing when no existing handoff exists.

```bash
python3 scripts/handoff_template_generator.py --refresh --goal "<updated goal>"
```

Keeps the save location uncluttered when work continues past the original handoff. Ensures the SessionStart hook always loads the up-to-date version (not a stale duplicate).

## Verification

- All 9 Python files compile clean.
- `handoff_self_check.py --sample` exits 1 with 3 findings as expected (2 high + 1 medium).
- `handoff_self_check.py` against `assets/example_handoff.md` exits 0.
- `--refresh` smoke test: finds the latest `/tmp/handoff-*.md` and prints its path.
- SessionEnd hook smoke test: prints the reminder when no recent handoff exists.
- `check_plugin_json.py` + marketplace.json + hooks.json all parse.
- Plugin audit re-run: **structure 84.2 → 86.0**, **quality 62.2 → 63.0**, **security PASS** (0 critical, 0 high).
- Codex + Gemini sync re-ran clean.

## What's still on the v1.2 deferred list

These were intentionally NOT shipped in v1.1:

- 5 template variants (debug / build / review / research / planning)
- `--list` flag to browse saved handoffs
- Cross-tool capability block in recommender output
- PR / ticket snapshot integration (`gh pr view`, Atlassian MCP)
- Empty-handoff guard at save time

All are "useful, not essential" per the prior weakness analysis.

## Test plan

- [ ] Start a fresh session in a project with a recent handoff → SessionStart hook loads it
- [ ] End that session immediately (no handoff written) → SessionEnd hook stays silent (handoff is recent)
- [ ] Wait >30 min, end a session → SessionEnd hook prints the reminder
- [ ] Set `HANDOFF_SESSIONEND=0` → hook stays silent on session end
- [ ] Run `/cs:handoff "x"`, then immediately `/cs:handoff --refresh "y"` → second call reuses first file's path
- [ ] Run self-check against a hand-crafted bad draft → flags the right issues per severity
- [ ] Run self-check against a clean draft → exits 0

https://claude.ai/code/session_01KLhHBAfEDXdQMeRe6G8sRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLhHBAfEDXdQMeRe6G8sRa)_