### PR TITLE
fix(marketplace): give duplicate handoff plugins unique names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -879,7 +879,7 @@
       "category": "development"
     },
     {
-      "name": "handoff",
+      "name": "handoff-engineering",
       "source": "./engineering/handoff",
       "description": "Conversation-handoff document generator. Compacts the current session into a markdown handoff for a fresh agent — references existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL instead of duplicating them. Derived from Matt Pocock's MIT-licensed handoff with: (1) 3 stdlib Python tools (template generator tailored to 5 next-session emphases, artifact deduplicator across 5 categories of duplication, skill recommender matching content to 14 skills in this repo), (2) 4 references citing 7-8 sources (handoff structure, deduplication discipline, next-session skill matching, companion tooling), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline + mktemp convention preserved verbatim per MIT.",
       "version": "2.6.0",
@@ -971,7 +971,7 @@
       "category": "productivity"
     },
     {
-      "name": "handoff",
+      "name": "handoff-productivity",
       "source": "./productivity/handoff",
       "description": "Compact the current conversation into a handoff document for another agent to pick up. Configurable save location, redaction enforcement, SessionStart auto-load + SessionEnd reminder, self-check fidelity script, --refresh flag, mtime-guarded cleanup. Inspired by Matt Pocock's handoff (MIT).",
       "version": "2.8.2",


### PR DESCRIPTION
## Summary

Maintainer-branch version of the fix in #744 (by @stanleynguyen), applied directly on a `dev`-targeting branch so it lands cleanly without the stale `check-target` CI artifact that affects the fork PR.

Both `./engineering/handoff` and `./productivity/handoff` were registered with the same `"name": "handoff"` in `marketplace.json`. Duplicate names pass the local `/plugin marketplace add` CLI but fail Claude.ai's stricter marketplace sync (used by Cowork), producing "Failed to add marketplace". Renamed to `handoff-engineering` and `handoff-productivity`.

## Changes
- `.claude-plugin/marketplace.json`: rename the two duplicate `handoff` entries (2 lines). No `source` path, version, or plugin contents changed.

## Verification
- `marketplace.json` parses as valid JSON; 61 plugins, **0 duplicate names** remaining.
- `scripts/check_plugin_json.py --all` passes.

## Credit
Same fix as #744 by @stanleynguyen — re-applied on a maintainer branch to bypass the stale main-target check. Close #744 in favor of this, or merge #744 directly if you prefer.

https://claude.ai/code/session_01DjuELpoFdFbFscr3kAatni

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjuELpoFdFbFscr3kAatni)_