### PR TITLE
fix(marketplace): sync 42 stale plugin versions with actual plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
       "name": "marketing-skills",
       "source": "./marketing-skill",
       "description": "44 marketing skills across 7 pods: Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs.",
-      "version": "2.2.3",
+      "version": "2.7.3",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -40,7 +40,7 @@
       "name": "c-level-skills",
       "source": "./c-level-advisor",
       "description": "33 C-level advisory skills + c-level-agents plugin layer: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO) plus General Counsel, CDO, CAIO, CCO, and VP of Engineering (DORA delivery throughput analyzer, engineering hiring funnel calculator with conversion + pipeline gap, eng team structure designer with squad/tribe + manager-trigger), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive intel, M&A playbook), culture frameworks, and 13 cs-* persona agents + 21 /cs:* slash commands (founder-mode router, office-hours intake, multi-role boardroom, strategic sprint pipeline, cross-model consensus, cooldown freeze).",
-      "version": "2.5.5",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -62,7 +62,7 @@
       "name": "c-level-agents",
       "source": "./c-level-advisor/c-level-agents",
       "description": "Founder-mode executive team plugin: 13 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer, Chief AI Officer, Chief Customer Officer, VP of Engineering) with distinct cognitive voices, plus 21 /cs:* slash commands — forcing-question office hours (CFO/CMO/CPO/CRO/CTO/CISO/GC/CDO/CAIO/CCO/VPE reviews), strategic sprint pipeline (brief → boardroom → decide → execute → post-mortem), and meta routing (/cs:founder-mode auto-router, /cs:onboard, /cs:cross-eval multi-model consensus, /cs:freeze cooldown lock). Wraps the 33 c-level skills with cognitive gearing, persona voice, and artifact-driven handoffs. The business-domain answer to YC Garry Tan's gstack.",
-      "version": "1.5.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -112,7 +112,7 @@
       "name": "general-counsel-advisor",
       "source": "./c-level-advisor/general-counsel-advisor",
       "description": "General Counsel advisory for startups: contract risk scanner (12 founder-killer patterns: auto-renew traps, uncapped indemnity, vague IP, MFN pricing, missing DPA, one-sided venue, broad non-solicit, perpetual license-back, etc.) and term sheet analyzer (0-100 founder-friendliness across 12 dimensions). 3 in-depth references: contracts playbook (7 startup contract types), IP + regulatory landscape mapping (HIPAA, GDPR, FDA, fintech, EU AI Act, SOC 2 → ISO sequencing), term sheet decoder (full glossary + founder-friendly defaults). Standalone-installable; also bundled in c-level-skills. Stdlib-only. NOT a substitute for licensed counsel.",
-      "version": "1.0.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -134,7 +134,7 @@
       "name": "chief-data-officer-advisor",
       "source": "./c-level-advisor/chief-data-officer-advisor",
       "description": "Chief Data Officer advisory for startups: AI training data audit (origin × class × use-case matrix with GDPR Art. 6 + EU AI Act citations), data product strategy picker (warehouse vs lakehouse vs mesh + 6-layer build-vs-buy + 12-month sequencing), data asset valuator (strategic value 0-10 + M&A multiplier with carve-out penalties + 3 ranked productization paths). 4 references answering one decision each: training rights, data product strategy, customer-data-as-asset, data team org evolution. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate engineering data skills.",
-      "version": "1.0.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -156,7 +156,7 @@
       "name": "vpe-advisor",
       "source": "./c-level-advisor/vpe-advisor",
       "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification with typical fixes per stage), engineering hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes from sourcing to offer-accept), engineering team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references citing DORA / Spotify / Conway / Google SRE / Larson / Fournier. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill — VPE owns how the team ships; CTO owns what to build.",
-      "version": "1.0.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -180,7 +180,7 @@
       "name": "chief-customer-officer-advisor",
       "source": "./c-level-advisor/chief-customer-officer-advisor",
       "description": "Chief Customer Officer advisory: retention decomposition analyzer (honest GRR vs NRR; 7-category churn taxonomy with preventable% scoring), customer segmentation designer (4-tier framework, ICP fit scoring across 7 weighted signals, kill list + upgrade candidates), CS coverage calculator (pooled vs named CSM ratio math + 12-month hiring plan with quarterly sequencing). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate business-growth tactical CS skills.",
-      "version": "1.0.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -202,7 +202,7 @@
       "name": "chief-ai-officer-advisor",
       "source": "./c-level-advisor/chief-ai-officer-advisor",
       "description": "Chief AI Officer advisory for startups: model build-vs-buy calculator (API vs fine-tune vs build with 3-year TCO across 6 paths + breakeven that balances economics with practical feasibility), AI risk classifier (EU AI Act tier with 7 Article citations + US state patchwork: NYC LL 144, CO AI Act, IL HB 53, CA SB 1001, IL BIPA + industry overlays for FDA AI/ML, CFPB Circular 2023-03, NYDFS Reg 23, NAIC, ECOA, Fed SR 11-7), AI cost economics (API vs self-hosted breakeven with 2026 pricing across A100/H100, utilization reality, hidden costs). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate engineering AI/ML skills.",
-      "version": "1.0.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -225,7 +225,7 @@
       "name": "engineering-advanced-skills",
       "source": "./engineering",
       "description": "40 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, self-eval, llm-cost-optimizer, prompt-governance, behuman, code-tour, demo-video, data-quality-auditor, statistical-analyst, llm-wiki (second brain for Obsidian + Claude Code, Karpathy pattern), feature-flags-architect (flag debt scanner, rollout planner, kill-switch audit), kubernetes-operator (CRD validator, reconcile linter, capability auditor), chaos-engineering (experiment designer, blast-radius calculator, postmortem generator), ship-gate (pre-production 8-category audit with deploy-intent intercept), slo-architect (SLO designer, error-budget calculator with multi-window burn-rate alerts, SLO reviewer per Google SRE Workbook), and more.",
-      "version": "2.4.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -275,7 +275,7 @@
       "name": "ra-qm-skills",
       "source": "./ra-qm-team",
       "description": "14 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation, SOC 2 compliance.",
-      "version": "2.2.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -295,7 +295,7 @@
       "name": "product-skills",
       "source": "./product-team",
       "description": "13 product skills with 17 Python tools: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer, apple-hig-expert.",
-      "version": "2.3.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -322,7 +322,7 @@
       "name": "pm-skills",
       "source": "./project-management",
       "description": "9 project management skills with 12 Python tools: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator.",
-      "version": "2.2.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -340,7 +340,7 @@
       "name": "business-growth-skills",
       "source": "./business-growth",
       "description": "5 business & growth skills: customer success manager, sales engineer, revenue operations, contract & proposal writer.",
-      "version": "2.2.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -357,7 +357,7 @@
       "name": "finance-skills",
       "source": "./finance",
       "description": "3 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, projections), and business investment advisor. 7 Python automation tools.",
-      "version": "2.2.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -381,7 +381,7 @@
       "name": "pw",
       "source": "./engineering-team/playwright-pro",
       "description": "Production-grade Playwright testing toolkit. 9 skills, 3 agents, 55 templates, TestRail + BrowserStack MCP integrations. Generate tests, fix flaky failures, migrate from Cypress/Selenium.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -400,7 +400,7 @@
       "name": "self-improving-agent",
       "source": "./engineering-team/self-improving-agent",
       "description": "Curate auto-memory, promote learnings to CLAUDE.md and rules, extract patterns into skills. Ships 5 slash commands (/si:review, /si:promote, /si:extract, /si:status, /si:remember) and 2 sub-agents (memory-analyst, skill-extractor).",
-      "version": "2.3.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -416,7 +416,7 @@
       "name": "autoresearch-agent",
       "source": "./engineering/autoresearch-agent",
       "description": "Autonomous experiment loop — optimize any file by a measurable metric. 5 slash commands (/ar:setup, /ar:run, /ar:loop, /ar:status, /ar:resume), 8 built-in evaluators, configurable loop intervals (10min to monthly).",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -435,7 +435,7 @@
       "name": "google-workspace-cli",
       "source": "./engineering-team/google-workspace-cli",
       "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. 5 Python tools, 3 reference guides, 43 built-in recipes, 10 persona bundles.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -454,7 +454,7 @@
       "name": "code-to-prd",
       "source": "./product-team/code-to-prd",
       "description": "Reverse-engineer any codebase into a complete PRD. Frontend (React, Vue, Angular, Next.js), backend (NestJS, Django, Express, FastAPI), and fullstack. 2 Python scripts (codebase_analyzer, prd_scaffolder), 2 reference guides, /code-to-prd slash command.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -481,7 +481,7 @@
       "name": "agenthub",
       "source": "./engineering/agenthub",
       "description": "Multi-agent collaboration — spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any task that benefits from diverse solutions. 7 slash commands (/hub:init, /hub:spawn, /hub:status, /hub:eval, /hub:merge, /hub:board, /hub:run), agent templates, DAG-based orchestration, LLM judge mode, message board coordination.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -503,7 +503,7 @@
       "name": "a11y-audit",
       "source": "./engineering-team/a11y-audit",
       "description": "WCAG 2.2 accessibility audit and fix for React, Next.js, Vue, Angular, Svelte, and HTML. Static scanner detecting 20+ violation types, contrast checker with suggest mode, framework-specific fix patterns, /a11y-audit slash command.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -522,7 +522,7 @@
       "name": "executive-mentor",
       "source": "./c-level-advisor/executive-mentor",
       "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for board meetings, navigates hard calls, runs postmortems. 5 sub-skills with slash commands.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -540,7 +540,7 @@
       "name": "docker-development",
       "source": "./engineering/docker-development",
       "description": "Docker and container development — Dockerfile optimization, docker-compose orchestration, multi-stage builds, security hardening, and CI/CD container pipelines.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -557,7 +557,7 @@
       "name": "helm-chart-builder",
       "source": "./engineering/helm-chart-builder",
       "description": "Helm chart development — chart scaffolding, values design, template patterns, dependency management, and Kubernetes deployment strategies.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -574,7 +574,7 @@
       "name": "terraform-patterns",
       "source": "./engineering/terraform-patterns",
       "description": "Terraform infrastructure-as-code — module design patterns, state management, provider configuration, CI/CD integration, and multi-environment strategies.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -591,7 +591,7 @@
       "name": "research-summarizer",
       "source": "./product-team/research-summarizer",
       "description": "Structured research summarization — summarize academic papers, market research, user interviews, and competitive analysis into actionable insights.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -608,7 +608,7 @@
       "name": "code-tour",
       "source": "./engineering/code-tour",
       "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. 10 developer personas, all CodeTour step types, SMIG description formula.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -625,7 +625,7 @@
       "name": "demo-video",
       "source": "./engineering/demo-video",
       "description": "Create polished demo videos from screenshots and scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts with story structure, scene design system, and narration guidance.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -643,7 +643,7 @@
       "name": "data-quality-auditor",
       "source": "./engineering/data-quality-auditor",
       "description": "Audit datasets for completeness, consistency, accuracy, and validity. 3 stdlib-only Python tools: data profiler with DQS scoring, missing value analyzer with MCAR/MAR/MNAR classification, and multi-method outlier detector.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -660,7 +660,7 @@
       "name": "statistical-analyst",
       "source": "./engineering/statistical-analyst",
       "description": "Hypothesis testing, A/B experiment analysis, sample size calculation, and confidence intervals. 3 stdlib-only Python tools: Z-test/t-test/chi-square with effect sizes, sample size calculator with power tradeoffs, and Wilson score confidence intervals.",
-      "version": "2.2.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -677,7 +677,7 @@
       "name": "apple-hig-expert",
       "source": "./product-team/apple-hig-expert",
       "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets and contrast.",
-      "version": "2.3.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -697,7 +697,7 @@
       "name": "llm-wiki",
       "source": "./engineering/llm-wiki",
       "description": "A second brain for Claude Code + Obsidian inspired by Karpathy's LLM Wiki gist. Turn any LLM CLI into a disciplined wiki maintainer: incrementally ingest sources into a persistent, interlinked markdown vault; update entity/concept/source pages; flag contradictions; maintain index and append-only log. Knowledge compounds instead of being re-derived by RAG on every query. Ships 3 sub-agents (wiki-ingestor, wiki-librarian, wiki-linter), 5 slash commands (/wiki-init, /wiki-ingest, /wiki-query, /wiki-lint, /wiki-log), 8 Python tools (stdlib only: init_vault, ingest_source, update_index, append_log, wiki_search BM25, lint_wiki, graph_analyzer, export_marp), 8 reference docs, full vault templates (CLAUDE.md, AGENTS.md, cursorrules, 5 page templates), and a worked example vault. Cross-tool compatible with Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, and Gemini CLI.",
-      "version": "2.3.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -719,7 +719,7 @@
       "name": "karpathy-coder",
       "source": "./engineering/karpathy-coder",
       "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, simplify, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check command, and pre-commit hook. All stdlib-only.",
-      "version": "2.3.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -739,7 +739,7 @@
       "name": "feature-flags-architect",
       "source": "./engineering/feature-flags-architect",
       "description": "End-to-end feature-flag discipline: classify, ship, ramp, retire. Detects stale flags as debt, generates phased rollout plans (ring/linear/log/cohort), and audits every flag for a documented kill switch. 3 stdlib Python tools, 4 references on flag taxonomy + provider trade-offs (LaunchDarkly/GrowthBook/Statsig/Unleash/Flipt/DIY) + rollout strategies + lifecycle. /flag-cleanup slash command. Cross-tool compatible.",
-      "version": "2.4.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -761,7 +761,7 @@
       "name": "kubernetes-operator",
       "source": "./engineering/kubernetes-operator",
       "description": "End-to-end Kubernetes Operator discipline: CRD design, reconcile-loop patterns, and OperatorHub Capability Levels. Ships CRD validator, reconcile-loop linter, and capability auditor (3 stdlib Python tools), 4 references on the operator pattern + CRD design + reconcile patterns + framework comparison (controller-runtime/kubebuilder/operator-sdk/metacontroller/KOPF), CRD + Go controller skeletons, and /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
-      "version": "2.4.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -783,7 +783,7 @@
       "name": "chaos-engineering",
       "source": "./engineering/chaos-engineering",
       "description": "End-to-end chaos engineering discipline: design experiments with hypothesis + steady-state metric + blast radius + abort criteria, calculate risk score against error budget, and generate blameless postmortems. 3 stdlib Python tools (experiment_designer, blast_radius_calculator, experiment_postmortem), 4 references on chaos principles + experiment design + 7-attack taxonomy + tooling landscape (Chaos Toolkit/Mesh/Litmus/Gremlin/AWS FIS/DIY), templates, and /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (chaos targets).",
-      "version": "2.4.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -805,7 +805,7 @@
       "name": "slo-architect",
       "source": "./engineering/slo-architect",
       "description": "End-to-end SLO/SLI/error-budget discipline per Google SRE Workbook. Ships SLO designer (refuses to render without required fields), error-budget calculator with multi-window burn-rate alert thresholds (PromQL-shaped), and SLO reviewer that catches the 7 common bugs. 4 references on principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. Asset templates for SLO YAML and error budget policy. /slo-design slash command. NOT a generic observability skill.",
-      "version": "2.4.4",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -826,7 +826,7 @@
       "name": "write-a-skill",
       "source": "./engineering/write-a-skill",
       "description": "Skill-author skill: create new agent skills with proper structure, progressive disclosure, and bundled resources. Derived from Matt Pocock's MIT-licensed write-a-skill with: (1) 3 stdlib Python validation tools (description validator, structure validator, review-checklist runner — all enforcing Matt's 6-item checklist), (2) 4 references citing 7-8 authoritative sources each (progressive disclosure principles, description design patterns, quality gates, companion tooling), (3) cs-skill-author persona agent + /cs:write-a-skill slash command. Matt's voice and 3-phase workflow (Gather → Draft → Review) preserved verbatim per MIT.",
-      "version": "2.6.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -845,7 +845,7 @@
       "name": "caveman",
       "source": "./engineering/caveman",
       "description": "Ultra-compressed communication mode. Cuts token usage 20-50% (75% upper bound) by dropping filler, articles, pleasantries, and hedging while keeping full technical accuracy. Derived from Matt Pocock's MIT-licensed caveman with: (1) 3 stdlib Python tools (deterministic compressor, token-savings estimator with $/Mtok cost extrapolation, lint that detects banned vocab with code-block + exception-zone whitelisting), (2) 3 references citing 7-8 sources (compression principles, when caveman backfires, companion tooling), (3) cs-caveman-mode persona agent + /cs:caveman slash command. Matt's persistence rules + auto-clarity exception preserved verbatim per MIT.",
-      "version": "2.6.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -863,7 +863,7 @@
       "name": "grill-me",
       "source": "./engineering/grill-me",
       "description": "Relentless plan-and-design interrogator. Walks the decision tree one branch at a time, asking forcing questions sequentially with recommended answers. Explores codebase before asking. Derived from Matt Pocock's MIT-licensed grill-me with: (1) 3 stdlib Python tools (decision-tree extractor across 6 branch kinds, question generator with dependency-aware ordering, JSON-backed session tracker for multi-day grills), (2) 3 references citing 7-8 sources (6 forcing-question patterns, when to stop grilling, companion tooling), (3) cs-grill-master persona agent + /cs:grill-me slash command. Matt's relentless one-at-a-time interview discipline preserved verbatim per MIT.",
-      "version": "2.6.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -882,7 +882,7 @@
       "name": "handoff-engineering",
       "source": "./engineering/handoff",
       "description": "Conversation-handoff document generator. Compacts the current session into a markdown handoff for a fresh agent — references existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL instead of duplicating them. Derived from Matt Pocock's MIT-licensed handoff with: (1) 3 stdlib Python tools (template generator tailored to 5 next-session emphases, artifact deduplicator across 5 categories of duplication, skill recommender matching content to 14 skills in this repo), (2) 4 references citing 7-8 sources (handoff structure, deduplication discipline, next-session skill matching, companion tooling), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline + mktemp convention preserved verbatim per MIT.",
-      "version": "2.6.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -900,7 +900,7 @@
       "name": "agile-product-owner",
       "source": "./product-team/agile-product-owner",
       "description": "Agile product ownership for backlog management and sprint execution. INVEST-compliant user story generation, acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool and 2 reference guides.",
-      "version": "2.3.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },


### PR DESCRIPTION
marketplace.json had outdated version numbers for 42 of 62 plugins, causing Claude Code to potentially serve stale cached artifacts during installation. For example, engineering-advanced-skills showed 2.4.3 in the marketplace but the actual plugin.json has 2.9.0 (with the skills path fix from PR #715).

Synced all marketplace entry versions to match their corresponding .claude-plugin/plugin.json versions.

## Summary

<!-- What does this PR add or change? -->

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [ ] Scripts (if any) run with `--help` without errors
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [x] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

<!-- How did you verify this works? -->
