### PR TITLE
Add LaunchMyStore — universal SKILL.md skill for the LaunchMyStore e-commerce platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 |---------|-------------|
 | [**Claude Code Skills & Agents Factory**](https://github.com/alirezarezvani/claude-code-skills-agents-factory) | Methodology for building skills at scale |
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
+| [**LaunchMyStore**](https://github.com/LaunchMyStore/skill) | Universal SKILL.md skill for the LaunchMyStore e-commerce platform — `lms` CLI scaffolding, App Bridge actions, WASM Functions (cart transform / discount / shipping / payment / delivery / order validation), Aqua/Liquid themes, and a 130+ tool MCP server for managing a real merchant store. Installs into Claude Code, OpenAI Codex, Cursor, Gemini CLI, Windsurf, Antigravity, Aider, OpenCode and more |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
 | [**toprank**](https://github.com/nowork-studio/toprank) | 9 SEO and Google Ads skills for Claude Code — connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag, schema markup, and keyword bid fixes to source or CMS. MIT, 107 stars |
 


### PR DESCRIPTION
## What

Adds **LaunchMyStore** — a universal SKILL.md skill for the LaunchMyStore e-commerce platform.

A single `/launchmystore` invocation routes plain-English intent to the right developer surface:

- **`@launchmystore/cli`** — scaffold apps, push extensions, build & deploy WASM Functions, tail webhooks
- **`@launchmystore/app-bridge`** + **`@launchmystore/app-bridge-react`** — 21 action families (Toast, Modal, ResourcePicker, SessionToken, TitleBar, …)
- **6 WASM Function types** — cart transform, discount, shipping rate, payment customization, delivery customization, order validation. Compiled locally with Javy, deployed via `lms function deploy --wasm`.
- **Aqua themes** — Liquid-dialect sections, blocks, snippets, section groups, settings schema, and the `{owner}.metafields.{namespace}.{key}` access pattern
- **LaunchMyStore MCP server** — 130+ tools for products, orders, customers, themes, billing, analytics (`chat_with_data`, `nightly_briefing`, etc.)

## Universal install

Built on the open **SKILL.md** standard — works identically in Claude Code, Claude.ai, the Claude API, OpenAI Codex, Cursor, Gemini CLI, Windsurf, Antigravity, Aider, OpenCode, Kilo Code, Augment, Hermes Agent, and Mistral Vibe.

- **npm:** `npm install -g @launchmystore/claude-skill` (postinstall fans out to every detected host)
- **Plugin marketplace:** `/plugin marketplace add LaunchMyStore/skill` then `/plugin install launchmystore@launchmystore`
- **Manual clone:** `git clone https://github.com/LaunchMyStore/skill ~/.skills/launchmystore`

## Repo

<https://github.com/LaunchMyStore/skill> · MIT licensed · v1.1.0

49 files, ~108 KB unpacked: SKILL.md + 10 references (~57 KB total) + worked examples for every function type and theme primitive + an admin-block App Bridge sample.

## Checklist

- [x] Skill is publicly available on GitHub with an open-source licence (MIT)
- [x] Published to npm under `@launchmystore/claude-skill`
- [x] Description is specific and accurate
- [x] No duplicate of an existing entry
- [x] Alphabetical position preserved
