### PR TITLE
chore(versioning,docs): normalize stale versions to 2.9.0 + refresh repo counts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
   },
-  "description": "329 production-ready skill packages for Claude AI across 14 domains: engineering advanced (76 — incl. 4 Matt Pocock-derived productivity skills + v2.7.3 security-guidance PreToolUse hook), engineering core (51), marketing (47 — incl. v2.7.3 AEO/Answer Engine Optimization), c-level advisory (66), product (17), regulatory/QMS (18), project management (9), business growth (5), finance (4), productivity (6), marketing top-level (2, v2.7.0), research (8, v2.7.0), business-operations (7, v2.8.0), and commercial (8, v2.8.0). Includes ~444 Python tools, ~598 reference documents, 49+ agents, 79+ slash commands.",
+  "description": "338 production-ready skill packages for Claude AI across 16 domains: engineering advanced (78), engineering core (51), marketing (46 — incl. AEO/Answer Engine Optimization), c-level advisory (66), product (17), regulatory/QMS (18), compliance-os (9), project management (9), business growth (5), finance (4), productivity (6), marketing top-level (1), research (8), research-ops (5, v2.9.0), business-operations (7), and commercial (8). Includes 533 Python tools, 676 reference documents, 51+ agents, 87+ slash commands across 62 marketplace plugins.",
   "homepage": "https://github.com/alirezarezvani/claude-skills",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "metadata": {
-    "description": "329 production-ready skill packages across 14 domains (engineering, marketing, product, c-level, project management, RA/QM, business growth, finance, productivity, marketing (top-level), research, business-operations [v2.8.0], commercial [v2.8.0], plus standards). ~444 Python tools, ~598 reference guides, 49+ agents (cs-* + personas), 79+ slash commands. v2.8.0 adds 2 new top-level domains (business-operations + commercial) with 15 new skills, context: fork chaining via Matt Pocock grill-with-docs discipline. v2.7.3 adds AEO + security-guidance PreToolUse hook. Compatible with Claude Code, Codex CLI, Gemini CLI, Cursor, OpenClaw, Hermes Agent, Mistral Vibe, and 5 more coding agents.",
-    "version": "2.8.0"
+    "description": "338 production-ready skills across 16 domains (engineering, engineering-core, marketing, product, c-level, compliance-os, project management, RA/QM, business growth, finance, productivity, marketing (top-level), research, research-ops, business-operations, commercial, plus standards). 533 Python tools, 676 reference guides, 51+ agents (cs-* + personas), 87+ slash commands across 62 marketplace plugins. v2.9.0 adds the research-ops domain — enterprise Research Operations (clinical-research + research-finance + market-research + product-research + orchestrator) with per-skill onboarding, customization config, and an opt-in autoresearch bridge. Compatible with Claude Code, Codex CLI, Gemini CLI, Cursor, OpenClaw, Hermes Agent, Mistral Vibe, and 5 more coding agents.",
+    "version": "2.9.0"
   },
   "plugins": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **comprehensive skills library** for Claude AI and Claude Code - reusable, production-ready skill packages that bundle domain expertise, best practices, analysis tools, and strategic frameworks. The repository provides modular skills that teams can download and use directly in their workflows.
 
-**Current Scope:** 335 production-ready skills across 15 domains with ~475 Python automation tools, ~602 reference guides, 51+ agents (cs-* + 7 personas), and 87+ slash commands. **v2.9.0 (complete)** added the **research-ops/** top-level domain — enterprise Research Operations (orchestrator + clinical-research + research-finance + market-research + product-research), the managed counterpart to the academic research/ domain, with `context: fork` orchestration and a Matt Pocock "Forcing-question library" in every SKILL.md plus `/cs:grill-research-ops`. **v2.8.0 (complete)** added 2 new top-level domains — **business-operations/** (7 internal-ops skills: orchestrator + process-mapper + vendor-management + capacity-planner + internal-comms + knowledge-ops + procurement-optimizer) and **commercial/** (8 per-deal-economics skills: orchestrator + pricing-strategist + deal-desk + partnerships-architect + channel-economics + commercial-policy + rfp-responder + commercial-forecaster) — with orchestrator skills using `context: fork` for chaining, Matt Pocock docs-anchored "Forcing-question library" in every SKILL.md, plus `/cs:grill-bizops` and `/cs:grill-commercial`. **v2.8.2** adds a productivity-shaped `handoff` skill (sibling to engineering/handoff) inspired by Matt Pocock — first-run setup with configurable save location, redaction linter, SessionStart + SessionEnd hooks, fidelity self-check, `--refresh` flag. **v2.8.1** upgraded the engineering role-skills (senior-fullstack / senior-frontend / senior-backend) with karpathy-coder + Matt Pocock decision engines + per-role forcing questions. v2.7.3 ports `alirezarezvani/aeo-box` — AEO (Answer Engine Optimization) skill into marketing-skill/ + security-guidance PreToolUse hook into engineering/. v2.7.0 added 13 Path-B skills across 3 top-level domains (productivity, marketing, research). v2.6.0 added 4 Matt Pocock-derived productivity skills.
+**Current Scope:** 338 production-ready skills across 16 domains with 533 Python automation tools, 676 reference guides, 51+ agents (cs-* + 7 personas), and 87+ slash commands, distributed as 62 marketplace plugins. **v2.9.0 (complete)** added the **research-ops/** top-level domain — enterprise Research Operations (orchestrator + clinical-research + research-finance + market-research + product-research), the managed counterpart to the academic research/ domain, with `context: fork` orchestration and a Matt Pocock "Forcing-question library" in every SKILL.md plus `/cs:grill-research-ops`. **v2.8.0 (complete)** added 2 new top-level domains — **business-operations/** (7 internal-ops skills: orchestrator + process-mapper + vendor-management + capacity-planner + internal-comms + knowledge-ops + procurement-optimizer) and **commercial/** (8 per-deal-economics skills: orchestrator + pricing-strategist + deal-desk + partnerships-architect + channel-economics + commercial-policy + rfp-responder + commercial-forecaster) — with orchestrator skills using `context: fork` for chaining, Matt Pocock docs-anchored "Forcing-question library" in every SKILL.md, plus `/cs:grill-bizops` and `/cs:grill-commercial`. **v2.8.2** adds a productivity-shaped `handoff` skill (sibling to engineering/handoff) inspired by Matt Pocock — first-run setup with configurable save location, redaction linter, SessionStart + SessionEnd hooks, fidelity self-check, `--refresh` flag. **v2.8.1** upgraded the engineering role-skills (senior-fullstack / senior-frontend / senior-backend) with karpathy-coder + Matt Pocock decision engines + per-role forcing questions. v2.7.3 ports `alirezarezvani/aeo-box` — AEO (Answer Engine Optimization) skill into marketing-skill/ + security-guidance PreToolUse hook into engineering/. v2.7.0 added 13 Path-B skills across 3 top-level domains (productivity, marketing, research). v2.6.0 added 4 Matt Pocock-derived productivity skills.
 
 **Key Distinction**: This is NOT a traditional application. It's a library of skill packages meant to be extracted and deployed by users into their own Claude workflows.
 
@@ -50,17 +50,21 @@ This repository uses **modular documentation**. For domain-specific guidance, se
 ```
 claude-code-skills/
 ├── .claude-plugin/            # Plugin registry (marketplace.json)
-├── agents/                    # 27 agents (20 cs-* + 7 personas)
-├── commands/                  # 33 slash commands (changelog, tdd, saas-health, prd, code-to-prd, plugin-audit, sprint-plan, slo-design, etc.)
-├── engineering-team/          # 32 core engineering skills + Playwright Pro + Self-Improving Agent + Security Suite
-├── engineering/               # 44 POWERFUL-tier advanced skills (incl. AgentHub, self-eval, llm-wiki, tc-tracker, ship-gate, slo-architect, write-a-skill, caveman, grill-me, handoff)
-├── product-team/              # 13 product skills (incl. apple-hig-expert) + Python tools
-├── marketing-skill/           # 44 marketing skills (7 pods) + Python tools
-├── c-level-advisor/           # 28 C-level advisory skills (10 roles + orchestration)
+├── agents/                    # 32 standalone agents (cs-* + 7 personas); 51+ cs-* agents repo-wide
+├── commands/                  # slash commands (changelog, tdd, saas-health, prd, code-to-prd, plugin-audit, sprint-plan, slo-design, etc.); 87+ repo-wide
+├── engineering-team/          # 51 core engineering skills + Playwright Pro + Self-Improving Agent + Security Suite
+├── engineering/               # 78 POWERFUL-tier advanced skills (incl. AgentHub, autoresearch-agent, self-eval, llm-wiki, tc-tracker, ship-gate, slo-architect, write-a-skill, caveman, grill-me, handoff)
+├── product-team/              # 17 product skills (incl. apple-hig-expert) + Python tools
+├── marketing-skill/           # 46 marketing skills (8 pods) + Python tools
+├── c-level-advisor/           # 66 C-level advisory skills (full C-suite + founder-mode agents + orchestration)
 ├── project-management/        # 9 PM skills + bundled Atlassian Remote MCP (.mcp.json)
-├── ra-qm-team/                # 14 RA/QM compliance skills
+├── ra-qm-team/                # 18 RA/QM compliance skills
+├── compliance-os/             # 9 compliance-OS skills
 ├── business-growth/           # 5 business & growth skills + Python tools
-├── finance/                   # 3 finance skills + Python tools
+├── business-operations/       # 7 internal-ops skills (orchestrator + 6 sub-skills)
+├── commercial/                # 8 per-deal-economics skills (orchestrator + 7 sub-skills)
+├── finance/                   # 4 finance skills + Python tools
+├── research/                  # 8 academic research skills (orchestrator + 7 specialists)
 ├── research-ops/              # 5 research-ops skills (orchestrator + clinical-research + research-finance + market-research + product-research)
 ├── eval-workspace/            # Skill evaluation results (Tessl)
 ├── standards/                 # 5 standards library files
@@ -150,7 +154,7 @@ New `research-ops/` top-level domain — the enterprise / cross-functional count
 - **`market-research`** — upstream sizing/survey/segmentation methodology (not campaign analytics `marketing-skill`). 3 tools: `market_sizer.py` (TAM/SAM/SOM both top-down AND bottoms-up + triangulation flag, never a single number), `sample_size_planner.py` (survey n + FPC + per-segment minima), `segmentation_scorer.py` (Kotler 5-criteria + substantiality/accessibility gate). Canon: Cochran, Dillman, Groves, Kotler, Bessemer/a16z sizing.
 - **`product-research`** — product/user research method + insight-repository discipline (not persona/journey/live-A-B `product-team`). 3 tools: `study_designer.py` (goal×stage → method + plan skeleton), `saturation_planner.py` (Nielsen-5 / Guest-12 with explicit confidence), `insight_synthesizer.py` (clusters coded observations, flags single-source anecdotes — never promotes them). Canon: Portigal, JTBD, Rohrer (NN/g), Nielsen, Guest et al., ResearchOps/Polaris.
 - **Hard rules:** clinical outputs are estimates + named clinical owner (never fact); finance surfaces assumptions and routes treatment to a named finance owner (never auto-decides); market sizes show method + assumptions (never a single number); product insights require recurrence across independent participants. `cs-research-ops-orchestrator` agent + `/cs:research-ops` router + `/cs:grill-research-ops` (Matt docs-anchored grilling) + 4 per-skill commands.
-- **Onboarding + customization + autoresearch (per sub-skill, isolated):** each sub-skill ships `onboard.py` (its own question set), `config_loader.py` (a customization config consumed by every tool, project>global>defaults precedence, `RESEARCH_OPS_NO_CONFIG=1` bypass), and `ar_evaluator.py` — an opt-in, locked-ground-truth bridge to `engineering/autoresearch-agent` (loop edits the skill's input file; metrics: clinical `feasibility_composite`↑, finance `runway_months`↑, market `tam_divergence`↓, product `validated_insights`↑). 24 stdlib tools total (12 analysis + 12 onboarding/customization/autoresearch; all pass `--help`/`--sample`), 12 reference docs (5-7 sources each). Marketplace 61 → 62 plugins; domains 14 → 15.
+- **Onboarding + customization + autoresearch (per sub-skill, isolated):** each sub-skill ships `onboard.py` (its own question set), `config_loader.py` (a customization config consumed by every tool, project>global>defaults precedence, `RESEARCH_OPS_NO_CONFIG=1` bypass), and `ar_evaluator.py` — an opt-in, locked-ground-truth bridge to `engineering/autoresearch-agent` (loop edits the skill's input file; metrics: clinical `feasibility_composite`↑, finance `runway_months`↑, market `tam_divergence`↓, product `validated_insights`↑). 24 stdlib tools total (12 analysis + 12 onboarding/customization/autoresearch; all pass `--help`/`--sample`), 12 reference docs (5-7 sources each). Marketplace 61 → 62 plugins; domains 15 → 16.
 
 **v2.8.3** shipped the Mistral Vibe cross-platform sync (`scripts/sync-vibe-skills.py`, `~/.vibe/skills/claude-skills/`) — bringing first-class tool support to 13 coding agents.
 
@@ -431,4 +435,4 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
 
 **Last Updated:** May 27, 2026
 **Version:** v2.9.0
-**Status:** 335 skills deployed across 15 domains, 62 marketplace plugins, docs site live
+**Status:** 338 skills deployed across 16 domains, 62 marketplace plugins, docs site live

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Claude Code Skills & Plugins — Agent Skills for Every Coding Tool
 
-**313 production-ready Claude Code skills, plugins, and agent skills for 12 AI coding tools.**
+**338 production-ready Claude Code skills, plugins, and agent skills for 13 AI coding tools.**
 
-The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 7 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing (incl. v2.7.3 AEO — Answer Engine Optimization for LLM citation), security (PreToolUse hooks), compliance, C-level advisory (incl. founder-mode CFO/CMO/CRO/CPO/COO/CHRO/CISO/GC/CDO/CAIO/CCO/VPE personas + 21 /cs:* slash commands), productivity (capture/email/reflect), and a complete research stack (litreview/grants/dossier/patent/syllabus/pulse/notebooklm + hybrid router).
+The most comprehensive open-source library of Claude Code skills and agent plugins — also works with OpenAI Codex, Gemini CLI, Cursor, and 9 more coding agents. Reusable expertise packages covering engineering, DevOps, marketing (incl. AEO — Answer Engine Optimization for LLM citation), security (PreToolUse hooks), compliance, C-level advisory (incl. founder-mode CFO/CMO/CRO/CPO/COO/CHRO/CISO/GC/CDO/CAIO/CCO/VPE personas + 21 /cs:* slash commands), productivity (capture/email/reflect), an academic research stack (litreview/grants/dossier/patent/syllabus/pulse/notebooklm + hybrid router), and enterprise Research Operations (clinical-research/research-finance/market-research/product-research, v2.9.0).
 
 **Works with:** Claude Code · OpenAI Codex · Gemini CLI · OpenClaw · Hermes Agent[^hermes] · Mistral Vibe[^vibe] · Cursor · Aider · Windsurf · Kilo Code · OpenCode · Augment · Antigravity
 
-[^hermes]: Hermes Agent is **BYO-sync tier**: the repo ships a pre-generated `.hermes/skills/claude-skills/` tree (305 skills across 12 domains as of v2.7.3), but you run `python scripts/sync-hermes-skills.py` once locally to install into `~/.hermes/skills/`. Uses the same agentskills.io SKILL.md standard — no format conversion.
-[^vibe]: Mistral Vibe is also **BYO-sync tier**: the repo ships a pre-generated `.vibe/skills/claude-skills/` tree (306 skills across 14 domains), run `./scripts/vibe-install.sh` once locally to install into `~/.vibe/skills/`. Same agentskills.io SKILL.md standard — no format conversion. Docs: <https://docs.mistral.ai/mistral-vibe/agents-skills>.
+[^hermes]: Hermes Agent is **BYO-sync tier**: the repo ships a pre-generated `.hermes/skills/claude-skills/` tree, but you run `python scripts/sync-hermes-skills.py` once locally to install into `~/.hermes/skills/`. Uses the same agentskills.io SKILL.md standard — no format conversion.
+[^vibe]: Mistral Vibe is also **BYO-sync tier**: the repo ships a pre-generated `.vibe/skills/claude-skills/` tree, run `./scripts/vibe-install.sh` once locally to install into `~/.vibe/skills/`. Same agentskills.io SKILL.md standard — no format conversion. Docs: <https://docs.mistral.ai/mistral-vibe/agents-skills>.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/Skills-330-brightgreen?style=for-the-badge)](#skills-overview)
-[![Agents](https://img.shields.io/badge/Agents-49+-blue?style=for-the-badge)](#agents)
+[![Skills](https://img.shields.io/badge/Skills-338-brightgreen?style=for-the-badge)](#skills-overview)
+[![Agents](https://img.shields.io/badge/Agents-51+-blue?style=for-the-badge)](#agents)
 [![Personas](https://img.shields.io/badge/Personas-7-purple?style=for-the-badge)](#personas)
-[![Commands](https://img.shields.io/badge/Commands-79+-orange?style=for-the-badge)](#commands)
+[![Commands](https://img.shields.io/badge/Commands-87+-orange?style=for-the-badge)](#commands)
 [![Stars](https://img.shields.io/github/stars/alirezarezvani/claude-skills?style=for-the-badge)](https://github.com/alirezarezvani/claude-skills/stargazers)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1?style=for-the-badge)](https://getskillcheck.com)
 
@@ -26,10 +26,10 @@ The most comprehensive open-source library of Claude Code skills and agent plugi
 Claude Code skills (also called agent skills or coding agent plugins) are modular instruction packages that give AI coding agents domain expertise they don't have out of the box. Each skill includes:
 
 - **SKILL.md** — structured instructions, workflows, and decision frameworks
-- **Python tools** — ~402 CLI scripts (all stdlib-only, zero pip installs)
-- **Reference docs** — templates, checklists, and domain-specific knowledge
+- **Python tools** — 533 CLI scripts (all stdlib-only, zero pip installs)
+- **Reference docs** — 676 templates, checklists, and domain-specific knowledge files
 
-**One repo, twelve platforms.** Works natively as Claude Code plugins, Codex agent skills, Gemini CLI skills, Hermes Agent skills, Mistral Vibe skills, and converts to 7 more tools via `scripts/convert.sh`. All ~402 Python tools run anywhere Python runs.
+**One repo, thirteen platforms.** Works natively as Claude Code plugins, Codex agent skills, Gemini CLI skills, Hermes Agent skills, Mistral Vibe skills, and converts to more tools via `scripts/convert.sh`. All 533 Python tools run anywhere Python runs.
 
 ### Skills vs Agents vs Personas
 
@@ -108,7 +108,7 @@ git clone https://github.com/alirezarezvani/claude-skills.git
 
 ## Multi-Tool Support (New)
 
-**Convert all 156 skills to 7 AI coding tools** with a single script:
+**Convert all 338 skills to 9 AI coding tools** with a single script:
 
 | Tool | Format | Install |
 |------|--------|---------|
@@ -135,11 +135,11 @@ git clone https://github.com/alirezarezvani/claude-skills.git
 ./scripts/install.sh --tool aider --target . --force
 
 # 3. Verify
-find .cursor/rules -name "*.mdc" | wc -l  # Should show 156
+find .cursor/rules -name "*.mdc" | wc -l  # Should show 338
 ```
 
 **Each tool gets:**
-- ✅ All 156 skills converted to native format
+- ✅ All 338 skills converted to native format
 - ✅ Per-tool README with install/verify/update steps
 - ✅ Support for scripts, references, templates where applicable
 - ✅ Zero manual conversion work
@@ -150,24 +150,26 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 
 ## Skills Overview
 
-**313 skills across 12 domains:**
+**338 skills across 16 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|
-| **🔧 Engineering — Core** | 32 | Architecture, frontend, backend, fullstack, QA, DevOps, SecOps, AI/ML, data, Playwright, self-improving agent, security suite (6), a11y audit | [engineering-team/](engineering-team/) |
-| **🎭 Playwright Pro** | 9+3 | Test generation, flaky fix, Cypress/Selenium migration, TestRail, BrowserStack, 55 templates | [engineering-team/playwright-pro](engineering-team/playwright-pro/) |
-| **🧠 Self-Improving Agent** | 5+2 | Auto-memory curation, pattern promotion, skill extraction, memory health | [engineering-team/self-improving-agent](engineering-team/self-improving-agent/) |
-| **⚡ Engineering — POWERFUL** | 45 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval, llm-wiki, tc-tracker, **reliability portfolio** (feature-flags-architect, kubernetes-operator, chaos-engineering, slo-architect), ship-gate, **security-guidance** (✨v2.7.3 — PreToolUse hook catching 12 anti-patterns), **Matt Pocock skills** (write-a-skill, caveman, grill-me, handoff, grill-with-docs) | [engineering/](engineering/) |
-| **🎯 Product** | 13 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder, analytics, experiment designer, discovery, roadmap communicator, code-to-prd, apple-hig-expert | [product-team/](product-team/) |
-| **📣 Marketing** | 45 | 8 pods: Content (8), SEO + AEO (6 incl. ✨v2.7.3 `aeo` — E-E-A-T audit, citation tracking across 5 LLMs), CRO (6), Channels (6), Growth (4), Intelligence (4), Sales (2) + context foundation + orchestration router. 58 Python tools. | [marketing-skill/](marketing-skill/) |
-| **🚀 Productivity** ✨v2.8.4 | 6 | `capture` (brain-dump-to-action), `email` pair (inbox-setup + inbox-triage with 7-file KB contract), `reflect` (light-prompt journal), **`handoff`** (Matt Pocock-inspired: first-run setup, redaction linter, SessionStart + SessionEnd hooks, fidelity self-check, `--refresh`), **`andreessen`** (✨v2.8.4 — market-first decision & productivity mode: market > team > product, PMF-first, 3x5-card + Anti-Todo, fixed anti-sycophancy operating prompt). Path-B from megaprompts 05-08 + Matt Pocock + Andreessen derivation. | [productivity/](productivity/) |
-| **🎨 Marketing (top-level)** ✨v2.7.0 | 1 | `landing` — single-file HTML landing-page generator (4 design styles, GSAP patterns, brand palette validator). Path-B from megaprompt 04. | [marketing/](marketing/) |
-| **🔬 Research** ✨v2.7.0 | 8 | `research` orchestrator (hybrid router + fallback, megaprompt 13) + 7 specialists: `pulse` (recency), `litreview` (academic), `grants` (NIH), `dossier` (entity), `patent` (prior-art), `syllabus` (course reading), `notebooklm` (browser-automation). | [research/](research/) |
+| **🔧 Engineering — Core** | 51 | Architecture, frontend, backend, fullstack, QA, DevOps, SecOps, AI/ML, data, Playwright Pro (test gen, flaky fix, migrations), self-improving agent (auto-memory curation), security suite, a11y audit | [engineering-team/](engineering-team/) |
+| **⚡ Engineering — POWERFUL** | 78 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval, llm-wiki, tc-tracker, autoresearch-agent, **reliability portfolio** (feature-flags-architect, kubernetes-operator, chaos-engineering, slo-architect), ship-gate, security-guidance PreToolUse hook, **Matt Pocock skills** (write-a-skill, caveman, grill-me, handoff, grill-with-docs) | [engineering/](engineering/) |
+| **🎯 Product** | 17 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder, analytics, experiment designer, discovery, roadmap communicator, code-to-prd, apple-hig-expert | [product-team/](product-team/) |
+| **📣 Marketing** | 46 | 8 pods: Content, SEO + AEO (`aeo` — E-E-A-T audit, citation tracking across 5 LLMs), CRO, Channels, Growth, Intelligence, Sales + context foundation + orchestration router | [marketing-skill/](marketing-skill/) |
+| **🚀 Productivity** | 6 | `capture` (brain-dump-to-action), `email` pair (inbox-setup + inbox-triage), `reflect` (journal), `handoff` (Matt Pocock-inspired), `andreessen` (market-first decision mode) | [productivity/](productivity/) |
+| **🎨 Marketing (top-level)** | 1 | `landing` — single-file HTML landing-page generator (4 design styles, GSAP patterns, brand palette validator) | [marketing/](marketing/) |
+| **🔬 Research (academic)** | 8 | `research` orchestrator (hybrid router + fallback) + 7 specialists: `pulse`, `litreview`, `grants` (NIH), `dossier`, `patent`, `syllabus`, `notebooklm` | [research/](research/) |
+| **🧪 Research Operations** ✨v2.9.0 | 5 | Enterprise/cross-functional research: orchestrator + `clinical-research` (study design), `research-finance` (R&D program finance), `market-research` (sizing/survey/segmentation), `product-research` (user research) — each with onboarding + customization + opt-in autoresearch bridge | [research-ops/](research-ops/) |
 | **📋 Project Management** | 9 | Senior PM, scrum master, Jira, Confluence, Atlassian admin, templates + bundled Atlassian Remote MCP | [project-management/](project-management/) |
-| **🏥 Regulatory & QM** | 14 | ISO 13485, MDR 2017/745, FDA, ISO 27001, GDPR, SOC 2, CAPA, risk management | [ra-qm-team/](ra-qm-team/) |
-| **💼 C-Level Advisory** | 28 | Full C-suite (10 roles) + orchestration + board meetings + culture & collaboration | [c-level-advisor/](c-level-advisor/) |
+| **🏥 Regulatory & QM** | 18 | ISO 13485, MDR 2017/745, FDA, ISO 27001, GDPR, SOC 2, CAPA, risk management | [ra-qm-team/](ra-qm-team/) |
+| **🛡️ Compliance OS** | 9 | Compliance operating system — controls, evidence, audit-readiness workflows | [compliance-os/](compliance-os/) |
+| **💼 C-Level Advisory** | 66 | Full C-suite (CEO/CTO/CFO/CMO/CRO/CPO/COO/CHRO/CISO/GC/CDO/CAIO/CCO/VPE) + founder-mode agents + orchestration + board meetings + culture & collaboration | [c-level-advisor/](c-level-advisor/) |
 | **📈 Business & Growth** | 5 | Customer success, sales engineer, revenue ops, contracts & proposals, BizDev toolkit | [business-growth/](business-growth/) |
-| **💰 Finance** | 3 | Financial analyst (DCF, budgeting, forecasting), SaaS metrics coach, business investment advisor | [finance/](finance/) |
+| **🏭 Business Operations** | 7 | Orchestrator + process-mapper, vendor-management, capacity-planner, internal-comms, knowledge-ops, procurement-optimizer | [business-operations/](business-operations/) |
+| **🤝 Commercial** | 8 | Orchestrator + pricing-strategist, deal-desk, partnerships-architect, channel-economics, commercial-policy, rfp-responder, commercial-forecaster | [commercial/](commercial/) |
+| **💰 Finance** | 4 | Financial analyst (DCF, budgeting, forecasting), SaaS metrics coach, business investment advisor | [finance/](finance/) |
 
 ---
 
@@ -304,7 +306,7 @@ for MDR Annex II compliance gaps.
 
 ## Python Analysis Tools
 
-~402 CLI tools ship with the skills (all verified, stdlib-only):
+533 CLI tools ship with the skills (all verified, stdlib-only):
 
 ```bash
 # SaaS health check
@@ -351,7 +353,7 @@ Yes. Skills work natively with 13 tools: Claude Code, OpenAI Codex, Gemini CLI, 
 No. We follow semantic versioning and maintain backward compatibility within patch releases. Existing script arguments, plugin source paths, and SKILL.md structures are never changed in patch versions. See the [CHANGELOG](CHANGELOG.md) for details on each release.
 
 **Are the Python tools dependency-free?**
-Yes. All ~402 Python CLI tools use the standard library only — zero pip installs required. Every script is verified to run with `--help`.
+Yes. All 533 Python CLI tools use the standard library only — zero pip installs required. Every script is verified to run with `--help`.
 
 **How do I create my own Claude Code skill?**
 Each skill is a folder with a `SKILL.md` (frontmatter + instructions), optional `scripts/`, `references/`, and `assets/`. See the [Skills & Agents Factory](https://github.com/alirezarezvani/claude-code-skills-agents-factory) for a step-by-step guide.

--- a/business-growth/.claude-plugin/plugin.json
+++ b/business-growth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-growth-skills",
   "description": "5 business & growth skills: customer success manager, sales engineer, revenue operations, contract & proposal writer, and BizDev-toolkit. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.2.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/business-growth",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/business-growth/skills/business-growth-skills/SKILL.md
+++ b/business-growth/skills/business-growth-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "business-growth-skills"
 description: "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only)."
-version: 1.1.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/c-level-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "c-level-skills",
   "description": "33 C-level advisory skills + c-level-agents plugin layer (13 cs-* persona agents + 21 /cs:* slash commands). Complete virtual board of directors with CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO advisors plus General Counsel, Chief Data Officer, Chief AI Officer, Chief Customer Officer, and VP of Engineering (delivery throughput DORA analyzer, eng hiring funnel calculator, eng team structure designer), executive mentor, founder coach, Chief of Staff router, board meetings, decision logger, board deck builder, scenario war room, competitive intel, org health diagnostic, M&A playbook, international expansion, culture architect, change management, strategic alignment, and the founder-mode plugin (office-hours, boardroom, brief/decide/execute/post-mortem pipeline, cross-model consensus, decision freeze).",
-  "version": "2.5.5",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/README.md
+++ b/c-level-advisor/README.md
@@ -376,5 +376,5 @@ This C-Level advisory skills collection provides executive leadership guidance f
 ---
 
 **Last Updated:** January 2026
-**Skills Deployed:** 2/2 C-Level advisory skills production-ready
+**Skills Deployed:** 66/66 C-Level advisory skills production-ready
 **Total Tools:** 6 Python analysis tools (strategy, finance, tech debt, team scaling)

--- a/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
+++ b/c-level-advisor/c-level-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "c-level-agents",
   "description": "Founder-mode executive team plugin: 13 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer, Chief AI Officer, Chief Customer Officer, VP of Engineering) plus 21 /cs:* slash commands for forcing-question office hours (incl. /cs:vpe-review), multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Wraps the 33 c-level skills (including vpe-advisor with delivery throughput DORA analyzer + eng hiring funnel calculator + eng team structure designer) with cognitive gearing and artifact handoffs.",
-  "version": "1.5.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/c-level-agents",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/c-level-agents/README.md
+++ b/c-level-advisor/c-level-agents/README.md
@@ -83,6 +83,6 @@ Existing `cs-ceo-advisor` and `cs-cto-advisor` live in `/agents/c-level/` and in
 
 ---
 
-**Version:** 1.0.0
+**Version:** 2.9.0
 **Status:** Production Ready
 **License:** MIT

--- a/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-ai-officer-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chief-ai-officer-advisor",
   "description": "Chief AI Officer advisory: model build-vs-buy calculator (API vs fine-tune vs build with 3-year TCO across 6 paths + breakeven balancing economics with practical feasibility), AI risk classifier (EU AI Act tier with 7 Article citations + US state patchwork: NYC LL 144, CO AI Act, IL HB 53, CA SB 1001, IL BIPA + industry overlays for FDA AI/ML, CFPB Circular 2023-03, NYDFS Reg 23, NAIC, ECOA, Fed SR 11-7), AI cost economics (API vs self-hosted breakeven with 2026 pricing across A100/H100, utilization reality, hidden costs). 4 in-depth references each citing 5+ authoritative sources. Stdlib-only. Standalone-installable; also bundled in c-level-skills. Strategic only - does not duplicate engineering AI/ML skills.",
-  "version": "1.0.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-ai-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-customer-officer-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chief-customer-officer-advisor",
   "description": "Chief Customer Officer advisory for startups: retention decomposition analyzer (honest GRR vs NRR + 7-category churn taxonomy), customer segmentation designer (4-tier framework + ICP fit scoring + kill list), CS coverage calculator (pooled vs named CSM models + ratio math + 12-month hiring plan). 4 in-depth references: retention decomposition, customer segmentation strategy, CS coverage model, CS team org evolution (CSM vs Support vs AM vs IM vs CS Ops). Stdlib-only. Standalone-installable; also bundled in c-level-skills. Strategic only - does not duplicate business-growth tactical CS skills.",
-  "version": "1.0.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-customer-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/chief-data-officer-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chief-data-officer-advisor",
   "description": "Chief Data Officer advisory: AI training data audit (origin x class x use-case matrix with GDPR Art. 6 + EU AI Act citations -> GO/MITIGATE/NO-GO per source), data product strategy picker (warehouse vs lakehouse vs mesh + 6-layer build-vs-buy + 12-month sequencing), data asset valuator (strategic value 0-10 + M&A multiplier with carve-out penalties + 3 ranked productization paths). 4 references answering one decision each: training rights, data product strategy, customer-data-as-asset, data team org evolution. Stdlib-only. Standalone-installable; also bundled in c-level-skills. Strategic only - does not duplicate engineering data skills.",
-  "version": "1.0.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/chief-data-officer-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
+++ b/c-level-advisor/executive-mentor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "executive-mentor",
   "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for board meetings, navigates hard decisions, and forces honest post-mortems.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/executive-mentor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/general-counsel-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "general-counsel-advisor",
   "description": "General Counsel advisory for startups: contract risk scanner (12 founder-killer patterns: auto-renew traps, uncapped indemnity, vague IP, MFN pricing, missing DPA, one-sided venue, broad non-solicit, perpetual license-back, etc.) and term sheet analyzer (0-100 founder-friendliness score across 12 dimensions: liquidation preference, anti-dilution, option pool, board, vesting, drag-along, protective provisions, info rights, dividends, valuation). 3 in-depth references: contracts playbook (7 startup contract types), IP + regulatory landscape (HIPAA, GDPR, FDA, fintech, EU AI Act + SOC 2 to ISO sequencing), term sheet decoder. Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a substitute for licensed counsel.",
-  "version": "1.0.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/general-counsel-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
+++ b/c-level-advisor/vpe-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vpe-advisor",
-  "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification), eng hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes), eng team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references: DORA framework, eng hiring funnel, eng team structure (Conway's Law), production discipline (on-call, incidents, deployment, SLOs). Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill — VPE owns how the team ships, CTO owns what to build.",
-  "version": "1.0.0",
+  "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification), eng hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes), eng team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references: DORA framework, eng hiring funnel, eng team structure (Conway's Law), production discipline (on-call, incidents, deployment, SLOs). Stdlib-only. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill \u2014 VPE owns how the team ships, CTO owns what to build.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/c-level-advisor/vpe-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/compliance-os/.claude-plugin/plugin.json
+++ b/compliance-os/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compliance-os",
-  "description": "Compliance OS — meta-orchestrator for multi-framework compliance programs. Configure-then-operate four stdlib Python tools: framework_selector.py (input: company profile across industry/geography/AI/medical/financial/headcount; output: applicable frameworks ranked across all 9 supported: ISO 27001, 13485, 42001, 14971, EU AI Act, MDR 745, GDPR, SOC 2, FDA QSR), cross_framework_mapper.py (input: 1+ framework control libraries; output: unified control matrix with overlap percentage + mapping confidence + unified evidence requirements per merged control), audit_simulator.py (input: framework scope; output: mock internal audit with 8-15 finding scenarios across 5 severity levels + interview questions per control), evidence_pool_generator.py (input: enabled framework configs; output: consolidated evidence checklist with reuse map). 4 in-depth references citing ISO 19011, IIA Standards, AICPA AT-C, NIST CSF, COSO ERM. Plus 3 cs-* persona agents (cs-compliance-officer, cs-aims-iso42001, cs-ai-act-compliance) + 3 /cs:* slash commands (/cs:compliance-readiness, /cs:aims-audit, /cs:ai-act-readiness). Reuses the 14 existing ra-qm-team skills and the 2 new compliance-team-* plugins.",
-  "version": "1.2.0",
+  "description": "Compliance OS \u2014 meta-orchestrator for multi-framework compliance programs. Configure-then-operate four stdlib Python tools: framework_selector.py (input: company profile across industry/geography/AI/medical/financial/headcount; output: applicable frameworks ranked across all 9 supported: ISO 27001, 13485, 42001, 14971, EU AI Act, MDR 745, GDPR, SOC 2, FDA QSR), cross_framework_mapper.py (input: 1+ framework control libraries; output: unified control matrix with overlap percentage + mapping confidence + unified evidence requirements per merged control), audit_simulator.py (input: framework scope; output: mock internal audit with 8-15 finding scenarios across 5 severity levels + interview questions per control), evidence_pool_generator.py (input: enabled framework configs; output: consolidated evidence checklist with reuse map). 4 in-depth references citing ISO 19011, IIA Standards, AICPA AT-C, NIST CSF, COSO ERM. Plus 3 cs-* persona agents (cs-compliance-officer, cs-aims-iso42001, cs-ai-act-compliance) + 3 /cs:* slash commands (/cs:compliance-readiness, /cs:aims-audit, /cs:ai-act-readiness). Reuses the 14 existing ra-qm-team skills and the 2 new compliance-team-* plugins.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,15 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/compliance-os",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/compliance-os", "./skills/compliance-readiness", "./skills/aims-audit", "./skills/ai-act-readiness", "./skills/iso27001-audit-prep", "./skills/iso13485-audit-prep", "./skills/gdpr-audit-prep", "./skills/soc2-audit-prep", "./skills/fda-qsr-audit-prep"]
+  "skills": [
+    "./skills/compliance-os",
+    "./skills/compliance-readiness",
+    "./skills/aims-audit",
+    "./skills/ai-act-readiness",
+    "./skills/iso27001-audit-prep",
+    "./skills/iso13485-audit-prep",
+    "./skills/gdpr-audit-prep",
+    "./skills/soc2-audit-prep",
+    "./skills/fda-qsr-audit-prep"
+  ]
 }

--- a/engineering-team/a11y-audit/.claude-plugin/plugin.json
+++ b/engineering-team/a11y-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "a11y-audit",
   "description": "WCAG 2.2 accessibility audit and fix skill for React, Next.js, Vue, Angular, Svelte, and HTML. Static scanner detecting 20+ violation types, contrast checker with suggest mode, framework-specific fix patterns, CI-friendly exit codes.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/a11y-audit",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
+++ b/engineering-team/google-workspace-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "google-workspace-cli",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. 5 Python tools, 3 reference guides, 43 built-in recipes, 10 persona bundles.",
   "author": {
     "name": "Alireza Rezvani",
@@ -8,6 +8,8 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"],
+  "skills": [
+    "./skills"
+  ],
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/google-workspace-cli"
 }

--- a/engineering-team/playwright-pro/.claude-plugin/plugin.json
+++ b/engineering-team/playwright-pro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pw",
   "description": "Production-grade Playwright testing toolkit. Generate tests from specs, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55+ ready-to-use templates, 3 specialized agents, smart reporting that plugs into your existing workflow.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/playwright-pro",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering-team/self-improving-agent/.claude-plugin/plugin.json
+++ b/engineering-team/self-improving-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "si",
-  "version": "2.3.1",
+  "version": "2.9.0",
   "description": "Self-Improving Agent: curate auto-memory, promote learnings to CLAUDE.md and rules, extract proven patterns into reusable skills. Provides /si:review, /si:promote, /si:extract, /si:status, and /si:remember slash commands.",
   "author": {
     "name": "Alireza Rezvani",
@@ -8,6 +8,8 @@
   },
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"],
+  "skills": [
+    "./skills"
+  ],
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/self-improving-agent"
 }

--- a/engineering-team/skills/adversarial-reviewer/SKILL.md
+++ b/engineering-team/skills/adversarial-reviewer/SKILL.md
@@ -5,7 +5,7 @@ tier: "STANDARD"
 category: "Engineering / Code Quality"
 dependencies: "None (prompt-only, no external tools required)"
 author: "ekreloff"
-version: "1.0.0"
+version: "2.9.0"
 license: "MIT"
 ---
 

--- a/engineering-team/skills/engineering-skills/SKILL.md
+++ b/engineering-team/skills/engineering-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "engineering-skills"
 description: "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only)."
-version: 1.1.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/engineering-team/skills/senior-qa/README.md
+++ b/engineering-team/skills/senior-qa/README.md
@@ -191,6 +191,6 @@ jobs:
 
 ---
 
-**Version:** 2.0.0
+**Version:** 2.9.0
 **Last Updated:** January 2026
 **Tech Focus:** React 18+, Next.js 14+, Jest 29+, Playwright 1.40+

--- a/engineering-team/snowflake-development/.claude-plugin/plugin.json
+++ b/engineering-team/snowflake-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "snowflake-development",
   "description": "Snowflake SQL, data pipelines (Dynamic Tables, Streams+Tasks), Cortex AI functions, Snowpark Python, and dbt integration. Includes query helper script, 3 reference guides, and troubleshooting.",
-  "version": "2.1.4",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering-team/snowflake-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/.claude-plugin/plugin.json
+++ b/engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engineering-advanced-skills",
   "description": "40 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, self-eval, llm-cost-optimizer, prompt-governance, llm-wiki (second brain for Obsidian + Claude Code, Karpathy pattern), tc-tracker (task context tracker with lifecycle and handoff format), feature-flags-architect, kubernetes-operator, chaos-engineering, ship-gate (pre-production 8-category audit with deploy-intent intercept), slo-architect (SLO designer, error-budget calculator with multi-window burn-rate alerts, SLO reviewer per Google SRE Workbook), and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.4.4",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/agenthub/.claude-plugin/plugin.json
+++ b/engineering/agenthub/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agenthub",
   "description": "Multi-agent collaboration plugin for Claude Code. Spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any problem that benefits from diverse solutions. Evaluate by metric or LLM judge, merge the winner. 7 slash commands, agent templates, git DAG orchestration, message board coordination.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/agenthub",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/autoresearch-agent/.claude-plugin/plugin.json
+++ b/engineering/autoresearch-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch-agent",
   "description": "Autonomous experiment loop that optimizes any file by a measurable metric. 5 slash commands, 8 evaluators, configurable loop intervals (10min to monthly).",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/autoresearch-agent",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/behuman/.claude-plugin/plugin.json
+++ b/engineering/behuman/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "behuman",
-  "description": "Self-Mirror consciousness loop for human-like AI responses. Adds inner dialogue (Self → Mirror → Conscious Response) to make AI output feel authentic, not robotic. Zero dependencies — pure prompt technique.",
-  "version": "2.2.2",
+  "description": "Self-Mirror consciousness loop for human-like AI responses. Adds inner dialogue (Self \u2192 Mirror \u2192 Conscious Response) to make AI output feel authentic, not robotic. Zero dependencies \u2014 pure prompt technique.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/behuman",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/caveman/.claude-plugin/plugin.json
+++ b/engineering/caveman/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "caveman",
   "description": "Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler, articles, and pleasantries while keeping full technical accuracy. Enhanced from Matt Pocock's MIT-licensed caveman skill (https://github.com/mattpocock/skills) with: (1) stdlib Python tools (text compressor, token-savings estimator, caveman-style linter), (2) 3 reference docs citing 5+ authoritative sources each (compression principles, technical communication patterns, when caveman backfires), (3) cs-caveman-mode persona agent + /cs:caveman slash command. Matt's voice and persistence rules preserved verbatim per MIT. Use when user says \"caveman mode\", \"talk like caveman\", \"use caveman\", \"less tokens\", \"be brief\", or invokes /caveman.",
-  "version": "1.0.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/caveman",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/caveman"],
+  "skills": [
+    "./skills/caveman"
+  ],
   "attribution": {
     "derived_from": "https://github.com/mattpocock/skills/tree/main/skills/productivity/caveman",
     "original_author": "Matt Pocock (@mattpocock)",

--- a/engineering/chaos-engineering/.claude-plugin/plugin.json
+++ b/engineering/chaos-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chaos-engineering",
   "description": "End-to-end chaos engineering discipline: design experiments with hypothesis + steady-state metric + blast radius + abort criteria, calculate risk score against error budget, and generate blameless postmortems. 3 stdlib Python tools (experiment_designer, blast_radius_calculator, experiment_postmortem), 4 references on chaos principles + experiment design + 7-attack taxonomy + tooling landscape (Chaos Toolkit/Mesh/Litmus/Gremlin/AWS FIS/DIY), templates for plans + postmortems, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (chaos targets).",
-  "version": "2.4.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/chaos-engineering",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/chaos-engineering/skills/chaos-engineering/SKILL.md
+++ b/engineering/chaos-engineering/skills/chaos-engineering/SKILL.md
@@ -2,7 +2,7 @@
 name: chaos-engineering
 description: Use when planning, running, or learning from chaos engineering experiments. Triggers on "chaos experiment", "fault injection", "gameday", "resilience test", "blast radius", "steady state", "abort criteria", "Chaos Toolkit", "Chaos Mesh", "Litmus", "Gremlin", "AWS FIS", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets).
 context: fork
-version: 2.4.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [chaos-engineering, resilience, fault-injection, gameday, sre, reliability, chaos-toolkit, chaos-mesh, litmus, gremlin, aws-fis]

--- a/engineering/claude-coach/.claude-plugin/plugin.json
+++ b/engineering/claude-coach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-coach",
-  "description": "Personal Claude power-user coach. On first activation, delivers a personalized, ranked cheat-code glossary filtered to the user's use cases. On every subsequent turn, scans for missed power-user opportunities and surfaces at most ONE ⚡ tip when a tip would genuinely 10x the next attempt. Silence is the default. Ships SKILL.md, cheat-codes glossary, coaching-rules decision tree, and three stdlib Python tools (cheat-code filter, prompt rater, 5-gate tip classifier). Includes cs-claude-coach agent persona and /cs:claude-coach slash command.",
-  "version": "1.0.0",
+  "description": "Personal Claude power-user coach. On first activation, delivers a personalized, ranked cheat-code glossary filtered to the user's use cases. On every subsequent turn, scans for missed power-user opportunities and surfaces at most ONE \u26a1 tip when a tip would genuinely 10x the next attempt. Silence is the default. Ships SKILL.md, cheat-codes glossary, coaching-rules decision tree, and three stdlib Python tools (cheat-code filter, prompt rater, 5-gate tip classifier). Includes cs-claude-coach agent persona and /cs:claude-coach slash command.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/claude-coach",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/claude-coach"]
+  "skills": [
+    "./skills/claude-coach"
+  ]
 }

--- a/engineering/claude-coach/skills/claude-coach/SKILL.md
+++ b/engineering/claude-coach/skills/claude-coach/SKILL.md
@@ -7,7 +7,7 @@ Category: meta
 Author: claude-skills
 Dependencies: python3.11
 Version: 1.0.0
-version: 1.0.0
+version: 2.9.0
 license: MIT
 ---
 

--- a/engineering/code-tour/.claude-plugin/plugin.json
+++ b/engineering/code-tour/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-tour",
-  "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Supports 10 developer personas (vibecoder, new joiner, architect, security reviewer, etc.), all CodeTour step types, and SMIG description formula.",
-  "version": "2.2.2",
+  "description": "Create CodeTour .tour files \u2014 persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Supports 10 developer personas (vibecoder, new joiner, architect, security reviewer, etc.), all CodeTour step types, and SMIG description formula.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/code-tour",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/data-quality-auditor/.claude-plugin/plugin.json
+++ b/engineering/data-quality-auditor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "data-quality-auditor",
   "description": "Audit datasets for completeness, consistency, accuracy, and validity. 3 stdlib-only Python tools: data profiler with DQS scoring, missing value analyzer with MCAR/MAR/MNAR classification, and multi-method outlier detector.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/data-quality-auditor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/demo-video/.claude-plugin/plugin.json
+++ b/engineering/demo-video/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "demo-video",
   "description": "Create polished demo videos from screenshots and scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts to produce product walkthroughs, feature showcases, and marketing teasers with story structure, scene design system, and narration guidance.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/demo-video",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/docker-development/.claude-plugin/plugin.json
+++ b/engineering/docker-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docker-development",
   "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Covers build performance, layer caching, and production-ready container patterns.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/docker-development",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/feature-flags-architect/.claude-plugin/plugin.json
+++ b/engineering/feature-flags-architect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-flags-architect",
   "description": "End-to-end feature-flag discipline: classify, ship, ramp, retire. Detects stale flags as debt, generates phased rollout plans (ring/linear/log/cohort), and audits every flag for a documented kill switch. 3 stdlib Python tools, 4 references on flag taxonomy + provider trade-offs (LaunchDarkly/GrowthBook/Statsig/Unleash/Flipt/DIY) + rollout strategies + lifecycle. /flag-cleanup slash command. Cross-tool compatible.",
-  "version": "2.4.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/feature-flags-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/feature-flags-architect/skills/feature-flags-architect/SKILL.md
+++ b/engineering/feature-flags-architect/skills/feature-flags-architect/SKILL.md
@@ -2,7 +2,7 @@
 name: feature-flags-architect
 description: Use when adding, retiring, or auditing feature flags. Triggers on "add a flag", "ship behind a flag", "rollout plan", "kill switch", "stale flags", "flag debt", "LaunchDarkly", "GrowthBook", "Statsig", "Unleash", "Flipt", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command.
 context: fork
-version: 2.4.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [feature-flags, progressive-delivery, rollout, kill-switch, launchdarkly, growthbook, statsig, unleash, flipt, release-engineering]

--- a/engineering/grill-me/.claude-plugin/plugin.json
+++ b/engineering/grill-me/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grill-me",
   "description": "Relentless plan-and-design interrogator. Walks the decision tree of a plan one branch at a time, asking forcing questions sequentially with recommended answers. Explores codebase to resolve answers where possible. Enhanced from Matt Pocock's MIT-licensed grill-me skill (https://github.com/mattpocock/skills) with: (1) stdlib Python tools (decision-tree extractor, question generator, session-state tracker), (2) 3 reference docs citing 5+ authoritative sources each (forcing-question patterns, decision-tree completeness, when to stop grilling), (3) cs-grill-master persona agent + /cs:grill-me slash command. Matt's relentless one-at-a-time interview discipline preserved verbatim per MIT. Use when user wants to stress-test a plan, get grilled on their design, or says \"grill me\".",
-  "version": "1.0.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/grill-me"],
+  "skills": [
+    "./skills/grill-me"
+  ],
   "attribution": {
     "derived_from": "https://github.com/mattpocock/skills/tree/main/skills/productivity/grill-me",
     "original_author": "Matt Pocock (@mattpocock)",

--- a/engineering/grill-with-docs/.claude-plugin/plugin.json
+++ b/engineering/grill-with-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grill-with-docs",
-  "description": "Docs-anchored grilling session — interrogates a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), updating those files inline as terminology and decisions crystallise. Derived from Matt Pocock's MIT-licensed grill-with-docs skill (https://github.com/mattpocock/skills) with: (1) 3 stdlib Python tools (CONTEXT.md linter, ADR scanner, glossary-to-code consistency check), (2) 3 reference docs each citing 7+ authoritative sources on ubiquitous language, ADR practice, and CONTEXT.md as a living artifact, (3) cs-grill-with-docs persona agent + /cs:grill-with-docs slash command. Matt's interview discipline + domain-awareness rules + ADR-when-3-criteria-are-met gate preserved verbatim per MIT.",
-  "version": "1.0.0",
+  "description": "Docs-anchored grilling session \u2014 interrogates a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), updating those files inline as terminology and decisions crystallise. Derived from Matt Pocock's MIT-licensed grill-with-docs skill (https://github.com/mattpocock/skills) with: (1) 3 stdlib Python tools (CONTEXT.md linter, ADR scanner, glossary-to-code consistency check), (2) 3 reference docs each citing 7+ authoritative sources on ubiquitous language, ADR practice, and CONTEXT.md as a living artifact, (3) cs-grill-with-docs persona agent + /cs:grill-with-docs slash command. Matt's interview discipline + domain-awareness rules + ADR-when-3-criteria-are-met gate preserved verbatim per MIT.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-with-docs",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/grill-with-docs"],
+  "skills": [
+    "./skills/grill-with-docs"
+  ],
   "attribution": {
     "derived_from": "https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs",
     "original_author": "Matt Pocock (@mattpocock)",

--- a/engineering/handoff/.claude-plugin/plugin.json
+++ b/engineering/handoff/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handoff",
-  "description": "Conversation-handoff document generator. Compacts the current conversation into a markdown handoff so a fresh agent can continue. References existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL — does not duplicate them. Enhanced from Matt Pocock's MIT-licensed handoff skill (https://github.com/mattpocock/skills) with: (1) stdlib Python tools (template generator, artifact deduplicator, skill recommender), (2) 3 reference docs citing 5+ authoritative sources each (handoff structure, deduplication discipline, next-session skill matching), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline preserved verbatim per MIT. Use when user wants to hand off the current conversation to a fresh agent or starts a new session that picks up prior work.",
-  "version": "1.0.0",
+  "description": "Conversation-handoff document generator. Compacts the current conversation into a markdown handoff so a fresh agent can continue. References existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL \u2014 does not duplicate them. Enhanced from Matt Pocock's MIT-licensed handoff skill (https://github.com/mattpocock/skills) with: (1) stdlib Python tools (template generator, artifact deduplicator, skill recommender), (2) 3 reference docs citing 5+ authoritative sources each (handoff structure, deduplication discipline, next-session skill matching), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline preserved verbatim per MIT. Use when user wants to hand off the current conversation to a fresh agent or starts a new session that picks up prior work.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/handoff",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/handoff"],
+  "skills": [
+    "./skills/handoff"
+  ],
   "attribution": {
     "derived_from": "https://github.com/mattpocock/skills/tree/main/skills/productivity/handoff",
     "original_author": "Matt Pocock (@mattpocock)",

--- a/engineering/helm-chart-builder/.claude-plugin/plugin.json
+++ b/engineering/helm-chart-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "helm-chart-builder",
-  "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing.",
-  "version": "2.2.2",
+  "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw \u2014 chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/helm-chart-builder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/karpathy-coder/.claude-plugin/plugin.json
+++ b/engineering/karpathy-coder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "karpathy-coder",
   "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, keep it simple, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check slash command, and a pre-commit hook. All tools stdlib-only.",
-  "version": "2.3.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/karpathy-coder",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/karpathy-coder/skills/karpathy-coder/SKILL.md
+++ b/engineering/karpathy-coder/skills/karpathy-coder/SKILL.md
@@ -2,7 +2,7 @@
 name: karpathy-coder
 description: Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on "review my diff", "check complexity", "am I overcomplicating this", "karpathy check", "before I commit", or any code quality concern where the LLM might be overcoding.
 context: fork
-version: 2.3.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [code-quality, discipline, karpathy, simplicity, surgical-changes, anti-patterns, review]

--- a/engineering/kubernetes-operator/.claude-plugin/plugin.json
+++ b/engineering/kubernetes-operator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kubernetes-operator",
-  "description": "End-to-end Kubernetes Operator discipline: CRD design, reconcile-loop patterns, and OperatorHub Capability Levels. Ships CRD validator, reconcile-loop linter, and capability auditor (3 stdlib Python tools), 4 references on the operator pattern + CRD design + reconcile patterns + framework comparison (controller-runtime/kubebuilder/operator-sdk/metacontroller/KOPF), CRD + Go controller skeletons, and /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
-  "version": "2.4.0",
+  "description": "End-to-end Kubernetes Operator discipline: CRD design, reconcile-loop patterns, and OperatorHub Capability Levels. Ships CRD validator, reconcile-loop linter, and capability auditor (3 stdlib Python tools), 4 references on the operator pattern + CRD design + reconcile patterns + framework comparison (controller-runtime/kubebuilder/operator-sdk/metacontroller/KOPF), CRD + Go controller skeletons, and /operator-audit slash command. NOT a generic k8s skill \u2014 specifically the Operator pattern.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/kubernetes-operator",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/kubernetes-operator/skills/kubernetes-operator/SKILL.md
+++ b/engineering/kubernetes-operator/skills/kubernetes-operator/SKILL.md
@@ -2,7 +2,7 @@
 name: kubernetes-operator
 description: Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on "build an operator", "CRD design", "reconcile loop", "controller-runtime", "kubebuilder", "operator-sdk", "metacontroller", "KOPF", "operator capability levels", or "custom resource". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.
 context: fork
-version: 2.4.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [kubernetes, operator, crd, controller-runtime, kubebuilder, operator-sdk, metacontroller, kopf, reconcile, devops]

--- a/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
+++ b/engineering/llm-cost-optimizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-cost-optimizer",
   "description": "Use when you need to reduce LLM API spend, control token usage, route between models by cost/quality, implement prompt caching, or build cost observability for AI features. Triggers: 'my AI costs are ",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-cost-optimizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/llm-wiki/.claude-plugin/plugin.json
+++ b/engineering/llm-wiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-wiki",
-  "description": "Turn Claude Code + Obsidian into a second brain. The LLM incrementally ingests sources into a persistent, interlinked markdown wiki — building entity/concept/source pages, flagging contradictions, maintaining an index and log. Knowledge compounds instead of being re-derived by RAG on every query. Inspired by Karpathy's LLM Wiki gist. Ships SKILL, 3 sub-agents, 5 slash commands, 8 Python tools (stdlib only), full vault templates, and cross-tool compatibility (Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI).",
-  "version": "2.3.2",
+  "description": "Turn Claude Code + Obsidian into a second brain. The LLM incrementally ingests sources into a persistent, interlinked markdown wiki \u2014 building entity/concept/source pages, flagging contradictions, maintaining an index and log. Knowledge compounds instead of being re-derived by RAG on every query. Inspired by Karpathy's LLM Wiki gist. Ships SKILL, 3 sub-agents, 5 slash commands, 8 Python tools (stdlib only), full vault templates, and cross-tool compatibility (Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, Gemini CLI).",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/llm-wiki",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/llm-wiki/skills/llm-wiki/SKILL.md
+++ b/engineering/llm-wiki/skills/llm-wiki/SKILL.md
@@ -2,7 +2,7 @@
 name: llm-wiki
 description: Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include "second brain", "Obsidian wiki", "personal knowledge management", "ingest this paper/article/book", "build a research wiki", "compound knowledge", "Memex", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.
 context: fork
-version: 1.0.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [knowledge-management, obsidian, second-brain, pkm, rag-alternative, wiki, karpathy, memex]

--- a/engineering/prompt-governance/.claude-plugin/plugin.json
+++ b/engineering/prompt-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-governance",
   "description": "Use when managing prompts in production at scale: versioning prompts, running A/B tests on prompts, building prompt registries, preventing prompt regressions, or creating eval pipelines for production",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/prompt-governance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/skills/chaos-engineering/SKILL.md
+++ b/engineering/skills/chaos-engineering/SKILL.md
@@ -2,7 +2,7 @@
 name: chaos-engineering
 description: Use when planning, running, or learning from chaos engineering experiments. Triggers on "chaos experiment", "fault injection", "gameday", "resilience test", "blast radius", "steady state", "abort criteria", "Chaos Toolkit", "Chaos Mesh", "Litmus", "Gremlin", "AWS FIS", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets).
 context: fork
-version: 2.4.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [chaos-engineering, resilience, fault-injection, gameday, sre, reliability, chaos-toolkit, chaos-mesh, litmus, gremlin, aws-fis]

--- a/engineering/skills/engineering-advanced-skills/SKILL.md
+++ b/engineering/skills/engineering-advanced-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "engineering-advanced-skills"
 description: "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops."
-version: 1.1.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/engineering/skills/feature-flags-architect/SKILL.md
+++ b/engineering/skills/feature-flags-architect/SKILL.md
@@ -2,7 +2,7 @@
 name: feature-flags-architect
 description: Use when adding, retiring, or auditing feature flags. Triggers on "add a flag", "ship behind a flag", "rollout plan", "kill switch", "stale flags", "flag debt", "LaunchDarkly", "GrowthBook", "Statsig", "Unleash", "Flipt", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command.
 context: fork
-version: 2.4.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [feature-flags, progressive-delivery, rollout, kill-switch, launchdarkly, growthbook, statsig, unleash, flipt, release-engineering]

--- a/engineering/skills/kubernetes-operator/SKILL.md
+++ b/engineering/skills/kubernetes-operator/SKILL.md
@@ -2,7 +2,7 @@
 name: kubernetes-operator
 description: Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on "build an operator", "CRD design", "reconcile loop", "controller-runtime", "kubebuilder", "operator-sdk", "metacontroller", "KOPF", "operator capability levels", or "custom resource". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.
 context: fork
-version: 2.4.0
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [kubernetes, operator, crd, controller-runtime, kubebuilder, operator-sdk, metacontroller, kopf, reconcile, devops]

--- a/engineering/skills/slo-architect/SKILL.md
+++ b/engineering/skills/slo-architect/SKILL.md
@@ -2,7 +2,7 @@
 name: slo-architect
 description: Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on "define an SLO", "what should our SLO be", "error budget", "burn rate", "SLI", "service level objective", "Google SRE workbook", "multi-window burn-rate alert", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline.
 context: fork
-version: 2.4.4
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [slo, sli, sla, error-budget, burn-rate, sre, reliability, google-sre-workbook, observability]

--- a/engineering/slo-architect/.claude-plugin/plugin.json
+++ b/engineering/slo-architect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slo-architect",
   "description": "End-to-end SLO/SLI/error-budget discipline per Google SRE Workbook. Ships SLO designer (refuses to render without required fields), error-budget calculator with multi-window burn-rate alert thresholds (PromQL-shaped), and SLO reviewer that catches the 7 common bugs (target too high, window too short, no SLI definition, CPU-as-SLI, etc.). 4 references on principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. Asset templates for SLO YAML and error budget policy. /slo-design slash command. NOT a generic observability skill.",
-  "version": "2.4.4",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/slo-architect",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/slo-architect/skills/slo-architect/SKILL.md
+++ b/engineering/slo-architect/skills/slo-architect/SKILL.md
@@ -2,7 +2,7 @@
 name: slo-architect
 description: Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on "define an SLO", "what should our SLO be", "error budget", "burn rate", "SLI", "service level objective", "Google SRE workbook", "multi-window burn-rate alert", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline.
 context: fork
-version: 2.4.4
+version: 2.9.0
 author: claude-code-skills
 license: MIT
 tags: [slo, sli, sla, error-budget, burn-rate, sre, reliability, google-sre-workbook, observability]

--- a/engineering/statistical-analyst/.claude-plugin/plugin.json
+++ b/engineering/statistical-analyst/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "statistical-analyst",
   "description": "Hypothesis testing, A/B experiment analysis, sample size calculation, and confidence intervals. 3 stdlib-only Python tools with Z-test, t-test, chi-square, effect sizes, power analysis, and Wilson score intervals.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/statistical-analyst",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/terraform-patterns/.claude-plugin/plugin.json
+++ b/engineering/terraform-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "terraform-patterns",
   "description": "Terraform infrastructure-as-code agent skill and plugin for module design patterns, state management strategies, provider configuration, security hardening, and CI/CD plan/apply workflows. Covers mono-repo vs multi-repo, workspaces, policy-as-code, and drift detection.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/terraform-patterns",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/engineering/terraform-patterns/skills/terraform-patterns/SKILL.md
+++ b/engineering/terraform-patterns/skills/terraform-patterns/SKILL.md
@@ -603,7 +603,7 @@ jobs:
 
 ```yaml
 # infracost.yml — policy file
-version: 0.1
+version: 2.9.0
 policies:
   - path: "*"
     max_monthly_cost: "5000"    # Fail PR if estimated cost exceeds $5,000/month

--- a/engineering/write-a-skill/.claude-plugin/plugin.json
+++ b/engineering/write-a-skill/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "write-a-skill",
-  "description": "Skill-author skill: create new agent skills with proper structure, progressive disclosure, and bundled resources. Enhanced from Matt Pocock's MIT-licensed write-a-skill (https://github.com/mattpocock/skills) with: (1) stdlib Python validation tools (description validator, structure validator, review-checklist runner), (2) 3 reference docs citing 5+ authoritative sources each (progressive disclosure principles, description design patterns, quality gates), (3) cs-skill-author persona agent + /cs:write-a-skill slash command. Matt's voice and 3-phase workflow (Gather → Draft → Review) preserved verbatim per his MIT license. Use when user wants to create, write, build, or author a new agent skill.",
-  "version": "1.0.0",
+  "description": "Skill-author skill: create new agent skills with proper structure, progressive disclosure, and bundled resources. Enhanced from Matt Pocock's MIT-licensed write-a-skill (https://github.com/mattpocock/skills) with: (1) stdlib Python validation tools (description validator, structure validator, review-checklist runner), (2) 3 reference docs citing 5+ authoritative sources each (progressive disclosure principles, description design patterns, quality gates), (3) cs-skill-author persona agent + /cs:write-a-skill slash command. Matt's voice and 3-phase workflow (Gather \u2192 Draft \u2192 Review) preserved verbatim per his MIT license. Use when user wants to create, write, build, or author a new agent skill.",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/write-a-skill",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills/write-a-skill"],
+  "skills": [
+    "./skills/write-a-skill"
+  ],
   "attribution": {
     "derived_from": "https://github.com/mattpocock/skills/tree/main/skills/productivity/write-a-skill",
     "original_author": "Matt Pocock (@mattpocock)",

--- a/finance/.claude-plugin/plugin.json
+++ b/finance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "finance-skills",
   "description": "3 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, 12-month projections), and business investment advisor. 7 Python automation tools. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.2.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/finance/business-investment-advisor/.claude-plugin/plugin.json
+++ b/finance/business-investment-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-investment-advisor",
   "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use f",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/finance/business-investment-advisor",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/finance/skills/finance-skills/SKILL.md
+++ b/finance/skills/finance-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "finance-skills"
 description: "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only)."
-version: 1.0.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/marketing-skill/skills/marketing-skills/SKILL.md
+++ b/marketing-skill/skills/marketing-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "marketing-skills"
 description: "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only)."
-version: 2.0.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
+++ b/marketing-skill/video-content-strategist/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "video-content-strategist",
   "description": "Use when planning video content strategy, writing video scripts, optimizing YouTube channels, building short-form video pipelines (Reels, TikTok, Shorts), or repurposing long-form content into video. ",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/video-content-strategist",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/.claude-plugin/plugin.json
+++ b/product-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "product-skills",
   "description": "13 production-ready product skills: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer, apple-hig-expert (Apple Human Interface Guidelines), spec-to-repo. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.3.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/README.md
+++ b/product-team/README.md
@@ -1,6 +1,6 @@
 # Product Team Skills Collection
 
-**8 production-ready product skills** covering product management, agile delivery, strategy, UX research, design systems, competitive intelligence, landing pages, and SaaS scaffolding.
+**17 production-ready product skills** covering product management, agile delivery, strategy, UX research, design systems, competitive intelligence, landing pages, and SaaS scaffolding.
 
 ---
 
@@ -111,6 +111,6 @@ python saas-scaffolder/scripts/project_bootstrapper.py config.json
 ---
 
 **Last Updated:** March 10, 2026
-**Version:** v2.1.2
-**Skills Deployed:** 8/8 production-ready
+**Version:** v2.9.0
+**Skills Deployed:** 17/17 production-ready
 **Total Tools:** 9 Python automation tools

--- a/product-team/agile-product-owner/.claude-plugin/plugin.json
+++ b/product-team/agile-product-owner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agile-product-owner",
   "description": "Agile product ownership for backlog management and sprint execution. User story generation (INVEST-compliant), acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool.",
-  "version": "2.3.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/agile-product-owner",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/apple-hig-expert/.claude-plugin/plugin.json
+++ b/product-team/apple-hig-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-hig-expert",
   "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets, contrast, and accessibility validation. Reference docs cover visual design, platform specifics (iOS/macOS/visionOS), and accessibility best practices.",
-  "version": "2.3.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/apple-hig-expert",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/code-to-prd/.claude-plugin/plugin.json
+++ b/product-team/code-to-prd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-to-prd",
   "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, models, APIs, and interactions for frontend (React, Vue, Angular, Next.js), backend (NestJS, Django, Express, FastAPI), and fullstack applications.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/code-to-prd",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/research-summarizer/.claude-plugin/plugin.json
+++ b/product-team/research-summarizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-summarizer",
   "description": "Structured research summarization agent skill and plugin for Claude Code, Codex, and Gemini CLI. Summarize academic papers, compare web articles, extract citations, and produce actionable research briefs.",
-  "version": "2.2.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/research-summarizer",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/product-team/skills/product-skills/SKILL.md
+++ b/product-team/skills/product-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "product-skills"
 description: "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only)."
-version: 1.1.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/productivity/andreessen/README.md
+++ b/productivity/andreessen/README.md
@@ -96,5 +96,5 @@ affiliated with or endorsed by Marc Andreessen or a16z.**
 
 ---
 
-**Version:** 1.0.0 (ships in repo release v2.8.4)
+**Version:** 2.9.0 (ships in repo release v2.9.0)
 **License:** MIT

--- a/productivity/andreessen/skills/andreessen/README.md
+++ b/productivity/andreessen/skills/andreessen/README.md
@@ -53,4 +53,4 @@ or endorsed by Marc Andreessen or a16z.**
 
 ---
 
-**Version:** 1.0.0 · **License:** MIT
+**Version:** 2.9.0 · **License:** MIT

--- a/project-management/.claude-plugin/plugin.json
+++ b/project-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-skills",
   "description": "9 project management skills: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template scaffolder, and Atlassian MCP-bundled (Remote SSE) integration. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.2.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/project-management",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/project-management/README.md
+++ b/project-management/README.md
@@ -500,5 +500,5 @@ mcp__atlassian__search_issues jql="project = PROJ AND status = 'In Progress'"
 ---
 
 **Last Updated:** January 2026
-**Skills Deployed:** 6/6 project management skills production-ready
+**Skills Deployed:** 9/9 project management skills production-ready
 **Key Feature:** Atlassian MCP integration for direct Jira/Confluence operations

--- a/project-management/skills/pm-skills/SKILL.md
+++ b/project-management/skills/pm-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "pm-skills"
 description: "6 project management agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Senior PM, scrum master, Jira expert (JQL), Confluence expert, Atlassian admin, template creator. MCP integration for live Jira/Confluence automation."
-version: 1.0.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:

--- a/ra-qm-team/.claude-plugin/plugin.json
+++ b/ra-qm-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ra-qm-skills",
   "description": "14 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, SOC 2, CAPA management, risk management, clinical evaluation, and more. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.2.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-eu-ai-act/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compliance-team-eu-ai-act",
-  "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance specialist for compliance teams. Three deterministic tools: AI system risk classifier (Article 5 prohibited / Article 6 + Annex III high-risk / Article 50 limited-risk / minimal-risk per the binding regulation), conformity assessment planner (Article 43 Module A vs Module H + notified-body routing + Annex IV technical documentation checklist), obligation tracker (provider/deployer/importer/distributor obligations matrix per Title III Chapter 3 + GPAI obligations per Articles 51-55). 4 in-depth references: Titles I-XII Article-by-Article walkthrough, Annex III 8 high-risk categories with Article 6(2) carve-outs, GPAI obligations including systemic-risk threshold, cross-framework mapping to ISO 42001 + NIST AI RMF + GDPR. Stdlib-only. Built for compliance officers executing Article-level conformity work — not for executive AI strategy (see chief-ai-officer-advisor for that).",
-  "version": "1.0.0",
+  "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance specialist for compliance teams. Three deterministic tools: AI system risk classifier (Article 5 prohibited / Article 6 + Annex III high-risk / Article 50 limited-risk / minimal-risk per the binding regulation), conformity assessment planner (Article 43 Module A vs Module H + notified-body routing + Annex IV technical documentation checklist), obligation tracker (provider/deployer/importer/distributor obligations matrix per Title III Chapter 3 + GPAI obligations per Articles 51-55). 4 in-depth references: Titles I-XII Article-by-Article walkthrough, Annex III 8 high-risk categories with Article 6(2) carve-outs, GPAI obligations including systemic-risk threshold, cross-framework mapping to ISO 42001 + NIST AI RMF + GDPR. Stdlib-only. Built for compliance officers executing Article-level conformity work \u2014 not for executive AI strategy (see chief-ai-officer-advisor for that).",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-eu-ai-act",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
+++ b/ra-qm-team/compliance-team-iso42001/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compliance-team-iso42001",
-  "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams: AIMS gap analyzer (Clauses 4-10 coverage scoring + remediation priority), AI risk register builder (Annex A 38 controls + risk-to-treatment map per ISO 23894), AIMS audit scheduler (Clause 9.2 internal audit cadence + 12-month plan + auditor independence checks). 4 in-depth references: ISO 42001 Clauses 4-10 walkthrough, Annex A controls A.1-A.10, AIMS implementation maturity model, cross-framework mapping (42001 ↔ EU AI Act ↔ NIST AI RMF ↔ ISO 23894). Stdlib-only. Standalone-installable; also bundled in ra-qm-skills. Built for compliance officers running internal AIMS audits, not for executive AI strategy decisions (see chief-ai-officer-advisor for those).",
-  "version": "1.0.0",
+  "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams: AIMS gap analyzer (Clauses 4-10 coverage scoring + remediation priority), AI risk register builder (Annex A 38 controls + risk-to-treatment map per ISO 23894), AIMS audit scheduler (Clause 9.2 internal audit cadence + 12-month plan + auditor independence checks). 4 in-depth references: ISO 42001 Clauses 4-10 walkthrough, Annex A controls A.1-A.10, AIMS implementation maturity model, cross-framework mapping (42001 \u2194 EU AI Act \u2194 NIST AI RMF \u2194 ISO 23894). Stdlib-only. Standalone-installable; also bundled in ra-qm-skills. Built for compliance officers running internal AIMS audits, not for executive AI strategy decisions (see chief-ai-officer-advisor for those).",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -9,5 +9,7 @@
   "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/ra-qm-team/compliance-team-iso42001",
   "repository": "https://github.com/alirezarezvani/claude-skills",
   "license": "MIT",
-  "skills": ["./skills"]
+  "skills": [
+    "./skills"
+  ]
 }

--- a/ra-qm-team/skills/ra-qm-skills/SKILL.md
+++ b/ra-qm-team/skills/ra-qm-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ra-qm-skills"
 description: "12 regulatory & QM agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, ISO 27001 ISMS, GDPR/DSGVO, risk management (ISO 14971), CAPA, document control, auditing. Python tools (stdlib-only)."
-version: 1.0.0
+version: 2.9.0
 author: Alireza Rezvani
 license: MIT
 tags:


### PR DESCRIPTION
## Summary

Systematic version normalization + repo-wide documentation count refresh, per the agreed scope (bump only pre-2.7.0 packages; clean up all READMEs; use recomputed raw counts).

### Version normalization (only `<2.7.0` → `2.9.0`)
- **52 plugin.json** + **21 SKILL.md** `version` fields bumped from stale pre-2.7.0 values (1.0.0 / 2.0.x / 2.2.x / 2.3.x / 2.4.x / 2.5.x) to **2.9.0**.
- 2.7.0+ packages left untouched (e.g. business-operations/commercial stay 2.8.0).
- Tool mirrors (`.codex` / `.gemini` / `.vibe` / `.hermes`) excluded — they regenerate via sync.
- `check_plugin_json.py --all` still passes; all bumped manifests keep their `source`/`attribution` extension fields and structure.

### Documentation refresh (recomputed raw figures)
Canonical: **338 skills · 16 domains · 62 plugins · 533 Python tools · 676 references** (agents/commands kept at curated 51+/87+ since raw file counts overcount bundled duplicates).

- **marketplace.json** — both descriptions rewritten + `metadata.version` → 2.9.0.
- **Root README.md** — headline (338 skills / 13 tools), badges (Skills 338, Agents 51+, Commands 87+), intro counts, footnotes, "Multi-Tool" convert section (338 skills / 9 tools), and the **domain table fully rebuilt** to 16 domains summing to 338 (adds research-ops, business-operations, commercial, compliance-os; corrects product 17, marketing 46, c-level 66, ra-qm 18, finance 4, engineering 51/78).
- **Per-skill READMEs** — fixed `Version:` lines left inconsistent by the bump (andreessen ×2, c-level-agents, senior-qa) and stale domain footers (product-team 17/17, c-level 66/66, project-management 9/9).
- **CLAUDE.md** — scope line, architecture tree, v2.9.0 highlight, and status footer synced to the raw figures.

## Test plan
- [x] `python3 scripts/check_plugin_json.py --all` passes
- [x] 0 plugin.json / SKILL.md remain below 2.7.0 (verified by the bump script's dry-run)
- [x] marketplace.json parses; 62 plugins; metadata.version 2.9.0
- [x] Spot-checked bumped manifests retain structure + `source` fields; SKILL.md frontmatter intact
- [x] Root README domain table sums to 338 across 16 domains
- [ ] Maintainer: optionally re-run `sync-*` scripts to refresh tool-mirror copies (version bumps don't affect the indices)

83 files changed (52 plugin.json, 21 SKILL.md, 8 README, marketplace.json, CLAUDE.md).

https://claude.ai/code/session_01PUNmQVE4WYvcrzpq2anC3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUNmQVE4WYvcrzpq2anC3D)_