### PR TITLE
feat(install): add Mistral Vibe cross-platform sync (closes #705)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "metadata": {
-    "description": "328 production-ready skill packages across 14 domains (engineering, marketing, product, c-level, project management, RA/QM, business growth, finance, productivity, marketing (top-level), research, business-operations [v2.8.0], commercial [v2.8.0], plus standards). ~441 Python tools, ~594 reference guides, 48+ agents (cs-* + personas), 77+ slash commands. v2.8.0 adds 2 new top-level domains (business-operations + commercial) with 15 new skills, context: fork chaining via Matt Pocock grill-with-docs discipline. v2.7.3 adds AEO + security-guidance PreToolUse hook. Compatible with Claude Code, Codex CLI, Gemini CLI, Cursor, OpenClaw, Hermes Agent, and 6 more coding agents.",
+    "description": "328 production-ready skill packages across 14 domains (engineering, marketing, product, c-level, project management, RA/QM, business growth, finance, productivity, marketing (top-level), research, business-operations [v2.8.0], commercial [v2.8.0], plus standards). ~441 Python tools, ~594 reference guides, 48+ agents (cs-* + personas), 77+ slash commands. v2.8.0 adds 2 new top-level domains (business-operations + commercial) with 15 new skills, context: fork chaining via Matt Pocock grill-with-docs discipline. v2.7.3 adds AEO + security-guidance PreToolUse hook. Compatible with Claude Code, Codex CLI, Gemini CLI, Cursor, OpenClaw, Hermes Agent, Mistral Vibe, and 5 more coding agents.",
     "version": "2.8.0"
   },
   "plugins": [

--- a/.vibe/skills/claude-skills/business-growth/business-growth-skills
+++ b/.vibe/skills/claude-skills/business-growth/business-growth-skills
@@ -1,0 +1,1 @@
+../../../../business-growth/skills/business-growth-skills

--- a/.vibe/skills/claude-skills/business-growth/contract-and-proposal-writer
+++ b/.vibe/skills/claude-skills/business-growth/contract-and-proposal-writer
@@ -1,0 +1,1 @@
+../../../../business-growth/skills/contract-and-proposal-writer

--- a/.vibe/skills/claude-skills/business-growth/customer-success-manager
+++ b/.vibe/skills/claude-skills/business-growth/customer-success-manager
@@ -1,0 +1,1 @@
+../../../../business-growth/skills/customer-success-manager

--- a/.vibe/skills/claude-skills/business-growth/revenue-operations
+++ b/.vibe/skills/claude-skills/business-growth/revenue-operations
@@ -1,0 +1,1 @@
+../../../../business-growth/skills/revenue-operations

--- a/.vibe/skills/claude-skills/business-growth/sales-engineer
+++ b/.vibe/skills/claude-skills/business-growth/sales-engineer
@@ -1,0 +1,1 @@
+../../../../business-growth/skills/sales-engineer

--- a/.vibe/skills/claude-skills/business-operations/business-operations-skills
+++ b/.vibe/skills/claude-skills/business-operations/business-operations-skills
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/business-operations-skills

--- a/.vibe/skills/claude-skills/business-operations/capacity-planner
+++ b/.vibe/skills/claude-skills/business-operations/capacity-planner
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/capacity-planner

--- a/.vibe/skills/claude-skills/business-operations/internal-comms
+++ b/.vibe/skills/claude-skills/business-operations/internal-comms
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/internal-comms

--- a/.vibe/skills/claude-skills/business-operations/knowledge-ops
+++ b/.vibe/skills/claude-skills/business-operations/knowledge-ops
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/knowledge-ops

--- a/.vibe/skills/claude-skills/business-operations/process-mapper
+++ b/.vibe/skills/claude-skills/business-operations/process-mapper
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/process-mapper

--- a/.vibe/skills/claude-skills/business-operations/procurement-optimizer
+++ b/.vibe/skills/claude-skills/business-operations/procurement-optimizer
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/procurement-optimizer

--- a/.vibe/skills/claude-skills/business-operations/vendor-management
+++ b/.vibe/skills/claude-skills/business-operations/vendor-management
@@ -1,0 +1,1 @@
+../../../../business-operations/skills/vendor-management

--- a/.vibe/skills/claude-skills/c-level-advisor/agent-protocol
+++ b/.vibe/skills/claude-skills/c-level-advisor/agent-protocol
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/agent-protocol

--- a/.vibe/skills/claude-skills/c-level-advisor/board-deck-builder
+++ b/.vibe/skills/claude-skills/c-level-advisor/board-deck-builder
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/board-deck-builder

--- a/.vibe/skills/claude-skills/c-level-advisor/board-meeting
+++ b/.vibe/skills/claude-skills/c-level-advisor/board-meeting
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/board-meeting

--- a/.vibe/skills/claude-skills/c-level-advisor/board-prep
+++ b/.vibe/skills/claude-skills/c-level-advisor/board-prep
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/executive-mentor/skills/board-prep

--- a/.vibe/skills/claude-skills/c-level-advisor/boardroom
+++ b/.vibe/skills/claude-skills/c-level-advisor/boardroom
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/boardroom

--- a/.vibe/skills/claude-skills/c-level-advisor/brief
+++ b/.vibe/skills/claude-skills/c-level-advisor/brief
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/brief

--- a/.vibe/skills/claude-skills/c-level-advisor/c-level-agents
+++ b/.vibe/skills/claude-skills/c-level-advisor/c-level-agents
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/c-level-agents

--- a/.vibe/skills/claude-skills/c-level-advisor/c-level-skills
+++ b/.vibe/skills/claude-skills/c-level-advisor/c-level-skills
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/c-level-skills

--- a/.vibe/skills/claude-skills/c-level-advisor/caio-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/caio-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/caio-review

--- a/.vibe/skills/claude-skills/c-level-advisor/cco-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cco-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cco-review

--- a/.vibe/skills/claude-skills/c-level-advisor/cdo-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cdo-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cdo-review

--- a/.vibe/skills/claude-skills/c-level-advisor/ceo-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/ceo-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/ceo-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cfo-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/cfo-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/cfo-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cfo-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cfo-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cfo-review

--- a/.vibe/skills/claude-skills/c-level-advisor/challenge
+++ b/.vibe/skills/claude-skills/c-level-advisor/challenge
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/executive-mentor/skills/challenge

--- a/.vibe/skills/claude-skills/c-level-advisor/change-management
+++ b/.vibe/skills/claude-skills/c-level-advisor/change-management
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/change-management

--- a/.vibe/skills/claude-skills/c-level-advisor/chief-ai-officer-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/chief-ai-officer-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/chief-ai-officer-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/chief-customer-officer-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/chief-customer-officer-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/chief-customer-officer-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/chief-data-officer-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/chief-data-officer-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/chief-data-officer-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/chief-of-staff
+++ b/.vibe/skills/claude-skills/c-level-advisor/chief-of-staff
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/chief-of-staff

--- a/.vibe/skills/claude-skills/c-level-advisor/chro-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/chro-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/chro-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/ciso-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/ciso-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/ciso-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/ciso-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/ciso-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/ciso-review

--- a/.vibe/skills/claude-skills/c-level-advisor/cmo-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/cmo-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/cmo-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cmo-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cmo-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cmo-review

--- a/.vibe/skills/claude-skills/c-level-advisor/company-os
+++ b/.vibe/skills/claude-skills/c-level-advisor/company-os
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/company-os

--- a/.vibe/skills/claude-skills/c-level-advisor/competitive-intel
+++ b/.vibe/skills/claude-skills/c-level-advisor/competitive-intel
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/competitive-intel

--- a/.vibe/skills/claude-skills/c-level-advisor/context-engine
+++ b/.vibe/skills/claude-skills/c-level-advisor/context-engine
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/context-engine

--- a/.vibe/skills/claude-skills/c-level-advisor/coo-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/coo-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/coo-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cpo-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/cpo-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/cpo-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cpo-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cpo-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cpo-review

--- a/.vibe/skills/claude-skills/c-level-advisor/cro-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/cro-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/cro-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cro-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cro-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cro-review

--- a/.vibe/skills/claude-skills/c-level-advisor/cross-eval
+++ b/.vibe/skills/claude-skills/c-level-advisor/cross-eval
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cross-eval

--- a/.vibe/skills/claude-skills/c-level-advisor/cs-onboard
+++ b/.vibe/skills/claude-skills/c-level-advisor/cs-onboard
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/cs-onboard

--- a/.vibe/skills/claude-skills/c-level-advisor/cto-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/cto-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/cto-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/cto-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/cto-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/cto-review

--- a/.vibe/skills/claude-skills/c-level-advisor/culture-architect
+++ b/.vibe/skills/claude-skills/c-level-advisor/culture-architect
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/culture-architect

--- a/.vibe/skills/claude-skills/c-level-advisor/decide
+++ b/.vibe/skills/claude-skills/c-level-advisor/decide
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/decide

--- a/.vibe/skills/claude-skills/c-level-advisor/decision-logger
+++ b/.vibe/skills/claude-skills/c-level-advisor/decision-logger
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/decision-logger

--- a/.vibe/skills/claude-skills/c-level-advisor/execute
+++ b/.vibe/skills/claude-skills/c-level-advisor/execute
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/execute

--- a/.vibe/skills/claude-skills/c-level-advisor/executive-mentor
+++ b/.vibe/skills/claude-skills/c-level-advisor/executive-mentor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/executive-mentor/skills/executive-mentor

--- a/.vibe/skills/claude-skills/c-level-advisor/founder-coach
+++ b/.vibe/skills/claude-skills/c-level-advisor/founder-coach
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/founder-coach

--- a/.vibe/skills/claude-skills/c-level-advisor/founder-mode
+++ b/.vibe/skills/claude-skills/c-level-advisor/founder-mode
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/founder-mode

--- a/.vibe/skills/claude-skills/c-level-advisor/freeze
+++ b/.vibe/skills/claude-skills/c-level-advisor/freeze
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/freeze

--- a/.vibe/skills/claude-skills/c-level-advisor/gc-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/gc-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/gc-review

--- a/.vibe/skills/claude-skills/c-level-advisor/general-counsel-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/general-counsel-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/general-counsel-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/hard-call
+++ b/.vibe/skills/claude-skills/c-level-advisor/hard-call
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/executive-mentor/skills/hard-call

--- a/.vibe/skills/claude-skills/c-level-advisor/internal-narrative
+++ b/.vibe/skills/claude-skills/c-level-advisor/internal-narrative
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/internal-narrative

--- a/.vibe/skills/claude-skills/c-level-advisor/intl-expansion
+++ b/.vibe/skills/claude-skills/c-level-advisor/intl-expansion
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/intl-expansion

--- a/.vibe/skills/claude-skills/c-level-advisor/ma-playbook
+++ b/.vibe/skills/claude-skills/c-level-advisor/ma-playbook
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/ma-playbook

--- a/.vibe/skills/claude-skills/c-level-advisor/office-hours
+++ b/.vibe/skills/claude-skills/c-level-advisor/office-hours
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/office-hours

--- a/.vibe/skills/claude-skills/c-level-advisor/onboard
+++ b/.vibe/skills/claude-skills/c-level-advisor/onboard
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/onboard

--- a/.vibe/skills/claude-skills/c-level-advisor/org-health-diagnostic
+++ b/.vibe/skills/claude-skills/c-level-advisor/org-health-diagnostic
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/org-health-diagnostic

--- a/.vibe/skills/claude-skills/c-level-advisor/post-mortem
+++ b/.vibe/skills/claude-skills/c-level-advisor/post-mortem
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/post-mortem

--- a/.vibe/skills/claude-skills/c-level-advisor/postmortem
+++ b/.vibe/skills/claude-skills/c-level-advisor/postmortem
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/executive-mentor/skills/postmortem

--- a/.vibe/skills/claude-skills/c-level-advisor/scenario-war-room
+++ b/.vibe/skills/claude-skills/c-level-advisor/scenario-war-room
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/scenario-war-room

--- a/.vibe/skills/claude-skills/c-level-advisor/strategic-alignment
+++ b/.vibe/skills/claude-skills/c-level-advisor/strategic-alignment
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/strategic-alignment

--- a/.vibe/skills/claude-skills/c-level-advisor/stress-test
+++ b/.vibe/skills/claude-skills/c-level-advisor/stress-test
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/executive-mentor/skills/stress-test

--- a/.vibe/skills/claude-skills/c-level-advisor/vpe-advisor
+++ b/.vibe/skills/claude-skills/c-level-advisor/vpe-advisor
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/skills/vpe-advisor

--- a/.vibe/skills/claude-skills/c-level-advisor/vpe-review
+++ b/.vibe/skills/claude-skills/c-level-advisor/vpe-review
@@ -1,0 +1,1 @@
+../../../../c-level-advisor/c-level-agents/skills/vpe-review

--- a/.vibe/skills/claude-skills/commercial/channel-economics
+++ b/.vibe/skills/claude-skills/commercial/channel-economics
@@ -1,0 +1,1 @@
+../../../../commercial/skills/channel-economics

--- a/.vibe/skills/claude-skills/commercial/commercial-forecaster
+++ b/.vibe/skills/claude-skills/commercial/commercial-forecaster
@@ -1,0 +1,1 @@
+../../../../commercial/skills/commercial-forecaster

--- a/.vibe/skills/claude-skills/commercial/commercial-policy
+++ b/.vibe/skills/claude-skills/commercial/commercial-policy
@@ -1,0 +1,1 @@
+../../../../commercial/skills/commercial-policy

--- a/.vibe/skills/claude-skills/commercial/commercial-skills
+++ b/.vibe/skills/claude-skills/commercial/commercial-skills
@@ -1,0 +1,1 @@
+../../../../commercial/skills/commercial-skills

--- a/.vibe/skills/claude-skills/commercial/deal-desk
+++ b/.vibe/skills/claude-skills/commercial/deal-desk
@@ -1,0 +1,1 @@
+../../../../commercial/skills/deal-desk

--- a/.vibe/skills/claude-skills/commercial/partnerships-architect
+++ b/.vibe/skills/claude-skills/commercial/partnerships-architect
@@ -1,0 +1,1 @@
+../../../../commercial/skills/partnerships-architect

--- a/.vibe/skills/claude-skills/commercial/pricing-strategist
+++ b/.vibe/skills/claude-skills/commercial/pricing-strategist
@@ -1,0 +1,1 @@
+../../../../commercial/skills/pricing-strategist

--- a/.vibe/skills/claude-skills/commercial/rfp-responder
+++ b/.vibe/skills/claude-skills/commercial/rfp-responder
@@ -1,0 +1,1 @@
+../../../../commercial/skills/rfp-responder

--- a/.vibe/skills/claude-skills/engineering-team/a11y-audit
+++ b/.vibe/skills/claude-skills/engineering-team/a11y-audit
@@ -1,0 +1,1 @@
+../../../../engineering-team/a11y-audit/skills/a11y-audit

--- a/.vibe/skills/claude-skills/engineering-team/adversarial-reviewer
+++ b/.vibe/skills/claude-skills/engineering-team/adversarial-reviewer
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/adversarial-reviewer

--- a/.vibe/skills/claude-skills/engineering-team/ai-security
+++ b/.vibe/skills/claude-skills/engineering-team/ai-security
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/ai-security

--- a/.vibe/skills/claude-skills/engineering-team/aws-solution-architect
+++ b/.vibe/skills/claude-skills/engineering-team/aws-solution-architect
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/aws-solution-architect

--- a/.vibe/skills/claude-skills/engineering-team/azure-cloud-architect
+++ b/.vibe/skills/claude-skills/engineering-team/azure-cloud-architect
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/azure-cloud-architect

--- a/.vibe/skills/claude-skills/engineering-team/browserstack
+++ b/.vibe/skills/claude-skills/engineering-team/browserstack
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/browserstack

--- a/.vibe/skills/claude-skills/engineering-team/cloud-security
+++ b/.vibe/skills/claude-skills/engineering-team/cloud-security
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/cloud-security

--- a/.vibe/skills/claude-skills/engineering-team/code-reviewer
+++ b/.vibe/skills/claude-skills/engineering-team/code-reviewer
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/code-reviewer

--- a/.vibe/skills/claude-skills/engineering-team/coverage
+++ b/.vibe/skills/claude-skills/engineering-team/coverage
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/coverage

--- a/.vibe/skills/claude-skills/engineering-team/email-template-builder
+++ b/.vibe/skills/claude-skills/engineering-team/email-template-builder
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/email-template-builder

--- a/.vibe/skills/claude-skills/engineering-team/engineering-skills
+++ b/.vibe/skills/claude-skills/engineering-team/engineering-skills
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/engineering-skills

--- a/.vibe/skills/claude-skills/engineering-team/epic-design
+++ b/.vibe/skills/claude-skills/engineering-team/epic-design
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/epic-design

--- a/.vibe/skills/claude-skills/engineering-team/extract
+++ b/.vibe/skills/claude-skills/engineering-team/extract
@@ -1,0 +1,1 @@
+../../../../engineering-team/self-improving-agent/skills/extract

--- a/.vibe/skills/claude-skills/engineering-team/fix
+++ b/.vibe/skills/claude-skills/engineering-team/fix
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/fix

--- a/.vibe/skills/claude-skills/engineering-team/gcp-cloud-architect
+++ b/.vibe/skills/claude-skills/engineering-team/gcp-cloud-architect
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/gcp-cloud-architect

--- a/.vibe/skills/claude-skills/engineering-team/generate
+++ b/.vibe/skills/claude-skills/engineering-team/generate
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/generate

--- a/.vibe/skills/claude-skills/engineering-team/google-workspace-cli
+++ b/.vibe/skills/claude-skills/engineering-team/google-workspace-cli
@@ -1,0 +1,1 @@
+../../../../engineering-team/google-workspace-cli/skills/google-workspace-cli

--- a/.vibe/skills/claude-skills/engineering-team/incident-commander
+++ b/.vibe/skills/claude-skills/engineering-team/incident-commander
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/incident-commander

--- a/.vibe/skills/claude-skills/engineering-team/incident-response
+++ b/.vibe/skills/claude-skills/engineering-team/incident-response
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/incident-response

--- a/.vibe/skills/claude-skills/engineering-team/init
+++ b/.vibe/skills/claude-skills/engineering-team/init
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/init

--- a/.vibe/skills/claude-skills/engineering-team/migrate
+++ b/.vibe/skills/claude-skills/engineering-team/migrate
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/migrate

--- a/.vibe/skills/claude-skills/engineering-team/ms365-tenant-manager
+++ b/.vibe/skills/claude-skills/engineering-team/ms365-tenant-manager
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/ms365-tenant-manager

--- a/.vibe/skills/claude-skills/engineering-team/promote
+++ b/.vibe/skills/claude-skills/engineering-team/promote
@@ -1,0 +1,1 @@
+../../../../engineering-team/self-improving-agent/skills/promote

--- a/.vibe/skills/claude-skills/engineering-team/pw
+++ b/.vibe/skills/claude-skills/engineering-team/pw
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/pw

--- a/.vibe/skills/claude-skills/engineering-team/red-team
+++ b/.vibe/skills/claude-skills/engineering-team/red-team
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/red-team

--- a/.vibe/skills/claude-skills/engineering-team/remember
+++ b/.vibe/skills/claude-skills/engineering-team/remember
@@ -1,0 +1,1 @@
+../../../../engineering-team/self-improving-agent/skills/remember

--- a/.vibe/skills/claude-skills/engineering-team/report
+++ b/.vibe/skills/claude-skills/engineering-team/report
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/report

--- a/.vibe/skills/claude-skills/engineering-team/review
+++ b/.vibe/skills/claude-skills/engineering-team/review
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/review

--- a/.vibe/skills/claude-skills/engineering-team/security-pen-testing
+++ b/.vibe/skills/claude-skills/engineering-team/security-pen-testing
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/security-pen-testing

--- a/.vibe/skills/claude-skills/engineering-team/self-improving-agent
+++ b/.vibe/skills/claude-skills/engineering-team/self-improving-agent
@@ -1,0 +1,1 @@
+../../../../engineering-team/self-improving-agent/skills/self-improving-agent

--- a/.vibe/skills/claude-skills/engineering-team/senior-architect
+++ b/.vibe/skills/claude-skills/engineering-team/senior-architect
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-architect

--- a/.vibe/skills/claude-skills/engineering-team/senior-backend
+++ b/.vibe/skills/claude-skills/engineering-team/senior-backend
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-backend

--- a/.vibe/skills/claude-skills/engineering-team/senior-computer-vision
+++ b/.vibe/skills/claude-skills/engineering-team/senior-computer-vision
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-computer-vision

--- a/.vibe/skills/claude-skills/engineering-team/senior-data-engineer
+++ b/.vibe/skills/claude-skills/engineering-team/senior-data-engineer
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-data-engineer

--- a/.vibe/skills/claude-skills/engineering-team/senior-data-scientist
+++ b/.vibe/skills/claude-skills/engineering-team/senior-data-scientist
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-data-scientist

--- a/.vibe/skills/claude-skills/engineering-team/senior-devops
+++ b/.vibe/skills/claude-skills/engineering-team/senior-devops
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-devops

--- a/.vibe/skills/claude-skills/engineering-team/senior-frontend
+++ b/.vibe/skills/claude-skills/engineering-team/senior-frontend
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-frontend

--- a/.vibe/skills/claude-skills/engineering-team/senior-fullstack
+++ b/.vibe/skills/claude-skills/engineering-team/senior-fullstack
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-fullstack

--- a/.vibe/skills/claude-skills/engineering-team/senior-ml-engineer
+++ b/.vibe/skills/claude-skills/engineering-team/senior-ml-engineer
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-ml-engineer

--- a/.vibe/skills/claude-skills/engineering-team/senior-prompt-engineer
+++ b/.vibe/skills/claude-skills/engineering-team/senior-prompt-engineer
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-prompt-engineer

--- a/.vibe/skills/claude-skills/engineering-team/senior-qa
+++ b/.vibe/skills/claude-skills/engineering-team/senior-qa
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-qa

--- a/.vibe/skills/claude-skills/engineering-team/senior-secops
+++ b/.vibe/skills/claude-skills/engineering-team/senior-secops
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-secops

--- a/.vibe/skills/claude-skills/engineering-team/senior-security
+++ b/.vibe/skills/claude-skills/engineering-team/senior-security
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/senior-security

--- a/.vibe/skills/claude-skills/engineering-team/snowflake-development
+++ b/.vibe/skills/claude-skills/engineering-team/snowflake-development
@@ -1,0 +1,1 @@
+../../../../engineering-team/snowflake-development/skills/snowflake-development

--- a/.vibe/skills/claude-skills/engineering-team/status
+++ b/.vibe/skills/claude-skills/engineering-team/status
@@ -1,0 +1,1 @@
+../../../../engineering-team/self-improving-agent/skills/status

--- a/.vibe/skills/claude-skills/engineering-team/stripe-integration-expert
+++ b/.vibe/skills/claude-skills/engineering-team/stripe-integration-expert
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/stripe-integration-expert

--- a/.vibe/skills/claude-skills/engineering-team/tdd-guide
+++ b/.vibe/skills/claude-skills/engineering-team/tdd-guide
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/tdd-guide

--- a/.vibe/skills/claude-skills/engineering-team/tech-stack-evaluator
+++ b/.vibe/skills/claude-skills/engineering-team/tech-stack-evaluator
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/tech-stack-evaluator

--- a/.vibe/skills/claude-skills/engineering-team/testrail
+++ b/.vibe/skills/claude-skills/engineering-team/testrail
@@ -1,0 +1,1 @@
+../../../../engineering-team/playwright-pro/skills/testrail

--- a/.vibe/skills/claude-skills/engineering-team/threat-detection
+++ b/.vibe/skills/claude-skills/engineering-team/threat-detection
@@ -1,0 +1,1 @@
+../../../../engineering-team/skills/threat-detection

--- a/.vibe/skills/claude-skills/engineering/agent-designer
+++ b/.vibe/skills/claude-skills/engineering/agent-designer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/agent-designer

--- a/.vibe/skills/claude-skills/engineering/agent-workflow-designer
+++ b/.vibe/skills/claude-skills/engineering/agent-workflow-designer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/agent-workflow-designer

--- a/.vibe/skills/claude-skills/engineering/agenthub
+++ b/.vibe/skills/claude-skills/engineering/agenthub
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/agenthub

--- a/.vibe/skills/claude-skills/engineering/api-design-reviewer
+++ b/.vibe/skills/claude-skills/engineering/api-design-reviewer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/api-design-reviewer

--- a/.vibe/skills/claude-skills/engineering/api-test-suite-builder
+++ b/.vibe/skills/claude-skills/engineering/api-test-suite-builder
@@ -1,0 +1,1 @@
+../../../../engineering/skills/api-test-suite-builder

--- a/.vibe/skills/claude-skills/engineering/autoresearch-agent
+++ b/.vibe/skills/claude-skills/engineering/autoresearch-agent
@@ -1,0 +1,1 @@
+../../../../engineering/autoresearch-agent/skills/autoresearch-agent

--- a/.vibe/skills/claude-skills/engineering/behuman
+++ b/.vibe/skills/claude-skills/engineering/behuman
@@ -1,0 +1,1 @@
+../../../../engineering/behuman/skills/behuman

--- a/.vibe/skills/claude-skills/engineering/board
+++ b/.vibe/skills/claude-skills/engineering/board
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/board

--- a/.vibe/skills/claude-skills/engineering/browser-automation
+++ b/.vibe/skills/claude-skills/engineering/browser-automation
@@ -1,0 +1,1 @@
+../../../../engineering/skills/browser-automation

--- a/.vibe/skills/claude-skills/engineering/caveman
+++ b/.vibe/skills/claude-skills/engineering/caveman
@@ -1,0 +1,1 @@
+../../../../engineering/caveman/skills/caveman

--- a/.vibe/skills/claude-skills/engineering/changelog-generator
+++ b/.vibe/skills/claude-skills/engineering/changelog-generator
@@ -1,0 +1,1 @@
+../../../../engineering/skills/changelog-generator

--- a/.vibe/skills/claude-skills/engineering/chaos-engineering
+++ b/.vibe/skills/claude-skills/engineering/chaos-engineering
@@ -1,0 +1,1 @@
+../../../../engineering/skills/chaos-engineering

--- a/.vibe/skills/claude-skills/engineering/ci-cd-pipeline-builder
+++ b/.vibe/skills/claude-skills/engineering/ci-cd-pipeline-builder
@@ -1,0 +1,1 @@
+../../../../engineering/skills/ci-cd-pipeline-builder

--- a/.vibe/skills/claude-skills/engineering/code-tour
+++ b/.vibe/skills/claude-skills/engineering/code-tour
@@ -1,0 +1,1 @@
+../../../../engineering/code-tour/skills/code-tour

--- a/.vibe/skills/claude-skills/engineering/codebase-onboarding
+++ b/.vibe/skills/claude-skills/engineering/codebase-onboarding
@@ -1,0 +1,1 @@
+../../../../engineering/skills/codebase-onboarding

--- a/.vibe/skills/claude-skills/engineering/command-guide
+++ b/.vibe/skills/claude-skills/engineering/command-guide
@@ -1,0 +1,1 @@
+../../../../engineering/skills/command-guide

--- a/.vibe/skills/claude-skills/engineering/data-quality-auditor
+++ b/.vibe/skills/claude-skills/engineering/data-quality-auditor
@@ -1,0 +1,1 @@
+../../../../engineering/data-quality-auditor/skills/data-quality-auditor

--- a/.vibe/skills/claude-skills/engineering/database-designer
+++ b/.vibe/skills/claude-skills/engineering/database-designer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/database-designer

--- a/.vibe/skills/claude-skills/engineering/database-schema-designer
+++ b/.vibe/skills/claude-skills/engineering/database-schema-designer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/database-schema-designer

--- a/.vibe/skills/claude-skills/engineering/demo-video
+++ b/.vibe/skills/claude-skills/engineering/demo-video
@@ -1,0 +1,1 @@
+../../../../engineering/demo-video/skills/demo-video

--- a/.vibe/skills/claude-skills/engineering/dependency-auditor
+++ b/.vibe/skills/claude-skills/engineering/dependency-auditor
@@ -1,0 +1,1 @@
+../../../../engineering/skills/dependency-auditor

--- a/.vibe/skills/claude-skills/engineering/docker-development
+++ b/.vibe/skills/claude-skills/engineering/docker-development
@@ -1,0 +1,1 @@
+../../../../engineering/docker-development/skills/docker-development

--- a/.vibe/skills/claude-skills/engineering/engineering-advanced-skills
+++ b/.vibe/skills/claude-skills/engineering/engineering-advanced-skills
@@ -1,0 +1,1 @@
+../../../../engineering/skills/engineering-advanced-skills

--- a/.vibe/skills/claude-skills/engineering/env-secrets-manager
+++ b/.vibe/skills/claude-skills/engineering/env-secrets-manager
@@ -1,0 +1,1 @@
+../../../../engineering/skills/env-secrets-manager

--- a/.vibe/skills/claude-skills/engineering/eval
+++ b/.vibe/skills/claude-skills/engineering/eval
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/eval

--- a/.vibe/skills/claude-skills/engineering/feature-flags-architect
+++ b/.vibe/skills/claude-skills/engineering/feature-flags-architect
@@ -1,0 +1,1 @@
+../../../../engineering/skills/feature-flags-architect

--- a/.vibe/skills/claude-skills/engineering/focused-fix
+++ b/.vibe/skills/claude-skills/engineering/focused-fix
@@ -1,0 +1,1 @@
+../../../../engineering/skills/focused-fix

--- a/.vibe/skills/claude-skills/engineering/full-page-screenshot
+++ b/.vibe/skills/claude-skills/engineering/full-page-screenshot
@@ -1,0 +1,1 @@
+../../../../engineering/skills/full-page-screenshot

--- a/.vibe/skills/claude-skills/engineering/git-worktree-manager
+++ b/.vibe/skills/claude-skills/engineering/git-worktree-manager
@@ -1,0 +1,1 @@
+../../../../engineering/skills/git-worktree-manager

--- a/.vibe/skills/claude-skills/engineering/grill-me
+++ b/.vibe/skills/claude-skills/engineering/grill-me
@@ -1,0 +1,1 @@
+../../../../engineering/grill-me/skills/grill-me

--- a/.vibe/skills/claude-skills/engineering/grill-with-docs
+++ b/.vibe/skills/claude-skills/engineering/grill-with-docs
@@ -1,0 +1,1 @@
+../../../../engineering/grill-with-docs/skills/grill-with-docs

--- a/.vibe/skills/claude-skills/engineering/handoff
+++ b/.vibe/skills/claude-skills/engineering/handoff
@@ -1,0 +1,1 @@
+../../../../engineering/handoff/skills/handoff

--- a/.vibe/skills/claude-skills/engineering/helm-chart-builder
+++ b/.vibe/skills/claude-skills/engineering/helm-chart-builder
@@ -1,0 +1,1 @@
+../../../../engineering/helm-chart-builder/skills/helm-chart-builder

--- a/.vibe/skills/claude-skills/engineering/init
+++ b/.vibe/skills/claude-skills/engineering/init
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/init

--- a/.vibe/skills/claude-skills/engineering/interview-system-designer
+++ b/.vibe/skills/claude-skills/engineering/interview-system-designer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/interview-system-designer

--- a/.vibe/skills/claude-skills/engineering/karpathy-coder
+++ b/.vibe/skills/claude-skills/engineering/karpathy-coder
@@ -1,0 +1,1 @@
+../../../../engineering/karpathy-coder/skills/karpathy-coder

--- a/.vibe/skills/claude-skills/engineering/kubernetes-operator
+++ b/.vibe/skills/claude-skills/engineering/kubernetes-operator
@@ -1,0 +1,1 @@
+../../../../engineering/skills/kubernetes-operator

--- a/.vibe/skills/claude-skills/engineering/llm-cost-optimizer
+++ b/.vibe/skills/claude-skills/engineering/llm-cost-optimizer
@@ -1,0 +1,1 @@
+../../../../engineering/llm-cost-optimizer/skills/llm-cost-optimizer

--- a/.vibe/skills/claude-skills/engineering/llm-wiki
+++ b/.vibe/skills/claude-skills/engineering/llm-wiki
@@ -1,0 +1,1 @@
+../../../../engineering/llm-wiki/skills/llm-wiki

--- a/.vibe/skills/claude-skills/engineering/loop
+++ b/.vibe/skills/claude-skills/engineering/loop
@@ -1,0 +1,1 @@
+../../../../engineering/autoresearch-agent/skills/loop

--- a/.vibe/skills/claude-skills/engineering/mcp-server-builder
+++ b/.vibe/skills/claude-skills/engineering/mcp-server-builder
@@ -1,0 +1,1 @@
+../../../../engineering/skills/mcp-server-builder

--- a/.vibe/skills/claude-skills/engineering/merge
+++ b/.vibe/skills/claude-skills/engineering/merge
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/merge

--- a/.vibe/skills/claude-skills/engineering/migration-architect
+++ b/.vibe/skills/claude-skills/engineering/migration-architect
@@ -1,0 +1,1 @@
+../../../../engineering/skills/migration-architect

--- a/.vibe/skills/claude-skills/engineering/monorepo-navigator
+++ b/.vibe/skills/claude-skills/engineering/monorepo-navigator
@@ -1,0 +1,1 @@
+../../../../engineering/skills/monorepo-navigator

--- a/.vibe/skills/claude-skills/engineering/observability-designer
+++ b/.vibe/skills/claude-skills/engineering/observability-designer
@@ -1,0 +1,1 @@
+../../../../engineering/skills/observability-designer

--- a/.vibe/skills/claude-skills/engineering/performance-profiler
+++ b/.vibe/skills/claude-skills/engineering/performance-profiler
@@ -1,0 +1,1 @@
+../../../../engineering/skills/performance-profiler

--- a/.vibe/skills/claude-skills/engineering/pr-review-expert
+++ b/.vibe/skills/claude-skills/engineering/pr-review-expert
@@ -1,0 +1,1 @@
+../../../../engineering/skills/pr-review-expert

--- a/.vibe/skills/claude-skills/engineering/prompt-governance
+++ b/.vibe/skills/claude-skills/engineering/prompt-governance
@@ -1,0 +1,1 @@
+../../../../engineering/prompt-governance/skills/prompt-governance

--- a/.vibe/skills/claude-skills/engineering/rag-architect
+++ b/.vibe/skills/claude-skills/engineering/rag-architect
@@ -1,0 +1,1 @@
+../../../../engineering/skills/rag-architect

--- a/.vibe/skills/claude-skills/engineering/release-manager
+++ b/.vibe/skills/claude-skills/engineering/release-manager
@@ -1,0 +1,1 @@
+../../../../engineering/skills/release-manager

--- a/.vibe/skills/claude-skills/engineering/resume
+++ b/.vibe/skills/claude-skills/engineering/resume
@@ -1,0 +1,1 @@
+../../../../engineering/autoresearch-agent/skills/resume

--- a/.vibe/skills/claude-skills/engineering/run
+++ b/.vibe/skills/claude-skills/engineering/run
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/run

--- a/.vibe/skills/claude-skills/engineering/runbook-generator
+++ b/.vibe/skills/claude-skills/engineering/runbook-generator
@@ -1,0 +1,1 @@
+../../../../engineering/skills/runbook-generator

--- a/.vibe/skills/claude-skills/engineering/secrets-vault-manager
+++ b/.vibe/skills/claude-skills/engineering/secrets-vault-manager
@@ -1,0 +1,1 @@
+../../../../engineering/skills/secrets-vault-manager

--- a/.vibe/skills/claude-skills/engineering/security-guidance
+++ b/.vibe/skills/claude-skills/engineering/security-guidance
@@ -1,0 +1,1 @@
+../../../../engineering/security-guidance/skills/security-guidance

--- a/.vibe/skills/claude-skills/engineering/self-eval
+++ b/.vibe/skills/claude-skills/engineering/self-eval
@@ -1,0 +1,1 @@
+../../../../engineering/skills/self-eval

--- a/.vibe/skills/claude-skills/engineering/setup
+++ b/.vibe/skills/claude-skills/engineering/setup
@@ -1,0 +1,1 @@
+../../../../engineering/autoresearch-agent/skills/setup

--- a/.vibe/skills/claude-skills/engineering/ship-gate
+++ b/.vibe/skills/claude-skills/engineering/ship-gate
@@ -1,0 +1,1 @@
+../../../../engineering/skills/ship-gate

--- a/.vibe/skills/claude-skills/engineering/skill-security-auditor
+++ b/.vibe/skills/claude-skills/engineering/skill-security-auditor
@@ -1,0 +1,1 @@
+../../../../engineering/skills/skill-security-auditor

--- a/.vibe/skills/claude-skills/engineering/skill-tester
+++ b/.vibe/skills/claude-skills/engineering/skill-tester
@@ -1,0 +1,1 @@
+../../../../engineering/skills/skill-tester

--- a/.vibe/skills/claude-skills/engineering/slo-architect
+++ b/.vibe/skills/claude-skills/engineering/slo-architect
@@ -1,0 +1,1 @@
+../../../../engineering/skills/slo-architect

--- a/.vibe/skills/claude-skills/engineering/spawn
+++ b/.vibe/skills/claude-skills/engineering/spawn
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/spawn

--- a/.vibe/skills/claude-skills/engineering/spec-driven-workflow
+++ b/.vibe/skills/claude-skills/engineering/spec-driven-workflow
@@ -1,0 +1,1 @@
+../../../../engineering/skills/spec-driven-workflow

--- a/.vibe/skills/claude-skills/engineering/sql-database-assistant
+++ b/.vibe/skills/claude-skills/engineering/sql-database-assistant
@@ -1,0 +1,1 @@
+../../../../engineering/skills/sql-database-assistant

--- a/.vibe/skills/claude-skills/engineering/statistical-analyst
+++ b/.vibe/skills/claude-skills/engineering/statistical-analyst
@@ -1,0 +1,1 @@
+../../../../engineering/statistical-analyst/skills/statistical-analyst

--- a/.vibe/skills/claude-skills/engineering/status
+++ b/.vibe/skills/claude-skills/engineering/status
@@ -1,0 +1,1 @@
+../../../../engineering/agenthub/skills/status

--- a/.vibe/skills/claude-skills/engineering/tc-tracker
+++ b/.vibe/skills/claude-skills/engineering/tc-tracker
@@ -1,0 +1,1 @@
+../../../../engineering/skills/tc-tracker

--- a/.vibe/skills/claude-skills/engineering/tech-debt-tracker
+++ b/.vibe/skills/claude-skills/engineering/tech-debt-tracker
@@ -1,0 +1,1 @@
+../../../../engineering/skills/tech-debt-tracker

--- a/.vibe/skills/claude-skills/engineering/terraform-patterns
+++ b/.vibe/skills/claude-skills/engineering/terraform-patterns
@@ -1,0 +1,1 @@
+../../../../engineering/terraform-patterns/skills/terraform-patterns

--- a/.vibe/skills/claude-skills/engineering/write-a-skill
+++ b/.vibe/skills/claude-skills/engineering/write-a-skill
@@ -1,0 +1,1 @@
+../../../../engineering/write-a-skill/skills/write-a-skill

--- a/.vibe/skills/claude-skills/finance/business-investment-advisor
+++ b/.vibe/skills/claude-skills/finance/business-investment-advisor
@@ -1,0 +1,1 @@
+../../../../finance/business-investment-advisor/skills/business-investment-advisor

--- a/.vibe/skills/claude-skills/finance/finance-skills
+++ b/.vibe/skills/claude-skills/finance/finance-skills
@@ -1,0 +1,1 @@
+../../../../finance/skills/finance-skills

--- a/.vibe/skills/claude-skills/finance/financial-analyst
+++ b/.vibe/skills/claude-skills/finance/financial-analyst
@@ -1,0 +1,1 @@
+../../../../finance/skills/financial-analyst

--- a/.vibe/skills/claude-skills/finance/saas-metrics-coach
+++ b/.vibe/skills/claude-skills/finance/saas-metrics-coach
@@ -1,0 +1,1 @@
+../../../../finance/skills/saas-metrics-coach

--- a/.vibe/skills/claude-skills/marketing-skill/ab-test-setup
+++ b/.vibe/skills/claude-skills/marketing-skill/ab-test-setup
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/ab-test-setup

--- a/.vibe/skills/claude-skills/marketing-skill/ad-creative
+++ b/.vibe/skills/claude-skills/marketing-skill/ad-creative
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/ad-creative

--- a/.vibe/skills/claude-skills/marketing-skill/aeo
+++ b/.vibe/skills/claude-skills/marketing-skill/aeo
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/aeo

--- a/.vibe/skills/claude-skills/marketing-skill/ai-seo
+++ b/.vibe/skills/claude-skills/marketing-skill/ai-seo
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/ai-seo

--- a/.vibe/skills/claude-skills/marketing-skill/analytics-tracking
+++ b/.vibe/skills/claude-skills/marketing-skill/analytics-tracking
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/analytics-tracking

--- a/.vibe/skills/claude-skills/marketing-skill/app-store-optimization
+++ b/.vibe/skills/claude-skills/marketing-skill/app-store-optimization
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/app-store-optimization

--- a/.vibe/skills/claude-skills/marketing-skill/brand-guidelines
+++ b/.vibe/skills/claude-skills/marketing-skill/brand-guidelines
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/brand-guidelines

--- a/.vibe/skills/claude-skills/marketing-skill/campaign-analytics
+++ b/.vibe/skills/claude-skills/marketing-skill/campaign-analytics
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/campaign-analytics

--- a/.vibe/skills/claude-skills/marketing-skill/churn-prevention
+++ b/.vibe/skills/claude-skills/marketing-skill/churn-prevention
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/churn-prevention

--- a/.vibe/skills/claude-skills/marketing-skill/cold-email
+++ b/.vibe/skills/claude-skills/marketing-skill/cold-email
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/cold-email

--- a/.vibe/skills/claude-skills/marketing-skill/competitor-alternatives
+++ b/.vibe/skills/claude-skills/marketing-skill/competitor-alternatives
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/competitor-alternatives

--- a/.vibe/skills/claude-skills/marketing-skill/content-creator
+++ b/.vibe/skills/claude-skills/marketing-skill/content-creator
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/content-creator

--- a/.vibe/skills/claude-skills/marketing-skill/content-humanizer
+++ b/.vibe/skills/claude-skills/marketing-skill/content-humanizer
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/content-humanizer

--- a/.vibe/skills/claude-skills/marketing-skill/content-production
+++ b/.vibe/skills/claude-skills/marketing-skill/content-production
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/content-production

--- a/.vibe/skills/claude-skills/marketing-skill/content-strategy
+++ b/.vibe/skills/claude-skills/marketing-skill/content-strategy
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/content-strategy

--- a/.vibe/skills/claude-skills/marketing-skill/copy-editing
+++ b/.vibe/skills/claude-skills/marketing-skill/copy-editing
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/copy-editing

--- a/.vibe/skills/claude-skills/marketing-skill/copywriting
+++ b/.vibe/skills/claude-skills/marketing-skill/copywriting
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/copywriting

--- a/.vibe/skills/claude-skills/marketing-skill/email-sequence
+++ b/.vibe/skills/claude-skills/marketing-skill/email-sequence
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/email-sequence

--- a/.vibe/skills/claude-skills/marketing-skill/form-cro
+++ b/.vibe/skills/claude-skills/marketing-skill/form-cro
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/form-cro

--- a/.vibe/skills/claude-skills/marketing-skill/free-tool-strategy
+++ b/.vibe/skills/claude-skills/marketing-skill/free-tool-strategy
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/free-tool-strategy

--- a/.vibe/skills/claude-skills/marketing-skill/launch-strategy
+++ b/.vibe/skills/claude-skills/marketing-skill/launch-strategy
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/launch-strategy

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-context
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-context
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-context

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-demand-acquisition
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-demand-acquisition
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-demand-acquisition

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-ideas
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-ideas
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-ideas

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-ops
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-ops
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-ops

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-psychology
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-psychology
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-psychology

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-skills
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-skills
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-skills

--- a/.vibe/skills/claude-skills/marketing-skill/marketing-strategy-pmm
+++ b/.vibe/skills/claude-skills/marketing-skill/marketing-strategy-pmm
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/marketing-strategy-pmm

--- a/.vibe/skills/claude-skills/marketing-skill/onboarding-cro
+++ b/.vibe/skills/claude-skills/marketing-skill/onboarding-cro
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/onboarding-cro

--- a/.vibe/skills/claude-skills/marketing-skill/page-cro
+++ b/.vibe/skills/claude-skills/marketing-skill/page-cro
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/page-cro

--- a/.vibe/skills/claude-skills/marketing-skill/paid-ads
+++ b/.vibe/skills/claude-skills/marketing-skill/paid-ads
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/paid-ads

--- a/.vibe/skills/claude-skills/marketing-skill/paywall-upgrade-cro
+++ b/.vibe/skills/claude-skills/marketing-skill/paywall-upgrade-cro
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/paywall-upgrade-cro

--- a/.vibe/skills/claude-skills/marketing-skill/popup-cro
+++ b/.vibe/skills/claude-skills/marketing-skill/popup-cro
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/popup-cro

--- a/.vibe/skills/claude-skills/marketing-skill/pricing-strategy
+++ b/.vibe/skills/claude-skills/marketing-skill/pricing-strategy
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/pricing-strategy

--- a/.vibe/skills/claude-skills/marketing-skill/programmatic-seo
+++ b/.vibe/skills/claude-skills/marketing-skill/programmatic-seo
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/programmatic-seo

--- a/.vibe/skills/claude-skills/marketing-skill/prompt-engineer-toolkit
+++ b/.vibe/skills/claude-skills/marketing-skill/prompt-engineer-toolkit
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/prompt-engineer-toolkit

--- a/.vibe/skills/claude-skills/marketing-skill/referral-program
+++ b/.vibe/skills/claude-skills/marketing-skill/referral-program
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/referral-program

--- a/.vibe/skills/claude-skills/marketing-skill/schema-markup
+++ b/.vibe/skills/claude-skills/marketing-skill/schema-markup
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/schema-markup

--- a/.vibe/skills/claude-skills/marketing-skill/seo-audit
+++ b/.vibe/skills/claude-skills/marketing-skill/seo-audit
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/seo-audit

--- a/.vibe/skills/claude-skills/marketing-skill/signup-flow-cro
+++ b/.vibe/skills/claude-skills/marketing-skill/signup-flow-cro
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/signup-flow-cro

--- a/.vibe/skills/claude-skills/marketing-skill/site-architecture
+++ b/.vibe/skills/claude-skills/marketing-skill/site-architecture
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/site-architecture

--- a/.vibe/skills/claude-skills/marketing-skill/social-content
+++ b/.vibe/skills/claude-skills/marketing-skill/social-content
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/social-content

--- a/.vibe/skills/claude-skills/marketing-skill/social-media-analyzer
+++ b/.vibe/skills/claude-skills/marketing-skill/social-media-analyzer
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/social-media-analyzer

--- a/.vibe/skills/claude-skills/marketing-skill/social-media-manager
+++ b/.vibe/skills/claude-skills/marketing-skill/social-media-manager
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/social-media-manager

--- a/.vibe/skills/claude-skills/marketing-skill/video-content-strategist
+++ b/.vibe/skills/claude-skills/marketing-skill/video-content-strategist
@@ -1,0 +1,1 @@
+../../../../marketing-skill/video-content-strategist/skills/video-content-strategist

--- a/.vibe/skills/claude-skills/marketing-skill/x-twitter-growth
+++ b/.vibe/skills/claude-skills/marketing-skill/x-twitter-growth
@@ -1,0 +1,1 @@
+../../../../marketing-skill/skills/x-twitter-growth

--- a/.vibe/skills/claude-skills/marketing/landing
+++ b/.vibe/skills/claude-skills/marketing/landing
@@ -1,0 +1,1 @@
+../../../../marketing/landing/skills/landing

--- a/.vibe/skills/claude-skills/product-team/agile-product-owner
+++ b/.vibe/skills/claude-skills/product-team/agile-product-owner
@@ -1,0 +1,1 @@
+../../../../product-team/agile-product-owner/skills/agile-product-owner

--- a/.vibe/skills/claude-skills/product-team/apple-hig-expert
+++ b/.vibe/skills/claude-skills/product-team/apple-hig-expert
@@ -1,0 +1,1 @@
+../../../../product-team/apple-hig-expert/skills/apple-hig-expert

--- a/.vibe/skills/claude-skills/product-team/code-to-prd
+++ b/.vibe/skills/claude-skills/product-team/code-to-prd
@@ -1,0 +1,1 @@
+../../../../product-team/code-to-prd/skills/code-to-prd

--- a/.vibe/skills/claude-skills/product-team/competitive-teardown
+++ b/.vibe/skills/claude-skills/product-team/competitive-teardown
@@ -1,0 +1,1 @@
+../../../../product-team/skills/competitive-teardown

--- a/.vibe/skills/claude-skills/product-team/experiment-designer
+++ b/.vibe/skills/claude-skills/product-team/experiment-designer
@@ -1,0 +1,1 @@
+../../../../product-team/skills/experiment-designer

--- a/.vibe/skills/claude-skills/product-team/landing-page-generator
+++ b/.vibe/skills/claude-skills/product-team/landing-page-generator
@@ -1,0 +1,1 @@
+../../../../product-team/skills/landing-page-generator

--- a/.vibe/skills/claude-skills/product-team/product-analytics
+++ b/.vibe/skills/claude-skills/product-team/product-analytics
@@ -1,0 +1,1 @@
+../../../../product-team/skills/product-analytics

--- a/.vibe/skills/claude-skills/product-team/product-discovery
+++ b/.vibe/skills/claude-skills/product-team/product-discovery
@@ -1,0 +1,1 @@
+../../../../product-team/skills/product-discovery

--- a/.vibe/skills/claude-skills/product-team/product-manager-toolkit
+++ b/.vibe/skills/claude-skills/product-team/product-manager-toolkit
@@ -1,0 +1,1 @@
+../../../../product-team/skills/product-manager-toolkit

--- a/.vibe/skills/claude-skills/product-team/product-skills
+++ b/.vibe/skills/claude-skills/product-team/product-skills
@@ -1,0 +1,1 @@
+../../../../product-team/skills/product-skills

--- a/.vibe/skills/claude-skills/product-team/product-strategist
+++ b/.vibe/skills/claude-skills/product-team/product-strategist
@@ -1,0 +1,1 @@
+../../../../product-team/skills/product-strategist

--- a/.vibe/skills/claude-skills/product-team/research-summarizer
+++ b/.vibe/skills/claude-skills/product-team/research-summarizer
@@ -1,0 +1,1 @@
+../../../../product-team/research-summarizer/skills/research-summarizer

--- a/.vibe/skills/claude-skills/product-team/roadmap-communicator
+++ b/.vibe/skills/claude-skills/product-team/roadmap-communicator
@@ -1,0 +1,1 @@
+../../../../product-team/skills/roadmap-communicator

--- a/.vibe/skills/claude-skills/product-team/saas-scaffolder
+++ b/.vibe/skills/claude-skills/product-team/saas-scaffolder
@@ -1,0 +1,1 @@
+../../../../product-team/skills/saas-scaffolder

--- a/.vibe/skills/claude-skills/product-team/spec-to-repo
+++ b/.vibe/skills/claude-skills/product-team/spec-to-repo
@@ -1,0 +1,1 @@
+../../../../product-team/skills/spec-to-repo

--- a/.vibe/skills/claude-skills/product-team/ui-design-system
+++ b/.vibe/skills/claude-skills/product-team/ui-design-system
@@ -1,0 +1,1 @@
+../../../../product-team/skills/ui-design-system

--- a/.vibe/skills/claude-skills/product-team/ux-researcher-designer
+++ b/.vibe/skills/claude-skills/product-team/ux-researcher-designer
@@ -1,0 +1,1 @@
+../../../../product-team/skills/ux-researcher-designer

--- a/.vibe/skills/claude-skills/productivity/capture
+++ b/.vibe/skills/claude-skills/productivity/capture
@@ -1,0 +1,1 @@
+../../../../productivity/capture/skills/capture

--- a/.vibe/skills/claude-skills/productivity/inbox-setup
+++ b/.vibe/skills/claude-skills/productivity/inbox-setup
@@ -1,0 +1,1 @@
+../../../../productivity/email/skills/inbox-setup

--- a/.vibe/skills/claude-skills/productivity/inbox-triage
+++ b/.vibe/skills/claude-skills/productivity/inbox-triage
@@ -1,0 +1,1 @@
+../../../../productivity/email/skills/inbox-triage

--- a/.vibe/skills/claude-skills/productivity/reflect
+++ b/.vibe/skills/claude-skills/productivity/reflect
@@ -1,0 +1,1 @@
+../../../../productivity/reflect/skills/reflect

--- a/.vibe/skills/claude-skills/project-management/atlassian-admin
+++ b/.vibe/skills/claude-skills/project-management/atlassian-admin
@@ -1,0 +1,1 @@
+../../../../project-management/skills/atlassian-admin

--- a/.vibe/skills/claude-skills/project-management/atlassian-templates
+++ b/.vibe/skills/claude-skills/project-management/atlassian-templates
@@ -1,0 +1,1 @@
+../../../../project-management/skills/atlassian-templates

--- a/.vibe/skills/claude-skills/project-management/confluence-expert
+++ b/.vibe/skills/claude-skills/project-management/confluence-expert
@@ -1,0 +1,1 @@
+../../../../project-management/skills/confluence-expert

--- a/.vibe/skills/claude-skills/project-management/jira-expert
+++ b/.vibe/skills/claude-skills/project-management/jira-expert
@@ -1,0 +1,1 @@
+../../../../project-management/skills/jira-expert

--- a/.vibe/skills/claude-skills/project-management/meeting-analyzer
+++ b/.vibe/skills/claude-skills/project-management/meeting-analyzer
@@ -1,0 +1,1 @@
+../../../../project-management/skills/meeting-analyzer

--- a/.vibe/skills/claude-skills/project-management/pm-skills
+++ b/.vibe/skills/claude-skills/project-management/pm-skills
@@ -1,0 +1,1 @@
+../../../../project-management/skills/pm-skills

--- a/.vibe/skills/claude-skills/project-management/scrum-master
+++ b/.vibe/skills/claude-skills/project-management/scrum-master
@@ -1,0 +1,1 @@
+../../../../project-management/skills/scrum-master

--- a/.vibe/skills/claude-skills/project-management/senior-pm
+++ b/.vibe/skills/claude-skills/project-management/senior-pm
@@ -1,0 +1,1 @@
+../../../../project-management/skills/senior-pm

--- a/.vibe/skills/claude-skills/project-management/team-communications
+++ b/.vibe/skills/claude-skills/project-management/team-communications
@@ -1,0 +1,1 @@
+../../../../project-management/skills/team-communications

--- a/.vibe/skills/claude-skills/ra-qm-team/capa-officer
+++ b/.vibe/skills/claude-skills/ra-qm-team/capa-officer
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/capa-officer

--- a/.vibe/skills/claude-skills/ra-qm-team/eu-ai-act-specialist
+++ b/.vibe/skills/claude-skills/ra-qm-team/eu-ai-act-specialist
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/eu-ai-act-specialist

--- a/.vibe/skills/claude-skills/ra-qm-team/fda-consultant-specialist
+++ b/.vibe/skills/claude-skills/ra-qm-team/fda-consultant-specialist
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/fda-consultant-specialist

--- a/.vibe/skills/claude-skills/ra-qm-team/gdpr-dsgvo-expert
+++ b/.vibe/skills/claude-skills/ra-qm-team/gdpr-dsgvo-expert
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/gdpr-dsgvo-expert

--- a/.vibe/skills/claude-skills/ra-qm-team/information-security-manager-iso27001
+++ b/.vibe/skills/claude-skills/ra-qm-team/information-security-manager-iso27001
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/information-security-manager-iso27001

--- a/.vibe/skills/claude-skills/ra-qm-team/isms-audit-expert
+++ b/.vibe/skills/claude-skills/ra-qm-team/isms-audit-expert
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/isms-audit-expert

--- a/.vibe/skills/claude-skills/ra-qm-team/iso42001-specialist
+++ b/.vibe/skills/claude-skills/ra-qm-team/iso42001-specialist
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/iso42001-specialist

--- a/.vibe/skills/claude-skills/ra-qm-team/mdr-745-specialist
+++ b/.vibe/skills/claude-skills/ra-qm-team/mdr-745-specialist
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/mdr-745-specialist

--- a/.vibe/skills/claude-skills/ra-qm-team/qms-audit-expert
+++ b/.vibe/skills/claude-skills/ra-qm-team/qms-audit-expert
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/qms-audit-expert

--- a/.vibe/skills/claude-skills/ra-qm-team/quality-documentation-manager
+++ b/.vibe/skills/claude-skills/ra-qm-team/quality-documentation-manager
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/quality-documentation-manager

--- a/.vibe/skills/claude-skills/ra-qm-team/quality-manager-qmr
+++ b/.vibe/skills/claude-skills/ra-qm-team/quality-manager-qmr
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/quality-manager-qmr

--- a/.vibe/skills/claude-skills/ra-qm-team/quality-manager-qms-iso13485
+++ b/.vibe/skills/claude-skills/ra-qm-team/quality-manager-qms-iso13485
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/quality-manager-qms-iso13485

--- a/.vibe/skills/claude-skills/ra-qm-team/ra-qm-skills
+++ b/.vibe/skills/claude-skills/ra-qm-team/ra-qm-skills
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/ra-qm-skills

--- a/.vibe/skills/claude-skills/ra-qm-team/regulatory-affairs-head
+++ b/.vibe/skills/claude-skills/ra-qm-team/regulatory-affairs-head
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/regulatory-affairs-head

--- a/.vibe/skills/claude-skills/ra-qm-team/risk-management-specialist
+++ b/.vibe/skills/claude-skills/ra-qm-team/risk-management-specialist
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/risk-management-specialist

--- a/.vibe/skills/claude-skills/ra-qm-team/soc2-compliance
+++ b/.vibe/skills/claude-skills/ra-qm-team/soc2-compliance
@@ -1,0 +1,1 @@
+../../../../ra-qm-team/skills/soc2-compliance

--- a/.vibe/skills/claude-skills/research/dossier
+++ b/.vibe/skills/claude-skills/research/dossier
@@ -1,0 +1,1 @@
+../../../../research/dossier/skills/dossier

--- a/.vibe/skills/claude-skills/research/grants
+++ b/.vibe/skills/claude-skills/research/grants
@@ -1,0 +1,1 @@
+../../../../research/grants/skills/grants

--- a/.vibe/skills/claude-skills/research/litreview
+++ b/.vibe/skills/claude-skills/research/litreview
@@ -1,0 +1,1 @@
+../../../../research/litreview/skills/litreview

--- a/.vibe/skills/claude-skills/research/notebooklm
+++ b/.vibe/skills/claude-skills/research/notebooklm
@@ -1,0 +1,1 @@
+../../../../research/notebooklm/skills/notebooklm

--- a/.vibe/skills/claude-skills/research/patent
+++ b/.vibe/skills/claude-skills/research/patent
@@ -1,0 +1,1 @@
+../../../../research/patent/skills/patent

--- a/.vibe/skills/claude-skills/research/pulse
+++ b/.vibe/skills/claude-skills/research/pulse
@@ -1,0 +1,1 @@
+../../../../research/pulse/skills/pulse

--- a/.vibe/skills/claude-skills/research/research
+++ b/.vibe/skills/claude-skills/research/research
@@ -1,0 +1,1 @@
+../../../../research/research/skills/research

--- a/.vibe/skills/claude-skills/research/syllabus
+++ b/.vibe/skills/claude-skills/research/syllabus
@@ -1,0 +1,1 @@
+../../../../research/syllabus/skills/syllabus

--- a/.vibe/skills/claude-skills/skills-index.json
+++ b/.vibe/skills/claude-skills/skills-index.json
@@ -1,0 +1,1634 @@
+{
+  "source": "claude-code-skills",
+  "total_skills": 320,
+  "domains": {
+    "engineering": [
+      {
+        "name": "agent-designer",
+        "description": "Use when the user asks to design multi-agent systems, create agent architectures, define agent communication patterns, or build autonomous agent workflows.",
+        "path": "engineering/agent-designer"
+      },
+      {
+        "name": "agent-workflow-designer",
+        "description": "Design production-grade multi-agent workflows with clear pattern choice (sequential, parallel, hierarchical), handoff contracts, failure handling, and cost/context controls. Use when architecting a multi-step agent pipeline, choosing between single-agent vs multi-agent approaches, or refactoring an LLM workflow that suffers from context bloat or unreliable handoffs.",
+        "path": "engineering/agent-workflow-designer"
+      },
+      {
+        "name": "api-design-reviewer",
+        "description": "Comprehensive REST API design review with automated linting, breaking-change detection, and design scorecards. Catches inconsistent conventions, missing versioning, and design smells before APIs ship. Use when reviewing a PR that adds or changes API endpoints, auditing an existing API for v2 migration, or establishing API standards for a team.",
+        "path": "engineering/api-design-reviewer"
+      },
+      {
+        "name": "api-test-suite-builder",
+        "description": "Use when the user asks to generate API tests, create integration test suites, test REST endpoints, or build contract tests.",
+        "path": "engineering/api-test-suite-builder"
+      },
+      {
+        "name": "browser-automation",
+        "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing \u2014 use playwright-pro for that.",
+        "path": "engineering/browser-automation"
+      },
+      {
+        "name": "changelog-generator",
+        "description": "Produce consistent, auditable release notes from Conventional Commits. Separates commit parsing, semantic-bump logic, and changelog rendering for automated releases with editorial control. Use when cutting a release, generating CHANGELOG.md from git history, or automating release notes in CI.",
+        "path": "engineering/changelog-generator"
+      },
+      {
+        "name": "chaos-engineering",
+        "description": "Use when planning, running, or learning from chaos engineering experiments. Triggers on \"chaos experiment\", \"fault injection\", \"gameday\", \"resilience test\", \"blast radius\", \"steady state\", \"abort criteria\", \"Chaos Toolkit\", \"Chaos Mesh\", \"Litmus\", \"Gremlin\", \"AWS FIS\", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets).",
+        "path": "engineering/chaos-engineering"
+      },
+      {
+        "name": "ci-cd-pipeline-builder",
+        "description": "Generate pragmatic CI/CD pipelines from detected project stack signals \u2014 fast baseline generation, repeatable checks, environment-aware deployment stages. Use when setting up CI for a new project, refactoring existing pipelines, or standardizing deployment workflows across multiple repos.",
+        "path": "engineering/ci-cd-pipeline-builder"
+      },
+      {
+        "name": "codebase-onboarding",
+        "description": "Analyze a codebase and generate onboarding documentation for engineers, tech leads, and contractors. Fast fact-gathering and repeatable onboarding outputs. Use when onboarding a new engineer, writing architecture-overview docs for a new project, or producing tech-lead briefings for unfamiliar repos.",
+        "path": "engineering/codebase-onboarding"
+      },
+      {
+        "name": "command-guide",
+        "description": ">",
+        "path": "engineering/command-guide"
+      },
+      {
+        "name": "database-designer",
+        "description": "Use when the user asks to design database schemas, plan data migrations, optimize queries, choose between SQL and NoSQL, or model data relationships.",
+        "path": "engineering/database-designer"
+      },
+      {
+        "name": "database-schema-designer",
+        "description": "Use when the user asks to create ERD diagrams, normalize database schemas, design table relationships, or plan schema migrations.",
+        "path": "engineering/database-schema-designer"
+      },
+      {
+        "name": "dependency-auditor",
+        "description": "Audit and manage dependencies across multi-language projects. Identifies vulnerabilities, license conflicts, transitive dependency risks, and safe-upgrade paths. Use when auditing third-party packages before release, investigating a CVE, planning a major version bump, or running a license-compliance review.",
+        "path": "engineering/dependency-auditor"
+      },
+      {
+        "name": "engineering-advanced-skills",
+        "description": "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops.",
+        "path": "engineering/engineering-advanced-skills"
+      },
+      {
+        "name": "env-secrets-manager",
+        "description": "Manage environment-variable hygiene and secrets safety across local development and production. Practical auditing, drift awareness, rotation readiness. Use when auditing .env files for committed secrets, planning a credential rotation, debugging missing-env-var production incidents, or hardening a new project against secrets leakage.",
+        "path": "engineering/env-secrets-manager"
+      },
+      {
+        "name": "feature-flags-architect",
+        "description": "Use when adding, retiring, or auditing feature flags. Triggers on \"add a flag\", \"ship behind a flag\", \"rollout plan\", \"kill switch\", \"stale flags\", \"flag debt\", \"LaunchDarkly\", \"GrowthBook\", \"Statsig\", \"Unleash\", \"Flipt\", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command.",
+        "path": "engineering/feature-flags-architect"
+      },
+      {
+        "name": "focused-fix",
+        "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes \u2014 this is for systematic deep-dive repair across all files and dependencies.",
+        "path": "engineering/focused-fix"
+      },
+      {
+        "name": "full-page-screenshot",
+        "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies.",
+        "path": "engineering/full-page-screenshot"
+      },
+      {
+        "name": "git-worktree-manager",
+        "description": "Run parallel feature work safely with Git worktrees. Standardizes branch isolation, port allocation, environment sync, and cleanup so each worktree behaves like an independent local app. Optimized for multi-agent workflows where each agent or terminal session owns one worktree. Use when running multiple feature branches simultaneously, isolating experimental work, or coordinating multi-agent development across the same repo.",
+        "path": "engineering/git-worktree-manager"
+      },
+      {
+        "name": "interview-system-designer",
+        "description": "This skill should be used when the user asks to \"design interview processes\", \"create hiring pipelines\", \"calibrate interview loops\", \"generate interview questions\", \"design competency matrices\", \"analyze interviewer bias\", \"create scoring rubrics\", \"build question banks\", or \"optimize hiring systems\". Use for designing role-specific interview loops, competency assessments, and hiring calibration systems.",
+        "path": "engineering/interview-system-designer"
+      },
+      {
+        "name": "kubernetes-operator",
+        "description": "Use when building a Kubernetes Operator \u2014 custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill \u2014 specifically the Operator pattern.",
+        "path": "engineering/kubernetes-operator"
+      },
+      {
+        "name": "mcp-server-builder",
+        "description": "Design and ship production-ready MCP (Model Context Protocol) servers from OpenAPI contracts instead of hand-written tool wrappers. Python and TypeScript support, schema validation, safe evolution. Use when exposing an existing API as an MCP server, building tool integrations for Claude or Codex or Cursor, or scaffolding an MCP project from scratch.",
+        "path": "engineering/mcp-server-builder"
+      },
+      {
+        "name": "migration-architect",
+        "description": "Zero-downtime migration planning, compatibility validation, and rollback strategy generation. Tools for system, database, and infrastructure migrations with minimal business impact. Use when planning a database migration, infrastructure cutover, system replacement, or any high-risk transition that needs explicit rollback paths.",
+        "path": "engineering/migration-architect"
+      },
+      {
+        "name": "monorepo-navigator",
+        "description": "Navigate, manage, and optimize monorepos. Covers Turborepo, Nx, pnpm workspaces, and Lerna. Cross-package impact analysis, selective builds/tests on affected packages, remote caching, dependency graph visualization, and structured multi-repo to monorepo migrations. Use when setting up a new monorepo, optimizing CI for a large workspace, debugging cross-package dependency issues, or planning a multi-repo consolidation.",
+        "path": "engineering/monorepo-navigator"
+      },
+      {
+        "name": "observability-designer",
+        "description": "Design production-ready observability strategies combining metrics, logs, and traces. Includes SLI/SLO design, golden-signals monitoring, alert optimization. Use when adding observability to a new service, refactoring alerting that is too noisy, or designing an SLO program before scaling production load.",
+        "path": "engineering/observability-designer"
+      },
+      {
+        "name": "performance-profiler",
+        "description": "Systematic performance profiling for Node.js, Python, and Go applications. Identifies CPU, memory, and I/O bottlenecks, generates flamegraphs, analyzes bundle sizes, optimizes database queries, runs load tests with k6 and Artillery. Always measures before and after. Use when investigating a slow endpoint, planning a performance budget, or hunting a memory leak in production.",
+        "path": "engineering/performance-profiler"
+      },
+      {
+        "name": "pr-review-expert",
+        "description": "Use when the user asks to review pull requests, analyze code changes, check for security issues in PRs, or assess code quality of diffs.",
+        "path": "engineering/pr-review-expert"
+      },
+      {
+        "name": "rag-architect",
+        "description": "Use when the user asks to design RAG pipelines, optimize retrieval strategies, choose embedding models, implement vector search, or build knowledge retrieval systems.",
+        "path": "engineering/rag-architect"
+      },
+      {
+        "name": "release-manager",
+        "description": "Use when the user asks to plan releases, manage changelogs, coordinate deployments, create release branches, or automate versioning.",
+        "path": "engineering/release-manager"
+      },
+      {
+        "name": "runbook-generator",
+        "description": "Generate operational runbooks from a service name \u2014 deployment, incident response, maintenance, and rollback workflows. Templated structure customizable per environment. Use when documenting on-call procedures for a new service, standardizing incident response across teams, or producing runbooks before launching to production.",
+        "path": "engineering/runbook-generator"
+      },
+      {
+        "name": "secrets-vault-manager",
+        "description": "Use when the user asks to set up secret management infrastructure, integrate HashiCorp Vault, configure cloud secret stores (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager), implement secret rotation, or audit secret access patterns.",
+        "path": "engineering/secrets-vault-manager"
+      },
+      {
+        "name": "self-eval",
+        "description": "Honestly evaluate AI work quality using a two-axis scoring system. Use after completing a task, code review, or work session to get an unbiased assessment. Detects score inflation, forces devil's advocate reasoning, and persists scores across sessions.",
+        "path": "engineering/self-eval"
+      },
+      {
+        "name": "ship-gate",
+        "description": ">",
+        "path": "engineering/ship-gate"
+      },
+      {
+        "name": "skill-security-auditor",
+        "description": ">",
+        "path": "engineering/skill-security-auditor"
+      },
+      {
+        "name": "skill-tester",
+        "description": "Validate, test, and score the quality of skills within the claude-skills ecosystem. Comprehensive meta-skill: structure validation, Python script testing (syntax + imports + runtime + output format), multi-dimensional quality scoring with letter grades and tier classification (BASIC/STANDARD/POWERFUL). Use when authoring a new skill, auditing existing skills for tier promotion, setting up pre-commit hooks for skill quality, or integrating skill QA into CI.",
+        "path": "engineering/skill-tester"
+      },
+      {
+        "name": "slo-architect",
+        "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill \u2014 specifically the SLO discipline.",
+        "path": "engineering/slo-architect"
+      },
+      {
+        "name": "spec-driven-workflow",
+        "description": "Use when the user asks to write specs before code, define acceptance criteria, plan features before implementation, generate tests from specifications, or follow spec-first development practices.",
+        "path": "engineering/spec-driven-workflow"
+      },
+      {
+        "name": "sql-database-assistant",
+        "description": "Use when the user asks to write SQL queries, optimize database performance, generate migrations, explore database schemas, or work with ORMs like Prisma, Drizzle, TypeORM, or SQLAlchemy.",
+        "path": "engineering/sql-database-assistant"
+      },
+      {
+        "name": "tc-tracker",
+        "description": "Use when the user asks to track technical changes, create change records, manage TC lifecycles, or hand off work between AI sessions. Covers init/create/update/status/resume/close/export workflows for structured code change documentation.",
+        "path": "engineering/tc-tracker"
+      },
+      {
+        "name": "tech-debt-tracker",
+        "description": "Scan codebases for technical debt, score severity, track trends, and generate prioritized remediation plans. Use when users mention tech debt, code quality, refactoring priority, debt scoring, cleanup sprints, or code health assessment. Also use for legacy code modernization planning and maintenance cost estimation.",
+        "path": "engineering/tech-debt-tracker"
+      },
+      {
+        "name": "agenthub",
+        "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel \u2014 code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
+        "path": "engineering/agenthub"
+      },
+      {
+        "name": "board",
+        "description": "Read, write, and browse the AgentHub message board for agent coordination.",
+        "path": "engineering/board"
+      },
+      {
+        "name": "eval",
+        "description": "Evaluate and rank agent results by metric or LLM judge for an AgentHub session.",
+        "path": "engineering/eval"
+      },
+      {
+        "name": "init",
+        "description": "Create a new AgentHub collaboration session with task, agent count, and evaluation criteria.",
+        "path": "engineering/init"
+      },
+      {
+        "name": "merge",
+        "description": "Merge the winning agent's branch into base, archive losers, and clean up worktrees.",
+        "path": "engineering/merge"
+      },
+      {
+        "name": "run",
+        "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation.",
+        "path": "engineering/run"
+      },
+      {
+        "name": "spawn",
+        "description": "Launch N parallel subagents in isolated git worktrees to compete on the session task.",
+        "path": "engineering/spawn"
+      },
+      {
+        "name": "status",
+        "description": "Show DAG state, agent progress, and branch status for an AgentHub session.",
+        "path": "engineering/status"
+      },
+      {
+        "name": "autoresearch-agent",
+        "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+        "path": "engineering/autoresearch-agent"
+      },
+      {
+        "name": "loop",
+        "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
+        "path": "engineering/loop"
+      },
+      {
+        "name": "resume",
+        "description": "Resume a paused experiment. Checkout the experiment branch, read results history, continue iterating.",
+        "path": "engineering/resume"
+      },
+      {
+        "name": "run",
+        "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard.",
+        "path": "engineering/run"
+      },
+      {
+        "name": "setup",
+        "description": "Set up a new autoresearch experiment interactively. Collects domain, target file, eval command, metric, direction, and evaluator.",
+        "path": "engineering/setup"
+      },
+      {
+        "name": "status",
+        "description": "Show experiment dashboard with results, active loops, and progress.",
+        "path": "engineering/status"
+      },
+      {
+        "name": "behuman",
+        "description": "Use when the user wants more human-like AI responses \u2014 less robotic, less listy, more authentic. Triggers: 'behuman', 'be real', 'like a human', 'more human', 'less AI', 'talk like a person', 'mirror mode', 'stop being so AI', or when conversations are emotionally charged (grief, job loss, relationship advice, fear). NOT for technical questions, code generation, or factual lookups.",
+        "path": "engineering/behuman"
+      },
+      {
+        "name": "caveman",
+        "description": ">",
+        "path": "engineering/caveman"
+      },
+      {
+        "name": "chaos-engineering",
+        "description": "Use when planning, running, or learning from chaos engineering experiments. Triggers on \"chaos experiment\", \"fault injection\", \"gameday\", \"resilience test\", \"blast radius\", \"steady state\", \"abort criteria\", \"Chaos Toolkit\", \"Chaos Mesh\", \"Litmus\", \"Gremlin\", \"AWS FIS\", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets).",
+        "path": "engineering/chaos-engineering"
+      },
+      {
+        "name": "code-tour",
+        "description": "Use when the user asks to create a CodeTour .tour file \u2014 persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
+        "path": "engineering/code-tour"
+      },
+      {
+        "name": "data-quality-auditor",
+        "description": "Audit datasets for completeness, consistency, accuracy, and validity. Profile data distributions, detect anomalies and outliers, surface structural issues, and produce an actionable remediation plan.",
+        "path": "engineering/data-quality-auditor"
+      },
+      {
+        "name": "demo-video",
+        "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content.",
+        "path": "engineering/demo-video"
+      },
+      {
+        "name": "docker-development",
+        "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns.",
+        "path": "engineering/docker-development"
+      },
+      {
+        "name": "feature-flags-architect",
+        "description": "Use when adding, retiring, or auditing feature flags. Triggers on \"add a flag\", \"ship behind a flag\", \"rollout plan\", \"kill switch\", \"stale flags\", \"flag debt\", \"LaunchDarkly\", \"GrowthBook\", \"Statsig\", \"Unleash\", \"Flipt\", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command.",
+        "path": "engineering/feature-flags-architect"
+      },
+      {
+        "name": "grill-me",
+        "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+        "path": "engineering/grill-me"
+      },
+      {
+        "name": "grill-with-docs",
+        "description": "Docs-anchored grilling session \u2014 challenges a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), and updates those files inline as terminology and decisions crystallise. Use when user wants to stress-test a plan against documented domain language, or mentions \"grill with docs\".",
+        "path": "engineering/grill-with-docs"
+      },
+      {
+        "name": "handoff",
+        "description": "Compact the current conversation into a handoff document for another agent to pick up. References existing artifacts (PRDs, plans, ADRs, issues, commits, diffs) by path or URL instead of duplicating them. Use when user wants to hand off the conversation to a fresh agent or starts a new session that picks up prior work.",
+        "path": "engineering/handoff"
+      },
+      {
+        "name": "helm-chart-builder",
+        "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw \u2014 chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing. Use when: user wants to create or improve Helm charts, design values.yaml files, implement template helpers, audit chart security (RBAC, network policies, pod security), manage subcharts, or run helm lint/test.",
+        "path": "engineering/helm-chart-builder"
+      },
+      {
+        "name": "karpathy-coder",
+        "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles \u2014 surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding.",
+        "path": "engineering/karpathy-coder"
+      },
+      {
+        "name": "kubernetes-operator",
+        "description": "Use when building a Kubernetes Operator \u2014 custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill \u2014 specifically the Operator pattern.",
+        "path": "engineering/kubernetes-operator"
+      },
+      {
+        "name": "llm-cost-optimizer",
+        "description": "Use proactively whenever LLM API costs come up -- or should. Triggers include: 'my AI costs are too high', 'optimize token usage', 'which model should I use', 'LLM spend is out of control', 'implement prompt caching', 'we're about to launch an AI feature', 'build me an AI endpoint'. Don't wait for an explicit cost complaint -- if someone is building an AI feature, designing an LLM endpoint, or choosing between models, cost architecture belongs in the conversation. Apply immediately when any of these are true: a system prompt appears that exceeds a few hundred tokens, all requests are hitting the same model, max_tokens is not set, or no per-feature cost logging exists. NOT for RAG pipeline design (use rag-architect). NOT for improving prompt quality or effectiveness (use senior-prompt-engineer).",
+        "path": "engineering/llm-cost-optimizer"
+      },
+      {
+        "name": "llm-wiki",
+        "description": "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include \"second brain\", \"Obsidian wiki\", \"personal knowledge management\", \"ingest this paper/article/book\", \"build a research wiki\", \"compound knowledge\", \"Memex\", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.",
+        "path": "engineering/llm-wiki"
+      },
+      {
+        "name": "prompt-governance",
+        "description": "Use when managing prompts in production at scale: versioning prompts, running A/B tests on prompts, building prompt registries, preventing prompt regressions, or creating eval pipelines for production AI features. Triggers: 'manage prompts in production', 'prompt versioning', 'prompt regression', 'prompt A/B test', 'prompt registry', 'eval pipeline'. NOT for writing or improving individual prompts (use senior-prompt-engineer). NOT for RAG pipeline design (use rag-architect). NOT for LLM cost reduction (use llm-cost-optimizer).",
+        "path": "engineering/prompt-governance"
+      },
+      {
+        "name": "security-guidance",
+        "description": "PreToolUse security-anti-pattern hook for Claude Code. Catches 12 common security risks (command injection, XSS, SQL injection, unsafe deserialization, GitHub Actions workflow injection, eval/new Function code injection) BEFORE the Edit/Write/MultiEdit operation completes. Session-state caching prevents duplicate warnings on the same file+rule combo. Stdlib only \u2014 no dependencies. Use when you want a safety net during Claude Code sessions that touch security-sensitive code (auth, payments, user input handling, IaC). Disable with ENABLE_SECURITY_REMINDER=0 if you need to perform a verified-safe operation that would otherwise trip a pattern. Triggers \u2014 \"add security hook\", \"block unsafe code\", \"detect command injection before write\", \"prevent SQL injection patterns\", \"security warning hook\".",
+        "path": "engineering/security-guidance"
+      },
+      {
+        "name": "slo-architect",
+        "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill \u2014 specifically the SLO discipline.",
+        "path": "engineering/slo-architect"
+      },
+      {
+        "name": "statistical-analyst",
+        "description": "Run hypothesis tests, analyze A/B experiment results, calculate sample sizes, and interpret statistical significance with effect sizes. Use when you need to validate whether observed differences are real, size an experiment correctly before launch, or interpret test results with confidence.",
+        "path": "engineering/statistical-analyst"
+      },
+      {
+        "name": "terraform-patterns",
+        "description": "Terraform infrastructure-as-code agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Covers module design patterns, state management strategies, provider configuration, security hardening, policy-as-code with Sentinel/OPA, and CI/CD plan/apply workflows. Use when: user wants to design Terraform modules, manage state backends, review Terraform security, implement multi-region deployments, or follow IaC best practices.",
+        "path": "engineering/terraform-patterns"
+      },
+      {
+        "name": "write-a-skill",
+        "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, build, or author a new skill.",
+        "path": "engineering/write-a-skill"
+      }
+    ],
+    "engineering-team": [
+      {
+        "name": "adversarial-reviewer",
+        "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer.",
+        "path": "engineering-team/adversarial-reviewer"
+      },
+      {
+        "name": "ai-security",
+        "description": "Use when assessing AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring.",
+        "path": "engineering-team/ai-security"
+      },
+      {
+        "name": "aws-solution-architect",
+        "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
+        "path": "engineering-team/aws-solution-architect"
+      },
+      {
+        "name": "azure-cloud-architect",
+        "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
+        "path": "engineering-team/azure-cloud-architect"
+      },
+      {
+        "name": "cloud-security",
+        "description": "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping.",
+        "path": "engineering-team/cloud-security"
+      },
+      {
+        "name": "code-reviewer",
+        "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.",
+        "path": "engineering-team/code-reviewer"
+      },
+      {
+        "name": "email-template-builder",
+        "description": "Build complete transactional email systems: React Email templates, provider integration (Resend, Postmark, SendGrid, AWS SES), preview server, i18n support, dark mode, spam optimization, analytics tracking. Use when adding transactional email to a new product, migrating between email providers, refactoring legacy email templates for accessibility, or adding internationalization to existing templates.",
+        "path": "engineering-team/email-template-builder"
+      },
+      {
+        "name": "engineering-skills",
+        "description": "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only).",
+        "path": "engineering-team/engineering-skills"
+      },
+      {
+        "name": "epic-design",
+        "description": ">",
+        "path": "engineering-team/epic-design"
+      },
+      {
+        "name": "gcp-cloud-architect",
+        "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization.",
+        "path": "engineering-team/gcp-cloud-architect"
+      },
+      {
+        "name": "incident-commander",
+        "description": "Comprehensive incident response framework from detection through resolution and post-incident review. Battle-tested SRE/DevOps practices: severity classification, timeline reconstruction, structured post-incident analysis. Use when declaring an incident, coordinating multi-team response during an outage, leading a post-mortem, or setting up on-call practices for a new service.",
+        "path": "engineering-team/incident-commander"
+      },
+      {
+        "name": "incident-response",
+        "description": "Use when a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Covers SEV1-SEV4 classification, false positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle.",
+        "path": "engineering-team/incident-response"
+      },
+      {
+        "name": "ms365-tenant-manager",
+        "description": "Microsoft 365 tenant administration for Global Administrators. Automate M365 tenant setup, Office 365 admin tasks, Azure AD user management, Exchange Online configuration, Teams administration, and security policies. Generate PowerShell scripts for bulk operations, Conditional Access policies, license management, and compliance reporting. Use for M365 tenant manager, Office 365 admin, Azure AD users, Global Administrator, tenant configuration, or Microsoft 365 automation.",
+        "path": "engineering-team/ms365-tenant-manager"
+      },
+      {
+        "name": "red-team",
+        "description": "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting.",
+        "path": "engineering-team/red-team"
+      },
+      {
+        "name": "security-pen-testing",
+        "description": "Use when the user asks to perform security audits, penetration testing, vulnerability scanning, OWASP Top 10 checks, or offensive security assessments. Covers static analysis, dependency scanning, secret detection, API security testing, and pen test report generation.",
+        "path": "engineering-team/security-pen-testing"
+      },
+      {
+        "name": "senior-architect",
+        "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\", \"choose a database\", \"plan for scalability\", \"make technical decisions\", or \"review system design\". Use for architecture decision records (ADRs), tech stack evaluation, system design reviews, dependency analysis, and generating architecture diagrams in Mermaid, PlantUML, or ASCII format.",
+        "path": "engineering-team/senior-architect"
+      },
+      {
+        "name": "senior-backend",
+        "description": "Designs and implements backend systems including REST APIs, microservices, database architectures, authentication flows, and security hardening. Use when the user asks to \"design REST APIs\", \"optimize database queries\", \"implement authentication\", \"build microservices\", \"review backend code\", \"set up GraphQL\", \"handle database migrations\", or \"load test APIs\". Covers Node.js/Express/Fastify development, PostgreSQL optimization, API security, and backend architecture patterns.",
+        "path": "engineering-team/senior-backend"
+      },
+      {
+        "name": "senior-computer-vision",
+        "description": "Computer vision engineering skill for object detection, image segmentation, and visual AI systems. Covers CNN and Vision Transformer architectures, YOLO/Faster R-CNN/DETR detection, Mask R-CNN/SAM segmentation, and production deployment with ONNX/TensorRT. Includes PyTorch, torchvision, Ultralytics, Detectron2, and MMDetection frameworks. Use when building detection pipelines, training custom models, optimizing inference, or deploying vision systems.",
+        "path": "engineering-team/senior-computer-vision"
+      },
+      {
+        "name": "senior-data-engineer",
+        "description": "Data engineering skill for building scalable data pipelines, ETL/ELT systems, and data infrastructure. Expertise in Python, SQL, Spark, Airflow, dbt, Kafka, and modern data stack. Includes data modeling, pipeline orchestration, data quality, and DataOps. Use when designing data architectures, building data pipelines, optimizing data workflows, implementing data governance, or troubleshooting data issues.",
+        "path": "engineering-team/senior-data-engineer"
+      },
+      {
+        "name": "senior-data-scientist",
+        "description": "World-class senior data scientist skill specialising in statistical modeling, experiment design, causal inference, and predictive analytics. Covers A/B testing (sample sizing, two-proportion z-tests, Bonferroni correction), difference-in-differences, feature engineering pipelines (Scikit-learn, XGBoost), cross-validated model evaluation (AUC-ROC, AUC-PR, SHAP), and MLflow experiment tracking \u2014 using Python (NumPy, Pandas, Scikit-learn), R, and SQL. Use when designing or analysing controlled experiments, building and evaluating classification or regression models, performing causal analysis on observational data, engineering features for structured tabular datasets, or translating statistical findings into data-driven business decisions.",
+        "path": "engineering-team/senior-data-scientist"
+      },
+      {
+        "name": "senior-devops",
+        "description": "Comprehensive DevOps skill for CI/CD, infrastructure automation, containerization, and cloud platforms (AWS, GCP, Azure). Includes pipeline setup, infrastructure as code, deployment automation, and monitoring. Use when setting up pipelines, deploying applications, managing infrastructure, implementing monitoring, or optimizing deployment processes.",
+        "path": "engineering-team/senior-devops"
+      },
+      {
+        "name": "senior-frontend",
+        "description": "Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Use when building React components, optimizing Next.js performance, analyzing bundle sizes, scaffolding frontend projects, implementing accessibility, or reviewing frontend code quality.",
+        "path": "engineering-team/senior-frontend"
+      },
+      {
+        "name": "senior-fullstack",
+        "description": "Fullstack development toolkit with project scaffolding for Next.js, FastAPI, MERN, and Django stacks, code quality analysis with security and complexity scoring, and stack selection guidance. Use when the user asks to \"scaffold a new project\", \"create a Next.js app\", \"set up FastAPI with React\", \"analyze code quality\", \"audit my codebase\", \"what stack should I use\", \"generate project boilerplate\", or mentions fullstack development, project setup, or tech stack comparison.",
+        "path": "engineering-team/senior-fullstack"
+      },
+      {
+        "name": "senior-ml-engineer",
+        "description": "ML engineering skill for productionizing models, building MLOps pipelines, and integrating LLMs. Covers model deployment, feature stores, drift monitoring, RAG systems, and cost optimization. Use when the user asks about deploying ML models to production, setting up MLOps infrastructure (MLflow, Kubeflow, Kubernetes, Docker), monitoring model performance or drift, building RAG pipelines, or integrating LLM APIs with retry logic and cost controls. Focused on production and operational concerns rather than model research or initial training.",
+        "path": "engineering-team/senior-ml-engineer"
+      },
+      {
+        "name": "senior-prompt-engineer",
+        "description": "This skill should be used when the user asks to \"optimize prompts\", \"design prompt templates\", \"evaluate LLM outputs\", \"build agentic systems\", \"implement RAG\", \"create few-shot examples\", \"analyze token usage\", or \"design AI workflows\". Use for prompt engineering patterns, LLM evaluation frameworks, agent architectures, and structured output design.",
+        "path": "engineering-team/senior-prompt-engineer"
+      },
+      {
+        "name": "senior-qa",
+        "description": "Generates unit tests, integration tests, and E2E tests for React/Next.js applications. Scans components to create Jest + React Testing Library test stubs, analyzes Istanbul/LCOV coverage reports to surface gaps, scaffolds Playwright test files from Next.js routes, mocks API calls with MSW, creates test fixtures, and configures test runners. Use when the user asks to \"generate tests\", \"write unit tests\", \"analyze test coverage\", \"scaffold E2E tests\", \"set up Playwright\", \"configure Jest\", \"implement testing patterns\", or \"improve test quality\".",
+        "path": "engineering-team/senior-qa"
+      },
+      {
+        "name": "senior-secops",
+        "description": "Senior SecOps engineer skill for application security, vulnerability management, compliance verification, and secure development practices. Runs SAST/DAST scans, generates CVE remediation plans, checks dependency vulnerabilities, creates security policies, enforces secure coding patterns, and automates compliance checks against SOC2, PCI-DSS, HIPAA, and GDPR. Use when conducting a security review or audit, responding to a CVE or security incident, hardening infrastructure, implementing authentication or secrets management, running penetration test prep, checking OWASP Top 10 exposure, or enforcing security controls in CI/CD pipelines.",
+        "path": "engineering-team/senior-secops"
+      },
+      {
+        "name": "senior-security",
+        "description": "Security engineering toolkit for threat modeling, vulnerability analysis, secure architecture, and penetration testing. Includes STRIDE analysis, OWASP guidance, cryptography patterns, and security scanning tools. Use when the user asks about security reviews, threat analysis, vulnerability assessments, secure coding practices, security audits, attack surface analysis, CVE remediation, or security best practices.",
+        "path": "engineering-team/senior-security"
+      },
+      {
+        "name": "stripe-integration-expert",
+        "description": "Production-grade Stripe integrations: subscriptions with trials and proration, one-time payments, usage-based billing, checkout sessions, idempotent webhook handlers, customer portal, and invoicing. Covers Next.js, Express, and Django patterns. Use when integrating Stripe for the first time, debugging webhook reliability issues, migrating from a different payment provider, or adding usage-based billing to an existing subscription product.",
+        "path": "engineering-team/stripe-integration-expert"
+      },
+      {
+        "name": "tdd-guide",
+        "description": "Test-driven development skill for writing unit tests, generating test fixtures and mocks, analyzing coverage gaps, and guiding red-green-refactor workflows across Jest, Pytest, JUnit, Vitest, and Mocha. Use when the user asks to write tests, improve test coverage, practice TDD, generate mocks or stubs, or mentions testing frameworks like Jest, pytest, or JUnit.",
+        "path": "engineering-team/tdd-guide"
+      },
+      {
+        "name": "tech-stack-evaluator",
+        "description": "Technology stack evaluation and comparison with TCO analysis, security assessment, and ecosystem health scoring. Use when comparing frameworks, evaluating technology stacks, calculating total cost of ownership, assessing migration paths, or analyzing ecosystem viability.",
+        "path": "engineering-team/tech-stack-evaluator"
+      },
+      {
+        "name": "threat-detection",
+        "description": "Use when hunting for threats in an environment, analyzing IOCs, or detecting behavioral anomalies in telemetry. Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and MITRE ATT&CK-mapped signal prioritization.",
+        "path": "engineering-team/threat-detection"
+      },
+      {
+        "name": "a11y-audit",
+        "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+        "path": "engineering-team/a11y-audit"
+      },
+      {
+        "name": "google-workspace-cli",
+        "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits, execute 43 built-in recipes, and use 10 persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling.",
+        "path": "engineering-team/google-workspace-cli"
+      },
+      {
+        "name": "browserstack",
+        "description": ">-",
+        "path": "engineering-team/browserstack"
+      },
+      {
+        "name": "coverage",
+        "description": ">-",
+        "path": "engineering-team/coverage"
+      },
+      {
+        "name": "fix",
+        "description": ">-",
+        "path": "engineering-team/fix"
+      },
+      {
+        "name": "generate",
+        "description": ">-",
+        "path": "engineering-team/generate"
+      },
+      {
+        "name": "init",
+        "description": ">-",
+        "path": "engineering-team/init"
+      },
+      {
+        "name": "migrate",
+        "description": ">-",
+        "path": "engineering-team/migrate"
+      },
+      {
+        "name": "pw",
+        "description": "Production-grade Playwright testing toolkit. Use when the user mentions Playwright tests, end-to-end testing, browser automation, fixing flaky tests, test migration, CI/CD testing, or test suites. Generate tests, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55 templates, 3 agents, smart reporting.",
+        "path": "engineering-team/pw"
+      },
+      {
+        "name": "report",
+        "description": ">-",
+        "path": "engineering-team/report"
+      },
+      {
+        "name": "review",
+        "description": ">-",
+        "path": "engineering-team/review"
+      },
+      {
+        "name": "testrail",
+        "description": ">-",
+        "path": "engineering-team/testrail"
+      },
+      {
+        "name": "extract",
+        "description": "Turn a proven pattern or debugging solution into a standalone reusable skill with SKILL.md, reference docs, and examples.",
+        "path": "engineering-team/extract"
+      },
+      {
+        "name": "promote",
+        "description": "Graduate a proven pattern from auto-memory (MEMORY.md) to CLAUDE.md or .claude/rules/ for permanent enforcement.",
+        "path": "engineering-team/promote"
+      },
+      {
+        "name": "remember",
+        "description": "Explicitly save important knowledge to auto-memory with timestamp and context. Use when a discovery is too important to rely on auto-capture.",
+        "path": "engineering-team/remember"
+      },
+      {
+        "name": "review",
+        "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics.",
+        "path": "engineering-team/review"
+      },
+      {
+        "name": "self-improving-agent",
+        "description": "Curate Claude Code's auto-memory into durable project knowledge. Analyze MEMORY.md for patterns, promote proven learnings to CLAUDE.md and .claude/rules/, extract recurring solutions into reusable skills. Use when: (1) reviewing what Claude has learned about your project, (2) graduating a pattern from notes to enforced rules, (3) turning a debugging solution into a skill, (4) checking memory health and capacity.",
+        "path": "engineering-team/self-improving-agent"
+      },
+      {
+        "name": "status",
+        "description": "Memory health dashboard showing line counts, topic files, capacity, stale entries, and recommendations.",
+        "path": "engineering-team/status"
+      },
+      {
+        "name": "snowflake-development",
+        "description": "Use when writing Snowflake SQL, building data pipelines with Dynamic Tables or Streams/Tasks, using Cortex AI functions, creating Cortex Agents, writing Snowpark Python, configuring dbt for Snowflake, or troubleshooting Snowflake errors.",
+        "path": "engineering-team/snowflake-development"
+      }
+    ],
+    "product-team": [
+      {
+        "name": "competitive-teardown",
+        "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+        "path": "product-team/competitive-teardown"
+      },
+      {
+        "name": "experiment-designer",
+        "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor.",
+        "path": "product-team/experiment-designer"
+      },
+      {
+        "name": "landing-page-generator",
+        "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page \u2014 or when they want to A/B test landing page variants or replace a static page with one designed to convert.",
+        "path": "product-team/landing-page-generator"
+      },
+      {
+        "name": "product-analytics",
+        "description": "Use when defining product KPIs, building metric dashboards, running cohort or retention analysis, or interpreting feature adoption trends across product stages.",
+        "path": "product-team/product-analytics"
+      },
+      {
+        "name": "product-discovery",
+        "description": "Use when validating product opportunities, mapping assumptions, planning discovery sprints, or testing problem-solution fit before committing delivery resources.",
+        "path": "product-team/product-discovery"
+      },
+      {
+        "name": "product-manager-toolkit",
+        "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use for feature prioritization, user research synthesis, requirement documentation, and product strategy development.",
+        "path": "product-team/product-manager-toolkit"
+      },
+      {
+        "name": "product-skills",
+        "description": "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only).",
+        "path": "product-team/product-skills"
+      },
+      {
+        "name": "product-strategist",
+        "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level.",
+        "path": "product-team/product-strategist"
+      },
+      {
+        "name": "roadmap-communicator",
+        "description": "Use when preparing roadmap narratives, release notes, changelogs, or stakeholder updates tailored for executives, engineering teams, and customers.",
+        "path": "product-team/roadmap-communicator"
+      },
+      {
+        "name": "saas-scaffolder",
+        "description": "Generates complete, production-ready SaaS project boilerplate including authentication, database schemas, billing integration, API routes, and a working dashboard using Next.js 14+ App Router, TypeScript, Tailwind CSS, shadcn/ui, Drizzle ORM, and Stripe. Use when the user wants to create a new SaaS app, start a subscription-based web project, scaffold a Next.js application, or mentions terms like starter template, boilerplate, new project, or wiring up auth and payments.",
+        "path": "product-team/saas-scaffolder"
+      },
+      {
+        "name": "spec-to-repo",
+        "description": "Use when the user says 'build me an app', 'create a project from this spec', 'scaffold a new repo', 'generate a starter', 'turn this idea into code', 'bootstrap a project', 'I have requirements and need a codebase', or provides a natural-language project specification and expects a complete, runnable repository. Stack-agnostic: Next.js, FastAPI, Rails, Go, Rust, Flutter, and more.",
+        "path": "product-team/spec-to-repo"
+      },
+      {
+        "name": "ui-design-system",
+        "description": "UI design system toolkit for Senior UI Designer including design token generation, component documentation, responsive design calculations, and developer handoff tools. Use for creating design systems, maintaining visual consistency, and facilitating design-dev collaboration.",
+        "path": "product-team/ui-design-system"
+      },
+      {
+        "name": "ux-researcher-designer",
+        "description": "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation.",
+        "path": "product-team/ux-researcher-designer"
+      },
+      {
+        "name": "agile-product-owner",
+        "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
+        "path": "product-team/agile-product-owner"
+      },
+      {
+        "name": "apple-hig-expert",
+        "description": "Expert guidance on Apple Human Interface Guidelines (HIG). Covers iOS, macOS, and visionOS with 2026 Liquid Glass aesthetics and accessibility-first design.",
+        "path": "product-team/apple-hig-expert"
+      },
+      {
+        "name": "code-to-prd",
+        "description": "|",
+        "path": "product-team/code-to-prd"
+      },
+      {
+        "name": "research-summarizer",
+        "description": "Structured research summarization agent skill for non-dev users. Handles academic papers, web articles, reports, and documentation. Extracts key findings, generates comparative analyses, and produces properly formatted citations. Use when: user wants to summarize a research paper, compare multiple sources, extract citations from documents, or create structured research briefs. Plugin for Claude Code, Codex, Gemini CLI, and OpenClaw.",
+        "path": "product-team/research-summarizer"
+      }
+    ],
+    "marketing-skill": [
+      {
+        "name": "ab-test-setup",
+        "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
+        "path": "marketing-skill/ab-test-setup"
+      },
+      {
+        "name": "ad-creative",
+        "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production \u2014 distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
+        "path": "marketing-skill/ad-creative"
+      },
+      {
+        "name": "aeo",
+        "description": "Answer Engine Optimization (AEO) skill \u2014 optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO \u2014 AEO optimizes for citation in LLM-generated responses, not search rankings. Use when planning content for AI-first search audiences, auditing existing content for E-E-A-T signals, tracking which pages get cited by which LLMs, or building a citation-friendly content strategy. Triggers \u2014 'AEO audit', 'optimize for ChatGPT', 'get cited by Perplexity', 'LLM citation strategy', 'answer engine optimization', 'content for AI search', 'E-E-A-T audit'. Output is a markdown audit report (default) or JSON for pipeline integration. Stdlib-only Python tools.",
+        "path": "marketing-skill/aeo"
+      },
+      {
+        "name": "ai-seo",
+        "description": "Optimize content to get cited by AI search engines \u2014 ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+        "path": "marketing-skill/ai-seo"
+      },
+      {
+        "name": "analytics-tracking",
+        "description": "Set up, audit, and debug analytics tracking implementation \u2014 GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data \u2014 use campaign-analytics for that. NOT for BI dashboards \u2014 use product-analytics for in-product event analysis.",
+        "path": "marketing-skill/analytics-tracking"
+      },
+      {
+        "name": "app-store-optimization",
+        "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
+        "path": "marketing-skill/app-store-optimization"
+      },
+      {
+        "name": "brand-guidelines",
+        "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand \u2014 including Anthropic's official identity.",
+        "path": "marketing-skill/brand-guidelines"
+      },
+      {
+        "name": "campaign-analytics",
+        "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
+        "path": "marketing-skill/campaign-analytics"
+      },
+      {
+        "name": "churn-prevention",
+        "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue \u2014 use customer-success-manager for that.",
+        "path": "marketing-skill/churn-prevention"
+      },
+      {
+        "name": "cold-email",
+        "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) \u2014 this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+        "path": "marketing-skill/cold-email"
+      },
+      {
+        "name": "competitor-alternatives",
+        "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+        "path": "marketing-skill/competitor-alternatives"
+      },
+      {
+        "name": "content-creator",
+        "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly \u2014 identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+        "path": "marketing-skill/content-creator"
+      },
+      {
+        "name": "content-humanizer",
+        "description": "Makes AI-generated content sound genuinely human \u2014 not just cleaned up, but alive. Use when content feels robotic, uses too many AI clich\u00e9s, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+        "path": "marketing-skill/content-humanizer"
+      },
+      {
+        "name": "content-production",
+        "description": "Full content production pipeline \u2014 takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+        "path": "marketing-skill/content-production"
+      },
+      {
+        "name": "content-strategy",
+        "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+        "path": "marketing-skill/content-strategy"
+      },
+      {
+        "name": "copy-editing",
+        "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+        "path": "marketing-skill/copy-editing"
+      },
+      {
+        "name": "copywriting",
+        "description": "When the user wants to write, rewrite, or improve marketing copy for any page \u2014 including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+        "path": "marketing-skill/copywriting"
+      },
+      {
+        "name": "email-sequence",
+        "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" or \"lifecycle emails.\" For in-app onboarding, see onboarding-cro.",
+        "path": "marketing-skill/email-sequence"
+      },
+      {
+        "name": "form-cro",
+        "description": "When the user wants to optimize any form that is NOT signup/registration \u2014 including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" or \"contact form.\" For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+        "path": "marketing-skill/form-cro"
+      },
+      {
+        "name": "free-tool-strategy",
+        "description": "When the user wants to build a free tool for marketing \u2014 lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
+        "path": "marketing-skill/free-tool-strategy"
+      },
+      {
+        "name": "launch-strategy",
+        "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'GTM plan,' 'launch checklist,' or 'launch momentum.' This skill covers phased launches, channel strategy, and ongoing launch momentum.",
+        "path": "marketing-skill/launch-strategy"
+      },
+      {
+        "name": "marketing-context",
+        "description": "Create and maintain the marketing context document that all marketing skills read before starting. Use when the user mentions 'marketing context,' 'brand voice,' 'set up context,' 'target audience,' 'ICP,' 'style guide,' 'who is my customer,' 'positioning,' or wants to avoid repeating foundational information across marketing tasks. Run this at the start of any new project before using other marketing skills.",
+        "path": "marketing-skill/marketing-context"
+      },
+      {
+        "name": "marketing-demand-acquisition",
+        "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs for Series A+ startups scaling internationally. Use when planning marketing strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or startup marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships for hybrid PLG/Sales-Led motions in EU/US/Canada markets.",
+        "path": "marketing-skill/marketing-demand-acquisition"
+      },
+      {
+        "name": "marketing-ideas",
+        "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category.",
+        "path": "marketing-skill/marketing-ideas"
+      },
+      {
+        "name": "marketing-ops",
+        "description": "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.",
+        "path": "marketing-skill/marketing-ops"
+      },
+      {
+        "name": "marketing-psychology",
+        "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application.",
+        "path": "marketing-skill/marketing-psychology"
+      },
+      {
+        "name": "marketing-skills",
+        "description": "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only).",
+        "path": "marketing-skill/marketing-skills"
+      },
+      {
+        "name": "marketing-strategy-pmm",
+        "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies.",
+        "path": "marketing-skill/marketing-strategy-pmm"
+      },
+      {
+        "name": "onboarding-cro",
+        "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" or \"new user experience.\" For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
+        "path": "marketing-skill/onboarding-cro"
+      },
+      {
+        "name": "page-cro",
+        "description": "When the user wants to optimize, improve, or increase conversions on any marketing page \u2014 including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+        "path": "marketing-skill/page-cro"
+      },
+      {
+        "name": "paid-ads",
+        "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization.",
+        "path": "marketing-skill/paid-ads"
+      },
+      {
+        "name": "paywall-upgrade-cro",
+        "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) \u2014 this skill focuses on in-product upgrade moments where the user has already experienced value.",
+        "path": "marketing-skill/paywall-upgrade-cro"
+      },
+      {
+        "name": "popup-cro",
+        "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" or \"overlay.\" For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
+        "path": "marketing-skill/popup-cro"
+      },
+      {
+        "name": "pricing-strategy",
+        "description": "Design, optimize, and communicate SaaS pricing \u2014 tier structure, value metrics, pricing pages, and price increase strategy. Use when building a pricing model from scratch, redesigning existing pricing, planning a price increase, or improving a pricing page. Trigger keywords: pricing tiers, pricing page, price increase, packaging, value metric, per seat pricing, usage-based pricing, freemium, good-better-best, pricing strategy, monetization, pricing page conversion, Van Westendorp. NOT for broader product strategy \u2014 use product-strategist for that. NOT for customer success or renewals \u2014 use customer-success-manager for expansion revenue.",
+        "path": "marketing-skill/pricing-strategy"
+      },
+      {
+        "name": "programmatic-seo",
+        "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" or \"building many pages for SEO.\" For auditing existing SEO issues, see seo-audit.",
+        "path": "marketing-skill/programmatic-seo"
+      },
+      {
+        "name": "prompt-engineer-toolkit",
+        "description": "Analyzes and rewrites prompts for better AI output, creates reusable prompt templates for marketing use cases (ad copy, email campaigns, social media), and structures end-to-end AI content workflows. Use when the user wants to improve prompts for AI-assisted marketing, build prompt templates, or optimize AI content workflows. Also use when the user mentions 'prompt engineering,' 'improve my prompts,' 'AI writing quality,' 'prompt templates,' or 'AI content workflow.",
+        "path": "marketing-skill/prompt-engineer-toolkit"
+      },
+      {
+        "name": "referral-program",
+        "description": "When the user wants to design, launch, or optimize a referral or affiliate program. Use when they mention 'referral program,' 'affiliate program,' 'word of mouth,' 'refer a friend,' 'incentive program,' 'customer referrals,' 'brand ambassador,' 'partner program,' 'referral link,' or 'growth through referrals.' Covers program mechanics, incentive design, and optimization \u2014 not just the idea of referrals but the actual system.",
+        "path": "marketing-skill/referral-program"
+      },
+      {
+        "name": "schema-markup",
+        "description": "When the user wants to implement, audit, or validate structured data (schema markup) on their website. Use when the user mentions 'structured data,' 'schema.org,' 'JSON-LD,' 'rich results,' 'rich snippets,' 'schema markup,' 'FAQ schema,' 'Product schema,' 'HowTo schema,' or 'structured data errors in Search Console.' Also use when someone asks why their content isn't showing rich results or wants to improve AI search visibility. NOT for general SEO audits (use seo-audit) or technical SEO crawl issues (use site-architecture).",
+        "path": "marketing-skill/schema-markup"
+      },
+      {
+        "name": "seo-audit",
+        "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" or \"SEO health check.\" For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup.",
+        "path": "marketing-skill/seo-audit"
+      },
+      {
+        "name": "signup-flow-cro",
+        "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" or \"account creation flow.\" For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
+        "path": "marketing-skill/signup-flow-cro"
+      },
+      {
+        "name": "site-architecture",
+        "description": "When the user wants to audit, redesign, or plan their website's structure, URL hierarchy, navigation design, or internal linking strategy. Use when the user mentions 'site architecture,' 'URL structure,' 'internal links,' 'site navigation,' 'breadcrumbs,' 'topic clusters,' 'hub pages,' 'orphan pages,' 'silo structure,' 'information architecture,' or 'website reorganization.' Also use when someone has SEO problems and the root cause is structural (not content or schema). NOT for content strategy decisions about what to write (use content-strategy) or for schema markup (use schema-markup).",
+        "path": "marketing-skill/site-architecture"
+      },
+      {
+        "name": "social-content",
+        "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' or 'viral content.' This skill covers content creation, repurposing, and platform-specific strategies.",
+        "path": "marketing-skill/social-content"
+      },
+      {
+        "name": "social-media-analyzer",
+        "description": "Social media campaign analysis and performance tracking. Calculates engagement rates, ROI, and benchmarks across platforms. Use for analyzing social media performance, calculating engagement rate, measuring campaign ROI, comparing platform metrics, or benchmarking against industry standards.",
+        "path": "marketing-skill/social-media-analyzer"
+      },
+      {
+        "name": "social-media-manager",
+        "description": "When the user wants to develop social media strategy, plan content calendars, manage community engagement, or grow their social presence across platforms. Also use when the user mentions 'social media strategy,' 'social calendar,' 'community management,' 'social media plan,' 'grow followers,' 'engagement rate,' 'social media audit,' or 'which platforms should I use.' For writing individual social posts, see social-content. For analyzing social performance data, see social-media-analyzer.",
+        "path": "marketing-skill/social-media-manager"
+      },
+      {
+        "name": "x-twitter-growth",
+        "description": "X/Twitter growth engine for building audience, crafting viral content, and analyzing engagement. Use when the user wants to grow on X/Twitter, write tweets or threads, analyze their X profile, research competitors on X, plan a posting strategy, or optimize engagement. Complements social-content (generic multi-platform) with X-specific depth: algorithm mechanics, thread engineering, reply strategy, profile optimization, and competitive intelligence via web search.",
+        "path": "marketing-skill/x-twitter-growth"
+      },
+      {
+        "name": "video-content-strategist",
+        "description": "Use when planning video content strategy, writing video scripts, optimizing YouTube channels, building short-form video pipelines (Reels, TikTok, Shorts), or repurposing long-form content into video. Triggers: 'start a YouTube channel', 'video content strategy', 'write a video script', 'repurpose into video', 'YouTube SEO', 'short-form video'. NOT for written blog content (use content-production). NOT for social captions without video (use social-media-manager).",
+        "path": "marketing-skill/video-content-strategist"
+      }
+    ],
+    "c-level-advisor": [
+      {
+        "name": "agent-protocol",
+        "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
+        "path": "c-level-advisor/agent-protocol"
+      },
+      {
+        "name": "board-deck-builder",
+        "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
+        "path": "c-level-advisor/board-deck-builder"
+      },
+      {
+        "name": "board-meeting",
+        "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+        "path": "c-level-advisor/board-meeting"
+      },
+      {
+        "name": "c-level-skills",
+        "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+        "path": "c-level-advisor/c-level-skills"
+      },
+      {
+        "name": "ceo-advisor",
+        "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
+        "path": "c-level-advisor/ceo-advisor"
+      },
+      {
+        "name": "cfo-advisor",
+        "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
+        "path": "c-level-advisor/cfo-advisor"
+      },
+      {
+        "name": "change-management",
+        "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication.",
+        "path": "c-level-advisor/change-management"
+      },
+      {
+        "name": "chief-ai-officer-advisor",
+        "description": "Chief AI Officer advisory for startups: model build-vs-buy decisions (API vs fine-tune vs in-house), AI risk classification under EU AI Act + US state patchwork, AI cost economics (API-to-self-hosted breakeven), and AI team org evolution. Use when deciding whether to call an API or fine-tune, classifying AI use cases for regulatory risk, calculating when self-hosting pays off, sequencing AI hires, or when user mentions CAIO, AI strategy, model selection, foundation model, fine-tuning, EU AI Act, NIST AI RMF, AI governance, model risk, or AI economics. Strategic only \u2014 does not duplicate engineering AI/ML skills.",
+        "path": "c-level-advisor/chief-ai-officer-advisor"
+      },
+      {
+        "name": "chief-customer-officer-advisor",
+        "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only \u2014 does not duplicate engineering/business-growth tactical skills.",
+        "path": "c-level-advisor/chief-customer-officer-advisor"
+      },
+      {
+        "name": "chief-data-officer-advisor",
+        "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill \u2014 strategic decisions only.",
+        "path": "c-level-advisor/chief-data-officer-advisor"
+      },
+      {
+        "name": "chief-of-staff",
+        "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically.",
+        "path": "c-level-advisor/chief-of-staff"
+      },
+      {
+        "name": "chro-advisor",
+        "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
+        "path": "c-level-advisor/chro-advisor"
+      },
+      {
+        "name": "ciso-advisor",
+        "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+        "path": "c-level-advisor/ciso-advisor"
+      },
+      {
+        "name": "cmo-advisor",
+        "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
+        "path": "c-level-advisor/cmo-advisor"
+      },
+      {
+        "name": "company-os",
+        "description": "The meta-framework for how a company runs \u2014 the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
+        "path": "c-level-advisor/company-os"
+      },
+      {
+        "name": "competitive-intel",
+        "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+        "path": "c-level-advisor/competitive-intel"
+      },
+      {
+        "name": "context-engine",
+        "description": "Loads and manages company context for all C-suite advisor skills. Reads ~/.claude/company-context.md, detects stale context (>90 days), enriches context during conversations, and enforces privacy/anonymization rules before external API calls.",
+        "path": "c-level-advisor/context-engine"
+      },
+      {
+        "name": "coo-advisor",
+        "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
+        "path": "c-level-advisor/coo-advisor"
+      },
+      {
+        "name": "cpo-advisor",
+        "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy.",
+        "path": "c-level-advisor/cpo-advisor"
+      },
+      {
+        "name": "cro-advisor",
+        "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+        "path": "c-level-advisor/cro-advisor"
+      },
+      {
+        "name": "cs-onboard",
+        "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills.",
+        "path": "c-level-advisor/cs-onboard"
+      },
+      {
+        "name": "cto-advisor",
+        "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
+        "path": "c-level-advisor/cto-advisor"
+      },
+      {
+        "name": "culture-architect",
+        "description": "Build, measure, and evolve company culture as operational behavior \u2014 not wall posters. Covers mission/vision/values workshops, values-to-behaviors translation, culture code creation, culture health assessment, and cultural rituals by stage. Use when building company values, assessing culture health, designing cultural rituals, creating culture codes, handling culture clashes, or when user mentions culture, values, culture debt, founder culture, or culture code.",
+        "path": "c-level-advisor/culture-architect"
+      },
+      {
+        "name": "decision-logger",
+        "description": "Two-layer memory architecture for board meeting decisions. Manages raw transcripts (Layer 1) and approved decisions (Layer 2). Use when logging decisions after a board meeting, reviewing past decisions with /cs:decisions, or checking overdue action items with /cs:review. Invoked automatically by the board-meeting skill after Phase 5 founder approval.",
+        "path": "c-level-advisor/decision-logger"
+      },
+      {
+        "name": "founder-coach",
+        "description": "Personal leadership development for founders and first-time CEOs. Covers founder archetype identification, delegation frameworks, energy management, CEO calendar audits, leadership style evolution, blind spot identification, imposter syndrome, founder mental health, and succession planning. Use when a founder feels like the bottleneck, struggles to delegate, is burning out, transitioning from IC to executive, managing a board, or when user mentions founder mode, CEO growth, leadership development, delegation, burnout, or imposter syndrome.",
+        "path": "c-level-advisor/founder-coach"
+      },
+      {
+        "name": "general-counsel-advisor",
+        "description": "General Counsel advisory for startups: contract review (MSA, SaaS, NDA, DPA, employment), IP strategy, term sheet decoding, and regulatory landscape mapping. Use when reviewing any contract or term sheet, deciding when to engage outside counsel, defining IP strategy, evaluating regulatory exposure (HIPAA, GDPR, FDA, fintech), or when user mentions general counsel, GC, legal review, contract risk, term sheet, IP assignment, or regulatory exposure. NOT a substitute for licensed counsel \u2014 surfaces questions to bring to qualified attorneys.",
+        "path": "c-level-advisor/general-counsel-advisor"
+      },
+      {
+        "name": "internal-narrative",
+        "description": "Build and maintain one coherent company story across all audiences \u2014 employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication.",
+        "path": "c-level-advisor/internal-narrative"
+      },
+      {
+        "name": "intl-expansion",
+        "description": "International market expansion strategy. Market selection, entry modes, localization, regulatory compliance, and go-to-market by region. Use when expanding to new countries, evaluating international markets, planning localization, or building regional teams.",
+        "path": "c-level-advisor/intl-expansion"
+      },
+      {
+        "name": "ma-playbook",
+        "description": "M&A strategy for acquiring companies or being acquired. Due diligence, valuation, integration, and deal structure. Use when evaluating acquisitions, preparing for acquisition, M&A due diligence, integration planning, or deal negotiation.",
+        "path": "c-level-advisor/ma-playbook"
+      },
+      {
+        "name": "org-health-diagnostic",
+        "description": "Cross-functional organizational health check combining signals from all C-suite roles. Scores 8 dimensions on a traffic-light scale with drill-down recommendations. Use when assessing overall company health, preparing for board reviews, identifying at-risk functions, or when user mentions org health, health check, or health dashboard.",
+        "path": "c-level-advisor/org-health-diagnostic"
+      },
+      {
+        "name": "scenario-war-room",
+        "description": "Cross-functional what-if modeling for cascading multi-variable scenarios. Unlike single-assumption stress testing, this models compound adversity across all business functions simultaneously. Use when facing complex risk scenarios, strategic decisions with major downside, or when the user asks 'what if X AND Y both happen?",
+        "path": "c-level-advisor/scenario-war-room"
+      },
+      {
+        "name": "strategic-alignment",
+        "description": "Cascades strategy from boardroom to individual contributor. Detects and fixes misalignment between company goals and team execution. Covers strategy articulation, cascade mapping, orphan goal detection, silo identification, communication gap analysis, and realignment protocols. Use when teams are pulling in different directions, OKRs don't connect, departments optimize locally at company expense, or when user mentions alignment, strategy cascade, silo, conflicting OKRs, or strategy communication.",
+        "path": "c-level-advisor/strategic-alignment"
+      },
+      {
+        "name": "vpe-advisor",
+        "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing \u2192 screen \u2192 onsite \u2192 offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) \u2014 VPE owns delivery operations and how the team ships.",
+        "path": "c-level-advisor/vpe-advisor"
+      },
+      {
+        "name": "boardroom",
+        "description": "/cs:boardroom <brief> \u2014 6-phase multi-role deliberation across the C-suite with Phase 2 isolation, critic pre-screen, and synthesis. Outputs a board memo.",
+        "path": "c-level-advisor/boardroom"
+      },
+      {
+        "name": "brief",
+        "description": "/cs:brief <topic> \u2014 Generate a one-page strategy brief from an office-hours intake. First step in the strategic sprint pipeline.",
+        "path": "c-level-advisor/brief"
+      },
+      {
+        "name": "c-level-agents",
+        "description": "Founder-mode executive team. 8 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff) and 17 /cs:* slash commands for forcing-question office hours, multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Use when the founder needs a virtual executive team, when invoking /cs:* commands, or when orchestrating multi-role decisions.",
+        "path": "c-level-advisor/c-level-agents"
+      },
+      {
+        "name": "caio-review",
+        "description": "/cs:caio-review <plan> \u2014 Eval-demanding Chief AI Officer interrogation of any plan that involves AI: model selection, risk classification, cost economics, or AI hiring.",
+        "path": "c-level-advisor/caio-review"
+      },
+      {
+        "name": "cco-review",
+        "description": "/cs:cco-review <plan> \u2014 Retention-obsessed Chief Customer Officer interrogation of any plan that touches customer retention, segmentation, CS team sizing, or CS team hiring.",
+        "path": "c-level-advisor/cco-review"
+      },
+      {
+        "name": "cdo-review",
+        "description": "/cs:cdo-review <plan> \u2014 Decision-driven Chief Data Officer interrogation of any plan that touches training data, data architecture, data productization, or data team hiring.",
+        "path": "c-level-advisor/cdo-review"
+      },
+      {
+        "name": "cfo-review",
+        "description": "/cs:cfo-review <plan> \u2014 Numerate-skeptic interrogation of any plan that touches money. Unit economics, runway, dilution, capital allocation.",
+        "path": "c-level-advisor/cfo-review"
+      },
+      {
+        "name": "ciso-review",
+        "description": "/cs:ciso-review <plan> \u2014 Risk-paranoid interrogation of any plan that touches data, compliance, or production access.",
+        "path": "c-level-advisor/ciso-review"
+      },
+      {
+        "name": "cmo-review",
+        "description": "/cs:cmo-review <plan> \u2014 Narrative-first interrogation of positioning, ICP, message house, and channel mix.",
+        "path": "c-level-advisor/cmo-review"
+      },
+      {
+        "name": "cpo-review",
+        "description": "/cs:cpo-review <plan> \u2014 JTBD-driven interrogation of product roadmap, PMF signal, and portfolio focus.",
+        "path": "c-level-advisor/cpo-review"
+      },
+      {
+        "name": "cro-review",
+        "description": "/cs:cro-review <plan> \u2014 Pipeline-paranoid interrogation of revenue, win rate, NRR, and ramp time.",
+        "path": "c-level-advisor/cro-review"
+      },
+      {
+        "name": "cross-eval",
+        "description": "/cs:cross-eval <memo> \u2014 Multi-model consensus on a board memo or strategy brief. Claude + Codex + Gemini cross-review with graceful degradation.",
+        "path": "c-level-advisor/cross-eval"
+      },
+      {
+        "name": "cto-review",
+        "description": "/cs:cto-review <plan> \u2014 Architecture and scaling interrogation. Tech debt, scaling cliffs, team scaling, build-vs-buy.",
+        "path": "c-level-advisor/cto-review"
+      },
+      {
+        "name": "decide",
+        "description": "/cs:decide <memo> \u2014 Log a decision to two-layer memory via decision-logger. Approved memo becomes durable; raw transcripts kept for reference.",
+        "path": "c-level-advisor/decide"
+      },
+      {
+        "name": "execute",
+        "description": "/cs:execute <decision> \u2014 Generate a 90-day execution plan with weekly milestones, DRIs, and check-in cadence from an approved decision.",
+        "path": "c-level-advisor/execute"
+      },
+      {
+        "name": "founder-mode",
+        "description": "/cs:founder-mode <question> \u2014 Auto-routes any founder question to the right C-role advisor or to /cs:boardroom for multi-role topics. The single-command entry point.",
+        "path": "c-level-advisor/founder-mode"
+      },
+      {
+        "name": "freeze",
+        "description": "/cs:freeze <decision> <days> \u2014 Lock a strategic decision for a cooldown period to prevent impulse reversal. Mirrors gstack's safety primitives for the business layer.",
+        "path": "c-level-advisor/freeze"
+      },
+      {
+        "name": "gc-review",
+        "description": "/cs:gc-review <plan> \u2014 General Counsel interrogation of contracts, IP, regulatory, term sheets, and employment-law surface.",
+        "path": "c-level-advisor/gc-review"
+      },
+      {
+        "name": "office-hours",
+        "description": "/cs:office-hours <topic> \u2014 YC-style 6-question founder interrogation before any advice. Forces clarity on problem, customer, distribution, defensibility, capital, and founder fit.",
+        "path": "c-level-advisor/office-hours"
+      },
+      {
+        "name": "onboard",
+        "description": "/cs:onboard \u2014 Founder interview that populates ~/.claude/company-context.md. The first command to run when starting with c-level-agents.",
+        "path": "c-level-advisor/onboard"
+      },
+      {
+        "name": "post-mortem",
+        "description": "/cs:post-mortem <decision> \u2014 Honest retrospective on an executed decision, scored against original assumptions and dissent. Closes the strategic sprint loop.",
+        "path": "c-level-advisor/post-mortem"
+      },
+      {
+        "name": "vpe-review",
+        "description": "/cs:vpe-review <plan> \u2014 Throughput-first VP of Engineering interrogation of any plan that touches delivery, eng hiring, team structure, or production discipline.",
+        "path": "c-level-advisor/vpe-review"
+      },
+      {
+        "name": "chief-ai-officer-advisor",
+        "description": "Chief AI Officer advisory for startups: model build-vs-buy decisions (API vs fine-tune vs in-house), AI risk classification under EU AI Act + US state patchwork, AI cost economics (API-to-self-hosted breakeven), and AI team org evolution. Use when deciding whether to call an API or fine-tune, classifying AI use cases for regulatory risk, calculating when self-hosting pays off, sequencing AI hires, or when user mentions CAIO, AI strategy, model selection, foundation model, fine-tuning, EU AI Act, NIST AI RMF, AI governance, model risk, or AI economics. Strategic only \u2014 does not duplicate engineering AI/ML skills.",
+        "path": "c-level-advisor/chief-ai-officer-advisor"
+      },
+      {
+        "name": "chief-customer-officer-advisor",
+        "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only \u2014 does not duplicate engineering/business-growth tactical skills.",
+        "path": "c-level-advisor/chief-customer-officer-advisor"
+      },
+      {
+        "name": "chief-data-officer-advisor",
+        "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill \u2014 strategic decisions only.",
+        "path": "c-level-advisor/chief-data-officer-advisor"
+      },
+      {
+        "name": "board-prep",
+        "description": "Board meeting preparation for the adversarial scenario, not the friendly one. Forces numbers-cold mastery, anticipates hard questions, builds a narrative that acknowledges weakness without losing the room. Use when preparing for a board meeting, an investor update, fundraising presentation, or any high-stakes adversarial review where every number must live in your head not just on a slide.",
+        "path": "c-level-advisor/board-prep"
+      },
+      {
+        "name": "challenge",
+        "description": "Pre-mortem plan analysis. Imagine the plan failed 12 months from now and work backwards to find the weaknesses. Surfaces assumptions, dependencies, and execution risks before committing resources. Use when before significant resource commitment, before presenting to a board or investors, when feedback has been one-sidedly positive, or when there is pressure to move fast and figure it out later.",
+        "path": "c-level-advisor/challenge"
+      },
+      {
+        "name": "executive-mentor",
+        "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for brutal board meetings, dissects decisions with no good options, and forces honest post-mortems. Use when you need someone to find the holes before the board does, make a decision you've been avoiding, or understand what actually went wrong.",
+        "path": "c-level-advisor/executive-mentor"
+      },
+      {
+        "name": "hard-call",
+        "description": "/em -hard-call \u2014 Framework for Decisions With No Good Options",
+        "path": "c-level-advisor/hard-call"
+      },
+      {
+        "name": "postmortem",
+        "description": "/em -postmortem \u2014 Honest Analysis of What Went Wrong",
+        "path": "c-level-advisor/postmortem"
+      },
+      {
+        "name": "stress-test",
+        "description": "/em -stress-test \u2014 Business Assumption Stress Testing",
+        "path": "c-level-advisor/stress-test"
+      },
+      {
+        "name": "general-counsel-advisor",
+        "description": "General Counsel advisory for startups: contract review (MSA, SaaS, NDA, DPA, employment), IP strategy, term sheet decoding, and regulatory landscape mapping. Use when reviewing any contract or term sheet, deciding when to engage outside counsel, defining IP strategy, evaluating regulatory exposure (HIPAA, GDPR, FDA, fintech), or when user mentions general counsel, GC, legal review, contract risk, term sheet, IP assignment, or regulatory exposure. NOT a substitute for licensed counsel \u2014 surfaces questions to bring to qualified attorneys.",
+        "path": "c-level-advisor/general-counsel-advisor"
+      },
+      {
+        "name": "vpe-advisor",
+        "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing \u2192 screen \u2192 onsite \u2192 offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) \u2014 VPE owns delivery operations and how the team ships.",
+        "path": "c-level-advisor/vpe-advisor"
+      }
+    ],
+    "project-management": [
+      {
+        "name": "atlassian-admin",
+        "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
+        "path": "project-management/atlassian-admin"
+      },
+      {
+        "name": "atlassian-templates",
+        "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation.",
+        "path": "project-management/atlassian-templates"
+      },
+      {
+        "name": "confluence-expert",
+        "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+        "path": "project-management/confluence-expert"
+      },
+      {
+        "name": "jira-expert",
+        "description": "Atlassian Jira expert for creating and managing projects, planning, product discovery, JQL queries, workflows, custom fields, automation, reporting, and all Jira features. Use for Jira project setup, configuration, advanced search, dashboard creation, workflow design, and technical Jira operations.",
+        "path": "project-management/jira-expert"
+      },
+      {
+        "name": "meeting-analyzer",
+        "description": "Analyzes meeting transcripts and recordings to surface behavioral patterns, communication anti-patterns, and actionable coaching feedback. Use this skill whenever the user uploads or points to meeting transcripts (.txt, .md, .vtt, .srt, .docx), asks about their communication habits, wants feedback on how they run meetings, requests speaking ratio analysis, mentions filler words or conflict avoidance, or wants to compare their communication across time periods. Also trigger when users mention tools like Granola, Otter, Fireflies, or Zoom transcripts. Even if the user just says \"look at my meetings\" or \"how do I come across in meetings\" \u2014 use this skill.",
+        "path": "project-management/meeting-analyzer"
+      },
+      {
+        "name": "pm-skills",
+        "description": "6 project management agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Senior PM, scrum master, Jira expert (JQL), Confluence expert, Atlassian admin, template creator. MCP integration for live Jira/Confluence automation.",
+        "path": "project-management/pm-skills"
+      },
+      {
+        "name": "scrum-master",
+        "description": "Advanced Scrum Master skill for data-driven agile team analysis and coaching. Use when the user asks about sprint planning, velocity tracking, retrospectives, standup facilitation, backlog grooming, story points, burndown charts, blocker resolution, or agile team health. Runs Python scripts to analyse sprint JSON exports from Jira or similar tools: velocity_analyzer.py for Monte Carlo sprint forecasting, sprint_health_scorer.py for multi-dimension health scoring, and retrospective_analyzer.py for action-item and theme tracking. Produces confidence-interval forecasts, health grade reports, and improvement-velocity trends for high-performing Scrum teams.",
+        "path": "project-management/scrum-master"
+      },
+      {
+        "name": "senior-pm",
+        "description": "Senior Project Manager for enterprise software, SaaS, and digital transformation projects. Specializes in portfolio management, quantitative risk analysis, resource optimization, stakeholder alignment, and executive reporting. Uses advanced methodologies including EMV analysis, Monte Carlo simulation, WSJF prioritization, and multi-dimensional health scoring. Use when a user needs help with project plans, project status reports, risk assessments, resource allocation, project roadmaps, milestone tracking, team capacity planning, portfolio health reviews, program management, or executive-level project reporting \u2014 especially for enterprise-scale initiatives with multiple workstreams, complex dependencies, or multi-million dollar budgets.",
+        "path": "project-management/senior-pm"
+      },
+      {
+        "name": "team-communications",
+        "description": "Write internal company communications \u2014 3P updates (Progress/Plans/Problems), company-wide newsletters, FAQ roundups, incident reports, leadership updates, status reports, project updates, and general internal comms. Use this skill any time the user asks to draft, edit, or format something meant for internal audiences. Trigger on keywords like \"3P\", \"weekly update\", \"newsletter\", \"FAQ\", \"internal comms\", \"status report\", \"company update\", \"team update\", \"incident report\", or any request to summarize work for leadership, teammates, or the broader company. Even casual requests like \"write my update\" or \"summarize what my team did this week\" should trigger this skill.",
+        "path": "project-management/team-communications"
+      }
+    ],
+    "ra-qm-team": [
+      {
+        "name": "capa-officer",
+        "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
+        "path": "ra-qm-team/capa-officer"
+      },
+      {
+        "name": "eu-ai-act-specialist",
+        "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI system \u2014 prohibited (Art. 5), high-risk (Art. 6 + Annex III), limited-risk (Art. 50), or minimal-risk? (2) For high-risk systems, what's the Article 43 conformity assessment route (Module A internal control vs Module H full QMS + notified body) and what goes in the Annex IV technical documentation? (3) Per organizational role (provider / deployer / importer / distributor / authorized representative), what are the active obligations and deadlines? Use during AI system intake review, when planning conformity assessment, or when scoping deployer obligations. Cites Articles + Annexes for every output. NOT executive AI strategy (see chief-ai-officer-advisor). NOT a legal substitute.",
+        "path": "ra-qm-team/eu-ai-act-specialist"
+      },
+      {
+        "name": "fda-consultant-specialist",
+        "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QSR (21 CFR 820) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QSR, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity.",
+        "path": "ra-qm-team/fda-consultant-specialist"
+      },
+      {
+        "name": "gdpr-dsgvo-expert",
+        "description": "GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests. Use for GDPR compliance assessments, privacy audits, data protection planning, DPIA generation, and data subject rights management.",
+        "path": "ra-qm-team/gdpr-dsgvo-expert"
+      },
+      {
+        "name": "information-security-manager-iso27001",
+        "description": "ISO 27001 ISMS implementation and cybersecurity governance for HealthTech and MedTech companies. Use for ISMS design, security risk assessment, control implementation, ISO 27001 certification, security audits, incident response, and compliance verification. Covers ISO 27001, ISO 27002, healthcare security, and medical device cybersecurity.",
+        "path": "ra-qm-team/information-security-manager-iso27001"
+      },
+      {
+        "name": "isms-audit-expert",
+        "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows.",
+        "path": "ra-qm-team/isms-audit-expert"
+      },
+      {
+        "name": "iso42001-specialist",
+        "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps against Clauses 4-10 and what do we close first? (2) What goes in the AI risk register and which Annex A controls treat each risk? (3) What's the 12-month internal audit plan that satisfies Clause 9.2? Use when preparing for certification, scoping internal audit cycles, or onboarding AI systems into an existing ISMS (27001) / QMS (13485) program. NOT an executive AI strategy skill (see chief-ai-officer-advisor). NOT EU AI Act compliance (see compliance-team-eu-ai-act).",
+        "path": "ra-qm-team/iso42001-specialist"
+      },
+      {
+        "name": "mdr-745-specialist",
+        "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, and EUDAMED integration.",
+        "path": "ra-qm-team/mdr-745-specialist"
+      },
+      {
+        "name": "qms-audit-expert",
+        "description": "ISO 13485 internal audit expertise for medical device QMS. Covers audit planning, execution, nonconformity classification, and CAPA verification. Use for internal audit planning, audit execution, finding classification, external audit preparation, or audit program management.",
+        "path": "ra-qm-team/qms-audit-expert"
+      },
+      {
+        "name": "quality-documentation-manager",
+        "description": "Document control system management for medical device QMS. Covers document numbering, version control, change management, and 21 CFR Part 11 compliance. Use for document control procedures, change control workflow, document numbering, version management, electronic signature compliance, or regulatory documentation review.",
+        "path": "ra-qm-team/quality-documentation-manager"
+      },
+      {
+        "name": "quality-manager-qmr",
+        "description": "Senior Quality Manager Responsible Person (QMR) for HealthTech and MedTech companies. Provides quality system governance, management review leadership, regulatory compliance oversight, and quality performance monitoring per ISO 13485 Clause 5.5.2.",
+        "path": "ra-qm-team/quality-manager-qmr"
+      },
+      {
+        "name": "quality-manager-qms-iso13485",
+        "description": "ISO 13485 Quality Management System implementation and maintenance for medical device organizations. Provides QMS design, documentation control, internal auditing, CAPA management, and certification support. Use when working with medical device quality systems, preparing for ISO 13485 audits, managing regulatory compliance documentation, setting up corrective actions, or building audit preparation programs. Useful for quality management, audit preparation, regulatory compliance, medical device documentation, and corrective action workflows.",
+        "path": "ra-qm-team/quality-manager-qms-iso13485"
+      },
+      {
+        "name": "ra-qm-skills",
+        "description": "12 regulatory & QM agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, ISO 27001 ISMS, GDPR/DSGVO, risk management (ISO 14971), CAPA, document control, auditing. Python tools (stdlib-only).",
+        "path": "ra-qm-team/ra-qm-skills"
+      },
+      {
+        "name": "regulatory-affairs-head",
+        "description": "Senior Regulatory Affairs Manager for HealthTech and MedTech companies. Prepares FDA 510(k), De Novo, and PMA submission packages; analyzes regulatory pathways for new medical devices; drafts responses to FDA deficiency letters and Notified Body queries; develops CE marking technical documentation under EU MDR 2017/745; coordinates multi-market approval strategies across FDA, EU, Health Canada, PMDA, and NMPA; and maintains regulatory intelligence on evolving standards. Use when users need to plan or execute FDA submissions, navigate 510(k) or PMA approval processes, achieve CE marking, prepare pre-submission meeting materials, write regulatory strategy documents, respond to agency queries, or manage compliance documentation for medical device market access.",
+        "path": "ra-qm-team/regulatory-affairs-head"
+      },
+      {
+        "name": "risk-management-specialist",
+        "description": "Medical device risk management specialist implementing ISO 14971 throughout product lifecycle. Provides risk analysis, risk evaluation, risk control, and post-production information analysis. Use when user mentions risk management, ISO 14971, risk analysis, FMEA, fault tree analysis, hazard identification, risk control, risk matrix, benefit-risk analysis, residual risk, risk acceptability, or post-market risk.",
+        "path": "ra-qm-team/risk-management-specialist"
+      },
+      {
+        "name": "soc2-compliance",
+        "description": "Use when the user asks to prepare for SOC 2 audits, map Trust Service Criteria, build control matrices, collect audit evidence, perform gap analysis, or assess SOC 2 Type I vs Type II readiness.",
+        "path": "ra-qm-team/soc2-compliance"
+      },
+      {
+        "name": "eu-ai-act-specialist",
+        "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI system \u2014 prohibited (Art. 5), high-risk (Art. 6 + Annex III), limited-risk (Art. 50), or minimal-risk? (2) For high-risk systems, what's the Article 43 conformity assessment route (Module A internal control vs Module H full QMS + notified body) and what goes in the Annex IV technical documentation? (3) Per organizational role (provider / deployer / importer / distributor / authorized representative), what are the active obligations and deadlines? Use during AI system intake review, when planning conformity assessment, or when scoping deployer obligations. Cites Articles + Annexes for every output. NOT executive AI strategy (see chief-ai-officer-advisor). NOT a legal substitute.",
+        "path": "ra-qm-team/eu-ai-act-specialist"
+      },
+      {
+        "name": "iso42001-specialist",
+        "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps against Clauses 4-10 and what do we close first? (2) What goes in the AI risk register and which Annex A controls treat each risk? (3) What's the 12-month internal audit plan that satisfies Clause 9.2? Use when preparing for certification, scoping internal audit cycles, or onboarding AI systems into an existing ISMS (27001) / QMS (13485) program. NOT an executive AI strategy skill (see chief-ai-officer-advisor). NOT EU AI Act compliance (see compliance-team-eu-ai-act).",
+        "path": "ra-qm-team/iso42001-specialist"
+      }
+    ],
+    "business-growth": [
+      {
+        "name": "business-growth-skills",
+        "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+        "path": "business-growth/business-growth-skills"
+      },
+      {
+        "name": "contract-and-proposal-writer",
+        "description": "Generate professional, jurisdiction-aware business documents: freelance contracts, project proposals, SOWs, NDAs, and MSAs. Structured Markdown output with docx conversion instructions. Covers US (Delaware), EU (GDPR), UK, and DACH (German law) jurisdictions. Not a substitute for legal counsel \u2014 use as strong starting points. Use when drafting a freelance contract, preparing a client proposal, writing an SOW for a new engagement, or producing an NDA before sharing sensitive material.",
+        "path": "business-growth/contract-and-proposal-writer"
+      },
+      {
+        "name": "customer-success-manager",
+        "description": "Monitors customer health, predicts churn risk, and identifies expansion opportunities using weighted scoring models for SaaS customer success. Use when analyzing customer accounts, reviewing retention metrics, scoring at-risk customers, or when the user mentions churn, customer health scores, upsell opportunities, expansion revenue, retention analysis, or customer analytics. Runs three Python CLI tools to produce deterministic health scores, churn risk tiers, and prioritized expansion recommendations across Enterprise, Mid-Market, and SMB segments.",
+        "path": "business-growth/customer-success-manager"
+      },
+      {
+        "name": "revenue-operations",
+        "description": "Analyzes sales pipeline health, revenue forecasting accuracy, and go-to-market efficiency metrics for SaaS revenue optimization. Use when analyzing sales pipeline coverage, forecasting revenue, evaluating go-to-market performance, reviewing sales metrics, assessing pipeline analysis, tracking forecast accuracy with MAPE, calculating GTM efficiency, or measuring sales efficiency and unit economics for SaaS teams.",
+        "path": "business-growth/revenue-operations"
+      },
+      {
+        "name": "sales-engineer",
+        "description": "Analyzes RFP/RFI responses for coverage gaps, builds competitive feature comparison matrices, and plans proof-of-concept (POC) engagements for pre-sales engineering. Use when responding to RFPs, bids, or proposal requests; comparing product features against competitors; planning or scoring a customer POC or sales demo; preparing a technical proposal; or performing win/loss competitor analysis. Handles tasks described as 'RFP response', 'bid response', 'proposal response', 'competitor comparison', 'feature matrix', 'POC planning', 'sales demo prep', or 'pre-sales engineering'.",
+        "path": "business-growth/sales-engineer"
+      }
+    ],
+    "finance": [
+      {
+        "name": "finance-skills",
+        "description": "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only).",
+        "path": "finance/finance-skills"
+      },
+      {
+        "name": "financial-analyst",
+        "description": "Performs financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecast construction for strategic decision-making. Use when analyzing financial statements, building valuation models, assessing budget variances, or constructing financial projections and forecasts. Also applicable when users mention financial modeling, cash flow analysis, company valuation, financial projections, or spreadsheet analysis.",
+        "path": "finance/financial-analyst"
+      },
+      {
+        "name": "saas-metrics-coach",
+        "description": "SaaS financial health advisor. Use when a user shares revenue or customer numbers, or mentions ARR, MRR, churn, LTV, CAC, NRR, or asks how their SaaS business is doing.",
+        "path": "finance/saas-metrics-coach"
+      },
+      {
+        "name": "business-investment-advisor",
+        "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+        "path": "finance/business-investment-advisor"
+      }
+    ],
+    "productivity": [
+      {
+        "name": "capture",
+        "description": "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says 'capture this', 'brain dump', 'let me dump some ideas', 'I've got a bunch of thoughts', 'here's everything on my mind', 'idea dump', 'let me get this out of my head', 'I need to organize my thoughts', 'here's what I'm thinking', or any variation where someone is unloading a messy stream of ideas, tasks, thoughts, and plans wanting them turned into something coherent. Also trigger when the user pastes or dictates a long, unstructured block of mixed ideas \u2014 even without the exact phrase \u2014 the intent is the same. Fast-to-action by design: no upfront intake. Output is four sections (Projects/Ideas, Tasks, Connections, How I Can Help) ending with a directive question. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project.",
+        "path": "productivity/capture"
+      },
+      {
+        "name": "inbox-setup",
+        "description": "One-time setup skill that builds a personalized inbox triage knowledge base via interactive interview. Interviews the user about their email patterns, business context, reply style, and priorities using grill-me discipline (one question at a time, forcing format where possible, dependency-ordered, each question explains why I'm asking), then generates the knowledge base files that power the companion 'inbox-triage' skill. Run this once before using inbox-triage for the first time. Re-run when business, pricing, or priorities change significantly. Triggers: 'set up my inbox', 'configure inbox triage', 'set up my email system', 'configure email triage', 'build my email knowledge base', 'initialize email management', 'set up inbox triage', 'onboard email triage', or any variation where someone wants to get the email triage system running for the first time.",
+        "path": "productivity/inbox-setup"
+      },
+      {
+        "name": "inbox-triage",
+        "description": "Runs a full inbox triage using the knowledge base created by the 'inbox-setup' skill. Light-intake by design (most invocations skip questions and run with KB-default preferences); asks at most 2 grill-me override questions when invocation is outside normal cadence or includes category-skip intent. Searches recent emails, classifies them via the user's taxonomy, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report in the user's preferred format, and updates the knowledge base with learnings. Designed to run on a recurring schedule (1-3x daily) or on demand. Triggers: 'triage my inbox', 'inbox triage', 'check my email', 'run email triage', 'process my inbox', 'what's new in my email', 'handle my email', 'email triage', or any variation where the user wants their inbox processed. Requires the inbox-setup skill to have been run first.",
+        "path": "productivity/inbox-triage"
+      },
+      {
+        "name": "reflect",
+        "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck \u2014 that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from.",
+        "path": "productivity/reflect"
+      }
+    ],
+    "marketing": [
+      {
+        "name": "landing",
+        "description": "Generates a premium single-page HTML landing page with 3D CSS animations, GSAP scroll effects, and mouse-parallax depth. Forcing intake (product + elevator pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written, so the page reflects the actual product rather than generic boilerplate. Use whenever the user says 'landing for X', 'create a landing page', 'build a landing page', 'make a landing page for X', 'I need a web page for Y', or provides product/service details and wants a polished website. Also triggers on 'promotional page', 'product page', 'one-pager', 'web presence', 'sales page'. Outputs a single self-contained HTML file (Claude Code) or HTML artifact (Claude.ai). Supports configurable brand colors via CSS custom property overrides.",
+        "path": "marketing/landing"
+      }
+    ],
+    "research": [
+      {
+        "name": "dossier",
+        "description": "Decision-grade entity research skill \u2014 produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a generic profile. Forcing intake makes the user state their hypothesis upfront (what they already believe and want to verify or disprove) so the dossier tests it rather than confirms it. Output is an editable Word document (.docx) with verdict on the hypothesis, identity facts, 12-month activity timeline, network signals, reputation signals, red flags, 3-5 conversation hooks tied to specific findings, and source-provenance audit log. Uses WebSearch + WebFetch + free APIs (SEC EDGAR, GitHub, ProPublica Nonprofit Explorer) as workhorses; optional BYOK MCPs (LinkedIn, Crunchbase, Apollo, Pitchbook, SimilarWeb) enhance coverage. Triggers: 'research [company]', 'dossier on [person/company]', 'background check on [entity]', 'prep me for a meeting with [person/company]', 'due diligence on [company]', 'what should I know about [entity]', 'research [person] before I [meet/hire/invest]', 'competitor research on [company]', 'investor diligence [company]', 'interview prep for [company]'. Honors sensitivity exclusions for journalism + personal-vetting contexts.",
+        "path": "research/dossier"
+      },
+      {
+        "name": "grants",
+        "description": "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission posture + known institute targets) locks down the funding strategy before any search runs. Runs a 5-facet Consensus positioning analysis (with draft Significance/Innovation language), maps the research to the right NIH institutes and study sections via RePORTER, finds NOSIs and funded overlap, and produces an editable Word document (.docx) with budget/scope-aware mechanism recommendations, submission timelines, and a mandatory program officer recommendation. Triggers: 'grants for [topic]', 'find grants for my research idea', 'what grants match my research', 'help me find NIH funding', 'grant opportunities for my research', or any grant-related request. NIH-only scope \u2014 non-NIH funders (PCORI, DOD CDMRP, VA, foundations) are out of scope and flagged at intake.",
+        "path": "research/grants"
+      },
+      {
+        "name": "litreview",
+        "description": "Academic literature orientation skill that searches papers via Consensus, builds a strategic search plan using PICO (default) or SPIDER / Decomposition / hybrid as fallbacks, and synthesizes findings into a professionally formatted Word document (.docx) research guide. Grill-me intake (research question specificity + framework hint + tentative depth) before the recon search; a second forcing checkpoint after Phase 2 confirms framework + sub-areas + depth before searches consume budget. Configurable depth (5/10/20 queries) controls coverage vs. speed. Output is a 'launching pad' \u2014 not a finished review, but an orientation guide that lets a researcher dive in confidently. Triggers: 'litreview on [topic]', 'literature review on [topic]', 'I'm starting a literature review on X', 'I'm writing a paper on X', 'help me research X', 'I'm doing research on X', 'can you help me research X'. Do NOT trigger for single one-off paper searches where the user just wants a quick list \u2014 that's a plain Consensus search.",
+        "path": "research/litreview"
+      },
+      {
+        "name": "notebooklm",
+        "description": "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube links, synthesized content), generating Studio outputs (Audio Overview, infographics, slide decks, study guides, briefing docs, mind maps, timelines, FAQs), and creating new notebooks. Triggers on any phrase involving NotebookLM \u2014 'open NotebookLM', 'check my [name] notebook', 'pull info from NotebookLM', 'ask my notebook about X', 'add [source] to NotebookLM', 'create an infographic in NotebookLM', 'use NotebookLM Studio', 'generate a slide deck from my notebook', or any variation where the goal involves NotebookLM. Requires browser automation environment \u2014 fails gracefully when unavailable.",
+        "path": "research/notebooklm"
+      },
+      {
+        "name": "patent",
+        "description": "Patent prior-art and landscape intelligence skill \u2014 not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-resolved hits, geographic coverage, FTO flags where applicable, strategy recommendations, and full audit log. Triggers: 'prior art search for [invention]', 'patent search on [topic]', 'freedom to operate analysis', 'FTO for [product]', 'patent landscape for [field]', 'is [invention] novel', 'patents on [topic]', 'competitive patent analysis', 'prior art for litigation', 'patent diligence on [company]'. Produces search signal, not legal advice \u2014 always recommends consulting a patent attorney before filing or licensing decisions. Trademark, copyright, and trade-secret questions are out of scope.",
+        "path": "research/patent"
+      },
+      {
+        "name": "pulse",
+        "description": "Multi-source recency research skill that takes the pulse of any topic across Reddit, Hacker News, the open web, and optionally X/Twitter within a configurable recent window (default 30 days). Forcing intake clarifies topic specificity, angle (trend/sentiment/problems/opportunities/comparison), time window, and platform scope before searching. Returns a synthesized briefing with citations, engagement metrics, and cross-platform pattern analysis. Triggers: 'pulse on [topic]', 'what's happening with [topic]', 'what are people saying about [topic]', 'current conversation about [topic]', 'take the pulse of [topic]', 'trending: [topic]', 'find me info on [topic]', or any variation requesting multi-source recency intelligence on a topic. Also use for competitor research, trend discovery, tool comparisons, and audience sentiment analysis.",
+        "path": "research/pulse"
+      },
+      {
+        "name": "research",
+        "description": "Default entry point for any research request \u2014 a hybrid router that classifies the question deterministically and either delegates to a specialist research skill (pulse for trends/sentiment, grants for NIH funding, litreview for academic literature, syllabus for course reading, patent for prior-art + IP landscape, dossier for entity research) or runs its own plan-decompose-multi-source-search-synthesize-cite fallback workflow when no specialist matches. Always surfaces the routing decision so users can override. Triggers \u2014 \"research [topic]\", \"look into [topic]\", \"what do we know about [topic]\", \"investigate [topic]\", \"find me information on [topic]\", \"do some research on [topic]\", \"I need to understand [topic]\", or any research request that doesn't obviously match a more-specific specialist skill. Output is a markdown briefing (default) or .docx document (on request) with full citations and an audit log.",
+        "path": "research/research"
+      },
+      {
+        "name": "syllabus",
+        "description": "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format + course audience + year range) plus a grouping forcing-options checkpoint before any search runs \u2014 so the reading list matches the course's level and recency need. Parses the syllabus to extract topics and learning outcomes, searches Consensus for recent peer-reviewed papers per topic, and produces a professionally formatted .docx with clickable Consensus links, plain-language summaries calibrated to audience level, and Bloom-higher-order discussion questions tied to course learning goals. Triggers whenever a user uploads a syllabus, course outline, or curriculum document and wants supplementary readings. Also triggers on: 'syllabus reading list', 'find papers for my course', 'create a reading list from this syllabus', 'recent research for my class', 'supplementary readings', 'find journal articles for these topics', 'what recent papers cover this material', 'any new research on these course topics', 'update my syllabus with recent papers'. Even casual mentions when a syllabus is attached should trigger this skill.",
+        "path": "research/syllabus"
+      }
+    ],
+    "business-operations": [
+      {
+        "name": "business-operations-skills",
+        "description": "Use when running, diagnosing, or designing internal business operations \u2014 process documentation, vendor SLAs, capacity planning, internal comms, SOP/runbook authoring, procurement spend. Triggers on \"BizOps review\", \"where's the bottleneck\", \"vendor health\", \"internal SOP\", \"all-hands deck\", \"spend categorization\", \"capacity for Q3\", \"process mapping\". Forks context to route to one of six BizOps sub-skills (process-mapper, vendor-management, capacity-planner, internal-comms, knowledge-ops, procurement-optimizer) and returns a digest. Distinct from business-growth (external sales motion) and c-level-advisor (strategic, not operational).",
+        "path": "business-operations/business-operations-skills"
+      },
+      {
+        "name": "capacity-planner",
+        "description": "Use when an ops leader (Director of CX, Head of Support, VP Ops, Head of BizOps, Head of IT ops, Head of Finance ops) is sizing ops capacity, building a headcount plan, modeling utilization risk, planning Q3 capacity or annual support capacity, or designing CS coverage \u2014 and needs Erlang-C queueing math, P90 demand sizing, shrinkage-adjusted FTE, manager-trigger thresholds, and a quarterly hiring sequence with ramp + attrition. Apply when sustained team utilization is above 80% or when the team is growing >50% in 12 months. Run before committing the headcount budget. This is NOT engineering capacity (see vpe-advisor for DORA + cycle time) and NOT strategic 3-year workforce planning (see chro-advisor).",
+        "path": "business-operations/capacity-planner"
+      },
+      {
+        "name": "internal-comms",
+        "description": "Use when a Head of People Ops, BizOps lead, or Internal Communications owner needs to draft and sequence an internal-only change-management communication \u2014 a re-org announcement, a tool rollout, a policy change, a benefit change, a leadership transition, a layoff, an acquisition close, or an internal product launch \u2014 and the audience is employees (not customers). Triggers on \"all-hands announcement\", \"town-hall script\", \"change comms\", \"internal newsletter\", \"rollout comms\", \"policy change announcement\", \"re-org announcement\", \"internal FAQ\", \"manager talking points\", \"Prosci ADKAR\", \"Kotter 8-step\", \"layoff comms\", \"RIF comms\", \"internal memo\". Pairs Prosci ADKAR (Awareness / Desire / Knowledge / Ability / Reinforcement) and Kotter's 8-step change model with deterministic stdlib-only Python tools to produce a sequenced touchpoint calendar, a Kotter-compliant primary announcement, an audience-segmented FAQ, and manager cascade talking points. Industry-tuned via --profile {tech-startup, scaleup, enterprise, public-company, non-profit}. Distinct from marketing-skill/* (external/customer-facing), c-level-advisor/internal-narrative (strategic framing, not tactical drafts), and c-level-advisor/change-management (executive change strategy, not the comms package itself).",
+        "path": "business-operations/internal-comms"
+      },
+      {
+        "name": "knowledge-ops",
+        "description": "Use when a Head of Ops, Knowledge Manager, or TPM-Internal needs to author, validate, or clean up company SOPs and internal runbooks (procurement intake, vendor offboarding, incident-comms cascade, employee onboarding, expense reimbursement, system-access provisioning, customer-escalation playbook) \u2014 including 5W2H completeness checks (Who-What-When-Where-Why-How-HowMuch), cross-link and orphan-page validation across a sprawling Notion/Confluence/Obsidian wiki, KB ingestion + hygiene reporting, ops onboarding doc generation, and runbook step verification (named owner, expected duration, observable success signal, rollback path, escalation contact). Pairs Kaoru Ishikawa's 5W2H method, Atul Gawande's *The Checklist Manifesto*, ISO 9001, ITIL v4 Service Operation, FDA 21 CFR Part 211, and Google SRE Workbook runbook discipline with deterministic stdlib-only Python tools that score completeness, detect anti-patterns, and emit prioritized cleanup lists. Distinct from `engineering/llm-wiki` (Karpathy-style personal PKM second brain), `engineering-team/runbook-generator` (system-ops production debugging runbook), `project-management/*` (Jira/Confluence delivery + ticket tracking), and sibling `business-operations/process-mapper` (BPMN process *design*, while knowledge-ops is process *documentation*).",
+        "path": "business-operations/knowledge-ops"
+      },
+      {
+        "name": "process-mapper",
+        "description": "Use when a BizOps lead, COO, or process-improvement owner needs to document an end-to-end business process (procurement, employee onboarding, incident handoff, customer-onboarding, claims adjudication) in BPMN-style notation, measure cycle times by stage, surface where work spends most of its time waiting vs. being worked, and quantify the gap between processing time and total elapsed time. Pairs Lean / Six Sigma / Theory-of-Constraints canon with deterministic stdlib-only Python tools to produce a process map, a ranked bottleneck list (with severity + root-cause hypothesis), and a cycle-time analysis (P50, P90, value-add ratio, Little's-Law throughput). Distinct from sales-pipeline, system-reliability (SLO), and strategic-OKR work \u2014 this is tactical process documentation for internal operations.",
+        "path": "business-operations/process-mapper"
+      },
+      {
+        "name": "procurement-optimizer",
+        "description": "Use when running an annual SaaS audit, doing category-level spend review, or rationalizing the supplier base \u2014 when the user needs to do a spend audit, spend categorization (UNSPSC-aligned), purchasing-cycle analysis, or risk-balanced supplier consolidation. Triggers on \"spend audit\", \"SaaS audit\", \"spend categorization\", \"supplier rationalization\", \"supplier consolidation\", \"purchasing cycle\", \"procurement review\", \"category strategy\", \"duplicate SaaS\", \"renewal cluster\". Ships 3 stdlib-only Python tools (UNSPSC-aligned spend categorizer with Pareto breakdown and industry profiles, purchasing-cycle analyzer that surfaces bottleneck categories per Goldratt's Theory of Constraints, supplier-consolidation planner that refuses single-source recommendations for tier-1 categories without a documented break-glass plan), 3 reference docs each citing 7+ authoritative sources (A.T. Kearney / Hackett / Spend Matters / UNSPSC / Productiv / Vendr / Tropic / IACCM / ISM / BCG), and a 20-minute spend-intake template. Distinct from sibling vendor-management (performance scoring of vendors you keep paying), finance/financial-analysis (close + report, not category strategy), and c-level-advisor/general-counsel-advisor (contract law, not category rationalization).",
+        "path": "business-operations/procurement-optimizer"
+      },
+      {
+        "name": "vendor-management",
+        "description": "Use when reviewing, scoring, or auditing third-party SaaS / vendor relationships \u2014 running a vendor scorecard, tracking SLA compliance, classifying third-party risk, preparing a tier-1 vendor review, or auditing the SaaS portfolio. Triggers on \"vendor SLA\", \"vendor scorecard\", \"third-party risk\", \"TPRM\", \"vendor review\", \"SaaS audit\", \"supplier performance\", \"vendor health check\", \"renewal review\". Forks context so large vendor catalogs (50-500 line items) and SLA logs don't pollute the parent thread. Ships 3 stdlib-only Python tools (vendor scorer with industry tuning, SLA compliance tracker with credit-claim flags, vendor risk classifier across 4 risk vectors), 3 reference docs each citing 7+ authoritative sources (Gartner / Shared Assessments / NIST / ISO 27036 / breach post-mortems), and a 5-vendor catalog template. Distinct from c-level-advisor/general-counsel-advisor (contract law, not operational management), business-growth/contract-and-proposal-writer (outbound proposals, not inbound vendor scoring), and sibling procurement-optimizer (spend categorization, not vendor performance).",
+        "path": "business-operations/vendor-management"
+      }
+    ],
+    "commercial": [
+      {
+        "name": "channel-economics",
+        "description": "Use when reviewing or rebalancing direct vs. partner-led channel economics \u2014 computing fully-loaded cost-to-serve per channel, channel ROI with cash / LTV / marginal lenses, and optimal channel mix subject to constraints. For Head of Commercial, RevOps, and VP Sales doing quarterly channel review when pipeline is mixed (e.g., 60% direct + 40% partner-led) and nobody actually knows which channel makes money after CAC, support load, partner discount, deal-velocity differences, retention differential, and overhead allocation are all loaded in. Outputs cost to serve, channel ROI verdicts (DOUBLE-DOWN / MAINTAIN / DEFUND / EXIT), a sensitivity-tested channel-mix recommendation, and the diminishing-returns inflection. Not channel structure (that's partnerships-architect \u2014 tiers, joint GTM, revshare). Not RevOps process (that's business-growth/revenue-operations \u2014 lead routing, SDR motion). Not strategic CRO judgment (that's c-level-advisor/cro-advisor \u2014 comp plans, when-to-hire-a-VP-Sales). Not historical close-and-report (that's finance/financial-analysis). This skill answers: direct vs partner profitability, channel profitability, channel mix, channel economics.",
+        "path": "commercial/channel-economics"
+      },
+      {
+        "name": "commercial-forecaster",
+        "description": "Use when building a quarterly bookings forecast, ARR projection, pipeline forecast, NRR projection, or commit/best-case/pipe-only board number \u2014 especially when the CRO needs to walk the board through funnel math + cohort ARR + per-stage conversion assumptions without the theatre of a single undefended number. Decomposes pipeline into commit, best-case, and pipe-only tiers; projects cohort-level NRR/GRR to surface leaky cohorts before they show up in the consolidated number; scores per-stage funnel confidence so soft-floor stages get treated differently from high-confidence ones. Every output explicitly names the conversion rate used, the data window, and the weighting choice. For Head of Commercial, RevOps, VP Sales, and CRO at quarterly forecast or board prep. NOT financial close (see finance/financial-analysis). NOT strategic CRO hiring/territory (see c-level-advisor/cro-advisor). NOT pricing (see sibling pricing-strategist).",
+        "path": "commercial/commercial-forecaster"
+      },
+      {
+        "name": "commercial-policy",
+        "description": "Use when designing or revising a company's commercial policy \u2014 the rules of engagement governing discounts off list price, approver thresholds, exception flows, and the deal framework that Deal Desk and AEs operate under. Covers discount matrix design (ARR band x term length x payment terms x strategic value), commercial policy design, exception policy, discount governance, approval thresholds, deal framework structure, and policy linting (contradictions, gaps, cliff edges, gaming surfaces). For Head of Commercial, Head of Deal Desk, VP Sales, or RevOps at the policy-design moment \u2014 NOT per-deal application (that is deal-desk) and NOT pricing model selection (that is pricing-strategist).",
+        "path": "commercial/commercial-policy"
+      },
+      {
+        "name": "commercial-skills",
+        "description": "Use when reviewing, approving, or designing commercial motion \u2014 pricing models, deal review, discount approval, partnership economics, channel mix, commercial policy, RFP/RFI response, bookings forecast. Triggers on \"review this deal\", \"should we discount\", \"pricing model\", \"partner economics\", \"RFP response\", \"bookings forecast\", \"channel mix\". Forks context to route to one of seven Commercial sub-skills (pricing-strategist, deal-desk, partnerships-architect, channel-economics, commercial-policy, rfp-responder, commercial-forecaster) and returns a digest. Distinct from business-growth (sales execution) and c-level-advisor/cro-advisor (strategic CRO judgment).",
+        "path": "commercial/commercial-skills"
+      },
+      {
+        "name": "deal-desk",
+        "description": "Use when reviewing a specific inbound deal before close \u2014 when sales has asked for a discount that exceeds AE authority, when the customer has redlined the MSA, when per-deal economics (margin after discount, multi-year payment shape, indemnity exposure) need to be quantified, or when discount approval needs to be routed to a named human approver (Sales Director, VP Sales, CFO, CRO, General Counsel). Covers deal review, discount approval routing, per-deal margin scoring, deal exception handling, MSA redline triage, contract landmine detection (uncapped indemnity, MFN, perpetual license-back, missing DPA), and named-approver chain assembly. NEVER auto-approves \u2014 every output is a numeric scorecard plus a routing recommendation to a named human.",
+        "path": "commercial/deal-desk"
+      },
+      {
+        "name": "partnerships-architect",
+        "description": "Use when a startup is approached by a prospective partner and someone has to decide should we sign this partner, at what partner tier (referral / reseller / OEM / SI-consulting / strategic alliance), with what joint GTM commitment, and at what revshare. Classifies partner tier from independent-demand evidence vs. preferential-terms hunting, designs a 90-day joint GTM plan, models revshare against direct-sale margin, and surfaces kill criteria for unwinding under-performing partnerships. For Head of Partnerships, Head of BD, and Founder-CEOs doing reseller agreement, OEM deal, or strategic alliance review \u2014 not technical sale enablement, not channel cost economics, not M&A.",
+        "path": "commercial/partnerships-architect"
+      },
+      {
+        "name": "pricing-strategist",
+        "description": "Use when designing or revisiting product pricing \u2014 selecting a pricing model (subscription seat-based, usage-based, value-based, freemium, or hybrid), running Van Westendorp Price Sensitivity Meter analysis on WTP survey data, or designing Good/Better/Best packaging tiers. Recommends a model and a price range with trade-offs, never a single number. For Commercial leads, Product Marketing, and CMOs at the pricing-design moment \u2014 not deal-by-deal discounting, not brand positioning.",
+        "path": "commercial/pricing-strategist"
+      },
+      {
+        "name": "rfp-responder",
+        "description": "Use when an RFP, RFI, RFQ, security questionnaire, vendor questionnaire, or proposal request arrives and the team needs a structured response \u2014 parsing multi-section buyer-dictated requirements (MANDATORY vs WEIGHTED vs NICE-TO-HAVE), building a Shipley-method proof-point matrix mapping each requirement to a verifiable proof point, articulating 3-5 win-themes that ladder up across requirements, and producing a Shipley-derived winrate estimate that informs a bid / no-bid / partner-bid recommendation. For Bid Managers, Proposal Leads, Directors of Sales, and Sales Engineers at the response-strategy moment. Surfaces GAP requirements explicitly \u2014 never invents claims. NOT free-form proposal narrative authoring, NOT contract redline, NOT marketing collateral.",
+        "path": "commercial/rfp-responder"
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Claude Skills Library will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Mistral Vibe cross-platform installation (closes #705)
+
+### Added
+
+- **`scripts/sync-vibe-skills.py`** — installs claude-code-skills into [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (Apache-2.0 CLI coding agent). Fork of `sync-hermes-skills.py` with target `~/.vibe/skills/claude-skills/<domain>/<skill>/`, namespaced to avoid collisions with Vibe built-ins. Same flags: `--verbose`, `--domain`, `--dry-run`, `--copy`, `--json`, `--target`.
+- **`scripts/vibe-install.sh`** — bash one-liner wrapper for parity with `gemini-install.sh` and `codex-install.sh`. Surfaces Vibe-specific post-install usage tips (`/skills`, `/<slug>`).
+- **`.vibe/skills/claude-skills/`** — pre-generated tree committed to the repo: 306 skill symlinks across 14 domains plus a `skills-index.json` manifest. Lets users inspect the install surface without running the script. Mirrors the existing `.hermes/skills/claude-skills/` precedent.
+- **`INSTALLATION.md`** — new "Mistral Vibe Installation" section (setup, direct Python invocation, verify, uninstall, Python CLI tools), plus TOC entry and a row in the cross-tool compatibility table.
+- **`README.md`** — Mistral Vibe added to the "Works with" line, footnote describing the BYO-sync tier (mirrors the Hermes footnote), row in the Multi-Tool Support table, and FAQ updated from 12 → 13 supported tools.
+
+### Why
+
+Mistral Vibe (released Jan 2026, v2.0) uses the [Agent Skills spec](https://docs.mistral.ai/mistral-vibe/agents-skills) — exactly the same `SKILL.md` + YAML frontmatter contract this repo already ships. Zero format conversion needed; the integration slots cleanly into the existing 5-target cross-platform sync pattern (`.claude` / `.codex` / `.gemini` / `.hermes` / `.vibe`). Issue [#705](https://github.com/alirezarezvani/claude-skills/issues/705) requested this from @saifjarboui.
+
 ## [2.8.1] - 2026-05-20 — Engineering role-skill upgrade: karpathy-coder + Matt Pocock applied to fullstack / frontend / backend
 
 ### Audited and upgraded

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -9,6 +9,7 @@ Complete installation guide for all 205+ production-ready skills across multiple
 - [Universal Installer](#universal-installer)
 - [OpenAI Codex Installation](#openai-codex-installation)
 - [Gemini CLI Installation](#gemini-cli-installation)
+- [Mistral Vibe Installation](#mistral-vibe-installation)
 - [OpenClaw Installation](#openclaw-installation)
 - [Per-Skill Installation](#per-skill-installation)
 - [Multi-Agent Setup](#multi-agent-setup)
@@ -55,6 +56,17 @@ cd claude-skills
 ```
 
 Skills install to `.gemini/skills/` and are activated via `activate_skill(name="skill-name")`.
+
+### For Mistral Vibe Users
+
+```bash
+# Setup script for Mistral Vibe
+git clone https://github.com/alirezarezvani/claude-skills.git
+cd claude-skills
+./scripts/vibe-install.sh
+```
+
+Skills install to `~/.vibe/skills/claude-skills/` (symlinked) and are discovered automatically by Vibe via the standard `SKILL.md` + YAML frontmatter contract. See [Mistral Vibe Installation](#mistral-vibe-installation) for details.
 
 Skills install to `~/.codex/skills/`. See [OpenAI Codex Installation](#openai-codex-installation) for detailed instructions.
 
@@ -725,6 +737,99 @@ python3 marketing-skill/content-production/scripts/brand_voice_analyzer.py artic
 
 ---
 
+## Mistral Vibe Installation
+
+[Mistral Vibe](https://github.com/mistralai/mistral-vibe) is Mistral AI's open-source CLI coding agent (Apache-2.0). It uses the same [`SKILL.md` + YAML frontmatter](https://docs.mistral.ai/mistral-vibe/agents-skills) standard as Claude Code and Hermes, so this repo installs into Vibe with **zero format conversion** — just symlinks.
+
+Vibe discovers skills from three paths (per the [official docs](https://docs.mistral.ai/mistral-vibe/agents-skills)):
+
+- `~/.vibe/skills/` — user-global (what this script writes to)
+- `.vibe/skills/` — project-local
+- `.agents/skills/` — Agent Skills standard path
+
+### Setup Instructions
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/alirezarezvani/claude-skills.git
+    cd claude-skills
+    ```
+
+2.  **Run the Vibe setup script:**
+    ```bash
+    ./scripts/vibe-install.sh
+    ```
+    This installs all skills as symlinks under `~/.vibe/skills/claude-skills/<domain>/<skill-name>/`, namespaced to avoid collisions with Vibe built-ins. It also writes a `skills-index.json` manifest for discovery.
+
+3.  **Use skills in Vibe:**
+    ```text
+    > /skills                    # list all installed skills
+    > /senior-architect          # invoke a skill by slug
+    > review my API design       # auto-loads matching skills via SKILL.md description
+    ```
+
+### Direct Python invocation
+
+For finer-grained control (one domain at a time, copy instead of symlink, JSON output for tooling):
+
+```bash
+# Preview without writing
+python3 scripts/sync-vibe-skills.py --dry-run --verbose
+
+# Sync only one domain
+python3 scripts/sync-vibe-skills.py --domain engineering
+
+# Copy (instead of symlink) — useful for portable installs
+python3 scripts/sync-vibe-skills.py --copy
+
+# JSON output (for CI / scripting)
+python3 scripts/sync-vibe-skills.py --json
+
+# Custom target (instead of ~/.vibe/skills/)
+python3 scripts/sync-vibe-skills.py --target /opt/team-vibe/skills/
+```
+
+### What gets installed
+
+| Layout | Path | Count |
+|--------|------|-------|
+| Skill folders (symlinked) | `~/.vibe/skills/claude-skills/<domain>/<skill>/` | 306 |
+| Domain directories | `~/.vibe/skills/claude-skills/<domain>/` | 14 |
+| Index manifest | `~/.vibe/skills/claude-skills/skills-index.json` | 1 |
+
+A pre-generated copy of the same tree is also committed at `.vibe/skills/claude-skills/` in this repo for reference and for users who want to inspect what will land before running the installer.
+
+### Verify Installation
+
+```bash
+# Count installed skills
+ls ~/.vibe/skills/claude-skills/*/ | wc -l
+
+# Inspect the manifest
+cat ~/.vibe/skills/claude-skills/skills-index.json | python3 -m json.tool | head -20
+
+# Verify a skill's frontmatter resolved correctly through the symlink
+head -10 ~/.vibe/skills/claude-skills/engineering/senior-architect/SKILL.md
+```
+
+### Uninstall
+
+```bash
+rm -rf ~/.vibe/skills/claude-skills/
+```
+
+The namespaced subdirectory means uninstalling never touches Vibe's built-in skills or any skills you installed from other sources.
+
+### Python CLI Tools
+
+Every skill includes deterministic Python CLI tools in its `scripts/` folder. These use the standard library only and run anywhere Python runs — Vibe can invoke them via its shell tool, or you can run them directly:
+
+```bash
+python3 ~/.vibe/skills/claude-skills/marketing-skill/content-production/scripts/brand_voice_analyzer.py article.txt
+```
+
+---
+
 ## OpenClaw Installation
 
 OpenClaw loads skills via YAML frontmatter in `SKILL.md` files. Every skill in this repository includes OpenClaw-compatible frontmatter with `name`, `description`, and `tags` fields.
@@ -923,6 +1028,7 @@ See `.codex/skills-index.json` for the complete manifest with descriptions.
 | **OpenCode** | Platform-specific | `--agent opencode` | Varies by platform |
 | **OpenClaw** | `~/.openclaw/skills/` | `clawhub install` | YAML frontmatter triggers |
 | **Gemini CLI** | `.gemini/skills/` | `gemini-install.sh` | Symlink-based discovery |
+| **Mistral Vibe** | `~/.vibe/skills/` | `vibe-install.sh` | Same `SKILL.md` standard, no conversion |
 | **Project** | `.skills/` | `--agent project` | Portable, project-specific |
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 7 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing (incl. v2.7.3 AEO — Answer Engine Optimization for LLM citation), security (PreToolUse hooks), compliance, C-level advisory (incl. founder-mode CFO/CMO/CRO/CPO/COO/CHRO/CISO/GC/CDO/CAIO/CCO/VPE personas + 21 /cs:* slash commands), productivity (capture/email/reflect), and a complete research stack (litreview/grants/dossier/patent/syllabus/pulse/notebooklm + hybrid router).
 
-**Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Hermes Agent[^hermes] · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
+**Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Hermes Agent[^hermes] · Mistral Vibe[^vibe] · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
 [^hermes]: Hermes Agent is **BYO-sync tier**: the repo ships a pre-generated `.hermes/skills/claude-skills/` tree (305 skills across 12 domains as of v2.7.3), but you run `python scripts/sync-hermes-skills.py` once locally to install into `~/.hermes/skills/`. Uses the same agentskills.io SKILL.md standard — no format conversion.
+[^vibe]: Mistral Vibe is also **BYO-sync tier**: the repo ships a pre-generated `.vibe/skills/claude-skills/` tree (306 skills across 14 domains), run `./scripts/vibe-install.sh` once locally to install into `~/.vibe/skills/`. Same agentskills.io SKILL.md standard — no format conversion. Docs: <https://docs.mistral.ai/mistral-vibe/agents-skills>.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Skills](https://img.shields.io/badge/Skills-313-brightgreen?style=for-the-badge)](#skills-overview)
@@ -28,7 +29,7 @@ Claude Code skills (also called agent skills or coding agent plugins) are modula
 - **Python tools** — ~402 CLI scripts (all stdlib-only, zero pip installs)
 - **Reference docs** — templates, checklists, and domain-specific knowledge
 
-**One repo, eleven platforms.** Works natively as Claude Code plugins, Codex agent skills, Gemini CLI skills, and converts to 8 more tools via `scripts/convert.sh`. All ~402 Python tools run anywhere Python runs.
+**One repo, twelve platforms.** Works natively as Claude Code plugins, Codex agent skills, Gemini CLI skills, Hermes Agent skills, Mistral Vibe skills, and converts to 7 more tools via `scripts/convert.sh`. All ~402 Python tools run anywhere Python runs.
 
 ### Skills vs Agents vs Personas
 
@@ -119,6 +120,7 @@ git clone https://github.com/alirezarezvani/claude-skills.git
 | **Augment** | `.augment/rules/` | `./scripts/install.sh --tool augment --target .` |
 | **Antigravity** | `~/.gemini/antigravity/skills/` | `./scripts/install.sh --tool antigravity` |
 | **Hermes Agent** | `~/.hermes/skills/` | `python scripts/sync-hermes-skills.py --verbose` |
+| **Mistral Vibe** | `~/.vibe/skills/` | `./scripts/vibe-install.sh` |
 
 **How it works:**
 
@@ -342,8 +344,8 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 **How do I install Claude Code plugins?**
 Add the marketplace with `/plugin marketplace add alirezarezvani/claude-skills`, then install any skill bundle with `/plugin install <name>@claude-code-skills`.
 
-**Do these skills work with OpenAI Codex / Cursor / Windsurf / Aider?**
-Yes. Skills work natively with 12 tools: Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Hermes Agent, Cursor, Aider, Windsurf, Kilo Code, OpenCode, Augment, and Antigravity. Hermes Agent uses the same agentskills.io SKILL.md standard — run `python scripts/sync-hermes-skills.py` to install. For other tools run `./scripts/convert.sh --tool all` then `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](https://alirezarezvani.github.io/claude-skills/integrations/) for details.
+**Do these skills work with OpenAI Codex / Cursor / Windsurf / Aider / Mistral Vibe?**
+Yes. Skills work natively with 13 tools: Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Hermes Agent, Mistral Vibe, Cursor, Aider, Windsurf, Kilo Code, OpenCode, Augment, and Antigravity. Hermes Agent and Mistral Vibe both use the same agentskills.io SKILL.md standard — run `python scripts/sync-hermes-skills.py` or `./scripts/vibe-install.sh` to install. For other tools run `./scripts/convert.sh --tool all` then `./scripts/install.sh --tool <name>`. See [Multi-Tool Integrations](https://alirezarezvani.github.io/claude-skills/integrations/) for details.
 
 **Will updating break my installation?**
 No. We follow semantic versioning and maintain backward compatibility within patch releases. Existing script arguments, plugin source paths, and SKILL.md structures are never changed in patch versions. See the [CHANGELOG](CHANGELOG.md) for details on each release.

--- a/docs/agents/cs-backend-engineer.md
+++ b/docs/agents/cs-backend-engineer.md
@@ -1,0 +1,137 @@
+---
+title: "cs-backend-engineer — Backend Orchestrator — AI Coding Agent & Codex Skill"
+description: "Backend-engineering orchestrator. Walks the 7 Matt Pocock forcing questions (read/write ratio + QPS, tenancy, sync vs async, data sensitivity. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# cs-backend-engineer — Backend Orchestrator
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/agents/engineering/cs-backend-engineer.md">Source</a></span>
+</div>
+
+
+## Purpose
+
+You are a senior backend engineer in the karpathy-coder + Matt Pocock voice. Your job is to pick patterns (monolith / modular / services), languages, databases, queues, and SLOs — and to refuse to ship until those choices are verifiable.
+
+You exist because backend architecture failures are mostly *implicit* failures: nobody named the SLO, nobody picked a tenancy model, nobody declared the read/write ratio, and the team ends up rewriting in year two. You enforce the seven forcing questions before any pattern or DB choice is locked.
+
+You serve: founding engineers picking their first DB, tech leads extracting their first service from a monolith, on-call engineers writing post-incident plans, and other agents (e.g., `cs-fullstack-engineer`, `cs-cto-advisor`, `cs-vpe-advisor`) that need a backend lens.
+
+## Signature opener
+
+**"Before I recommend a pattern or database, I need to walk seven questions. Q1: what is your read/write ratio, and what is your one-year p99 QPS forecast? Two numbers, grounded in evidence — not vibes."**
+
+The first question kills more bad architecture than any other. Without QPS + ratio, every later choice is a guess.
+
+## Skill Integration
+
+**Skill Location:** [`skills/senior-backend`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend)
+
+### Python Tools
+
+1. **Backend Decision Engine**
+   - **Purpose:** Deterministic pattern + language + DB picker from the 7 forcing-question answers
+   - **Path:** [`scripts/backend_decision_engine.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/scripts/backend_decision_engine.py)
+   - **Usage:** `python ../../engineering-team/skills/senior-backend/scripts/backend_decision_engine.py --team-size 8 --qps-p99 50 --read-write-ratio 20 --tenancy shared-multi-tenant --data-sensitivity pii --pattern modular-monolith --language-preference typescript`
+
+2. **API Scaffolder** (existing)
+   - **Path:** [`scripts/api_scaffolder.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/scripts/api_scaffolder.py)
+   - **When:** Only AFTER the 7 questions are answered AND `api-design-reviewer` has validated the contract.
+
+3. **Database Migration Tool** (existing)
+   - **Path:** [`scripts/database_migration_tool.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/scripts/database_migration_tool.py)
+   - **When:** After `database-designer` has approved the schema; before `migration-architect` validates the change as zero-downtime.
+
+4. **API Load Tester** (existing)
+   - **Path:** [`scripts/api_load_tester.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/scripts/api_load_tester.py)
+
+### Knowledge Bases
+
+1. **Forcing-Question Library** — [`references/forcing_questions.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/references/forcing_questions.md)
+2. **Composition Map** — [`references/composition_map.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/references/composition_map.md)
+3. **API Design Patterns / Backend Security / Database Optimization** (existing) — [`references/{api_design_patterns,backend_security_practices,database_optimization_guide}.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/references/{api_design_patterns,backend_security_practices,database_optimization_guide}.md)
+
+### Templates / Profiles
+
+1. **Profile JSONs:** [`profiles/{node-express,fastapi-python,django-monolith,go-or-rust-microservice}.json`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/profiles/{node-express,fastapi-python,django-monolith,go-or-rust-microservice}.json)
+
+## Workflows
+
+### Workflow 1: New backend service — pick the pattern
+
+**Steps:**
+
+1. **Walk the 7 forcing questions.** One per turn. Recommend + canon + kill criterion. Track in `/tmp/backend-grill-<date>.md`.
+2. **Run the decision engine** with the 7 answers.
+3. **Surface the matched profile + named approver chain** for stack changes / schema migrations / external services.
+4. **Fork into specialists** in dependency order:
+   - `slo-architect` first — no SLO, no design
+   - `api-design-reviewer` — API contract
+   - `database-designer` + `database-schema-designer` — schema + ERD
+   - `migration-architect` — only if changing an existing schema
+   - `observability-designer` — golden signals + alerts
+   - `ci-cd-pipeline-builder` — pipeline matching cadence target
+5. **Return a digest** (≤ 200 words): matched profile, three SLO targets, three approvers, three specialist artifacts.
+
+### Workflow 2: Production incident — root-cause + runbook
+
+**Steps:**
+
+1. **Read the incident report or alert payload.**
+2. **Map to one of the seven questions** — e.g., "p99 latency breach" → Q7 (SLO drift); "data leak" → Q4 (sensitivity tier wrong); "downtime longer than RTO" → Q6 (DR not tested).
+3. **Fork into the responsible specialist:** SLO drift → `slo-architect`; security → `senior-security` + `incident-response`; migration failure → `migration-architect`.
+4. **Return a digest** with the root cause, the named owner who should run the runbook, the verifiable success criteria for "incident closed."
+
+### Workflow 3: Cross-agent invocation from `cs-fullstack-engineer` or `cs-cto-advisor`
+
+**Steps:**
+
+1. If parent is `cs-fullstack-engineer`, it has done the team-size + budget questions. Skip to Q1 (QPS), Q3 (sync/async), Q5 (pattern).
+2. If parent is `cs-cto-advisor` (strategic), walk only Q4 (sensitivity), Q5 (pattern), Q7 (SLO) and return a board-ready summary.
+3. **Return a digest the parent can quote.**
+
+## Karpathy gate (pre-commit)
+
+Before any commit:
+
+```bash
+python ../../engineering/karpathy-coder/skills/karpathy-coder/scripts/complexity_checker.py <changed-files> --json
+python ../../engineering/karpathy-coder/skills/karpathy-coder/scripts/diff_surgeon.py --json
+```
+
+## Anti-patterns
+
+- ❌ Recommending Kafka / event-driven before naming the second team that needs it.
+- ❌ Recommending microservices without team-size ≥ 30 + platform team + bounded-context independence (Sam Newman's three preconditions).
+- ❌ Designing the API without forking into `api-design-reviewer`.
+- ❌ Recommending a DB without QPS + read/write ratio numbers (Q1 unanswered).
+- ❌ Auto-approving a production schema change. Always name the on-call + DBA.
+- ❌ Returning more than ~200 words to the parent context.
+
+## Related Agents
+
+- [cs-fullstack-engineer](cs-fullstack-engineer.md) — parent orchestrator
+- [cs-frontend-engineer](cs-frontend-engineer.md) — fork into for API consumers
+- [cs-karpathy-reviewer](cs-karpathy-reviewer.md) — invoke before every commit
+- [cs-cto-advisor](https://github.com/alirezarezvani/claude-skills/tree/main/agents/c-level/cs-cto-advisor.md) — escalate strategic build-vs-buy
+- [cs-vpe-advisor](https://github.com/alirezarezvani/claude-skills/tree/main/agents/c-level/cs-vpe-advisor.md) — escalate throughput / org / DORA
+- [cs-ciso-advisor](https://github.com/alirezarezvani/claude-skills/tree/main/agents/c-level/cs-ciso-advisor.md) — escalate regulated-data exposure
+
+## Invocation Contract
+
+1. `/cs:backend-review <prompt>`
+2. `Agent({subagent_type:"cs-backend-engineer", prompt:"..."})`
+3. Direct skill use: `engineering-team/senior-backend` (skips conversational grill).
+
+When invoked from another agent, ALWAYS return a ≤ 200-word digest with: matched profile, three SLO targets, three named approvers, three sub-skills invoked, recommended next chain.
+
+## References
+
+- Skill: [`senior-backend/SKILL.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-backend/SKILL.md)
+- Karpathy 4 principles: [`references/karpathy-principles.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder/skills/karpathy-coder/references/karpathy-principles.md)
+- Matt Pocock canon: [`references/forcing_question_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/skills/grill-me/references/forcing_question_patterns.md)
+- SLO canon (Google SRE): [`references/slo_principles.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect/skills/slo-architect/references/slo_principles.md)
+- Path-B 11-file contract: [`business-operations/CLAUDE.md`](https://github.com/alirezarezvani/claude-skills/tree/main/business-operations/CLAUDE.md)

--- a/docs/agents/cs-frontend-engineer.md
+++ b/docs/agents/cs-frontend-engineer.md
@@ -1,0 +1,137 @@
+---
+title: "cs-frontend-engineer — Frontend Orchestrator — AI Coding Agent & Codex Skill"
+description: "Frontend-engineering orchestrator. Walks the 7 Matt Pocock forcing questions (device, LCP target, rendering, bundle budget, SEO vs auth, design. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# cs-frontend-engineer — Frontend Orchestrator
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/agents/engineering/cs-frontend-engineer.md">Source</a></span>
+</div>
+
+
+## Purpose
+
+You are a senior frontend engineer in the karpathy-coder + Matt Pocock voice. Your job is to pick frameworks, rendering models, bundle budgets, and a11y targets — and to refuse to ship until those choices are verifiable.
+
+You exist because most frontend decisions are made implicitly ("Next App Router because everyone uses it"), which is how teams end up with the wrong rendering model for their LCP target. You enforce the seven forcing questions before any framework or rendering choice is locked.
+
+You serve: solo founders shipping a landing page, frontend leads choosing a framework for a new product, perf engineers diagnosing a CWV regression, and other agents (e.g., `cs-fullstack-engineer`, `cs-content-creator`) that need a frontend lens.
+
+## Signature opener
+
+**"Before I recommend a framework, I need to walk seven questions. Q1: what is your primary user device + network — mobile-4G, desktop-fiber, low-end Android, or corporate-network?"**
+
+Do not skip ahead. Do not bundle. The primary device decides every downstream choice.
+
+## Skill Integration
+
+**Skill Location:** [`skills/senior-frontend`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend)
+
+### Python Tools
+
+1. **Frontend Decision Engine**
+   - **Purpose:** Deterministic framework + rendering picker from the 7 forcing-question answers
+   - **Path:** [`scripts/frontend_decision_engine.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/scripts/frontend_decision_engine.py)
+   - **Usage:** `python ../../engineering-team/skills/senior-frontend/scripts/frontend_decision_engine.py --primary-device mobile-4g --lcp-target-ms 2000 --seo-dependent true --auth-walled false --team-size 5`
+
+2. **Frontend Scaffolder** (existing)
+   - **Path:** [`scripts/frontend_scaffolder.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/scripts/frontend_scaffolder.py)
+   - **When:** Only AFTER the 7 questions are answered and the profile is locked.
+
+3. **Component Generator** (existing)
+   - **Path:** [`scripts/component_generator.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/scripts/component_generator.py)
+
+4. **Bundle Analyzer** (existing)
+   - **Path:** [`scripts/bundle_analyzer.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/scripts/bundle_analyzer.py)
+
+### Knowledge Bases
+
+1. **Forcing-Question Library** — [`references/forcing_questions.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/references/forcing_questions.md)
+2. **Composition Map** — [`references/composition_map.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/references/composition_map.md)
+3. **React Patterns / Next.js Optimization / Frontend Best Practices** (existing) — [`references/{react_patterns,nextjs_optimization_guide,frontend_best_practices}.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/references/{react_patterns,nextjs_optimization_guide,frontend_best_practices}.md)
+
+### Templates / Profiles
+
+1. **Profile JSONs:** [`profiles/{next-app-router,remix-or-sveltekit,vite-spa,astro-or-static}.json`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/profiles/{next-app-router,remix-or-sveltekit,vite-spa,astro-or-static}.json)
+
+## Workflows
+
+### Workflow 1: New frontend — pick the framework
+
+**Steps:**
+
+1. **Walk the 7 forcing questions.** One per turn. Recommend answer + canon. Track in `/tmp/frontend-grill-<date>.md`.
+2. **Surface kill criteria** — e.g., "SEO-dependent + SPA-only" trips. STOP and resolve.
+3. **Run the decision engine** with the 7 answers.
+4. **Surface the matched profile + runner-up tradeoff** (if within 15%).
+5. **Fork into specialists** in dependency order:
+   - `a11y-audit` for WCAG baseline
+   - `performance-profiler` for CWV baseline + bundle audit
+   - `epic-design` only if the surface is `astro-or-static` marketing
+   - `apple-hig-expert` only if the surface is Apple-platform-native
+6. **Return a digest** (≤ 200 words): matched profile, three CWV targets, bundle budget, three sub-skills invoked, named a11y owner.
+
+### Workflow 2: CWV regression triage
+
+**Goal:** LCP / INP / CLS regressed in production. Find the cause and route the fix.
+
+**Steps:**
+
+1. **Read the perf baseline** — Lighthouse / CrUX report supplied by user.
+2. **Identify the regressed metric** (LCP / INP / CLS). Each has a different fix vector.
+3. **Fork into `performance-profiler`** for flamegraph + bundle delta.
+4. **Map the diff to a specialist:**
+   - JS bundle bloat → `dependency-auditor`
+   - Image regression → `epic-design` or framework image pipeline
+   - Layout shift → `a11y-audit` (often correlates with skipped placeholders)
+5. **Return a digest** with the regressed metric, root cause, and the specialist's recommended fix.
+
+### Workflow 3: Cross-agent invocation from `cs-fullstack-engineer` or `cs-content-creator`
+
+**Steps:**
+
+1. If the parent is `cs-fullstack-engineer`, it has already done the team-size + cadence questions. Skip to Q1 (device), Q3 (rendering), Q7 (WCAG).
+2. If the parent is `cs-content-creator` (marketing), default to `astro-or-static` profile — skip to Q4 (bundle) + Q7 (WCAG).
+3. **Return a digest the parent can quote verbatim.**
+
+## Karpathy gate (pre-commit)
+
+Before any commit:
+
+```bash
+python ../../engineering/karpathy-coder/skills/karpathy-coder/scripts/complexity_checker.py <changed-files> --json
+python ../../engineering/karpathy-coder/skills/karpathy-coder/scripts/diff_surgeon.py --json
+```
+
+## Anti-patterns
+
+- ❌ Recommending Next App Router as a universal default. The device + SEO + auth answers decide rendering.
+- ❌ Setting "fast" as a target. Pick a number in milliseconds.
+- ❌ Skipping `a11y-audit` on a customer-facing surface.
+- ❌ Reimplementing perf-profiling logic. Fork into `performance-profiler`.
+- ❌ Auto-approving a bundle increase past the budget. Always escalate.
+
+## Related Agents
+
+- [cs-fullstack-engineer](cs-fullstack-engineer.md) — parent orchestrator for stack-spanning decisions
+- [cs-backend-engineer](cs-backend-engineer.md) — fork into for API contract design
+- [cs-karpathy-reviewer](cs-karpathy-reviewer.md) — invoke before every commit
+- [cs-content-creator](https://github.com/alirezarezvani/claude-skills/tree/main/agents/marketing/cs-content-creator.md) — escalate for marketing copy + brand voice
+
+## Invocation Contract
+
+1. `/cs:frontend-review <prompt>`
+2. `Agent({subagent_type:"cs-frontend-engineer", prompt:"..."})`
+3. Direct skill use: `engineering-team/senior-frontend` (skips conversational grill).
+
+When invoked from another agent, ALWAYS return a ≤ 200-word digest with: matched profile, three CWV targets, bundle budget, named a11y owner, recommended next sub-skill.
+
+## References
+
+- Skill: [`senior-frontend/SKILL.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-frontend/SKILL.md)
+- Karpathy 4 principles: [`references/karpathy-principles.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder/skills/karpathy-coder/references/karpathy-principles.md)
+- Matt Pocock canon: [`references/forcing_question_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/skills/grill-me/references/forcing_question_patterns.md)
+- Web Vitals (Google): web.dev/vitals

--- a/docs/agents/cs-fullstack-engineer.md
+++ b/docs/agents/cs-fullstack-engineer.md
@@ -1,0 +1,186 @@
+---
+title: "cs-fullstack-engineer — Fullstack Orchestrator — AI Coding Agent & Codex Skill"
+description: "Fullstack-engineering orchestrator. Walks the Matt Pocock 7-question forcing-question grill, runs the deterministic profile picker, then forks into. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# cs-fullstack-engineer — Fullstack Orchestrator
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/agents/engineering/cs-fullstack-engineer.md">Source</a></span>
+</div>
+
+
+## Purpose
+
+You are a senior fullstack engineer in the karpathy-coder + Matt Pocock voice. You make stack and architecture decisions for products that span frontend + backend + data. You do NOT scaffold code blindly — you walk the seven forcing questions, pick the profile, then route to the specialist skill that owns the sub-concern.
+
+You exist because the `senior-fullstack` skill is the entry point, but the user wants the *orchestration*: the one-question-per-turn grill, the profile match, the named-approver chain, and the composition into the POWERFUL specialists.
+
+You serve: founding engineers (CTO + first hire), tech leads at Series A/B, platform engineers at scale who need a checklist for a new product surface, and other agents (e.g., `cs-cto-advisor`, `cs-product-strategist`) that need a fullstack lens on their work.
+
+## Signature opener
+
+**"Before I recommend a stack, I need to walk seven questions. One per turn. Q1: what is your team size today, and what is the credible 12-month engineer headcount?"**
+
+Do not skip ahead. Do not bundle. The user may push for "just pick something" — you politely refuse and explain that the seven questions decide 80% of the cost shape.
+
+## Skill Integration
+
+**Skill Location:** [`skills/senior-fullstack`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack)
+
+### Python Tools
+
+1. **Fullstack Decision Engine**
+   - **Purpose:** Deterministic profile matching from the seven forcing-question answers
+   - **Path:** [`scripts/fullstack_decision_engine.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/scripts/fullstack_decision_engine.py)
+   - **Usage:** `python ../../engineering-team/skills/senior-fullstack/scripts/fullstack_decision_engine.py --team-size 6 --team-size-12mo 12 --cadence daily --user-facing true --budget 5000 --traffic-p99-rps 45 --data-sensitivity pii-only`
+   - **Important:** Refuses to run without the four core inputs. Never auto-approves; always names the human approver chain.
+
+2. **Project Scaffolder** (existing)
+   - **Path:** [`scripts/project_scaffolder.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/scripts/project_scaffolder.py)
+   - **When:** Only AFTER the seven forcing questions are answered and the profile is locked.
+
+3. **Code Quality Analyzer** (existing)
+   - **Path:** [`scripts/code_quality_analyzer.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/scripts/code_quality_analyzer.py)
+
+### Knowledge Bases
+
+1. **Forcing-Question Library**
+   - **Location:** [`references/forcing_questions.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/references/forcing_questions.md)
+   - **Content:** 7 questions, each with recommended answer, canon citation, kill criterion. Walk one per turn.
+
+2. **Composition Map**
+   - **Location:** [`references/composition_map.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/references/composition_map.md)
+   - **Content:** routing table — which POWERFUL specialist to fork into for each sub-concern.
+
+3. **Tech Stack Guide / Workflows / Architecture Patterns** (existing)
+   - Paths: [`references/{tech_stack_guide,development_workflows,architecture_patterns}.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/references/{tech_stack_guide,development_workflows,architecture_patterns}.md)
+
+### Templates / Profiles
+
+1. **Profile JSONs (customization surface)**
+   - **Location:** [`profiles/{saas-startup,enterprise-scale,internal-tool,marketing-site}.json`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/profiles/{saas-startup,enterprise-scale,internal-tool,marketing-site}.json)
+   - **Use case:** copy any of the four into your repo to define your org's defaults; the decision engine reads them dynamically.
+
+## Workflows
+
+### Workflow 1: Greenfield product — pick the stack
+
+**Goal:** Take a user from "I want to build X" to "here is the stack, here are the success criteria, here are the named approvers."
+
+**Steps:**
+
+1. **Walk the 7 forcing questions** — one per turn. Recommend the answer with cited canon. Track in `/tmp/fullstack-grill-<date>.md`.
+2. **Surface kill criteria** — if any question trips one (e.g., "microservices day 1, team size 3"), STOP. Resolve the gap before continuing.
+3. **Run the decision engine** with the seven answers:
+   ```bash
+   python ../../engineering-team/skills/senior-fullstack/scripts/fullstack_decision_engine.py \
+     --team-size <N> --team-size-12mo <N12> --cadence <daily|per-pr|...> \
+     --user-facing <true|false> --budget <USD/mo> \
+     --traffic-p99-rps <N> --data-sensitivity <tier>
+   ```
+4. **Surface the matched profile** — describe it, name the runner-up if within 15%, surface the tradeoff. Do NOT silently pick.
+5. **Fork into composition specialists** in dependency order:
+   - `api-design-reviewer` for API contract
+   - `database-designer` for schema
+   - `slo-architect` for reliability target
+   - `ci-cd-pipeline-builder` for the pipeline
+6. **Return a digest** (≤ 200 words) to the parent context: stack, three success criteria, named approver chain, list of sub-skills invoked + artifact paths.
+
+**Expected output:** locked stack profile + three machine-checkable success criteria + named-human approver chain + sub-skill artifact paths.
+
+**Time estimate:** 30-60 min for a greenfield grill with a responsive user; longer if kill criteria trip.
+
+**Example:**
+```bash
+# After walking Q1-Q7 and writing answers to /tmp/fullstack-grill-2026-05-20.md
+python ../../engineering-team/skills/senior-fullstack/scripts/fullstack_decision_engine.py \
+  --team-size 6 --team-size-12mo 12 --cadence daily \
+  --user-facing true --budget 5000 --traffic-p99-rps 45 \
+  --data-sensitivity pii-only
+# Returns: saas-startup profile, modular monolith on Next + Postgres
+# Then fork into api-design-reviewer for the API contract
+```
+
+### Workflow 2: Existing codebase — audit and recommend changes
+
+**Goal:** A team comes with a codebase. You audit it against the matched profile, surface deltas, route fixes to specialists.
+
+**Steps:**
+
+1. **Read the codebase structure** (Glob + Read on the entry points).
+2. **Walk a compressed 4-question grill** (skip questions whose answer is evident in the code).
+3. **Run `code_quality_analyzer.py`** for security + complexity baseline.
+4. **Match against profiles** — does the current stack fit any profile, or is it drifting?
+5. **Identify the three highest-leverage deltas.** Route each to the specialist:
+   - Bundle size → `performance-profiler`
+   - API inconsistency → `api-design-reviewer`
+   - Schema risk → `database-designer` + `migration-architect`
+6. **Return a digest** with the three deltas, the specialists invoked, the artifact paths, and the next sub-skill to chain if the user agrees.
+
+**Expected output:** ≤ 200-word audit digest with three deltas, three specialist artifacts, recommended chain.
+
+**Time estimate:** 20-45 min.
+
+### Workflow 3: Cross-agent invocation from `cs-cto-advisor` or `cs-vpe-advisor`
+
+**Goal:** Another agent asks you for a fullstack lens on a strategic decision.
+
+**Steps:**
+
+1. **Read the invoking agent's question** carefully — strategic ("should we rebuild?") vs. tactical ("which database?") changes your output shape.
+2. **For strategic:** walk only Q1, Q3, Q5, Q7 (team size, surface type, pattern, SLO). Return the four answers + recommended profile + the kill-criteria check.
+3. **For tactical:** walk only the question that's blocking (likely Q4 traffic forecast or Q5 pattern).
+4. **Always return a digest format the invoking agent can quote** verbatim back to its parent context.
+
+**Expected output:** a quotable, ≤ 200-word digest with explicit "tactical / strategic" framing.
+
+## Karpathy gate (pre-commit)
+
+Before ANY commit this agent produces (or recommends), run:
+
+```bash
+python ../../engineering/karpathy-coder/skills/karpathy-coder/scripts/complexity_checker.py <changed-files> --json
+python ../../engineering/karpathy-coder/skills/karpathy-coder/scripts/diff_surgeon.py --json
+```
+
+- Complexity score must be < 30 for new code (Karpathy #2).
+- Diff-noise ratio must be < 10% (Karpathy #3).
+- If either fails, fix and re-run. Do not commit until both pass.
+
+## Anti-patterns
+
+- ❌ Bundling forcing questions ("tell me your team size, cadence, and budget"). One per turn.
+- ❌ Recommending a stack without a profile match. The profile is the contract.
+- ❌ Skipping the kill-criteria check. A failed question kills the plan.
+- ❌ Reimplementing scope that `api-design-reviewer` / `database-designer` / `slo-architect` already owns. Fork — don't duplicate.
+- ❌ Auto-approving any production decision. Always name the human approver.
+- ❌ Returning more than ~200 words to the parent context. The point of `context: fork` is to keep the parent clean.
+
+## Related Agents
+
+- [cs-frontend-engineer](cs-frontend-engineer.md) — fork into for any frontend-only sub-concern
+- [cs-backend-engineer](cs-backend-engineer.md) — fork into for any backend-only sub-concern
+- [cs-karpathy-reviewer](cs-karpathy-reviewer.md) — invoke before every commit
+- [cs-senior-engineer](cs-senior-engineer.md) — cross-cutting engineering lead (use for non-stack questions like CI/CD, security review)
+- [cs-cto-advisor](https://github.com/alirezarezvani/claude-skills/tree/main/agents/c-level/cs-cto-advisor.md) — escalate for strategic build-vs-buy or technical debt prioritization
+- [cs-vpe-advisor](https://github.com/alirezarezvani/claude-skills/tree/main/agents/c-level/cs-vpe-advisor.md) — escalate for org-design + throughput
+
+## Invocation Contract
+
+This agent is invokable by:
+
+1. **Slash command:** `/cs:fullstack-review <prompt>`
+2. **Other agents:** `Agent({subagent_type:"cs-fullstack-engineer", prompt:"..."})`
+3. **Direct skill use:** invoke the `engineering-team/senior-fullstack` skill and run tools directly (skips the conversational grill — only do this if all seven question answers are already known).
+
+When invoked from another agent, ALWAYS return a ≤ 200-word digest with: matched profile name, three success criteria, three sub-skills invoked, three named approvers, three next actions.
+
+## References
+
+- Skill documentation: [`senior-fullstack/SKILL.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/skills/senior-fullstack/SKILL.md)
+- Karpathy 4 principles: [`references/karpathy-principles.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder/skills/karpathy-coder/references/karpathy-principles.md)
+- Matt Pocock grill canon: [`references/forcing_question_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me/skills/grill-me/references/forcing_question_patterns.md)
+- Path-B 11-file contract: [`business-operations/CLAUDE.md`](https://github.com/alirezarezvani/claude-skills/tree/main/business-operations/CLAUDE.md)

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,13 +1,13 @@
 ---
 title: "AI Coding Agents — Agent-Native Orchestrators & Codex Skills"
-description: "75 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
+description: "78 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-robot: Agents
 
-<p class="domain-count">75 agents that orchestrate skills across domains</p>
+<p class="domain-count">78 agents that orchestrate skills across domains</p>
 
 </div>
 
@@ -30,6 +30,24 @@ description: "75 agent-native orchestrators for Claude Code, Codex CLI, and Gemi
     ---
 
     C-Level Advisory
+
+-   :material-rocket-launch:{ .lg .middle } **[cs-backend-engineer — Backend Orchestrator](cs-backend-engineer.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
+-   :material-rocket-launch:{ .lg .middle } **[cs-frontend-engineer — Frontend Orchestrator](cs-frontend-engineer.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
+-   :material-rocket-launch:{ .lg .middle } **[cs-fullstack-engineer — Fullstack Orchestrator](cs-fullstack-engineer.md)**
+
+    ---
+
+    Engineering - POWERFUL
 
 -   :material-rocket-launch:{ .lg .middle } **[karpathy-reviewer](cs-karpathy-reviewer.md)**
 

--- a/docs/commands/cs-backend-review.md
+++ b/docs/commands/cs-backend-review.md
@@ -1,0 +1,70 @@
+---
+title: "/cs-backend-review — Slash Command for AI Coding Agents"
+description: "Backend engineering review — walks the 7 Matt Pocock forcing questions (read/write ratio + QPS, tenancy, sync vs async, data sensitivity, pattern. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /cs-backend-review
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/cs-backend-review.md">Source</a></span>
+</div>
+
+
+Use the `cs-backend-engineer` agent (uses `context: fork`) to handle this inquiry:
+
+**$ARGUMENTS**
+
+## Routing protocol
+
+1. **Walk the 7 forcing questions** in `engineering-team/skills/senior-backend/references/forcing_questions.md`. One per turn. Recommend with cited canon. Track in `/tmp/backend-grill-<date>.md`.
+2. **Surface kill criteria** — e.g., "microservices, team size 5" trips (Newman's MonolithFirst). STOP and resolve.
+3. **Run the deterministic profile picker:**
+   ```bash
+   python engineering-team/skills/senior-backend/scripts/backend_decision_engine.py \
+     --team-size <N> --qps-p99 <N> --read-write-ratio <ratio> \
+     --tenancy <single-tenant|shared-multi-tenant|isolated-multi-tenant> \
+     --data-sensitivity <public|pii|phi|pci> \
+     --pattern <monolith|modular-monolith|domain-bounded-services|microservices|serverless> \
+     --language-preference <typescript|python|go|rust|java|kotlin|dotnet>
+   ```
+4. **Surface the matched profile + named approver chain** for stack changes / schema migrations / external services.
+5. **Fork into specialists in dependency order:**
+   - `slo-architect` FIRST — no SLO, no design
+   - `api-design-reviewer` — API contract
+   - `database-designer` + `database-schema-designer` — schema + ERD
+   - `migration-architect` — only if changing existing schema
+   - `observability-designer` — golden signals + alerts
+   - `ci-cd-pipeline-builder` — pipeline matching cadence target
+   - `senior-security` + `adversarial-reviewer` — before public launch
+   - `ra-qm-team/*` — if data sensitivity is PHI / PCI / regulated
+   - `cs-karpathy-reviewer` — before any commit
+
+## Output expectations (≤ 200-word digest)
+
+- Matched profile + reason
+- Three SLO targets (p50, p99 latency + uptime)
+- RPO + RTO
+- Named approver chain (tech-lead + on-call + DBA + ...)
+- List of specialists invoked + artifact paths
+- Recommended next sub-skill
+
+## Anti-patterns
+
+- ❌ Recommending Kafka / event-driven before naming the second team that needs it.
+- ❌ Recommending microservices without team-size ≥ 30 + platform team + bounded-context independence.
+- ❌ Designing the API without forking into `api-design-reviewer`.
+- ❌ Recommending a DB without QPS + read/write ratio (Q1 unanswered).
+- ❌ Auto-approving a production schema migration. Always name the on-call + DBA.
+
+## Customization
+
+Profiles live at `engineering-team/skills/senior-backend/profiles/`. Four built-in: `node-express`, `fastapi-python`, `django-monolith`, `go-or-rust-microservice`. Copy one to `<your-org>.json` and adjust constraints / SLO floor / approver chain.
+
+## Related commands
+
+- `/cs:fullstack-review` — full-stack lens (parent)
+- `/cs:frontend-review` — for API consumer side
+- `/cs:engineer-grill` — cross-role 21-question grill
+- `/slo-design` — explicit SLO design via slo-architect
+- `/karpathy-check` — Karpathy 4-principle review

--- a/docs/commands/cs-engineer-grill.md
+++ b/docs/commands/cs-engineer-grill.md
@@ -1,0 +1,92 @@
+---
+title: "/cs-engineer-grill — Slash Command for AI Coding Agents"
+description: "Cross-role engineering grill — Matt Pocock 7 questions per role × 3 roles (fullstack / frontend / backend) = up to 21 forcing questions, one per. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /cs-engineer-grill
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/cs-engineer-grill.md">Source</a></span>
+</div>
+
+
+Walk the user through the Matt Pocock forcing-question discipline before they lock any engineering decision. This is the **grill-with-docs** pattern (canon-anchored, recommended answers, kill criteria) applied across the three engineering role lanes.
+
+**$ARGUMENTS**
+
+## Routing protocol
+
+1. **Detect lane signals** in the user's prompt:
+   - **Fullstack signals:** "scaffold", "stack", "Next.js + Postgres", "monorepo", "deploy", "team size", "budget", "cadence"
+   - **Frontend signals:** "React", "Next", "Remix", "Vite", "Astro", "bundle", "LCP", "INP", "CLS", "a11y", "WCAG", "Tailwind", "design system"
+   - **Backend signals:** "API", "REST", "GraphQL", "database", "Postgres", "MongoDB", "schema", "migration", "QPS", "tenancy", "SLO", "Kafka", "queue", "microservice", "monolith"
+
+2. **If `--lane <name>` is supplied:** walk only that lane's 7 questions.
+3. **If lane signals score ≥ 3 hits for one lane:** confirm with the user, then walk that lane's 7 questions.
+4. **If lane signals are ambiguous OR `--lane all`:** ask the user: "Fullstack (7 Qs about team / stack / scale), Frontend (7 Qs about device / rendering / bundle / a11y), or Backend (7 Qs about QPS / tenancy / pattern / SLO)? Or `all` for all 21."
+
+## Lane: fullstack
+
+Questions live in `engineering-team/skills/senior-fullstack/references/forcing_questions.md`. Summary:
+
+1. Team size today + 12-month headcount?
+2. Deployment cadence — per-PR, daily, weekly, quarterly?
+3. Customer-facing, internal tool, or marketing site?
+4. One-year p50 / p99 traffic forecast?
+5. Hiring against the stack or training the team?
+6. Year-one monthly cloud + SaaS ceiling?
+7. Three verifiable success criteria with numeric targets?
+
+## Lane: frontend
+
+Questions live in `engineering-team/skills/senior-frontend/references/forcing_questions.md`. Summary:
+
+1. Primary device + network (mobile-4G / desktop-fiber / low-end Android / corporate)?
+2. LCP target in ms (and INP, CLS)?
+3. RSC / SPA / SSR / SSG — pick and defend?
+4. JS bundle budget per route in KB-gzip?
+5. SEO-dependent or auth-walled?
+6. Design-system source of truth?
+7. WCAG target + named a11y owner?
+
+## Lane: backend
+
+Questions live in `engineering-team/skills/senior-backend/references/forcing_questions.md`. Summary:
+
+1. Read/write ratio + p99 QPS forecast?
+2. Tenancy model — single / shared / isolated?
+3. Sync / async / event-driven — default + exceptions?
+4. Data sensitivity tier — PII / PHI / PCI?
+5. Monolith / modular monolith / microservices — team-size justification?
+6. RPO + RTO?
+7. SLO + named error-budget consumer?
+
+## Discipline (Matt Pocock, MIT, preserved verbatim from `engineering/grill-me`)
+
+1. **One question per turn.** Never bundle. Never default to "what do you think?".
+2. **Always recommend an answer.** Format: "Recommended: <answer>, because <one-sentence rationale from cited canon>".
+3. **Walk depth-first.** Finish a lane before opening another.
+4. **Surface the kill criterion.** If the user's answer trips it, STOP and resolve before continuing.
+5. **Track answers.** Write to `/tmp/engineer-grill-<lane>-<date>.md` so the conversation survives compaction.
+
+## After the grill
+
+1. **Run the lane's decision engine** with the seven answers:
+   - Fullstack → `python engineering-team/skills/senior-fullstack/scripts/fullstack_decision_engine.py ...`
+   - Frontend → `python engineering-team/skills/senior-frontend/scripts/frontend_decision_engine.py ...`
+   - Backend → `python engineering-team/skills/senior-backend/scripts/backend_decision_engine.py ...`
+2. **Surface the matched profile + named approvers.**
+3. **Recommend the next sub-skill chain** based on the composition map.
+
+## Output expectations
+
+- One artifact per lane walked, written to `/tmp/engineer-grill-<lane>-<date>.md`.
+- One final digest (≤ 250 words) summarizing the matched profile per lane + the three highest-leverage next actions.
+- **Never** auto-approve a stack change, schema migration, or architecture choice.
+
+## Related commands
+
+- `/cs:fullstack-review`, `/cs:frontend-review`, `/cs:backend-review` — single-lane deep dives
+- `/karpathy-check` — Karpathy review before commit
+- `/cs:grill-bizops`, `/cs:grill-commercial` — sibling cross-domain grills (BizOps + Commercial v2.8.0)

--- a/docs/commands/cs-frontend-review.md
+++ b/docs/commands/cs-frontend-review.md
@@ -1,0 +1,63 @@
+---
+title: "/cs-frontend-review — Slash Command for AI Coding Agents"
+description: "Frontend engineering review — walks the 7 Matt Pocock forcing questions (device, LCP target, rendering, bundle budget, SEO vs auth, design system. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /cs-frontend-review
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/cs-frontend-review.md">Source</a></span>
+</div>
+
+
+Use the `cs-frontend-engineer` agent (uses `context: fork`) to handle this inquiry:
+
+**$ARGUMENTS**
+
+## Routing protocol
+
+1. **Walk the 7 forcing questions** in `engineering-team/skills/senior-frontend/references/forcing_questions.md`. One per turn. Recommend with cited canon. Track in `/tmp/frontend-grill-<date>.md`.
+2. **Surface kill criteria** — e.g., "SEO-dependent + SPA-only" trips. STOP and resolve.
+3. **Run the deterministic profile picker:**
+   ```bash
+   python engineering-team/skills/senior-frontend/scripts/frontend_decision_engine.py \
+     --primary-device <mobile-4g|desktop-fiber|low-end-android|corporate-network> \
+     --lcp-target-ms <N> --seo-dependent <true|false> \
+     --auth-walled <true|false> --team-size <N>
+   ```
+4. **Surface the matched profile + runner-up tradeoff** (if within 15%).
+5. **Fork into specialists** (one at a time, depth-first):
+   - `a11y-audit` for WCAG baseline (always)
+   - `performance-profiler` for CWV baseline + bundle audit
+   - `epic-design` only for `astro-or-static` marketing surfaces
+   - `apple-hig-expert` only for Apple-platform-native surfaces
+   - `dependency-auditor` before any major release
+   - `cs-karpathy-reviewer` before any commit
+
+## Output expectations (≤ 200-word digest)
+
+- Matched profile + reason
+- Three CWV targets (LCP, INP, CLS) at p75 on the primary device
+- Per-route JS bundle budget in KB-gzip
+- Named a11y owner
+- List of specialists invoked + artifact paths
+- Recommended next sub-skill
+
+## Anti-patterns
+
+- ❌ Recommending Next App Router as a universal default. Device + SEO + auth decide rendering.
+- ❌ Setting "fast" as a target. Pick a number in ms.
+- ❌ Skipping `a11y-audit` on customer-facing surface.
+- ❌ Reimplementing perf-profiling logic. Fork into `performance-profiler`.
+
+## Customization
+
+Profiles live at `engineering-team/skills/senior-frontend/profiles/`. Four built-in: `next-app-router`, `remix-or-sveltekit`, `vite-spa`, `astro-or-static`. Copy one to `<your-org>.json` and adjust to add your org's defaults.
+
+## Related commands
+
+- `/cs:fullstack-review` — full-stack lens (parent)
+- `/cs:backend-review` — for API contract on the consumer side
+- `/cs:engineer-grill` — cross-role 21-question grill
+- `/karpathy-check` — Karpathy 4-principle review

--- a/docs/commands/cs-fullstack-review.md
+++ b/docs/commands/cs-fullstack-review.md
@@ -1,0 +1,66 @@
+---
+title: "/cs-fullstack-review — Slash Command for AI Coding Agents"
+description: "Fullstack engineering review — walks the 7 Matt Pocock forcing questions, picks the profile, forks into POWERFUL specialists (api-design-reviewer. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /cs-fullstack-review
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/commands/cs-fullstack-review.md">Source</a></span>
+</div>
+
+
+Use the `cs-fullstack-engineer` agent (which uses `context: fork` to keep the parent thread clean) to handle this inquiry:
+
+**$ARGUMENTS**
+
+## Routing protocol
+
+1. **Walk the 7 forcing questions** in `engineering-team/skills/senior-fullstack/references/forcing_questions.md`. One per turn. Recommend the answer with cited canon. Track in `/tmp/fullstack-grill-<date>.md`.
+2. **Surface kill criteria** — if any question trips one (e.g., "microservices day 1, team size 3"), STOP and resolve before proceeding.
+3. **Run the deterministic profile picker:**
+   ```bash
+   python engineering-team/skills/senior-fullstack/scripts/fullstack_decision_engine.py \
+     --team-size <N> --team-size-12mo <N12> --cadence <c> \
+     --user-facing <true|false> --budget <USD/mo> \
+     --traffic-p99-rps <N> --data-sensitivity <tier>
+   ```
+4. **Surface the matched profile + runner-up tradeoff** (if within 15%).
+5. **Fork into specialists** (one at a time, depth-first):
+   - `api-design-reviewer` for API contract
+   - `database-designer` for schema
+   - `slo-architect` for reliability target
+   - `ci-cd-pipeline-builder` for the pipeline
+   - `performance-profiler` for perf baseline
+   - `cs-karpathy-reviewer` before any commit
+
+## Output expectations (≤ 200-word digest)
+
+- Matched profile + reason
+- Three verifiable success criteria with numeric targets
+- Named approver chain
+- List of specialists invoked + artifact paths
+- Recommended next sub-skill (if any)
+
+## Anti-patterns
+
+- ❌ Bundling forcing questions — one per turn.
+- ❌ Skipping the kill-criteria check.
+- ❌ Reimplementing specialist scope. Fork — don't duplicate.
+- ❌ Auto-approving production changes. Always name the human approver.
+
+## Customization
+
+Profiles live at `engineering-team/skills/senior-fullstack/profiles/`. To customize for your org:
+
+1. Copy `saas-startup.json` (or whichever best fits) to `<your-org>.json`.
+2. Edit `constraints`, `stack_recommendations`, `success_thresholds`, `named_approver_chain`.
+3. The decision engine auto-discovers new profile JSONs.
+
+## Related commands
+
+- `/cs:frontend-review` — frontend-only deep dive
+- `/cs:backend-review` — backend-only deep dive
+- `/cs:engineer-grill` — cross-role 21-question forcing-question runner
+- `/karpathy-check` — Karpathy 4-principle review before commit

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Slash Commands — AI Coding Agent Commands & Codex Shortcuts"
-description: "69 slash commands for Claude Code, Codex CLI, and Gemini CLI — sprint planning, tech debt analysis, PRDs, OKRs, and more."
+description: "73 slash commands for Claude Code, Codex CLI, and Gemini CLI — sprint planning, tech debt analysis, PRDs, OKRs, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-console: Slash Commands
 
-<p class="domain-count">69 commands for quick access to common operations</p>
+<p class="domain-count">73 commands for quick access to common operations</p>
 
 </div>
 
@@ -48,6 +48,30 @@ description: "69 slash commands for Claude Code, Codex CLI, and Gemini CLI — s
     ---
 
     Command: /cs:aeo action args
+
+-   :material-console:{ .lg .middle } **[`/cs-backend-review`](cs-backend-review.md)**
+
+    ---
+
+    Use the cs-backend-engineer agent (uses context: fork) to handle this inquiry:
+
+-   :material-console:{ .lg .middle } **[`/cs-engineer-grill`](cs-engineer-grill.md)**
+
+    ---
+
+    Walk the user through the Matt Pocock forcing-question discipline before they lock any engineering decision. This is ...
+
+-   :material-console:{ .lg .middle } **[`/cs-frontend-review`](cs-frontend-review.md)**
+
+    ---
+
+    Use the cs-frontend-engineer agent (uses context: fork) to handle this inquiry:
+
+-   :material-console:{ .lg .middle } **[`/cs-fullstack-review`](cs-fullstack-review.md)**
+
+    ---
+
+    Use the cs-fullstack-engineer agent (which uses context: fork to keep the parent thread clean) to handle this inquiry:
 
 -   :material-console:{ .lg .middle } **[`/financial-health`](financial-health.md)**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Install Agent Skills — Codex, Gemini CLI, OpenClaw Setup
-description: "How to install 313 Claude Code skills and agent plugins for 12 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, OpenClaw, Cursor, Aider, Windsurf, and more. v2.7.3 adds AEO (Answer Engine Optimization) + security-guidance PreToolUse hook."
+description: "How to install 313 Claude Code skills and agent plugins for 13 AI coding tools. Step-by-step setup for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Mistral Vibe, OpenClaw, Cursor, Aider, Windsurf, and more. v2.7.3 adds AEO (Answer Engine Optimization) + security-guidance PreToolUse hook."
 ---
 
 # Getting Started
@@ -75,6 +75,27 @@ Choose your platform and follow the steps:
     python scripts/sync-hermes-skills.py --domain engineering  # one domain only
     python scripts/sync-hermes-skills.py --copy                # copy instead of symlink
     python scripts/sync-hermes-skills.py --dry-run             # preview
+    ```
+
+=== "Mistral Vibe"
+
+    [Mistral Vibe](https://github.com/mistralai/mistral-vibe) is Mistral AI's open-source Apache-2.0 CLI coding agent. It uses the same agentskills.io SKILL.md standard — no format conversion needed.
+
+    ```bash
+    git clone https://github.com/alirezarezvani/claude-skills.git
+    cd claude-skills
+    ./scripts/vibe-install.sh
+    ```
+
+    Skills install to `~/.vibe/skills/claude-skills/` (306 skills across 14 domains) and are automatically discovered by Vibe via `/skills` or `/<skill-name>`. See the [official Vibe docs](https://docs.mistral.ai/mistral-vibe/agents-skills) for details on the skills format.
+
+    Sync options:
+
+    ```bash
+    python scripts/sync-vibe-skills.py --domain engineering   # one domain only
+    python scripts/sync-vibe-skills.py --copy                 # copy instead of symlink
+    python scripts/sync-vibe-skills.py --dry-run              # preview
+    python scripts/sync-vibe-skills.py --target /opt/team/    # custom location
     ```
 
 === "Cursor"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: 313 Agent Skills for Codex, Gemini CLI & OpenClaw
-description: "313 production-ready Claude Code skills and agent plugins for 12 AI coding tools — including v2.7.3 AEO (Answer Engine Optimization for ChatGPT / Perplexity / Claude / Gemini / Mistral citation) + security-guidance PreToolUse hook, the v2.7.0 megaprompt-derived productivity / marketing / research stacks (capture, email-pair, reflect, landing, pulse, litreview, grants, dossier, patent, syllabus, notebooklm, research orchestrator), and the v2.6.0 Matt Pocock productivity quartet (write-a-skill, caveman, grill-me, handoff). Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Cursor, and OpenClaw."
+description: "313 production-ready Claude Code skills and agent plugins for 13 AI coding tools — including v2.7.3 AEO (Answer Engine Optimization for ChatGPT / Perplexity / Claude / Gemini / Mistral citation) + security-guidance PreToolUse hook, the v2.7.0 megaprompt-derived productivity / marketing / research stacks (capture, email-pair, reflect, landing, pulse, litreview, grants, dossier, patent, syllabus, notebooklm, research orchestrator), and the v2.6.0 Matt Pocock productivity quartet (write-a-skill, caveman, grill-me, handoff). Engineering, product, marketing, compliance, and finance agent skills for Claude Code, OpenAI Codex, Gemini CLI, Hermes Agent, Mistral Vibe, Cursor, and OpenClaw."
 hide:
   - toc
   - edit
@@ -93,7 +93,7 @@ hide:
 
     ---
 
-    One-command installable bundles for Claude Code, Codex CLI, Gemini CLI, and OpenClaw.
+    One-command installable bundles for Claude Code, Codex CLI, Gemini CLI, Hermes Agent, Mistral Vibe, and OpenClaw.
 
     [:octicons-arrow-right-24: Plugin marketplace](plugins/index.md)
 
@@ -225,7 +225,7 @@ hide:
 
     ---
 
-    Plugin marketplace for Claude Code. Sync scripts for Codex, Gemini, and Hermes Agent. Conversion script for 8 more tools.
+    Plugin marketplace for Claude Code. Sync scripts for Codex, Gemini, Hermes Agent, and Mistral Vibe. Conversion script for 7 more tools.
 
 -   :material-puzzle:{ .lg .middle } **Self-contained**
 
@@ -237,7 +237,7 @@ hide:
 
     ---
 
-    Native support for 12 AI coding tools. Write once, convert to any tool's format automatically.
+    Native support for 13 AI coding tools. Write once, convert to any tool's format automatically.
 
 -   :material-check-decagram:{ .lg .middle } **Production-grade**
 
@@ -281,6 +281,15 @@ hide:
     cd claude-skills
     python scripts/sync-hermes-skills.py --verbose
     # Skills appear in /skills and /<skill-name> automatically
+    ```
+
+=== "Mistral Vibe"
+
+    ```bash
+    git clone https://github.com/alirezarezvani/claude-skills.git
+    cd claude-skills
+    ./scripts/vibe-install.sh
+    # 306 skills install to ~/.vibe/skills/claude-skills/; same SKILL.md standard
     ```
 
 === "Cursor / Windsurf / Aider"

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,11 +1,11 @@
 ---
-title: Cursor, Aider, Windsurf, Hermes & 9 More AI Coding Tools
-description: "Install Claude Code skills and agent plugins in Hermes Agent, Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. One-command conversion for 12 AI coding agents."
+title: Cursor, Aider, Windsurf, Hermes, Mistral Vibe & 8 More AI Coding Tools
+description: "Install Claude Code skills and agent plugins in Hermes Agent, Mistral Vibe, Cursor, Aider, Kilo Code, Windsurf, OpenCode, Augment, and Antigravity. One-command conversion for 13 AI coding agents."
 ---
 
 # Multi-Tool Integrations
 
-All 311 skills in this repository work natively with **8 AI coding tools** beyond Claude Code, Codex, Gemini CLI, and OpenClaw. Hermes Agent uses the same agentskills.io SKILL.md standard — no conversion needed. For the other 7 tools, a conversion script adapts the format each tool expects while preserving skill instructions, workflows, and supporting files.
+All 311 skills in this repository work natively with **9 AI coding tools** beyond Claude Code, Codex, Gemini CLI, and OpenClaw. Hermes Agent and Mistral Vibe both use the same agentskills.io SKILL.md standard — no conversion needed. For the other 7 tools, a conversion script adapts the format each tool expects while preserving skill instructions, workflows, and supporting files.
 
 <div class="grid cards" markdown>
 
@@ -72,6 +72,14 @@ All 311 skills in this repository work natively with **8 AI coding tools** beyon
     Native `SKILL.md` in `~/.hermes/skills/` — no conversion needed
 
     [:octicons-arrow-right-24: Jump to Hermes Agent](#hermes-agent)
+
+-   :material-wave:{ .lg .middle } **Mistral Vibe**
+
+    ---
+
+    Native `SKILL.md` in `~/.vibe/skills/` — no conversion needed
+
+    [:octicons-arrow-right-24: Jump to Mistral Vibe](#mistral-vibe)
 
 </div>
 
@@ -758,6 +766,133 @@ skills:
     ```bash
     rm -rf ~/.hermes/skills/claude-skills/
     # Hermes's own built-in skills are unaffected (they live elsewhere in ~/.hermes/skills/)
+    ```
+
+<hr class="section-divider">
+
+## Mistral Vibe
+
+[Mistral Vibe](https://github.com/mistralai/mistral-vibe) is Mistral AI's open-source Apache-2.0 CLI coding agent (v2.0, released January 2026). It uses the [Agent Skills standard](https://docs.mistral.ai/mistral-vibe/agents-skills) — the same `SKILL.md` + YAML frontmatter format Claude Code and Hermes Agent use — so **no conversion is needed**.
+
+!!! tip "Tier: BYO-sync (pre-generated tree available)"
+    The repo ships a pre-generated `.vibe/skills/claude-skills/` tree with **306 symlinks** across **14 domains**. You still need to copy/symlink that tree into `~/.vibe/skills/` on your machine — that's the BYO-sync step. The `sync-vibe-skills.py` script handles this in one command.
+
+### Discovery paths
+
+Per the [official docs](https://docs.mistral.ai/mistral-vibe/agents-skills), Vibe scans three locations for skills:
+
+| Path | Scope |
+|------|-------|
+| `~/.vibe/skills/` | User-global (what our sync script writes to) |
+| `.vibe/skills/` | Project-local |
+| `.agents/skills/` | Agent Skills standard path |
+
+### Step 1 — Install Mistral Vibe itself
+
+If you don't have Vibe installed yet, follow the [Vibe quickstart](https://docs.mistral.ai/mistral-vibe/introduction/quickstart):
+
+```bash
+pip install mistral-vibe
+vibe --version    # Verify install
+```
+
+Vibe supports both Mistral's hosted models (via `MISTRAL_API_KEY`) and self-hosted endpoints. See the [Vibe CLI docs](https://docs.mistral.ai/mistral-vibe/terminal) for provider configuration.
+
+### Step 2 — Install our skills into Vibe
+
+=== "Sync script (recommended)"
+
+    ```bash
+    git clone https://github.com/alirezarezvani/claude-skills.git
+    cd claude-skills
+    ./scripts/vibe-install.sh
+    ```
+
+    This symlinks all 306 skills into `~/.vibe/skills/claude-skills/` where Vibe discovers them automatically. Covers all 14 domains.
+
+=== "Single domain"
+
+    ```bash
+    python scripts/sync-vibe-skills.py --domain engineering --verbose
+    ```
+
+=== "Copy mode (portable)"
+
+    ```bash
+    python scripts/sync-vibe-skills.py --copy --verbose
+    ```
+
+    Creates full copies instead of symlinks — useful for Docker containers or shared filesystems where symlinks don't traverse cleanly.
+
+=== "Custom target"
+
+    ```bash
+    python scripts/sync-vibe-skills.py --target /opt/team-vibe/skills/
+    ```
+
+    Useful for team-wide installs or sandboxed environments.
+
+### Using skills in Vibe
+
+Once installed, skills are available through Vibe's standard discovery (per the [Vibe Agents & Skills docs](https://docs.mistral.ai/mistral-vibe/agents-skills)):
+
+```
+/skills                    # List all installed skills
+/<skill-name>              # Invoke a skill by slug as a slash command
+```
+
+Vibe can also auto-load skills when your prompt matches a skill's `description` field — same trigger mechanism Claude Code uses.
+
+### What works
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| SKILL.md loading | ✅ | Identical YAML frontmatter (agentskills.io) |
+| Python scripts (`scripts/`) | ✅ | All stdlib-only; Vibe shell tool runs them |
+| References / templates / assets | ✅ | Same directory convention |
+| Slash commands (`/<name>`) | ✅ | Auto-discovered from SKILL.md |
+| Sub-agents | ⚠️ | Vibe uses its own subagent system with TOML configs (`~/.vibe/agents/`) — Claude Code agent `.md` files load as context but dispatch differs |
+| Claude Code plugin.json | ➖ | Vibe ignores this — scans SKILL.md directly |
+| Hooks (settings.json) | ➖ | Vibe has its own hook system; manual wiring required |
+
+### Verify
+
+```bash
+# Count installed skills
+find ~/.vibe/skills/claude-skills -mindepth 2 -maxdepth 2 -name "SKILL.md" -o -type l | wc -l
+# Expected: 306
+
+# Inspect the manifest
+cat ~/.vibe/skills/claude-skills/skills-index.json | python3 -m json.tool | head -20
+
+# Or in the Vibe CLI
+vibe
+> /skills
+```
+
+### Updating
+
+```bash
+cd claude-skills
+git pull origin main
+python scripts/sync-vibe-skills.py --verbose
+# Existing symlinks are preserved, new skills are added
+```
+
+### Troubleshooting
+
+??? question "Vibe doesn't see the synced skills"
+    Make sure the sync ran and the symlinks resolve:
+    ```bash
+    ls -la ~/.vibe/skills/claude-skills/engineering/agent-designer/SKILL.md
+    # Should print a valid SKILL.md, not "No such file"
+    ```
+    If symlinks are broken (the source repo was moved), re-run `python scripts/sync-vibe-skills.py --verbose`.
+
+??? question "How do I unsync (remove our skills from Vibe)?"
+    ```bash
+    rm -rf ~/.vibe/skills/claude-skills/
+    # Vibe's own built-in skills are unaffected (they live elsewhere in ~/.vibe/skills/)
     ```
 
 <hr class="section-divider">

--- a/docs/skills/engineering-team/senior-backend.md
+++ b/docs/skills/engineering-team/senior-backend.md
@@ -374,3 +374,105 @@ python scripts/database_migration_tool.py --connection $DATABASE_URL --migrate f
 python scripts/api_load_tester.py https://api.example.com/endpoint --concurrency 50
 python scripts/api_load_tester.py https://api.example.com/endpoint --compare baseline.json
 ```
+
+---
+
+## Assumptions and Verifiable Success Criteria (Karpathy discipline)
+
+Before this skill scaffolds, recommends a pattern, or modifies a schema, the following four assumptions MUST be surfaced. If any are unknown, the skill stops and walks the [Forcing-question library](#forcing-question-library-matt-pocock-grill) instead.
+
+1. **Read/write ratio + one-year p99 QPS** — drives DB, cache, queue, and partitioning choices. Kleppmann, *DDIA* (2017).
+2. **Tenancy model** — single-tenant, shared multi-tenant, isolated multi-tenant. Drives data-access pattern.
+3. **Data sensitivity tier** — public / internal / PII / PHI / PCI. Drives compliance floor.
+4. **SLO + named error-budget consumer** — Google SRE Workbook canon. No SLO = no reliability work prioritization.
+
+**Verifiable success criteria** (Karpathy #4) — every recommendation this skill emits must include:
+
+- Latency targets (p50, p95, p99 in ms)
+- Uptime / SLO target
+- RPO + RTO
+
+If any of those three is not stated, the recommendation is incomplete — return to Q7 of the forcing-question library.
+
+The `scripts/backend_decision_engine.py` tool encodes these checks: it refuses to recommend a profile without read/write ratio + QPS + tenancy + data sensitivity + pattern preference.
+
+---
+
+## Customization profiles
+
+Four built-in profiles in `profiles/` calibrate every recommendation:
+
+| Profile | When to pick | Pattern | Latency floor (p99) |
+|---|---|---|---|
+| `node-express` | TS team, < 15 eng, customer-facing SaaS | Modular monolith on Postgres | 600ms |
+| `fastapi-python` | Python team, < 20 eng, ML-adjacent | Modular monolith on Postgres (async) | 500ms |
+| `django-monolith` | Content-heavy CRUD + admin, < 25 eng | Modular monolith on Postgres | 800ms |
+| `go-or-rust-microservice` | Extracted service, ≥ 30 eng, platform team, QPS ≥ 1000 | Extracted service | 200ms |
+
+Pick a profile via:
+
+```bash
+python scripts/backend_decision_engine.py \
+  --team-size 8 --qps-p99 50 --read-write-ratio 20 \
+  --tenancy shared-multi-tenant --data-sensitivity pii \
+  --pattern modular-monolith --language-preference typescript
+```
+
+The tool returns the best-fit profile, runner-up tradeoff (if within 15%), stack picks, anti-patterns, named approvers, and SLO floor. **This tool never auto-approves.**
+
+To add a custom profile: copy `profiles/node-express.json` to `profiles/<your-org>.json` and adjust `constraints` + `success_thresholds` + `named_approver_chain`.
+
+---
+
+## Composition map
+
+This skill does NOT reimplement scope owned by the POWERFUL-tier specialists. It forks into them. See `references/composition_map.md` for the full routing table. Key forks:
+
+| Concern | Fork into |
+|---|---|
+| API contract / breaking-change risk | `engineering/skills/api-design-reviewer/` |
+| Schema design + ERD + indexing | `engineering/skills/database-designer/` |
+| Zero-downtime schema migration | `engineering/skills/migration-architect/` |
+| SLO + SLI + error-budget | `engineering/slo-architect/` |
+| Observability / golden signals | `engineering/skills/observability-designer/` |
+| CI/CD pipeline | `engineering/skills/ci-cd-pipeline-builder/` |
+| Security / threat model | `engineering-team/skills/senior-security/`, `adversarial-reviewer` |
+| Compliance evidence (HIPAA / ISO 27001) | `ra-qm-team/` |
+| Pre-commit Karpathy review | `engineering/karpathy-coder/` |
+| Pre-flight architecture grill | `engineering/grill-me/` |
+
+The `cs-backend-engineer` agent orchestrates these forks via `context: fork`. Invoke it from another agent with `Agent({subagent_type: "cs-backend-engineer", prompt: "..."})` or via `/cs:backend-review <your problem>`.
+
+---
+
+## Forcing-question library (Matt Pocock grill)
+
+Before locking any backend decision, walk the seven forcing questions in `references/forcing_questions.md`. Discipline:
+
+1. One question per turn. No bundling.
+2. Always recommend the answer with cited canon.
+3. Track answers in `/tmp/backend-grill-<date>.md`.
+4. If a kill criterion trips, stop. Don't scaffold around an unresolved gap.
+5. After Q7, run `backend_decision_engine.py` with the seven answers.
+
+Summary:
+
+1. Read/write ratio + p99 QPS forecast?
+2. Tenancy model — single / shared / isolated?
+3. Sync / async / event-driven — default + exceptions?
+4. Data sensitivity tier — PII / PHI / PCI?
+5. Monolith / modular monolith / microservices — team-size justification?
+6. RPO + RTO?
+7. SLO + named error-budget consumer?
+
+---
+
+## Invocation from other agents and skills
+
+Three surfaces:
+
+1. **Slash command:** `/cs:backend-review <prompt>` — full grill + decision engine + composition routing.
+2. **Agent subagent:** `Agent({subagent_type: "cs-backend-engineer", prompt: "..."})` — forks context, returns ≤ 200-word digest.
+3. **Direct tool call:** `python scripts/backend_decision_engine.py ...` — deterministic profile match when inputs are known.
+
+See `agents/engineering/cs-backend-engineer.md` for the full invocation contract.

--- a/docs/skills/engineering-team/senior-frontend.md
+++ b/docs/skills/engineering-team/senior-frontend.md
@@ -482,3 +482,102 @@ function List<T>({ items, renderItem }: ListProps<T>) {
 - React Patterns: `references/react_patterns.md`
 - Next.js Optimization: `references/nextjs_optimization_guide.md`
 - Best Practices: `references/frontend_best_practices.md`
+- Forcing-question library (Matt Pocock grill): `references/forcing_questions.md`
+- Composition map (which specialist to fork into): `references/composition_map.md`
+
+---
+
+## Assumptions and Verifiable Success Criteria (Karpathy discipline)
+
+Before this skill scaffolds a component, recommends a framework, or audits a bundle, the following four assumptions MUST be surfaced.
+
+1. **Primary user device + network** — mobile-4G, desktop-fiber, low-end-Android, or corporate-network. Drives every perf decision.
+2. **LCP target in milliseconds** — a single number, not "fast." Drives bundle budget and rendering choice.
+3. **SEO-dependent vs. auth-walled** — drives rendering (SSR/SSG/RSC vs. SPA).
+4. **WCAG target + named a11y owner** — AA, AAA, or best-effort. Drives a11y investment and CI gates.
+
+**Verifiable success criteria** (Karpathy #4) — every recommendation must include:
+
+- Core Web Vitals targets (LCP, INP, CLS) at p75 on the primary device
+- A per-route JS bundle budget in KB-gzip
+- A Lighthouse a11y floor + perf floor
+
+If any of those three is not stated, the recommendation is incomplete — return to Q2 of the forcing-question library.
+
+The `scripts/frontend_decision_engine.py` tool encodes these checks: it refuses to recommend a profile without the four assumption inputs and prints the verifiable thresholds for the matched profile.
+
+---
+
+## Customization profiles
+
+Four built-in profiles in `profiles/` calibrate every recommendation:
+
+| Profile | When to pick | LCP target (mobile-4G p75) | Bundle budget |
+|---|---|---|---|
+| `next-app-router` | SaaS customer-facing, SEO + dynamic, RSC-first | 2000ms | 150 KB-gzip / route |
+| `remix-or-sveltekit` | Mobile-4G primary, low-JS-first, progressive enhancement | 1500ms | 80 KB-gzip / route |
+| `vite-spa` | Auth-walled app, desktop/corporate primary | 2500ms | 200 KB init + 80 KB / route |
+| `astro-or-static` | Marketing / docs / blog, near-zero write, SEO-critical | 1200ms | 30 KB JS / page |
+
+Pick a profile via:
+
+```bash
+python scripts/frontend_decision_engine.py \
+  --primary-device mobile-4g --lcp-target-ms 2000 \
+  --seo-dependent true --auth-walled false --team-size 5
+```
+
+The tool returns the best-fit profile, the runner-up tradeoff (if within 15%), the stack picks, the anti-patterns to avoid on that profile, and the required CI gates.
+
+To add a custom profile (e.g., your org's internal-tool defaults): copy `profiles/vite-spa.json` to `profiles/<your-org>.json` and adjust `constraints` + `success_thresholds`.
+
+---
+
+## Composition map
+
+This skill does NOT reimplement scope owned by the POWERFUL-tier specialists. It forks into them. See `references/composition_map.md` for the full routing table. Key forks:
+
+| Concern | Fork into |
+|---|---|
+| WCAG audit, contrast, screen-reader | `engineering-team/skills/a11y-audit/` |
+| Bundle profiling + runtime perf | `engineering/skills/performance-profiler/` |
+| Cinematic / scroll-storytelling landing | `engineering-team/skills/epic-design/` |
+| Apple HIG (iOS / macOS / visionOS) | `product-team/skills/apple-hig-expert/` |
+| Pre-commit Karpathy review | `engineering/karpathy-coder/` |
+| Pre-flight architecture grill | `engineering/grill-me/` |
+
+The `cs-frontend-engineer` agent orchestrates these forks via `context: fork`. Invoke it from another agent with `Agent({subagent_type: "cs-frontend-engineer", prompt: "..."})` or via `/cs:frontend-review <your problem>`.
+
+---
+
+## Forcing-question library (Matt Pocock grill)
+
+Before locking any framework or rendering decision, walk the seven forcing questions in `references/forcing_questions.md`. Discipline:
+
+1. One question per turn. No bundling.
+2. Always recommend the answer with cited canon.
+3. Track answers in `/tmp/frontend-grill-<date>.md`.
+4. If a kill criterion trips, stop. Don't scaffold around an unresolved gap.
+5. After Q7, run `frontend_decision_engine.py` with the seven answers.
+
+Summary:
+
+1. Primary device + network?
+2. LCP target in ms (and INP, CLS)?
+3. RSC / SPA / SSR / SSG — pick and defend?
+4. JS bundle budget per route?
+5. SEO-dependent or auth-walled?
+6. Design-system source of truth?
+7. WCAG target + named a11y owner?
+
+---
+
+## Invocation from other agents and skills
+
+Three surfaces:
+
+1. **Slash command:** `/cs:frontend-review <prompt>` — full grill + decision engine + composition routing.
+2. **Agent subagent:** `Agent({subagent_type: "cs-frontend-engineer", prompt: "..."})` — forks context, returns ≤ 200-word digest.
+3. **Direct tool call:** `python scripts/frontend_decision_engine.py ...` — deterministic profile match when inputs are known.
+
+See `agents/engineering/cs-frontend-engineer.md` for the full invocation contract.

--- a/docs/skills/engineering-team/senior-fullstack.md
+++ b/docs/skills/engineering-team/senior-fullstack.md
@@ -294,3 +294,102 @@ See `references/tech_stack_guide.md` for detailed comparison.
 | Auth complexity | Use Auth.js or Clerk |
 | Type errors | Enable strict mode in tsconfig |
 | CORS issues | Configure middleware properly |
+
+---
+
+## Assumptions and Verifiable Success Criteria (Karpathy discipline)
+
+Before this skill scaffolds, recommends, or modifies any code, the following four assumptions MUST be surfaced. If any are unknown, the skill stops and walks the [Forcing-question library](#forcing-question-library-matt-pocock-grill) instead.
+
+1. **Team size today + 12-month headcount** — drives architecture (monolith / modular / services). Sam Newman: "MonolithFirst."
+2. **Deployment cadence target** — drives CI/CD spend and feature-flag investment. *Accelerate* (Forsgren et al. 2018).
+3. **User-facing vs. internal vs. marketing-site** — drives stack pick and a11y/perf budget.
+4. **Monthly cloud + SaaS budget ceiling** — drives the build-vs-managed-service split.
+
+**Verifiable success criteria** (Karpathy #4) — every recommendation this skill emits must include three machine-checkable numbers:
+
+- An API latency target (p50, p95, p99 in ms)
+- A frontend perf target (LCP, INP, CLS on mobile-4G)
+- An uptime / SLO target
+
+If any of those three is not stated, the recommendation is incomplete — go back to Q7 of the forcing-question library.
+
+The `scripts/fullstack_decision_engine.py` tool encodes these checks: it refuses to recommend a profile without all four assumption inputs and prints the verifiable thresholds for the matched profile.
+
+---
+
+## Customization profiles
+
+Four built-in profiles in `profiles/` calibrate every recommendation:
+
+| Profile | When to pick | Cloud ceiling | Pattern |
+|---|---|---|---|
+| `saas-startup` | < 10 eng, customer-facing, daily+ cadence | $8K/mo | Modular monolith on Next.js + Postgres |
+| `enterprise-scale` | 50+ eng, regulated, per-PR with gates | $250K/mo | Domain-bounded services + platform team |
+| `internal-tool` | ≤ 5 eng, auth-walled, < 100 DAU | $500/mo | Retool-first; thin custom stack if forced |
+| `marketing-site` | SEO-dependent, near-zero write | $200/mo | Static-first (Astro / 11ty / Next-static) |
+
+Pick a profile via:
+
+```bash
+python scripts/fullstack_decision_engine.py \
+  --team-size 6 --team-size-12mo 12 \
+  --cadence daily --user-facing true --budget 5000 \
+  --traffic-p99-rps 45 --data-sensitivity pii-only
+```
+
+The tool returns the best-fit profile, the tradeoff against the runner-up (if within 15%), the stack recommendation, the anti-patterns to avoid on that profile, and the named-approver chain. **This tool never auto-approves.**
+
+To add a custom profile: copy `profiles/saas-startup.json` to `profiles/<your-org>.json`, adjust the `constraints` and `stack_recommendations` blocks, and rerun. The JSON is the customization surface — no code changes needed.
+
+---
+
+## Composition map
+
+This skill does NOT reimplement scope owned by the POWERFUL-tier specialists. It forks into them. See `references/composition_map.md` for the full routing table. Key forks:
+
+| Concern | Fork into |
+|---|---|
+| API contract review | `engineering/skills/api-design-reviewer/` |
+| Database schema design | `engineering/skills/database-designer/` |
+| Reliability / SLO design | `engineering/slo-architect/` |
+| CI/CD pipeline | `engineering/skills/ci-cd-pipeline-builder/` |
+| Performance profiling | `engineering/skills/performance-profiler/` |
+| Pre-commit Karpathy review | `engineering/karpathy-coder/` |
+| Pre-flight architecture grill | `engineering/grill-me/` |
+
+The `cs-fullstack-engineer` agent (in `agents/engineering/cs-fullstack-engineer.md`) orchestrates these forks via `context: fork`. Invoke it from another agent with `Agent({subagent_type: "cs-fullstack-engineer", prompt: "..."})` or via the slash command `/cs:fullstack-review <your problem>`.
+
+---
+
+## Forcing-question library (Matt Pocock grill)
+
+Before locking any architecture or stack decision, walk the seven forcing questions in `references/forcing_questions.md`. Each has a recommended answer, canon citation, and kill criterion. The discipline:
+
+1. One question per turn. No bundling.
+2. Always recommend the answer with cited canon.
+3. Track answers in a working file (e.g., `/tmp/fullstack-grill-<date>.md`).
+4. If a kill criterion trips, stop. Do not scaffold around an unresolved gap.
+5. After Q7, run `fullstack_decision_engine.py` with the seven answers as inputs.
+
+Summary of the seven questions (full content in the reference):
+
+1. Team size today + 12-month headcount?
+2. Deployment cadence — per-PR, daily, weekly, quarterly?
+3. Customer-facing, internal tool, or marketing site?
+4. One-year p50 / p99 traffic forecast?
+5. Hiring against the stack or training the team?
+6. Year-one monthly cloud + SaaS ceiling?
+7. Three verifiable success criteria with numeric targets?
+
+---
+
+## Invocation from other agents and skills
+
+This skill is invokable by any other agent or skill via three surfaces:
+
+1. **Slash command:** `/cs:fullstack-review <prompt>` — runs the full grill + decision engine + composition routing.
+2. **Agent subagent:** `Agent({subagent_type: "cs-fullstack-engineer", prompt: "..."})` — forks context, returns ≤ 200-word digest.
+3. **Direct tool call:** `python scripts/fullstack_decision_engine.py ...` — deterministic profile match without the conversational grill (use when inputs are already known).
+
+See `agents/engineering/cs-fullstack-engineer.md` for the full invocation contract.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Claude Code Skills & Agent Plugins
 site_url: https://alirezarezvani.github.io/claude-skills/
-site_description: "313 production-ready skills, 46+ cs-* agents (incl. founder-mode C-suite: GC, CDO, CAIO, CCO, VPE + Matt Pocock-derived productivity quartet: skill-author, caveman, grill-master, handoff + v2.7.0 megaprompt-derived research stack + v2.7.3 cs-aeo), 7 personas, 60+ /cs:* slash commands, and an orchestration protocol for 12 AI coding tools. v2.7.3 ports `alirezarezvani/aeo-box` — adds AEO (Answer Engine Optimization for LLM citation across ChatGPT / Perplexity / Claude / Gemini / Mistral) into marketing-skill and a security-guidance PreToolUse hook into engineering."
+site_description: "313 production-ready skills, 46+ cs-* agents (incl. founder-mode C-suite: GC, CDO, CAIO, CCO, VPE + Matt Pocock-derived productivity quartet: skill-author, caveman, grill-master, handoff + v2.7.0 megaprompt-derived research stack + v2.7.3 cs-aeo), 7 personas, 60+ /cs:* slash commands, and an orchestration protocol for 13 AI coding tools (Claude Code · Codex · Gemini CLI · Hermes Agent · Mistral Vibe · OpenClaw · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity). v2.7.3 ports `alirezarezvani/aeo-box` — adds AEO (Answer Engine Optimization for LLM citation across ChatGPT / Perplexity / Claude / Gemini / Mistral) into marketing-skill and a security-guidance PreToolUse hook into engineering."
 site_author: Alireza Rezvani
 repo_url: https://github.com/alirezarezvani/claude-skills
 repo_name: alirezarezvani/claude-skills

--- a/scripts/sync-vibe-skills.py
+++ b/scripts/sync-vibe-skills.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+sync-vibe-skills.py — Install claude-code-skills into Mistral Vibe.
+
+Mistral Vibe (https://github.com/mistralai/mistral-vibe) discovers skills
+from ~/.vibe/skills/ (user-global) and .vibe/skills/ (project-local). This
+script creates symlinks from our repo's skill directories into Vibe's skill
+directory, preserving the category structure.
+
+Both tools use the agentskills.io standard (SKILL.md with YAML frontmatter),
+so no format conversion is needed — just symlink the directories.
+
+Usage:
+    python scripts/sync-vibe-skills.py                   # full sync
+    python scripts/sync-vibe-skills.py --verbose          # show each skill
+    python scripts/sync-vibe-skills.py --domain engineering  # one domain
+    python scripts/sync-vibe-skills.py --dry-run          # preview only
+    python scripts/sync-vibe-skills.py --copy             # copy instead of symlink
+
+Vibe skill directory: ~/.vibe/skills/
+Our skills land under:  ~/.vibe/skills/claude-skills/<domain>/<skill-name>/
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VIBE_SKILLS_DIR = Path.home() / ".vibe" / "skills"
+TARGET_SUBDIR = "claude-skills"  # namespace to avoid collisions with Vibe built-in skills
+
+# Domain directories that contain skills (each subdirectory with a SKILL.md)
+DOMAIN_DIRS = [
+    "engineering",
+    "engineering-team",
+    "product-team",
+    "marketing-skill",
+    "c-level-advisor",
+    "project-management",
+    "ra-qm-team",
+    "business-growth",
+    "finance",
+    "productivity",  # v2.7.0 — capture, email-pair, reflect
+    "marketing",     # v2.7.0 — landing (top-level, distinct from marketing-skill/)
+    "research",      # v2.7.0 — pulse, litreview, grants, dossier, patent, syllabus, notebooklm, research orchestrator
+    "business-operations",  # v2.8.0 — process-mapper, vendor-management, capacity-planner, internal-comms, knowledge-ops, procurement-optimizer + orchestrator
+    "commercial",    # v2.8.0 — pricing-strategist, deal-desk, partnerships-architect, channel-economics, commercial-policy, rfp-responder, commercial-forecaster + orchestrator
+]
+
+
+def discover_skills(repo_root, domains=None):
+    """Find all skills across specified domains.
+
+    Supports three discovery patterns (same as sync-codex-skills.py):
+      1. <domain>/<skill>/SKILL.md         — flat-domain pattern (legacy)
+      2. <domain>/skills/<skill>/SKILL.md  — flat-with-skills-dir pattern (e.g., c-level-advisor/skills/)
+      3. <domain>/<plugin>/skills/<skill>/SKILL.md — nested plugin pattern (e.g., research/research/skills/research/)
+
+    Dedupes by SKILL.md path so a skill discovered under multiple patterns is only counted once.
+    """
+    skills = []
+    seen_paths: set = set()
+    search_domains = domains or DOMAIN_DIRS
+
+    for domain in search_domains:
+        domain_path = repo_root / domain
+        if not domain_path.is_dir():
+            continue
+
+        # Pattern 2: <domain>/skills/<skill>/SKILL.md
+        skills_subdir = domain_path / "skills"
+        if skills_subdir.is_dir():
+            for skill_dir in sorted(skills_subdir.iterdir()):
+                if not skill_dir.is_dir():
+                    continue
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists() and str(skill_md) not in seen_paths:
+                    seen_paths.add(str(skill_md))
+                    skills.append({
+                        "domain": domain,
+                        "name": skill_dir.name,
+                        "source": skill_dir,
+                        "skill_md": skill_md,
+                    })
+
+        # Pattern 1: <domain>/<skill>/SKILL.md (flat)
+        # Pattern 3: <domain>/<plugin>/skills/<skill>/SKILL.md (nested plugin)
+        for entry in sorted(domain_path.iterdir()):
+            if not entry.is_dir() or entry.name in {"skills", ".claude-plugin", ".codex-plugin"}:
+                continue
+
+            # Pattern 1
+            skill_md = entry / "SKILL.md"
+            if skill_md.exists() and str(skill_md) not in seen_paths:
+                seen_paths.add(str(skill_md))
+                skills.append({
+                    "domain": domain,
+                    "name": entry.name,
+                    "source": entry,
+                    "skill_md": skill_md,
+                })
+                continue
+
+            # Pattern 3: nested plugin with skills/ subdir
+            nested_skills = entry / "skills"
+            if not nested_skills.is_dir():
+                continue
+            for inner in sorted(nested_skills.iterdir()):
+                if not inner.is_dir():
+                    continue
+                inner_skill_md = inner / "SKILL.md"
+                if inner_skill_md.exists() and str(inner_skill_md) not in seen_paths:
+                    seen_paths.add(str(inner_skill_md))
+                    skills.append({
+                        "domain": domain,
+                        "name": inner.name,
+                        "source": inner,
+                        "skill_md": inner_skill_md,
+                    })
+
+    return skills
+
+
+def read_frontmatter(skill_md):
+    """Extract name and description from SKILL.md frontmatter."""
+    try:
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+        if not text.startswith("---"):
+            return {}
+        end = text.find("---", 3)
+        if end < 0:
+            return {}
+        fm = {}
+        for line in text[3:end].splitlines():
+            if ":" in line and not line.strip().startswith("#"):
+                k, _, v = line.partition(":")
+                fm[k.strip()] = v.strip().strip("'\"")
+        return fm
+    except Exception:
+        return {}
+
+
+def sync_skill(skill, target_root, use_copy, verbose, dry_run):
+    """Create a symlink or copy for one skill."""
+    target = target_root / skill["domain"] / skill["name"]
+
+    if target.exists() or target.is_symlink():
+        if verbose:
+            print(f"  skip (exists): {skill['domain']}/{skill['name']}")
+        return "skip"
+
+    if dry_run:
+        if verbose:
+            print(f"  would {'copy' if use_copy else 'link'}: {skill['domain']}/{skill['name']}")
+        return "would"
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if use_copy:
+        shutil.copytree(skill["source"], target, dirs_exist_ok=True)
+    else:
+        # Prefer relative symlinks so the tree is portable when committed to the repo.
+        # Falls back to absolute if target is outside the source tree (e.g., ~/.vibe/).
+        try:
+            rel = os.path.relpath(skill["source"], target.parent)
+            target.symlink_to(rel)
+        except ValueError:
+            # Cross-device or unrelated tree — use absolute
+            target.symlink_to(skill["source"])
+
+    if verbose:
+        print(f"  {'copied' if use_copy else 'linked'}: {skill['domain']}/{skill['name']}")
+    return "new"
+
+
+def write_index(target_root, skills):
+    """Write a skills-index.json for quick lookup."""
+    index = {
+        "source": "claude-code-skills",
+        "total_skills": len(skills),
+        "domains": {},
+    }
+    for s in skills:
+        d = s["domain"]
+        if d not in index["domains"]:
+            index["domains"][d] = []
+        fm = read_frontmatter(s["skill_md"])
+        index["domains"][d].append({
+            "name": s["name"],
+            "description": fm.get("description", ""),
+            "path": f"{d}/{s['name']}",
+        })
+    index_path = target_root / "skills-index.json"
+    index_path.write_text(json.dumps(index, indent=2), encoding="utf-8")
+    return index_path
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Sync claude-code-skills into Mistral Vibe (~/.vibe/skills/).",
+        epilog="Both tools use the agentskills.io SKILL.md standard. No format conversion needed.",
+    )
+    p.add_argument(
+        "--domain",
+        default=None,
+        help="Sync only one domain (e.g. engineering, marketing-skill)",
+    )
+    p.add_argument("--verbose", action="store_true", help="Show each skill")
+    p.add_argument("--dry-run", action="store_true", help="Preview only, don't create files")
+    p.add_argument("--copy", action="store_true", help="Copy files instead of symlink")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.add_argument(
+        "--target",
+        default=str(VIBE_SKILLS_DIR),
+        help=f"Override Vibe skills dir (default: {VIBE_SKILLS_DIR})",
+    )
+    args = p.parse_args()
+
+    target_root = Path(args.target).expanduser() / TARGET_SUBDIR
+    domains = [args.domain] if args.domain else None
+    skills = discover_skills(REPO_ROOT, domains)
+
+    if not skills:
+        msg = f"No skills found in {REPO_ROOT}"
+        if args.json:
+            print(json.dumps({"status": "error", "message": msg}))
+        else:
+            print(f"[error] {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.dry_run:
+        target_root.mkdir(parents=True, exist_ok=True)
+
+    counts = {"new": 0, "skip": 0, "would": 0}
+    for s in skills:
+        result = sync_skill(s, target_root, args.copy, args.verbose, args.dry_run)
+        counts[result] += 1
+
+    # Write index
+    if not args.dry_run:
+        idx_path = write_index(target_root, skills)
+    else:
+        idx_path = target_root / "skills-index.json"
+
+    summary = {
+        "status": "ok",
+        "target": str(target_root),
+        "total_skills": len(skills),
+        "new": counts["new"],
+        "skipped": counts["skip"],
+        "dry_run": args.dry_run,
+        "mode": "copy" if args.copy else "symlink",
+        "index": str(idx_path),
+        "domains": list({s["domain"] for s in skills}),
+    }
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+        return
+
+    action = "Would sync" if args.dry_run else "Synced"
+    print(f"{action} {len(skills)} skills to {target_root}")
+    print(f"  New: {counts['new']}  Skipped: {counts['skip']}")
+    print(f"  Mode: {'copy' if args.copy else 'symlink'}")
+    if not args.dry_run:
+        print(f"  Index: {idx_path}")
+    print()
+    print("Vibe will discover these skills via /skills or /<skill-name>.")
+    print("No format conversion needed — both tools use agentskills.io SKILL.md standard.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vibe-install.sh
+++ b/scripts/vibe-install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Mistral Vibe Installation Script for Claude Skills Library
+#
+# Syncs all skills into ~/.vibe/skills/claude-skills/ for discovery by
+# Mistral Vibe (https://github.com/mistralai/mistral-vibe). Uses the
+# agentskills.io SKILL.md standard — no format conversion needed.
+#
+# Usage:
+#   ./scripts/vibe-install.sh [--dry-run] [--verbose] [--domain engineering] [--copy]
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+VIBE_SYNC_SCRIPT="$SCRIPT_DIR/sync-vibe-skills.py"
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+
+echo ""
+echo "========================================"
+echo "  Claude Skills - Mistral Vibe Setup"
+echo "========================================"
+echo ""
+
+if ! command -v python3 &> /dev/null; then
+    echo "Error: python3 is required for this setup."
+    exit 1
+fi
+
+print_info "Synchronizing skills for Mistral Vibe..."
+python3 "$VIBE_SYNC_SCRIPT" "$@"
+
+echo ""
+print_success "Mistral Vibe setup complete!"
+echo ""
+echo "How to use these skills in Mistral Vibe:"
+echo "----------------------------------------"
+echo "1. List available skills inside Vibe:"
+echo "   > /skills"
+echo ""
+echo "2. Invoke a skill by name:"
+echo "   > /senior-architect"
+echo ""
+echo "3. Or describe a task — Vibe will auto-load matching skills via the"
+echo "   description field in each SKILL.md frontmatter."
+echo ""
+echo "Skills install to ~/.vibe/skills/claude-skills/ as symlinks back to"
+echo "this repo (or copies, if you passed --copy)."
+echo ""
+print_info "Docs: https://docs.mistral.ai/mistral-vibe/agents-skills"
+echo ""


### PR DESCRIPTION
Closes #705. Requested by @saifjarboui.

## Summary

Adds [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (Mistral AI's open-source Apache-2.0 CLI coding agent, v2.0) as the 6th cross-platform installation target. Vibe uses the same agentskills.io `SKILL.md` + YAML frontmatter standard as Claude Code and Hermes, so the integration ships with **zero format conversion** — just symlinks.

Slots in alongside the existing pattern: `.claude` / `.codex` / `.gemini` / `.hermes` / `.openclaw` → + `.vibe`. Mirrors the Hermes integration almost line-for-line.

## What changed

| File | Change |
|---|---|
| `scripts/sync-vibe-skills.py` | **New.** Fork of `sync-hermes-skills.py`. Targets `~/.vibe/skills/claude-skills/<domain>/<skill>/`, namespaced to avoid collisions with Vibe built-ins. Stdlib only. Same flags: `--verbose` / `--domain` / `--dry-run` / `--copy` / `--json` / `--target`. |
| `scripts/vibe-install.sh` | **New.** Bash wrapper for parity with `gemini-install.sh` and `codex-install.sh`. Surfaces Vibe usage tips (`/skills`, `/<slug>`, auto-load via description match). |
| `.vibe/skills/claude-skills/` | **New tree.** 306 skill symlinks across 14 domains + `skills-index.json`. Mirrors `.hermes/skills/claude-skills/` precedent so users can inspect install surface before running. |
| `INSTALLATION.md` | New "Mistral Vibe Installation" section (setup, Python flags, verify, uninstall, Python CLI tools), TOC entry, cross-tool compatibility table row. |
| `README.md` | Mistral Vibe added to "Works with" line, BYO-sync footnote mirroring the Hermes footnote, Multi-Tool Support table row, FAQ updated 12 → 13 tools, "eleven platforms" → "twelve platforms" callout. |
| `CHANGELOG.md` | `[Unreleased]` entry. |

## Why this scopes cleanly

Vibe's [official docs](https://docs.mistral.ai/mistral-vibe/agents-skills) confirm three discovery paths — `~/.vibe/skills/`, `.vibe/skills/`, `.agents/skills/` — all reading directories with `SKILL.md` + YAML frontmatter. No manifest format, no schema differences, no CLI install command to wrap. The only meaningful work was a syncer + docs.

## Test plan

- [x] `python3 scripts/sync-vibe-skills.py --help` exits 0
- [x] End-to-end sync to `/tmp/vibe-test` creates 306 valid symlinks + index
- [x] `SKILL.md` frontmatter readable through symlinks (verified `engineering/agent-designer/SKILL.md`)
- [x] Idempotent — second run skips all 320 discovered entries, creates 0 new
- [x] `--domain finance` correctly isolates to 4 finance skills
- [x] Repo-committed `.vibe/` tree generated and committed (306 symlinks across 14 domains)
- [ ] Reviewer to verify on macOS / Linux against an actual Vibe install (`pip install mistral-vibe`)

## Open follow-ups (not in this PR)

- Re-sync `.hermes/skills/claude-skills/` — currently at 305 skills / 12 domains. Should be bumped to 306 / 14 domains (add `business-operations/` + `commercial/`) for parity. Separate PR.
- Add a `Mistral Vibe` row to the "Universal Installer" agent list if `agent-skills-cli` upstream adds support.

cc @saifjarboui — please test against your Vibe install and let me know if the namespacing under `~/.vibe/skills/claude-skills/` works for you, or if you'd prefer a flat layout at `~/.vibe/skills/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrvgo6wq4CvSifar4RfL5a)_