### PR TITLE
chore: sync codex + gemini indices after code-reviewer C# update

### DIFF
--- a/.codex/skills-index.json
+++ b/.codex/skills-index.json
@@ -685,15 +685,15 @@
     },
     {
       "name": "review",
-      "source": "../../engineering-team/playwright-pro/skills/review",
-      "category": "engineering",
-      "description": ">-"
-    },
-    {
-      "name": "review",
       "source": "../../engineering-team/self-improving-agent/skills/review",
       "category": "engineering",
       "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics."
+    },
+    {
+      "name": "review",
+      "source": "../../engineering-team/playwright-pro/skills/review",
+      "category": "engineering",
+      "description": ">-"
     },
     {
       "name": "security-pen-testing",
@@ -1159,15 +1159,15 @@
     },
     {
       "name": "run",
-      "source": "../../engineering/agenthub/skills/run",
-      "category": "engineering-advanced",
-      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
-    },
-    {
-      "name": "run",
       "source": "../../engineering/autoresearch-agent/skills/run",
       "category": "engineering-advanced",
       "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard."
+    },
+    {
+      "name": "run",
+      "source": "../../engineering/agenthub/skills/run",
+      "category": "engineering-advanced",
+      "description": "One-shot lifecycle command that chains init \u2192 baseline \u2192 spawn \u2192 eval \u2192 merge in a single invocation."
     },
     {
       "name": "runbook-generator",
@@ -1255,15 +1255,15 @@
     },
     {
       "name": "status",
-      "source": "../../engineering/agenthub/skills/status",
-      "category": "engineering-advanced",
-      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
-    },
-    {
-      "name": "status",
       "source": "../../engineering/autoresearch-agent/skills/status",
       "category": "engineering-advanced",
       "description": "Show experiment dashboard with results, active loops, and progress."
+    },
+    {
+      "name": "status",
+      "source": "../../engineering/agenthub/skills/status",
+      "category": "engineering-advanced",
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session."
     },
     {
       "name": "tc-tracker",

--- a/.codex/skills/review
+++ b/.codex/skills/review
@@ -1,1 +1,1 @@
-../../engineering-team/self-improving-agent/skills/review
+../../engineering-team/playwright-pro/skills/review

--- a/.codex/skills/run
+++ b/.codex/skills/run
@@ -1,1 +1,1 @@
-../../engineering/autoresearch-agent/skills/run
+../../engineering/agenthub/skills/run

--- a/.codex/skills/status
+++ b/.codex/skills/status
@@ -1,1 +1,1 @@
-../../engineering/autoresearch-agent/skills/status
+../../engineering/agenthub/skills/status

--- a/.gemini/skills-index.json
+++ b/.gemini/skills-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "gemini-cli-skills",
-  "total_skills": 393,
+  "total_skills": 394,
   "skills": [
     {
       "name": "README",
@@ -826,7 +826,7 @@
     {
       "name": "code-reviewer",
       "category": "engineering",
-      "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists."
+      "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, and .NET. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists."
     },
     {
       "name": "coverage",
@@ -1107,6 +1107,11 @@
       "name": "ci-cd-pipeline-builder",
       "category": "engineering-advanced",
       "description": "Generate pragmatic CI/CD pipelines from detected project stack signals \u2014 fast baseline generation, repeatable checks, environment-aware deployment stages. Use when setting up CI for a new project, refactoring existing pipelines, or standardizing deployment workflows across multiple repos."
+    },
+    {
+      "name": "claude-coach",
+      "category": "engineering-advanced",
+      "description": "Personal coach that teaches users to become Claude power users. Use this skill the FIRST time a user asks to \"learn Claude\", \"be a power user\", \"coach me\", \"teach me Claude tricks\", \"what can Claude do\", \"make me better at prompting\", or any variation. After activation, also use it on EVERY subsequent turn to detect missed optimization opportunities (vague prompts, ignored capabilities, manual work Claude could automate) and surface a single power-user tip. Trigger generously \u2014 most users do not know what they do not know, so err on the side of coaching."
     },
     {
       "name": "code-tour",
@@ -1999,7 +2004,7 @@
       "description": "Engineering resources"
     },
     "engineering-advanced": {
-      "count": 77,
+      "count": 78,
       "description": "Engineering-advanced resources"
     },
     "finance": {

--- a/.gemini/skills/claude-coach/SKILL.md
+++ b/.gemini/skills/claude-coach/SKILL.md
@@ -1,0 +1,1 @@
+../../../engineering/claude-coach/skills/claude-coach/SKILL.md


### PR DESCRIPTION
## Summary

Post-merge follow-up to #730. Phase 7 of the plugin audit on `engineering-team/skills/code-reviewer` found the cross-platform skill indices were stale — still showing the pre-#723 description without "C#, and .NET". This commits the auto-fix from `scripts/sync-codex-skills.py` + `scripts/sync-gemini-skills.py`.

Re-running the syncers also picked up two unrelated drifted entries (`.codex/skills/{review,run,status}` symlinks, `.gemini/skills/claude-coach/` symlink) — included in the same commit since they're all canonical-sync output.

## Audit verdict for code-reviewer (PR #730 changes)

| Phase | Result |
|-------|--------|
| 1 — Discovery | Single-skill, engineering-team, 3 scripts, 3 references |
| 2 — Structure | **PASS** 86.4/100 GOOD |
| 3 — Quality | WARN 54.8/100 D (pre-existing baseline — missing README/assets/expected_outputs; not regressions) |
| 4 — Scripts | **PASS** 3/3 |
| 5 — Security | **PASS** 0 critical, 0 high (9 files scanned) |
| 6 — Marketplace | **PASS** (bundled under parent engineering-team v2.8.1, plugin.json valid) |
| 7 — Ecosystem | **PASS WITH AUTO-FIX** (this PR) |
| 8 — Code review | **PASS** (cs-senior-engineer criteria) |

## Type of Change

- [x] Infrastructure / CI (index sync)

Draft for review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggp2J8MKgGXqSeWwC6oYaq)_