### PR TITLE
code-reviewer: new structure : universal rules + per-language files, add Java support

### DIFF
--- a/engineering-team/skills/code-reviewer/SKILL.md
+++ b/engineering-team/skills/code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "code-reviewer"
-description: Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, and .NET. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.
+description: Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, and Java. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.
 ---
 
 # Code Reviewer
@@ -9,14 +9,40 @@ Automated code review tools for analyzing pull requests, detecting code quality 
 
 ---
 
-## Table of Contents
+## How This Skill Is Organized
 
-- [Tools](#tools)
-  - [PR Analyzer](#pr-analyzer)
-  - [Code Quality Checker](#code-quality-checker)
-  - [Review Report Generator](#review-report-generator)
-- [Reference Guides](#reference-guides)
-- [Languages Supported](#languages-supported)
+```
+code-reviewer/
+  SKILL.md                        ← you are here (tools + dispatch table)
+  rules/
+    universal.md                  ← security, async, resources, exceptions, performance — all languages
+  languages/
+    python.md                     ← Python-specific rules + idioms
+    typescript.md                 ← TypeScript / JavaScript-specific rules + idioms
+    go.md                         ← Go-specific rules + idioms
+    swift.md                      ← Swift-specific rules + idioms
+    kotlin.md                     ← Kotlin-specific rules + idioms
+    csharp.md                     ← C# / .NET-specific rules + idioms
+    java.md                       ← Java-specific rules + idioms
+```
+
+### Loading order for every review
+
+1. This file (`SKILL.md`) — tools and thresholds
+2. `rules/universal.md` — always, for every language
+3. The matching `languages/*.md` — one file based on the extension table below
+
+That's always exactly **2 additional files**, regardless of scope.
+
+| Extension(s) | Load |
+|---|---|
+| `.py` | `languages/python.md` |
+| `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs` | `languages/typescript.md` |
+| `.go` | `languages/go.md` |
+| `.swift` | `languages/swift.md` |
+| `.kt`, `.kts` | `languages/kotlin.md` |
+| `.cs`, `.csx`, `.razor`, `.cshtml` | `languages/csharp.md` |
+| `.java` | `languages/java.md` |
 
 ---
 
@@ -37,15 +63,12 @@ python scripts/pr_analyzer.py . --base main --head feature-branch
 python scripts/pr_analyzer.py /path/to/repo --json
 ```
 
-**What it detects:**
+**What it detects (universal — see also language file for language-specific signals):**
 - Hardcoded secrets (passwords, API keys, tokens, connection strings)
-- SQL injection patterns (string concatenation in queries)
-- Debug statements (debugger, console.log, Debug.WriteLine)
-- ESLint / Roslyn analyzer rule disabling (`#pragma warning disable`, `[SuppressMessage]`)
-- TypeScript `any` types / C# `dynamic` overuse
+- SQL / query injection patterns
+- Debug statements left in production code
+- Lint / analyzer suppression annotations
 - TODO/FIXME comments
-- Unsafe code blocks (`unsafe { }` in C#)
-- Nullable reference type suppressions (`!` null-forgiving operator overuse)
 
 **Output includes:**
 - Complexity score (1-10)
@@ -63,26 +86,14 @@ Analyzes source code for structural issues, code smells, and SOLID violations.
 # Analyze a directory
 python scripts/code_quality_checker.py /path/to/code
 
-# Analyze specific language (valid values: python, typescript, javascript, go, swift, kotlin, csharp)
-python scripts/code_quality_checker.py . --language python
+# Analyze specific language (valid values: python, typescript, javascript, go, swift, kotlin, csharp, java)
+python scripts/code_quality_checker.py . --language java
 
 # JSON output
 python scripts/code_quality_checker.py /path/to/code --json
 ```
 
-**What it detects:**
-- Long functions/methods (>50 lines)
-- Large files (>500 lines)
-- God classes (>20 methods)
-- Deep nesting (>4 levels)
-- Too many parameters (>5)
-- High cyclomatic complexity
-- Missing error handling (bare `catch` / `catch (Exception)` swallowing)
-- Unused imports / unnecessary `using` directives
-- Magic numbers
-- C#-specific: missing `async`/`await` on async paths, `Task` not awaited, `IDisposable` not disposed
-
-**Thresholds:**
+**Universal thresholds:**
 
 | Issue | Threshold |
 |-------|-----------|
@@ -92,6 +103,8 @@ python scripts/code_quality_checker.py /path/to/code --json
 | Too many params | >5 |
 | Deep nesting | >4 levels |
 | High complexity | >10 branches |
+
+Language-specific checks are defined in each `languages/*.md` file.
 
 ---
 
@@ -112,13 +125,6 @@ python scripts/review_report_generator.py . \
   --quality-analysis quality_results.json
 ```
 
-**Report includes:**
-- Review verdict (approve, request changes, block)
-- Score (0-100)
-- Prioritized action items
-- Issue summary by severity
-- Suggested review order
-
 **Verdicts:**
 
 | Score | Verdict |
@@ -130,91 +136,9 @@ python scripts/review_report_generator.py . \
 
 ---
 
-## Reference Guides
+## Adding a New Language
 
-### Code Review Checklist
-`references/code_review_checklist.md`
-
-Systematic checklists covering:
-- Pre-review checks (build, tests, PR hygiene)
-- Correctness (logic, data handling, error handling)
-- Security (input validation, injection prevention)
-- Performance (efficiency, caching, scalability)
-- Maintainability (code quality, naming, structure)
-- Testing (coverage, quality, mocking)
-- Language-specific checks (including C# / .NET)
-
-### Coding Standards
-`references/coding_standards.md`
-
-Language-specific standards for:
-- TypeScript (type annotations, null safety, async/await)
-- JavaScript (declarations, patterns, modules)
-- Python (type hints, exceptions, class design)
-- Go (error handling, structs, concurrency)
-- Swift (optionals, protocols, errors)
-- Kotlin (null safety, data classes, coroutines)
-- **C# / .NET** (nullable reference types, async/await, LINQ, dependency injection, exception handling, record types, pattern matching)
-
-### Common Antipatterns
-`references/common_antipatterns.md`
-
-Antipattern catalog with examples and fixes:
-- Structural (god class, long method, deep nesting)
-- Logic (boolean blindness, stringly typed code)
-- Security (SQL injection, hardcoded credentials, unvalidated input in ASP.NET)
-- Performance (N+1 queries, unbounded collections, `async void`, blocking on async code with `.Result` / `.Wait()`)
-- Testing (duplication, testing implementation)
-- Async (floating promises, callback hell, `async void` in C#, deadlocks from `.GetAwaiter().GetResult()`)
-- **C# / .NET-specific**: catching and swallowing `Exception`, missing `ConfigureAwait`, overuse of `dynamic`, not disposing `IDisposable` resources, mutable public setters on domain models
-
----
-
-## C# / .NET Review Notes
-
-When reviewing C# or .NET code, pay special attention to:
-
-### Async / Await
-- Flag `async void` methods (except event handlers) — they can't be awaited and swallow exceptions
-- Flag `.Result`, `.Wait()`, or `.GetAwaiter().GetResult()` on `Task` — causes deadlocks in ASP.NET contexts
-- Flag missing `ConfigureAwait(false)` in library code
-
-### Nullable Reference Types
-- Flag excessive use of the null-forgiving operator (`!`) without justification
-- Ensure nullable annotations are enabled at the project level (`<Nullable>enable</Nullable>`)
-- Flag unchecked dereferences of potentially null values
-
-### Resource Management
-- Flag `IDisposable` objects not wrapped in `using` / `using var`
-- Flag `HttpClient` instantiated with `new` inside methods (should be injected or use `IHttpClientFactory`)
-- Flag `DbContext` not scoped correctly in DI
-
-### Exception Handling
-- Flag bare `catch { }` or `catch (Exception) { }` that swallows exceptions silently
-- Flag catching `Exception` when a more specific type is appropriate
-- Flag exceptions used for control flow
-
-### LINQ
-- Flag `.ToList()` / `.ToArray()` called prematurely on queryables, forcing unnecessary DB round-trips
-- Flag `First()` where `FirstOrDefault()` is safer
-- Flag complex LINQ chains that would be clearer as explicit loops
-
-### Security (ASP.NET)
-- Flag raw string interpolation in SQL queries — require parameterized queries or EF Core
-- Flag missing `[ValidateAntiForgeryToken]` on state-changing controller actions
-- Flag user-controlled data passed to `Process.Start()` or `File` APIs without validation
-- Flag hardcoded connection strings in source (should use `appsettings.json` + secrets management)
-
----
-
-## Languages Supported
-
-| Language | Extensions |
-|----------|------------|
-| Python | `.py` |
-| TypeScript | `.ts`, `.tsx` |
-| JavaScript | `.js`, `.jsx`, `.mjs` |
-| Go | `.go` |
-| Swift | `.swift` |
-| Kotlin | `.kt`, `.kts` |
-| **C# / .NET** | **`.cs`, `.csx`, `.razor`, `.cshtml`** |
+1. Create `languages/<name>.md` using any existing language file as a template — it must have sections: PR Analyzer Signals, Code Quality Checks, Security, Async, Resource Management, Exception Handling, Performance, Idioms.
+2. Add the extension row to the dispatch table above.
+3. Add the `--language` value to the Code Quality Checker comment.
+4. No other files need to change.

--- a/engineering-team/skills/code-reviewer/languages/csharp.md
+++ b/engineering-team/skills/code-reviewer/languages/csharp.md
@@ -1,0 +1,97 @@
+---
+language: csharp
+extensions: [".cs", ".csx", ".razor", ".cshtml"]
+---
+
+# C# / .NET — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only C#-specific rules and idioms.
+
+---
+
+## PR Analyzer — C# Risk Signals
+
+- `#pragma warning disable` and `[SuppressMessage]` — verify they are justified
+- `unsafe { }` blocks — require explicit sign-off
+- Null-forgiving operator (`!`) used broadly without justification
+- `dynamic` used outside of interop scenarios
+- Hardcoded connection strings in source files
+
+---
+
+## Code Quality — C# Checks
+
+- `async void` methods (except event handlers)
+- `Task` returned but not awaited
+- `IDisposable` objects not in `using` / `using var`
+- Bare `catch { }` or `catch (Exception e) { }` swallowing silently
+- Nullable reference types feature disabled at project level
+
+---
+
+## Security
+
+- Flag raw string interpolation in SQL queries — require parameterized queries (`SqlCommand`) or EF Core
+- Flag missing `[ValidateAntiForgeryToken]` on state-changing controller actions
+- Flag user-controlled data passed to `Process.Start()` or `File` APIs without validation
+- Flag hardcoded connection strings — require `appsettings.json` + secrets management
+- Flag `[AllowAnonymous]` on endpoints that should be protected
+
+---
+
+## Async / Await
+
+- Flag `async void` methods outside of event handlers — cannot be awaited and swallow exceptions
+- Flag `.Result`, `.Wait()`, or `.GetAwaiter().GetResult()` on `Task` — causes deadlocks in ASP.NET contexts
+- Flag missing `ConfigureAwait(false)` in library (non-application) code
+- Flag `Task.Run()` wrapping synchronous code inside ASP.NET request handlers unnecessarily
+- Flag `CancellationToken` not threaded through to downstream async calls
+
+---
+
+## Resource Management
+
+- Flag `IDisposable` objects (`SqlConnection`, `HttpClient`, `FileStream`, etc.) not wrapped in `using` / `using var`
+- Flag `HttpClient` instantiated with `new` inside a method — use `IHttpClientFactory` or a shared static instance to avoid socket exhaustion
+- Flag `DbContext` registered as a singleton in DI — it must be scoped
+- Flag `MemoryStream` / `MemoryCache` growing unboundedly without eviction policy
+
+---
+
+## Exception Handling
+
+- Flag `catch { }` or `catch (Exception) { }` with no logging or re-throw — silent swallow
+- Flag `catch (Exception e) { throw e; }` — resets the stack trace; use `throw;` instead
+- Flag catching `Exception` when a specific type (`IOException`, `HttpRequestException`) is appropriate
+- Flag exception filters (`when`) used for side effects that suppress the exception
+- Flag exceptions used for control flow in hot paths — use `Try*` pattern methods instead
+
+---
+
+## Performance
+
+- Flag `.ToList()` / `.ToArray()` on `IQueryable` before filtering — forces all rows into memory; filter server-side first
+- Flag `string` concatenation in loops — use `StringBuilder`
+- Flag `Enumerable.Count()` on `IQueryable` when only an existence check is needed — use `Any()`
+- Flag `await` in a loop where `Task.WhenAll()` would parallelize the work
+- Flag synchronous file or network I/O in an `async` method — use the async overload
+
+---
+
+## Idioms and Best Practices
+
+### Null Safety
+- Ensure `<Nullable>enable</Nullable>` is set in the project file
+- Flag excessive use of `!` (null-forgiving) without a comment explaining why
+- Prefer `is null` / `is not null` over `== null` for null checks
+
+### LINQ
+- Flag `First()` where `FirstOrDefault()` is safer
+- Flag complex LINQ chains that would be clearer as explicit loops
+
+### Modern C# (10+)
+- Prefer `record` types for immutable data carriers
+- Prefer `switch` expressions over `switch` statements where a value is returned
+- Prefer primary constructors (C# 12) for simple dependency injection
+- Prefer file-scoped namespaces (`namespace Foo;`) over block-scoped
+- Prefer `is` pattern matching over explicit casts

--- a/engineering-team/skills/code-reviewer/languages/go.md
+++ b/engineering-team/skills/code-reviewer/languages/go.md
@@ -1,0 +1,92 @@
+---
+language: go
+extensions: [".go"]
+---
+
+# Go — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Go-specific rules and idioms.
+
+---
+
+## PR Analyzer — Go Risk Signals
+
+- `fmt.Println` / `log.Println` debug statements left in production code
+- `//nolint` comments — verify they are justified
+- `unsafe` package imports — require explicit sign-off
+- Hardcoded credentials or tokens in source
+
+---
+
+## Code Quality — Go Checks
+
+- Errors returned but not checked (`_ = someFunc()`)
+- `panic()` used outside of package initialization
+- Goroutines started without a clear lifetime or cancellation path
+- `interface{}` / `any` used where a concrete type or typed interface would work
+- Missing context propagation (`context.Context` not threaded through call chains)
+
+---
+
+## Security
+
+- Flag `database/sql` queries built with `fmt.Sprintf` — require `?` / `$N` placeholders
+- Flag `os/exec` calls with user-controlled arguments without sanitization
+- Flag `html/template` bypassed in favor of `text/template` for HTML output
+- Flag `http.ListenAndServeTLS` with `InsecureSkipVerify: true`
+
+---
+
+## Async / Concurrency
+
+- Flag goroutines started with no clear lifetime or cancellation path — always pass `context.Context`
+- Flag goroutines that write to a channel with no receiver and no `select` default — causes a leak
+- Flag `time.Sleep()` used inside a goroutine as a synchronization mechanism
+- Flag `sync.WaitGroup.Add()` called inside the goroutine it tracks — race condition
+- Flag `sync.Mutex` copied by value — must always be used as a pointer or embedded in a struct
+
+---
+
+## Resource Management
+
+- Flag `http.Response.Body` not closed after reading — even on error paths (`defer resp.Body.Close()`)
+- Flag `os.File` not closed — use `defer f.Close()` immediately after opening
+- Flag `rows.Close()` missing after `sql.Query()` — leaks the DB connection
+- Flag `context.WithCancel` / `context.WithTimeout` cancel function not called — context and resources leak
+
+---
+
+## Exception Handling
+
+- Flag errors assigned to `_` without a comment explaining why it is safe to ignore
+- Flag errors not wrapped with `fmt.Errorf("...: %w", err)` — loses stack context
+- Flag `errors.New` / `fmt.Errorf` strings starting with a capital letter or ending in punctuation — violates Go conventions
+- Flag `panic()` used for expected runtime errors — reserve for programming errors and unrecoverable states
+- Flag `recover()` used to silently swallow panics without logging
+
+---
+
+## Performance
+
+- Flag `fmt.Sprintf` used for simple string concatenation — use `strings.Builder` or `+` for small cases
+- Flag `append()` in a tight loop without pre-allocating slice capacity — use `make([]T, 0, n)`
+- Flag `json.Marshal` / `json.Unmarshal` on large structs in hot paths — consider `json.Encoder` / streaming
+- Flag goroutines spawned per-request without a worker pool for CPU-bound tasks
+
+---
+
+## Idioms and Best Practices
+
+### Error Handling
+- All returned errors must be checked — never assign to `_` without a comment
+- Prefer wrapping with `fmt.Errorf("...: %w", err)` for stack context
+- Use `errors.Is` / `errors.As` for error inspection — never string comparison
+
+### Concurrency
+- Every goroutine must have an owner responsible for its lifetime
+- Always pass `context.Context` as the first argument to functions that do I/O or block
+- Prefer `sync.WaitGroup` or `errgroup` over ad-hoc channel coordination
+
+### Modern Go (1.18+)
+- Prefer generics over `interface{}` for container types and utility functions
+- Use `any` (alias for `interface{}`) in new code for readability

--- a/engineering-team/skills/code-reviewer/languages/java.md
+++ b/engineering-team/skills/code-reviewer/languages/java.md
@@ -1,0 +1,103 @@
+---
+language: java
+extensions: [".java"]
+---
+
+# Java — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Java-specific rules and idioms.
+
+---
+
+## PR Analyzer — Java Risk Signals
+
+- `System.out.println` / `e.printStackTrace()` left in production code
+- `@SuppressWarnings` annotations — verify they are justified
+- Hardcoded JDBC URLs or credentials in source
+- Raw type usage (`List`, `Map` without generics)
+
+---
+
+## Code Quality — Java Checks
+
+- Empty `catch` blocks swallowing exceptions silently
+- Checked exceptions caught and not re-thrown with context
+- `Closeable` / `AutoCloseable` resources not in try-with-resources
+- Raw type usage — defeats generics type safety
+- Missing `@Override` on overriding methods
+- `InterruptedException` caught without calling `Thread.currentThread().interrupt()`
+
+---
+
+## Security
+
+- Flag JPQL / HQL or native SQL string concatenation — require named parameters or `CriteriaBuilder`
+- Flag `@RequestMapping` without explicit HTTP method restriction on state-changing endpoints
+- Flag user-controlled input passed to `Runtime.exec()` or `ProcessBuilder` without validation
+- Flag `ObjectInputStream.readObject()` on untrusted data — unsafe deserialization
+- Flag hardcoded JDBC URLs or credentials — require environment variables or a vault
+
+---
+
+## Async / Concurrency
+
+- Flag `ExecutorService.submit()` return value ignored — exceptions are swallowed
+- Flag `Thread.sleep()` used as a synchronization mechanism — use `CountDownLatch`, `CompletableFuture`, or `await()`
+- Flag `CompletableFuture` chains with no `.exceptionally()` or `.handle()` terminal handler
+- Flag `InterruptedException` caught without calling `Thread.currentThread().interrupt()`
+- Flag `synchronized` on a non-final field — the lock object can be replaced
+- Flag `HashMap` used in multi-threaded context — use `ConcurrentHashMap`
+
+---
+
+## Resource Management
+
+- Flag `InputStream`, `OutputStream`, `Connection`, `ResultSet`, `PreparedStatement` not wrapped in try-with-resources
+- Flag manual `finally { resource.close() }` — replace with try-with-resources
+- Flag `HttpURLConnection` not disconnected after use
+- Flag JDBC `Connection` obtained from a pool and not returned (missing `close()`) on all paths
+- Flag `static` `HttpClient` or `Connection` fields shared across threads without connection pool management
+
+---
+
+## Exception Handling
+
+- Flag empty `catch` blocks — `catch (Exception e) {}`
+- Flag `InterruptedException` caught without `Thread.currentThread().interrupt()` — breaks cooperative cancellation
+- Flag checked exceptions swallowed in a `catch` and not re-thrown or logged with context
+- Flag `throw new RuntimeException(e)` without a descriptive message — loses context
+- Flag `printStackTrace()` as the sole error handling — use a proper logger
+
+---
+
+## Performance
+
+- Flag `String` concatenation in loops — use `StringBuilder`
+- Flag `List.contains()` / `Map.get()` in a loop on large collections — review data structure choice
+- Flag N+1 JPA / Hibernate queries — use `JOIN FETCH` or `@BatchSize`
+- Flag `new ObjectMapper()` / `new Gson()` instantiated per-request — share a singleton
+- Flag `ResultSet` fully iterated when only the first result is needed — use `LIMIT 1` in the query
+
+---
+
+## Idioms and Best Practices
+
+### Null Safety
+- Prefer returning `Optional<T>` over `null` from methods
+- Flag unchecked dereferences without a prior null guard
+- Do not catch `NullPointerException` — fix the root cause instead
+
+### Collections and Streams
+- Flag `==` used to compare `String` or boxed types — use `.equals()`
+- Flag `.collect(Collectors.toList())` where `.toList()` (Java 16+) suffices
+- Flag premature `.stream().collect()` round-trips that could be a single-pass operation
+
+### Generics
+- Flag raw types in any new code — always parameterize (`List<String>`, not `List`)
+- Flag unchecked cast warnings suppressed without explanation
+
+### Modern Java (11+)
+- Prefer `var` for local variables where the type is obvious from the right-hand side
+- Prefer records for pure data carriers over manual POJOs with getters/setters
+- Prefer `instanceof` pattern matching (`if (obj instanceof String s)`) over explicit casts
+- Prefer `switch` expressions over `switch` statements where a value is returned

--- a/engineering-team/skills/code-reviewer/languages/kotlin.md
+++ b/engineering-team/skills/code-reviewer/languages/kotlin.md
@@ -1,0 +1,88 @@
+---
+language: kotlin
+extensions: [".kt", ".kts"]
+---
+
+# Kotlin — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Kotlin-specific rules and idioms.
+
+---
+
+## PR Analyzer — Kotlin Risk Signals
+
+- `println()` statements left in production code
+- `@Suppress` annotations — verify they are justified
+- `!!` (not-null assertion) used broadly without justification
+- Hardcoded credentials or API keys in source
+
+---
+
+## Code Quality — Kotlin Checks
+
+- `!!` used broadly — prefer `?.let`, `?:`, or `requireNotNull()`
+- `lateinit var` accessed before initialization
+- Coroutines launched with `GlobalScope` — prefer scoped coroutines
+- `runBlocking` used outside of tests or top-level entry points
+
+---
+
+## Security
+
+- Flag Room / SQLite queries built with string concatenation — require parameterized queries
+- Flag `WebView.loadUrl()` with user-controlled input without validation
+- Flag credentials stored in `SharedPreferences` — require `EncryptedSharedPreferences` or Keychain
+
+---
+
+## Async / Coroutines
+
+- Flag `GlobalScope.launch` / `GlobalScope.async` in production code — use a structured scope
+- Flag `runBlocking` outside of tests or top-level main functions
+- Flag `launch` / `async` without a `CoroutineExceptionHandler` or `supervisorScope` where individual failures should not cancel siblings
+- Flag `Dispatchers.Main` used for CPU-bound work — use `Dispatchers.Default`
+- Flag coroutine cancellation not respected — long loops should check `isActive` or call `yield()`
+
+---
+
+## Resource Management
+
+- Flag `Closeable` / `AutoCloseable` not wrapped in `.use { }` (Kotlin's try-with-resources equivalent)
+- Flag `OkHttpClient` / `Retrofit` instantiated per-request — share a singleton
+- Flag `BroadcastReceiver` registered without a corresponding `unregisterReceiver` — memory / battery leak
+- Flag coroutines that hold a resource across a `suspend` point without structured cleanup in `finally`
+
+---
+
+## Exception Handling
+
+- Flag `runCatching { }.getOrNull()` used broadly — silently swallows all exceptions
+- Flag `catch (e: Exception)` in coroutines without re-throwing `CancellationException` — breaks structured concurrency
+- Flag empty `catch` blocks
+- Flag `throw RuntimeException(e)` without a descriptive message
+- Prefer typed `sealed class` error hierarchies over raw exceptions for domain errors in coroutine flows
+
+---
+
+## Performance
+
+- Flag `buildString` / `StringBuilder` not used for multi-step string construction in loops
+- Flag `List` used for frequent `contains` checks — prefer `Set`
+- Flag `flow.collect {}` re-subscribing on every recomposition in Jetpack Compose — use `collectAsStateWithLifecycle`
+- Flag `Dispatchers.IO` used for CPU-bound work — use `Dispatchers.Default`
+- Flag `suspend` functions calling non-suspend blocking APIs directly — wrap with `withContext(Dispatchers.IO)`
+
+---
+
+## Idioms and Best Practices
+
+### Null Safety
+- Prefer safe call (`?.`) and Elvis operator (`?:`) over `!!`
+- Use `requireNotNull()` / `checkNotNull()` with a descriptive message when null means a programming error
+- Prefer `val` over `var` — immutability by default
+
+### Modern Kotlin
+- Prefer `data class` for value carriers
+- Prefer `sealed class` / `sealed interface` for exhaustive `when` expressions
+- Prefer extension functions over utility classes
+- Prefer `object` declarations for singletons

--- a/engineering-team/skills/code-reviewer/languages/python.md
+++ b/engineering-team/skills/code-reviewer/languages/python.md
@@ -1,0 +1,94 @@
+---
+language: python
+extensions: [".py"]
+---
+
+# Python — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Python-specific rules and idioms.
+
+---
+
+## PR Analyzer — Python Risk Signals
+
+- `print()` statements left in production code
+- `# noqa` and `# type: ignore` comments — verify they are justified
+- `eval()` / `exec()` with any user-controlled input
+- `pickle` used to deserialize untrusted data
+- Hardcoded credentials or tokens in source
+
+---
+
+## Code Quality — Python Checks
+
+- Bare `except:` or `except Exception:` swallowing silently
+- Mutable default arguments (`def foo(items=[])`) — shared across calls
+- `import *` — pollutes namespace and hides dependencies
+- Missing type hints on public functions and methods
+- `assert` used for runtime validation — stripped by `-O` flag
+
+---
+
+## Security
+
+- Flag `eval()` / `exec()` with any user-controlled input
+- Flag `pickle.loads()` on untrusted data — use `json` or `msgpack`
+- Flag `subprocess` calls with `shell=True` and user input
+- Flag `flask.render_template_string()` with user data (SSTI)
+- Flag `SECRET_KEY` / `DEBUG = True` committed to source
+
+---
+
+## Async
+
+- Flag `asyncio.get_event_loop().run_until_complete()` inside an already-running loop
+- Flag mixing `threading` and `asyncio` without a clear bridge (`run_in_executor`)
+- Flag CPU-bound work inside an `async def` without offloading to `ProcessPoolExecutor`
+- Flag `time.sleep()` inside async functions — use `await asyncio.sleep()`
+
+---
+
+## Resource Management
+
+- Flag `open()` not used as a context manager (`with open(...) as f`)
+- Flag `requests.Session` created per-request instead of shared/reused
+- Flag database connections not closed or returned to a pool on all paths
+- Flag large files read entirely into memory with `.read()` — prefer streaming / chunked reads
+
+---
+
+## Exception Handling
+
+- Flag bare `except:` — catches `BaseException` including `KeyboardInterrupt` and `SystemExit`
+- Flag `except Exception: pass` — silently swallows errors
+- Flag re-raising with `raise e` instead of `raise` — loses the original traceback
+- Flag `except` clause too broad when the `try` block covers multiple operations with different failure modes — split them
+
+---
+
+## Performance
+
+- Flag `+` string concatenation in loops — use `"".join()`
+- Flag repeated `re.compile()` inside a loop — compile once at module level
+- Flag `list.append()` in a loop where a list comprehension would be more efficient
+- Flag `in` membership tests on `list` where the collection is large — use `set`
+- Flag loading entire large files into memory — prefer streaming or chunked reads
+
+---
+
+## Idioms and Best Practices
+
+### Type Safety
+- All public functions and methods should have type annotations
+- Prefer `X | None` (Python 3.10+) over `Optional[X]`
+- Use `TypedDict` or `dataclass` over plain `dict` for structured data
+
+### Modern Python (3.10+)
+- Prefer `match` statements over long `if/elif` chains
+- Prefer `dataclass` or `NamedTuple` over plain classes for data carriers
+- Prefer `pathlib.Path` over `os.path` for file operations
+- Prefer f-strings over `.format()` or `%` formatting
+
+### None Safety
+- Prefer explicit `if x is None` over falsy checks when `0` or `""` are valid values
+- Flag functions returning `None` implicitly — make it explicit or raise

--- a/engineering-team/skills/code-reviewer/languages/swift.md
+++ b/engineering-team/skills/code-reviewer/languages/swift.md
@@ -1,0 +1,88 @@
+---
+language: swift
+extensions: [".swift"]
+---
+
+# Swift — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Swift-specific rules and idioms.
+
+---
+
+## PR Analyzer — Swift Risk Signals
+
+- `print()` statements left in production code
+- Force unwrap (`!`) on optionals outside of tests or justified init
+- Force cast (`as!`) without a safe fallback
+- Hardcoded credentials or API keys in source
+
+---
+
+## Code Quality — Swift Checks
+
+- Force unwrap (`!`) used broadly — prefer `guard let` or `if let`
+- `try!` used outside of guaranteed-safe contexts
+- Retain cycles in closures — missing `[weak self]` or `[unowned self]`
+- `@objc` / `dynamic` used without an Objective-C interop reason
+
+---
+
+## Security
+
+- Flag credentials stored in `UserDefaults` — require Keychain
+- Flag `URLSession` requests over plain HTTP in production
+- Flag `WKWebView` loading arbitrary user-supplied URLs without validation
+
+---
+
+## Async / Concurrency
+
+- Flag `DispatchQueue.main.sync` called from the main thread — deadlock
+- Flag `@escaping` closures capturing `self` strongly in reference cycles — use `[weak self]`
+- Flag mixing `async/await` and `DispatchQueue` for the same operation without clear reasoning
+- Flag `Task { }` (unstructured) where a structured `async let` or `TaskGroup` would maintain structure
+- Flag data races — shared mutable state accessed from multiple tasks without an actor
+
+---
+
+## Resource Management
+
+- Flag `URLSessionDataTask` started with no cancellation handle stored — cannot be cancelled if the view disappears
+- Flag `NotificationCenter` observers added without a corresponding `removeObserver` — memory leak
+- Flag `CLLocationManager` / `AVCaptureSession` not stopped when the owning view controller is dismissed
+
+---
+
+## Exception Handling
+
+- Flag `try!` outside of guaranteed-safe contexts (test fixtures, constants) — crashes on failure
+- Flag `try?` discarding errors where the failure mode matters to the caller
+- Flag error types conforming to `Error` with no associated values or message — makes debugging hard
+- Flag throwing functions calling `fatalError()` as a fallback — choose one error strategy
+
+---
+
+## Performance
+
+- Flag `UIImage(named:)` called repeatedly for the same asset without caching
+- Flag synchronous network calls on the main thread
+- Flag `Array` used for frequent membership tests — prefer `Set`
+- Flag `String` interpolation inside tight loops where a pre-built string would avoid allocations
+
+---
+
+## Idioms and Best Practices
+
+### Optionals
+- Prefer `guard let` for early exit; `if let` for local scope
+- Prefer optional chaining (`?.`) over force unwrap
+- Flag implicitly unwrapped optionals (`var x: String!`) outside of `@IBOutlet`
+
+### Memory Management
+- Flag closures capturing `self` strongly in reference cycles — use `[weak self]`
+- Prefer `struct` over `class` for value semantics unless identity or inheritance is needed
+- Use `unowned` only when the lifetime is guaranteed — otherwise `weak`
+
+### Concurrency (Swift 5.5+)
+- Prefer `async/await` over completion handlers in new code
+- Flag `DispatchQueue.main.async` where `@MainActor` or `await MainActor.run` is more appropriate

--- a/engineering-team/skills/code-reviewer/languages/typescript.md
+++ b/engineering-team/skills/code-reviewer/languages/typescript.md
@@ -1,0 +1,97 @@
+---
+language: typescript
+extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"]
+---
+
+# TypeScript / JavaScript — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only TypeScript/JavaScript-specific rules and idioms.
+
+---
+
+## PR Analyzer — TypeScript / JavaScript Risk Signals
+
+- `console.log` / `debugger` statements left in production code
+- `// eslint-disable` comments — verify they are justified
+- `any` type annotations — require explicit justification
+- `@ts-ignore` / `@ts-expect-error` — verify they are justified
+- `eval()` with any dynamic or user-controlled input
+- Hardcoded API keys or tokens in source
+
+---
+
+## Code Quality — TypeScript / JavaScript Checks
+
+- `any` used broadly instead of proper typing
+- Non-null assertion (`!`) used without justification
+- `var` declarations — prefer `const` / `let`
+- Missing `await` on async function calls
+- Floating promises (no `.catch()` and no `await`)
+- `==` used instead of `===`
+
+---
+
+## Security
+
+- Flag `innerHTML`, `outerHTML`, `document.write()` with user-controlled data — use `textContent` or a sanitizer
+- Flag `dangerouslySetInnerHTML` in React without a sanitizer
+- Flag `eval()` / `new Function()` with dynamic input
+- Flag JWT decoded without signature verification
+- Flag missing `httpOnly` / `secure` flags on cookies
+
+---
+
+## Async / Promises
+
+- Flag floating promises — async calls not `await`-ed and without `.catch()`
+- Flag `Promise.all()` where `Promise.allSettled()` is safer (one failure should not cancel siblings)
+- Flag `async` functions inside `forEach` — `forEach` does not await; use `for...of` or `Promise.all()`
+- Flag unhandled promise rejection (no global `unhandledRejection` handler in Node.js services)
+
+---
+
+## Resource Management
+
+- Flag `fs.createReadStream` / `fs.createWriteStream` with no `close` or `destroy` on error
+- Flag `EventEmitter` listeners added in a loop without removal — memory leak
+- Flag `setInterval` / `setTimeout` handles not cleared when the owning component unmounts or exits
+- Flag database clients / pools not released after use in Node.js
+
+---
+
+## Exception Handling
+
+- Flag `catch (e) {}` (empty catch) — swallowed error
+- Flag `catch (e)` where `e` is used as `any` without narrowing — type the error properly
+- Flag `Promise` rejection not handled — `.catch()` or `try/await/catch` required
+- Flag re-throwing a new `Error` without wrapping the original — loses stack context
+- Use `Error` subclasses for domain errors rather than plain strings or object literals
+
+---
+
+## Performance
+
+- Flag `Array.prototype.find` / `filter` / `map` chained multiple times over the same array — combine into one pass
+- Flag DOM queries (`document.querySelector`) inside loops — cache the result
+- Flag `JSON.parse` / `JSON.stringify` in a hot path on large objects — consider streaming or partial parsing
+- Flag `async` functions called sequentially in a loop where `Promise.all()` would parallelize them
+
+---
+
+## Idioms and Best Practices
+
+### Type Safety (TypeScript)
+- Prefer `unknown` over `any` for truly unknown values — forces a type guard before use
+- Prefer type narrowing (`typeof`, `instanceof`, discriminated unions) over casting
+- Enable `strict` mode in `tsconfig.json`
+- Prefer `interface` for object shapes that may be extended; `type` for unions and aliases
+
+### Modern JavaScript / TypeScript
+- Prefer `const` by default; `let` only when reassignment is needed
+- Prefer optional chaining (`?.`) and nullish coalescing (`??`) over manual null guards
+- Prefer `structuredClone()` over manual deep-copy patterns
+- Prefer named exports over default exports for better refactoring support
+
+### Null / Undefined Safety
+- Distinguish between `null` (intentional absence) and `undefined` (not set) — be consistent
+- Flag `== null` checks that accidentally include `undefined` when only one is intended

--- a/engineering-team/skills/code-reviewer/rules/universal.md
+++ b/engineering-team/skills/code-reviewer/rules/universal.md
@@ -1,0 +1,49 @@
+# Universal Rules — All Languages
+
+These rules apply regardless of language. Load this file for every review, alongside the relevant `languages/*.md` file.
+
+---
+
+## Security
+
+- Flag any string interpolation or concatenation used to build SQL, shell, or LDAP queries — require parameterized queries or a safe API
+- Flag hardcoded credentials, API keys, tokens, or secrets anywhere in source — require environment variables or a secrets manager
+- Flag user-controlled input passed to file system, process execution, or URL redirect APIs without validation
+- Flag overly broad CORS or CSP policies
+
+---
+
+## Async / Concurrency
+
+- Flag shared mutable state accessed from multiple threads/coroutines/tasks without synchronization
+- Flag fire-and-forget async operations with no error handling path
+- Flag timeouts missing on any network or I/O call
+- Flag unbounded queues or thread pools with no backpressure mechanism
+
+---
+
+## Resource Management
+
+- Flag any resource (file, socket, DB connection, HTTP connection) acquired without a guaranteed release path
+- Flag connection pools not returned to the pool on all code paths (including exceptions)
+- Flag unbounded collections that grow without eviction — potential memory leak
+- Flag resources held open longer than the operation they serve
+
+---
+
+## Exception Handling
+
+- Flag empty catch/except blocks — swallowed exceptions hide bugs silently
+- Flag catching the broadest possible exception type (`Exception`, `Throwable`, `error`) where a specific type is appropriate
+- Flag exceptions used for normal control flow (signaling "not found", etc.) — use return values or `Optional`
+- Flag error context lost when re-throwing — always wrap with the original cause
+
+---
+
+## Performance
+
+- Flag N+1 query patterns — loading a collection then querying for each item individually
+- Flag unbounded queries or API calls with no pagination or limit
+- Flag synchronous I/O on a thread or event loop that serves concurrent requests
+- Flag large objects serialized/deserialized repeatedly when they could be cached
+- Flag string concatenation in tight loops — use a builder or join


### PR DESCRIPTION
## Summary
Refactors the code-reviewer skill into a leaner 9-file hybrid that scales cleanly as new languages are added.
rules/universal.md — all cross-language universal rules in one place (security, async, resource management, exceptions, performance)
languages/*.md — each language file is fully self-contained with its own Security / Async / Resource Management / Exception Handling / Performance / Idioms sections; no cross-references
Every review loads exactly 2 files: universal.md + one language file

Also adds Java support (languages/java.md) and a clear "Adding a new language" guide in SKILL.md — adding a new language requires creating one file only.

## Checklist

- [X ] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [X] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [X] Scripts (if any) run with `--help` without errors
- [X ] No hardcoded API keys, tokens, or secrets
- [X ] No vendor-locked dependencies without open-source fallback
- [ X] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [X] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

Verified the refactored skill against the following scenarios:
Each language file is self-contained, confirmed no remaining cross-references to the removed rules files
All previously supported languages (Python, TypeScript, JavaScript, Go, Swift, Kotlin, C#) retain their full rule sets, no content was dropped, only reorganized
New Java language file covers all 7 required sections: PR signals, code quality checks, security, async, resource management, exception handling, and idioms
rules/universal.md verified to contain no language-specific content, universal rules only
Dispatch table in SKILL.md maps all extensions correctly including new .java
"Adding a new language" guide tested manually, creating a stub language file and following the 4 steps produces a correctly wired skill
