### PR TITLE
feat(engineering): add workflow-builder skill for Claude Code workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -842,6 +842,27 @@
       "category": "development"
     },
     {
+      "name": "workflow-builder",
+      "source": "./engineering/workflow-builder",
+      "description": "Workflow-builder skill: design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool (CLAUDE_CODE_WORKFLOWS=1, /workflows). Every session opens with an intake question set; when the user is vague, a stdlib recommendation engine infers and proposes a topology with rationale instead of stalling. Ships 3 stdlib Python tools (intake recommendation engine, .js validator enforcing pure-literal-meta / no-non-determinism / guarded-loop / parallel-thunk rules, topology scaffolder), 3 references citing 7-8 authoritative sources each (API surface, orchestration patterns, decision + intake guide), templates + a runnable example, cs-workflow-architect persona agent + /cs:workflow-build slash command. Use when building, scaffolding, or running a custom Claude Code workflow or orchestrating sub-agents (fan-out, pipeline, loop, judge-panel).",
+      "version": "1.0.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "workflow",
+        "claude-code-workflows",
+        "multi-agent",
+        "orchestration",
+        "deterministic",
+        "fan-out",
+        "pipeline",
+        "sub-agents",
+        "meta-skill"
+      ],
+      "category": "development"
+    },
+    {
       "name": "caveman",
       "source": "./engineering/caveman",
       "description": "Ultra-compressed communication mode. Cuts token usage 20-50% (75% upper bound) by dropping filler, articles, pleasantries, and hedging while keeping full technical accuracy. Derived from Matt Pocock's MIT-licensed caveman with: (1) 3 stdlib Python tools (deterministic compressor, token-savings estimator with $/Mtok cost extrapolation, lint that detects banned vocab with code-block + exception-zone whitelisting), (2) 3 references citing 7-8 sources (compression principles, when caveman backfires, companion tooling), (3) cs-caveman-mode persona agent + /cs:caveman slash command. Matt's persistence rules + auto-clarity exception preserved verbatim per MIT.",

--- a/engineering/workflow-builder/.claude-plugin/plugin.json
+++ b/engineering/workflow-builder/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "workflow-builder",
+  "description": "Workflow-builder skill: design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool (CLAUDE_CODE_WORKFLOWS=1, /workflows). Every session opens with an intake question set; when the user is vague, a stdlib recommendation engine infers and proposes a topology with rationale instead of stalling. Ships 3 stdlib Python tools (intake recommendation engine, .js validator enforcing the pure-literal-meta / no-non-determinism / guarded-loop / parallel-thunk rules, topology scaffolder), 3 references citing 7-8 authoritative sources each (full API surface, orchestration patterns, decision + intake guide), templates + a runnable example, cs-workflow-architect persona agent + /cs:workflow-build slash command. Use when building, scaffolding, or running a custom Claude Code workflow or orchestrating sub-agents (fan-out, pipeline, loop, judge-panel).",
+  "version": "1.0.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": ["./skills/workflow-builder"],
+  "attribution": {
+    "inspired_by": "https://github.com/ray-amjad/claude-code-workflow-creator",
+    "original_author": "Ray Amjad",
+    "derivation_note": "Original content written for this repo from Claude Code's publicly-documented Workflow tool API. Ray Amjad's claude-code-workflow-creator (no LICENSE file at time of authoring) is credited as the conceptual inspiration for the workflow-authoring skill pattern; no text was copied verbatim."
+  }
+}

--- a/engineering/workflow-builder/README.md
+++ b/engineering/workflow-builder/README.md
@@ -1,0 +1,55 @@
+# workflow-builder
+
+Design and write deterministic multi-agent **workflow** scripts for Claude Code's Workflow tool — `.js` files in `.claude/workflows/` that fan work out to fresh-context sub-agents under plain JavaScript control flow. Only leaf `agent()` calls spend tokens, so the main session stays clean and the run is resumable.
+
+Targets the Workflow tool introduced in Claude Code v2.1.147 (gated behind `CLAUDE_CODE_WORKFLOWS=1`, browsable via `/workflows`).
+
+## The intake-first rule
+
+Every workflow-creation session opens with an intake question set (what task, what unit of work, known list vs. loop, barrier vs. pipeline, structured output, depth). **When the user is vague, the skill does not stall or interrogate in a loop** — it runs a deterministic recommendation engine that infers a topology and presents it *with the reasoning* ("here's what I'd build and why"), then confirms before writing any file.
+
+## What's in the box
+
+| Component | Where | What it does |
+|---|---|---|
+| **Intake recommendation engine** | `skills/workflow-builder/scripts/workflow_intake.py` | Classifies a (vague) task → recommended topology + runner-up + per-stage model plan + budget guard + a one-line rationale per choice. |
+| **Workflow validator** | `skills/workflow-builder/scripts/validate_workflow.py` | Stdlib linter for `.js` workflows: pure-literal `meta`, no `Date.now()`/`Math.random()`/argless `new Date()`, no FS/Node APIs in the orchestrator, `parallel()` thunks, guarded loops, `filter(Boolean)`, size cap. PASS / WARN / FAIL with line numbers. |
+| **Scaffolder** | `skills/workflow-builder/scripts/scaffold_workflow.py` | Emits a runnable starter for any of 5 topologies (fan-out, pipeline, barrier, loop, judge-panel). |
+| **3 references** | `skills/workflow-builder/references/` | API reference · orchestration patterns · decision + intake guide (7-8 sources each). |
+| **Templates + example** | `skills/workflow-builder/assets/` | Fan-out / pipeline / loop starters + a complete PR-triage workflow. |
+| **Persona agent** | `agents/cs-workflow-architect.md` | Design-first interrogator that refuses to write before the topology is confirmed. |
+| **Slash command** | `commands/cs-workflow-build.md` | `/cs:workflow-build <task>` — runs the full intake → scaffold → validate flow. |
+
+## Quick start
+
+```bash
+cd skills/workflow-builder
+
+# 1. Turn a vague request into a concrete proposal
+python scripts/workflow_intake.py --task "review my open PRs for bugs"
+
+# 2. Scaffold the confirmed topology
+python scripts/scaffold_workflow.py --topology pipeline --name pr-triage \
+  --description "Triage open PRs" > /tmp/pr-triage.js
+
+# 3. Validate before running
+python scripts/validate_workflow.py /tmp/pr-triage.js
+```
+
+All three tools run with `--sample` (no args) and `--help`.
+
+## Running the workflows it writes
+
+```bash
+export CLAUDE_CODE_WORKFLOWS=1          # the feature is off by default
+# save the .js under .claude/workflows/ , then launch + watch via /workflows
+# P = pause/resume , X = skip a sub-agent ; failed agents retry automatically
+```
+
+## Attribution
+
+Conceptually inspired by [Ray Amjad's claude-code-workflow-creator](https://github.com/ray-amjad/claude-code-workflow-creator). All content here was written for this repo against Claude Code's publicly-documented Workflow tool API; no text was copied verbatim.
+
+## License
+
+MIT.

--- a/engineering/workflow-builder/agents/cs-workflow-architect.md
+++ b/engineering/workflow-builder/agents/cs-workflow-architect.md
@@ -1,0 +1,96 @@
+---
+name: cs-workflow-architect
+description: Workflow-architect persona. Opens every workflow-creation session with the intake question set, infers-and-proposes when the user is vague (never interrogates in a loop), and refuses to write a workflow file before the topology is confirmed. Enforces the hard rules (pure-literal meta, no non-determinism, guarded loops, parallel thunks) via the validator before any run.
+skills: engineering/workflow-builder/skills/workflow-builder
+domain: engineering
+model: opus
+tools: [Read, Write, Bash, Grep, Glob]
+---
+
+# Workflow Architect Agent
+
+## Voice
+
+**Opening:** "Before any code — what repeatable, multi-step task do you want to automate, and what's the one unit of work a single sub-agent does once?"
+**When the user is vague:** "You were light on detail, so here's the topology I'd build and why — tell me what to change." (Never re-ask questions they already half-answered.)
+**Closing:** "Confirmed the shape? I'll scaffold it, validate it, and hand you the file for `.claude/workflows/`."
+
+Direct, decisive, design-first. Treats topology as a pre-code decision. Trusts the validator over judgement for the mechanical rules. Refuses to write a workflow when a single agent or a skill would do.
+
+## Purpose
+
+Orchestrates the `workflow-builder` skill across the three workflow-authoring decisions:
+
+1. **Intake** — ask what kind of workflow; map answers to a topology (fan-out / pipeline / barrier / loop / judge-panel).
+2. **Recommend** — when input is vague, run the intake engine to produce concrete proposals *with rationale*, then confirm the shape.
+3. **Build → validate → run** — scaffold the starter, lint it, and hand it off for `/workflows`.
+
+Differentiates clearly:
+
+- **vs `write-a-skill`** — that authors reusable *skills*; this authors deterministic *workflow* `.js` files.
+- **vs the plain Agent tool** — a single task needs an agent, not a workflow. Say so when intake reveals one unit, one task.
+- **vs a Skill** — a procedure where Claude picks steps dynamically should be a skill, not a fixed-topology workflow.
+
+**Hard rule:** never write a workflow file before the topology is confirmed, and never call a workflow "ready" until `validate_workflow.py` returns PASS or a documented WARN.
+
+## Skill Integration
+
+**Skill Location:** `../skills/workflow-builder/`
+
+### Python Tools (Stdlib)
+
+1. **Workflow Intake Engine** — `../skills/workflow-builder/scripts/workflow_intake.py`
+   - `python workflow_intake.py --task "..." [--units --stages --needs-all --structured]`
+   - Returns recommended topology + runner-up + per-stage model plan + budget guard + rationale.
+2. **Workflow Validator** — `../skills/workflow-builder/scripts/validate_workflow.py`
+   - `python validate_workflow.py path/to/workflow.js`
+   - PASS / WARN / FAIL with line numbers; enforces meta/non-determinism/Node-API/thunk/loop rules.
+3. **Workflow Scaffolder** — `../skills/workflow-builder/scripts/scaffold_workflow.py`
+   - `python scaffold_workflow.py --topology pipeline --name X --description "..."`
+   - Emits a runnable starter for the chosen topology.
+
+### Knowledge Bases
+
+- `../skills/workflow-builder/references/decision_and_intake_guide.md` — the question framework + vague-input playbook + worked examples.
+- `../skills/workflow-builder/references/api_reference.md` — full API surface (globals, options, caps, sandbox rules).
+- `../skills/workflow-builder/references/orchestration_patterns.md` — copy-paste topology shapes.
+
+## Workflow
+
+```bash
+# 1. Intake (always first). If the user is vague, infer and propose:
+python ../skills/workflow-builder/scripts/workflow_intake.py --task "their request"
+
+# 2. Confirm the topology + phases with the user. (Only approval gate.)
+
+# 3. Scaffold the confirmed topology:
+python ../skills/workflow-builder/scripts/scaffold_workflow.py \
+  --topology <fan-out|pipeline|barrier|loop|judge-panel> --name <name> --description "..." \
+  > .claude/workflows/<name>.js
+
+# 4. Edit agent prompts, then validate before running:
+python ../skills/workflow-builder/scripts/validate_workflow.py .claude/workflows/<name>.js
+
+# 5. Enable + run: export CLAUDE_CODE_WORKFLOWS=1 ; launch via /workflows (P=pause, X=skip).
+```
+
+## Output Standards
+
+```
+**Bottom Line:** [one sentence — recommended topology + whether a workflow is even the right tool]
+**The Decision:** [intake | recommend | scaffold | validate | run]
+**The Evidence:** [intake-engine rationale + validator verdict with line numbers]
+**How to Act:** [3 concrete next steps]
+**Your Decision:** [the call only the user can make — confirm topology, set budget, name the workflow]
+```
+
+## Related
+
+- Skill: [`workflow-builder`](../skills/workflow-builder/SKILL.md)
+- Command: [`/cs:workflow-build`](../commands/cs-workflow-build.md)
+- Adjacent: `../../write-a-skill/` (authoring skills, not workflows), `../../grill-me/` (forcing-question discipline)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready

--- a/engineering/workflow-builder/commands/cs-workflow-build.md
+++ b/engineering/workflow-builder/commands/cs-workflow-build.md
@@ -1,0 +1,95 @@
+---
+name: "cs-workflow-build"
+description: "/cs:workflow-build <task-description> — Design and write a deterministic Claude Code workflow (.js). Opens with intake questions, infers-and-proposes a topology when the request is vague, then scaffolds + validates the file. Use when building or running a custom Claude Code workflow."
+---
+
+# /cs:workflow-build — Workflow Architect Intake
+
+**Command:** `/cs:workflow-build <task-description>`
+
+Designs a deterministic multi-agent workflow for Claude Code's Workflow tool. Always opens with intake; never writes a file before the topology is confirmed.
+
+## When to Run
+
+- Building a new `.claude/workflows/*.js` file
+- Automating a repeatable, multi-step task across fresh-context sub-agents
+- Deciding whether a task even warrants a workflow (vs. a single agent or a skill)
+
+## Step 1 — Intake (always first)
+
+Ask the opening question set. Lead with #1.
+
+1. What repeatable, multi-step task do you want to automate?
+2. What is the one unit of work a single sub-agent does once?
+3. How many units — a known list, or discovered by looping?
+4. Do later steps need *all* prior results at once, or can each item flow on its own?
+5. Does any step need structured data back (a verdict, a list, scores)?
+6. Roughly how deep / how many tokens?
+
+## Step 2 — If the user is vague, infer and propose (don't loop on questions)
+
+```bash
+python ../skills/workflow-builder/scripts/workflow_intake.py --task "<their request>" \
+  --units unknown --stages unknown --needs-all unknown --structured unknown
+```
+
+Present the result as "here's what I'd build and why": recommended topology (+ runner-up), per-stage model picks, a budget guard, and the rationale for each choice. Then ask only "what should I change?"
+
+## Step 3 — Confirm the shape, then scaffold
+
+```bash
+python ../skills/workflow-builder/scripts/scaffold_workflow.py \
+  --topology <fan-out|pipeline|barrier|loop|judge-panel> --name <name> --description "..." \
+  > .claude/workflows/<name>.js
+```
+
+## Step 4 — Validate before running
+
+```bash
+python ../skills/workflow-builder/scripts/validate_workflow.py .claude/workflows/<name>.js
+```
+
+Fix every FAIL. WARNs need a one-line justification.
+
+## Step 5 — Run
+
+```bash
+export CLAUDE_CODE_WORKFLOWS=1   # the feature is off by default
+# Save under .claude/workflows/, then launch + monitor via /workflows.
+# P = pause/resume, X = skip a sub-agent. Failed agents retry automatically.
+```
+
+## The Hard Rules (validator enforces)
+
+1. `meta` is a pure literal and the first statement — no variables, spreads, template strings, or calls.
+2. No `Date.now()`, `Math.random()`, or argless `new Date()` — they break resume.
+3. No filesystem / Node APIs in the orchestrator — that work goes inside `agent()`.
+4. `parallel()` takes thunks (`() => agent(...)`); default to `pipeline()` unless a stage needs the whole prior set.
+5. Guard every open-ended loop with a counter or `budget.remaining()`.
+6. `results.filter(Boolean)` before using parallel/pipeline output.
+
+## Output Format
+
+```markdown
+# Workflow Build: <name>
+## The Decision
+[intake | recommend | scaffold | validate | run]
+## Recommended Topology
+[fan-out | pipeline | barrier | loop | judge-panel] — why
+## Model Plan
+[per-stage model + reason]
+## Validator Verdict
+🟢 PASS | 🟡 WARN (justified) | 🔴 FAIL (with line numbers)
+## Next Steps
+[3 concrete actions]
+```
+
+## Related
+
+- Agent: [`cs-workflow-architect`](../agents/cs-workflow-architect.md)
+- Skill: [`workflow-builder`](../skills/workflow-builder/SKILL.md)
+- Adjacent: `/cs:write-a-skill` (authoring skills, not workflows)
+
+---
+
+**Version:** 1.0.0

--- a/engineering/workflow-builder/skills/workflow-builder/SKILL.md
+++ b/engineering/workflow-builder/skills/workflow-builder/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: workflow-builder
+description: Design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool. Use when a user wants to build, create, author, scaffold, or run a custom Claude Code workflow, orchestrate sub-agents (fan-out, pipeline, loop, judge-panel), or automate a repeatable multi-step task across fresh-context agents.
+license: MIT
+metadata:
+  inspired_by: "https://github.com/ray-amjad/claude-code-workflow-creator (Ray Amjad)"
+  targets: "Claude Code Workflow tool (CLAUDE_CODE_WORKFLOWS=1, /workflows)"
+  version: 1.0.0
+---
+
+# Workflow Builder
+
+Author runnable workflow scripts for Claude Code's Workflow tool: deterministic multi-agent orchestration files (`.js`) that fan work out to fresh-context sub-agents under plain JavaScript control flow. Only leaf `agent()` calls spend tokens, so the main session stays clean and the whole run is resumable.
+
+## ALWAYS start every session with intake (non-negotiable)
+
+Before proposing or writing any workflow, run the intake. Do not skip to code.
+
+1. **Ask what kind of workflow they want.** Use this opening question set:
+   - What repeatable, multi-step task do you want to automate?
+   - What is the one unit of work a single sub-agent does once?
+   - How many units — a known list, or discovered by looping?
+   - Do later steps need *all* prior results at once, or can each item flow on its own?
+   - Does any step need structured data back (a verdict, a list, scores)?
+   - Roughly how many tokens / how deep should it go?
+
+2. **If the user is vague, do NOT stall.** Run the recommendation engine to turn whatever you have into 1-2 concrete proposals, then present them *with the reasoning*:
+   ```bash
+   python scripts/workflow_intake.py --task "their description" \
+     --units unknown --stages unknown --needs-all unknown --structured unknown
+   ```
+   The engine returns a recommended topology (fan-out / pipeline / loop / barrier / judge-panel), model picks, a budget guard, and a one-line rationale per choice. Present those as "Here's what I'd build and why" — never ask the user to re-answer questions they already half-answered.
+
+3. **Confirm the shape with the user** (topology + phases + parallel-vs-pipeline) before writing the file. This is the only approval gate.
+
+See [references/decision_and_intake_guide.md](references/decision_and_intake_guide.md) for the full question framework, the vague-input playbook, and worked recommendation examples.
+
+## Decide if a workflow is even the right tool
+
+| Scenario | Use |
+|----------|-----|
+| Single sub-agent, one task | plain Agent tool |
+| Reusable procedure, Claude picks steps dynamically | a Skill |
+| Many sub-agents in a fixed topology, deterministic + resumable | **Workflow** ✓ |
+
+Workflows earn their cost when work is parallel or multi-stage, must be reproducible, long enough to fail halfway (so resume matters), or benefits from isolating each step in its own context window. For one-off tasks, just use Claude directly.
+
+## Build → validate → run loop
+
+1. **Scaffold** a starter from the confirmed topology:
+   ```bash
+   python scripts/scaffold_workflow.py --topology pipeline --name pr-triage \
+     --description "Triage open PRs" > .claude/workflows/pr-triage.js
+   ```
+2. **Edit** the file: `meta` block first (pure literal, first statement), then the async body using the injected globals — `agent()`, `pipeline()`, `parallel()`, `phase()`, `log()`, `budget`, `args`, `workflow()`. Full surface in [references/api_reference.md](references/api_reference.md); copy-paste shapes in [references/orchestration_patterns.md](references/orchestration_patterns.md).
+3. **Validate** before running — catches the parser-fatal mistakes:
+   ```bash
+   python scripts/validate_workflow.py .claude/workflows/pr-triage.js
+   ```
+4. **Run** it: enable the feature with `export CLAUDE_CODE_WORKFLOWS=1`, save the file under `.claude/workflows/`, then use `/workflows` to launch and watch it live. Press **P** to pause/resume, **X** to skip a sub-agent. Failed agents retry automatically.
+
+## Hard rules (validator enforces these)
+
+- `meta` is a **pure literal** and the **first statement** — no variables, spreads, template strings, or function calls inside it.
+- **No non-determinism:** `Date.now()`, `Math.random()`, argless `new Date()` break resume — pass timestamps via `args`.
+- **No filesystem / Node APIs** (`require`, `fs`, `process`, network) in the orchestrator — that work belongs *inside* `agent()` prompts.
+- `parallel()` takes **thunks** (`() => agent(...)`), not bare promises. Default to `pipeline()` unless a stage needs the whole prior result set.
+- **Guard every open-ended loop** with a counter or `budget.remaining()` check — unguarded loops hit the 1000-agent cap.
+- Filter skipped/failed agents: `results.filter(Boolean)`.
+
+## Tooling
+
+- `scripts/workflow_intake.py` — intake recommendation engine (topology + model + budget + rationale from vague input).
+- `scripts/validate_workflow.py` — stdlib linter for the rules above; PASS / WARN / FAIL with line numbers.
+- `scripts/scaffold_workflow.py` — generate a starter `.js` for any topology.
+- `assets/templates/` — fan-out, pipeline, loop-until-budget starters. `assets/examples/` — a complete runnable workflow.
+
+All scripts run with `--sample` (no args) and `--help`.

--- a/engineering/workflow-builder/skills/workflow-builder/assets/examples/pr-triage.js
+++ b/engineering/workflow-builder/skills/workflow-builder/assets/examples/pr-triage.js
@@ -1,0 +1,98 @@
+// Example workflow: triage open PRs for bugs before merge.
+//
+// Shape: fan-out (one reviewer per PR) -> skeptic-vote (verify each high-severity
+// finding so a false positive doesn't waste review time) -> synthesize one report.
+//
+// Run: enable CLAUDE_CODE_WORKFLOWS=1, save under .claude/workflows/, launch via /workflows.
+// Pass PR identifiers in via args, e.g. Workflow({ scriptPath, args: { prs: ['#12', '#15'] } }).
+
+export const meta = {
+  name: 'pr-triage',
+  description: 'Triage open PRs for bugs before merge, with adversarial verification of high-severity findings',
+  whenToUse: 'Run before a merge window to surface and confirm likely bugs across open PRs',
+  phases: [
+    { title: 'Review', detail: 'One reviewer agent per PR', model: 'haiku' },
+    { title: 'Verify', detail: 'Skeptic vote on high-severity findings', model: 'sonnet' },
+    { title: 'Report', detail: 'Synthesize a single triage report', model: 'opus' }
+  ]
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    pr: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+          file: { type: 'string' }
+        },
+        required: ['title', 'severity']
+      }
+    }
+  },
+  required: ['pr', 'findings']
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: { refuted: { type: 'boolean' }, reason: { type: 'string' } },
+  required: ['refuted']
+}
+
+// args.prs is the list of PR identifiers to triage; gathering their diffs happens
+// inside each reviewer agent (the orchestrator has no filesystem/network access).
+const PRS = args?.prs ?? ['#101', '#102', '#103']
+
+// Phase 1 — fan out one reviewer per PR. Cheap model, structured output.
+phase('Review')
+const reviews = await parallel(
+  PRS.map((pr, i) => () =>
+    agent(
+      `Review PR ${pr} for likely bugs. Inspect the diff and report concrete findings.`,
+      { label: `review:${pr}`, phase: 'Review', model: 'haiku', schema: FINDINGS_SCHEMA }
+    )
+  )
+)
+
+// Collect every high-severity finding across all PRs.
+const highSeverity = reviews
+  .filter(Boolean)
+  .flatMap(r => (r.findings ?? []).map(f => ({ ...f, pr: r.pr })))
+  .filter(f => f.severity === 'high')
+
+log(`Reviewed ${reviews.filter(Boolean).length} PRs; ${highSeverity.length} high-severity findings to verify.`)
+
+// Phase 2 — skeptic vote: three independent agents try to refute each high finding.
+// A finding survives only if it is NOT refuted by a majority.
+phase('Verify')
+const confirmed = []
+for (let i = 0; i < highSeverity.length; i++) {
+  const f = highSeverity[i]
+  const votes = await parallel(
+    Array.from({ length: 3 }, (_, k) => () =>
+      agent(
+        `Try hard to REFUTE this bug claim about PR ${f.pr}: "${f.title}" in ${f.file ?? 'unknown file'}. ` +
+        `Return { refuted: boolean, reason }.`,
+        { label: `skeptic:${i + 1}.${k + 1}`, phase: 'Verify', model: 'sonnet', schema: VERDICT_SCHEMA }
+      )
+    )
+  )
+  const survives = votes.filter(v => v && !v.refuted).length >= 2
+  if (survives) confirmed.push(f)
+}
+
+log(`Verified findings: ${confirmed.length} of ${highSeverity.length} survived the skeptic vote.`)
+
+// Phase 3 — synthesize one report from the confirmed findings.
+phase('Report')
+const report = await agent(
+  `Write a concise PR-triage report. Group by PR. Only include these confirmed high-severity findings:\n` +
+  JSON.stringify(confirmed, null, 2),
+  { model: 'opus' }
+)
+
+return { report, confirmed, reviewed: reviews.filter(Boolean).length }

--- a/engineering/workflow-builder/skills/workflow-builder/assets/templates/fan-out.js
+++ b/engineering/workflow-builder/skills/workflow-builder/assets/templates/fan-out.js
@@ -1,0 +1,48 @@
+export const meta = {
+  name: 'fan-out-research',
+  description: 'Fan out independent units, then synthesize',
+  phases: [
+    { title: 'Fan out' },
+    { title: 'Synthesize' }
+  ]
+}
+
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] }
+        },
+        required: ['title']
+      }
+    }
+  },
+  required: ['findings']
+}
+
+
+// Fan-out: independent units in parallel, then one synthesis.
+const ITEMS = args?.items ?? ['item one', 'item two', 'item three']
+
+phase('Fan out')
+const results = await parallel(
+  ITEMS.map((item, i) => () =>
+    agent(`Do the unit of work for:\n${item}`,
+          { label: `unit:${i + 1}`, model: 'haiku', schema: FINDINGS_SCHEMA }))
+)
+
+phase('Synthesize')
+const clean = results.filter(Boolean)
+const report = await agent(
+  `Synthesize these results into one report:\n${JSON.stringify(clean)}`,
+  { model: 'opus' }
+)
+log(`Done: synthesized ${clean.length} results.`)
+return report
+

--- a/engineering/workflow-builder/skills/workflow-builder/assets/templates/loop-until-budget.js
+++ b/engineering/workflow-builder/skills/workflow-builder/assets/templates/loop-until-budget.js
@@ -1,0 +1,52 @@
+export const meta = {
+  name: 'loop-until-budget',
+  description: 'Discover items under a budget guard',
+  phases: [
+    { title: 'Discover' }
+  ]
+}
+
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] }
+        },
+        required: ['title']
+      }
+    }
+  },
+  required: ['findings']
+}
+
+
+// Loop: discover an unknown number of items. GUARDED against the agent cap.
+const found = []
+const seen = new Set()
+let dryRounds = 0
+const HARD_CAP = 100
+
+phase('Discover')
+while (
+  dryRounds < 2 &&
+  found.length < HARD_CAP &&
+  (!budget.total || budget.remaining() > 50_000)
+) {
+  const r = await agent(
+    `Find items NOT already found:\n${JSON.stringify([...seen])}`,
+    { model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+  const fresh = (r?.findings ?? []).filter(f => !seen.has(f.title))
+  fresh.forEach(f => seen.add(f.title))
+  found.push(...fresh)
+  dryRounds = fresh.length === 0 ? dryRounds + 1 : 0
+  log(`Round complete: ${fresh.length} new, ${found.length} total.`)
+}
+return found
+

--- a/engineering/workflow-builder/skills/workflow-builder/assets/templates/pipeline.js
+++ b/engineering/workflow-builder/skills/workflow-builder/assets/templates/pipeline.js
@@ -1,0 +1,46 @@
+export const meta = {
+  name: 'pipeline-review',
+  description: 'Stream items through ordered stages',
+  phases: [
+    { title: 'Triage' },
+    { title: 'Verify' }
+  ]
+}
+
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] }
+        },
+        required: ['title']
+      }
+    }
+  },
+  required: ['findings']
+}
+
+
+// Pipeline: each item flows through stages independently (no barrier).
+const ITEMS = args?.items ?? ['item one', 'item two', 'item three']
+
+const results = await pipeline(
+  ITEMS,
+  // Stage 1 — triage / extract (cheap, high volume).
+  (item, _orig, i) =>
+    agent(`Triage:\n${item}`, { label: `triage:${i + 1}`, phase: 'Triage', model: 'haiku', schema: FINDINGS_SCHEMA }),
+  // Stage 2 — verify / refine each finding (fewer items, more judgement).
+  (prev) =>
+    parallel((prev?.findings ?? []).map(f => () =>
+      agent(`Verify and refine: ${f.title}`, { phase: 'Verify', model: 'sonnet' })))
+)
+
+log(`Done: processed ${results.filter(Boolean).length} items through the pipeline.`)
+return results.filter(Boolean)
+

--- a/engineering/workflow-builder/skills/workflow-builder/references/api_reference.md
+++ b/engineering/workflow-builder/skills/workflow-builder/references/api_reference.md
@@ -1,0 +1,115 @@
+# Workflow API Reference
+
+Complete surface for Claude Code's Workflow tool: every global, option, cap, and constant a workflow `.js` file can rely on. A workflow file has exactly two parts in order — a `meta` literal, then an async body that uses the injected globals below.
+
+## 1. `meta` declaration
+
+`meta` must be the **first statement** and a **pure object literal** — no variables, spreads, template strings, or function calls inside it. Reserved keys (`__proto__`, `constructor`, `prototype`) are rejected by the parser.
+
+```js
+export const meta = {
+  name: 'workflow-name',            // required, non-empty string
+  description: 'One-line summary',  // required
+  whenToUse: 'When to run this',    // optional
+  phases: [                         // optional, one entry per phase() call
+    { title: 'Phase Name', detail: 'Description', model: 'haiku' }
+  ]
+}
+```
+
+## 2. Injected globals
+
+| Global | Signature | Returns |
+|--------|-----------|---------|
+| `agent()` | `agent(prompt, opts?) → Promise<string\|object>` | Text, or a validated object when `schema` is set |
+| `pipeline()` | `pipeline(items, ...stages) → Promise<any[]>` | Streamed per-item results (no barrier between stages) |
+| `parallel()` | `parallel(thunks) → Promise<any[]>` | Concurrent results (barrier — waits for all) |
+| `phase()` | `phase(title) → void` | Groups subsequent agents under a heading |
+| `log()` | `log(message) → void` | Narrator output to the workflow log |
+| `console` | `.log()`, `.error()`, … | Routed into the workflow log |
+| `workflow()` | `workflow(nameOrRef, args?) → Promise<any>` | Result of a nested workflow (one level deep max) |
+| `args` | any | The input passed to the workflow, unchanged |
+| `budget` | `{ total, spent(), remaining() }` | Token tracking |
+
+## 3. `agent()` options
+
+```js
+agent(prompt, {
+  label: 'string',           // display name (~60 char default)
+  phase: 'phase-name',       // progress-group assignment
+  schema: { type: 'object' },// JSON Schema — validates + structures the return
+  model: 'haiku',            // 'haiku' | 'sonnet' | 'opus' | 'inherit' | full-model-id
+  isolation: 'worktree',     // run in a fresh git worktree (~200-500 ms + disk)
+  agentType: 'agent-type',   // custom sub-agent type
+  stallMs: 180000            // per-agent stall timeout override (ms)
+})
+```
+
+**Model resolution:** `haiku`/`sonnet`/`opus` resolve to the current default of that family; `inherit` (the default) uses the session main-loop model; a full model ID passes through unchanged. Pick lighter models (Haiku) for classification/extraction and heavier ones (Opus) for synthesis or hard reasoning.
+
+**Resume cache key** includes `schema`, `model`, `isolation`, and `agentType` — changing any of these re-runs the agent on resume. `label` and `phase` do **not** invalidate the cache.
+
+## 4. `pipeline()` vs `parallel()`
+
+**`pipeline(items, stage1, stage2, …)`** — each item flows through every stage independently; there is no barrier between stages, so stage 2 starts for an item the moment stage 1 finishes for *that* item. Stage callbacks receive `(prevResult, originalItem, index)`. Wall-clock time ≈ the slowest single item's full chain, not the sum of slowest-per-stage. **Default choice for multi-stage work.**
+
+**`parallel(thunks)`** — runs an array of `() => Promise` thunks concurrently and waits for all (a barrier). Use only when the next step genuinely needs the entire prior result set — dedup, merge, or a count-based exit. Requires thunks, not bare promises: `parallel([() => agent(a), () => agent(b)])`.
+
+## 5. `budget` object
+
+```js
+budget.total        // user-set target, or null if none
+budget.spent()      // output tokens spent this turn
+budget.remaining()  // max(0, total - spent()), or Infinity when total is null
+```
+
+Throws `WorkflowBudgetExceededError` once `spent()` reaches `total`. Use `budget.remaining()` as a loop guard for depth-scaling workflows.
+
+## 6. Caps & limits
+
+| Limit | Value | Behavior on breach |
+|-------|-------|--------------------|
+| Agent calls per run | 1000 | throws `WorkflowAgentCapError` |
+| Concurrent agents | `min(16, max(2, cores − 2))` | excess calls queue |
+| Script size | 524,288 bytes | rejected before parsing |
+| Per-agent stall | 180,000 ms (3 min) | aborted, retried up to 5× |
+| Sync timeout | 30,000 ms | catches infinite synchronous loops |
+
+## 7. Sandbox restrictions
+
+**Banned (non-reproducible — break resume):**
+- `Math.random()` → vary the agent prompt by index instead.
+- `Date.now()` → pass timestamps in via `args`.
+- argless `new Date()` → use `new Date(specificValue)`.
+
+**No access** to filesystem, Node APIs (`require`, `fs`, `process`), or network from the orchestrator. Any work needing those must happen *inside* an `agent()` call (the sub-agent has full tool access).
+
+## 8. Execution & resume
+
+1. The script is persisted to the session directory.
+2. A background task launches and returns a run ID (`wf_…`).
+3. A journal records each `agent()` call keyed by a hash of `(prompt, opts)`.
+4. Resume via `Workflow({ scriptPath, resumeFromRunId })` — cached calls return instantly; only changed or new calls re-run. Resume works **same-session only**; edit the saved file and re-invoke with `scriptPath`.
+
+## 9. Enabling the feature
+
+The Workflow tool is gated behind an environment variable and off by default:
+
+```bash
+export CLAUDE_CODE_WORKFLOWS=1
+```
+
+Save workflow files under `.claude/workflows/` in the project, then browse, launch, and monitor them with the `/workflows` slash command. **P** pauses/resumes a run; **X** skips a sub-agent.
+
+---
+
+## Sources
+
+1. Anthropic — Claude Code documentation, Workflow tool & `/workflows` (code.claude.com/docs).
+2. Ray Amjad — `claude-code-workflow-creator`, `references/api-reference.md` (github.com/ray-amjad/claude-code-workflow-creator).
+3. Anthropic — Claude Code changelog, v2.1.147 release notes (Workflow tool introduction).
+4. Anthropic — sub-agents & the Agent tool documentation (fresh-context isolation model).
+5. Anthropic — Claude Agent SDK: orchestration and background-task execution patterns.
+6. JSON Schema specification (json-schema.org) — the `schema` option's validation contract.
+7. Node.js / ECMAScript — async/await and `Promise.all` semantics underlying `parallel()`.
+8. Google SRE Workbook — error-budget discipline, analogous to the `budget` guard pattern.

--- a/engineering/workflow-builder/skills/workflow-builder/references/decision_and_intake_guide.md
+++ b/engineering/workflow-builder/skills/workflow-builder/references/decision_and_intake_guide.md
@@ -1,0 +1,83 @@
+# Decision & Intake Guide
+
+The workflow-builder skill opens **every** session with intake. This file is the full framework behind that gate: the questions to ask, how to handle vague answers, and worked examples of turning a fuzzy request into a concrete proposal.
+
+## Why intake comes first
+
+A workflow's whole value is deterministic, resumable, fixed-topology orchestration. The topology is a *design decision* that must be made before any code — choosing pipeline vs. parallel, known-list vs. loop, or whether a step needs structured output changes the entire file. Asking first is cheaper than rewriting. It also catches the most common mistake: building a workflow when a single agent or a skill would do.
+
+## The opening question set
+
+Ask these at the start of a workflow-creation session. Lead with #1; the rest sharpen the shape.
+
+1. **What repeatable, multi-step task do you want to automate?** (the goal)
+2. **What is the one unit of work** a single sub-agent does once? (e.g., "review one file", "research one question")
+3. **How many units** — a known list, or discovered by looping until some condition?
+4. **Do later steps need *all* prior results at once** (dedup/merge/count), or can each item flow independently?
+5. **Does any step need structured data back** — a verdict, a list, scores?
+6. **How deep / how many tokens** should this go? (sets the budget guard)
+
+Map answers → topology:
+
+| Signal | Topology |
+|--------|----------|
+| Independent units, known list, combine at end | **fan-out → synthesize** (`parallel` + final `agent`) |
+| Ordered stages, each item advances on its own | **pipeline** |
+| A stage needs the whole prior set (dedup/merge/early-exit) | **barrier** (`parallel`, then process) |
+| Unknown count, stop on goal / budget / dryness | **loop** (guarded) |
+| Wide solution space, want best-of-N | **judge panel** |
+| A wrong result is costly | add **skeptic-vote** verification on that finding |
+
+## The vague-input playbook
+
+When the user gives a one-liner ("I want to review my PRs") or skips the topology questions, **do not interrogate them in a loop.** Infer, propose, and explain. Run:
+
+```bash
+python scripts/workflow_intake.py --task "review my open PRs for bugs" \
+  --units unknown --stages unknown --needs-all unknown --structured unknown
+```
+
+The engine classifies the task by keywords, fills unknowns with the safest default, and returns:
+- a **recommended topology** (and a runner-up if it's close),
+- **model picks** per stage (Haiku for triage/extraction, Opus for synthesis),
+- a **budget guard** suggestion,
+- a **one-line rationale for every choice** so you can present "here's what I'd build and why."
+
+Then say, in your own words: *"You were light on detail, so here's the approach I'd recommend and why — tell me what to change."* Present the topology, the phases, and the parallel-vs-pipeline call. Only after the user reacts do you scaffold.
+
+### Defaults the engine applies to unknowns (and why)
+
+| Unknown | Default | Why |
+|---------|---------|-----|
+| unit count | loop with a hard cap | safest when count is undiscovered; cap prevents the 1000-agent ceiling |
+| stages | single stage unless the task names a verb chain | most fuzzy asks are one-pass fan-outs, not pipelines |
+| needs-all-results | no (prefer pipeline) | pipeline is strictly faster and the default per the API; only add a barrier on evidence |
+| structured output | yes, lightweight schema | a small schema makes downstream stages reliable at near-zero cost |
+| budget | guard at `remaining() > 50k` | keeps runaway loops from draining the turn |
+
+## Worked examples
+
+**"Review my PRs."**
+Unit = one PR (a known list, gathered inside the first agent). Each PR is reviewed once, independently. Wrong result costly = yes (a false positive wastes review time, a miss ships a bug). → **fan-out** (one review per PR, Haiku, structured findings) → **skeptic-vote** on each high-severity finding (Sonnet) → a final synthesis. If you want a distinct *verify* pass after review, split it into a two-stage **pipeline** instead. Rationale handed to the user: fan-out because PRs are independent; skeptic-vote because acting on a false positive is costly.
+
+**"Summarize a folder of documents."**
+Unit = one document. Count = known list (the folder contents, gathered inside the first agent). Combine at end = yes. → **fan-out** (Haiku per doc, structured summary) → **synthesize** (Opus, one report). No loop, no barrier mid-stream. Rationale: documents are independent, so parallel; one final synthesis because the user wants a single summary.
+
+**"Find security issues until you run out of budget."**
+Unit = one issue. Count = unknown, budget-bounded. → **loop-until-budget** guarded by `budget.remaining() > 50_000`, structured issue schema, dedup by id. Rationale: depth scales to the token target; the guard is mandatory or it hits the agent cap.
+
+## When to walk away from a workflow
+
+If intake reveals a single agent and one task, say so and recommend the plain Agent tool. If it's a procedure where Claude should pick steps dynamically rather than a fixed topology, recommend a Skill instead. Not every multi-step task earns a workflow — only deterministic, resumable, fan-out/pipeline/loop shapes do.
+
+---
+
+## Sources
+
+1. Ray Amjad — `claude-code-workflow-creator`, `SKILL.md` (the five topology questions, tool-selection table).
+2. Anthropic — Claude Code documentation on when to use workflows vs. agents vs. skills.
+3. Matt Pocock — `grill-me` skill (forcing-question, one-recommendation-at-a-time intake discipline).
+4. Anthropic — sub-agent context-isolation rationale (why topology is a pre-code decision).
+5. Google SRE Workbook — budget-guard discipline for bounded loops.
+6. "LLM-as-a-judge" + ensemble verification literature (judge-panel / skeptic-vote selection).
+7. YC / product-discovery practice — infer-and-propose over interrogate-in-a-loop for vague requests.

--- a/engineering/workflow-builder/skills/workflow-builder/references/orchestration_patterns.md
+++ b/engineering/workflow-builder/skills/workflow-builder/references/orchestration_patterns.md
@@ -1,0 +1,160 @@
+# Orchestration Patterns
+
+Copy-paste shapes for the common multi-agent topologies. Pick by answering the topology questions in [decision_and_intake_guide.md](decision_and_intake_guide.md), then adapt one of these.
+
+## 1. Fan-out then synthesize
+
+**When:** a known list of independent items, one pass each, and you need one combined answer at the end.
+
+```js
+const findings = await parallel(
+  questions.map((q, i) => () =>
+    agent(`Research and report verified facts:\n\n${q}`,
+          { label: `q${i + 1}`, schema: RESEARCH_SCHEMA }))
+)
+const report = await agent(
+  `Synthesize these findings into one report:\n${JSON.stringify(findings.filter(Boolean))}`,
+  { model: 'opus' }
+)
+```
+
+## 2. Pipeline: stage then stage (no barrier)
+
+**When:** items progress through ordered stages and each item should advance the instant it's ready, not wait for siblings.
+
+```js
+const results = await pipeline(
+  DIMENSIONS,
+  d => agent(d.prompt, { label: `review:${d.key}`, phase: 'Review', schema: FINDINGS_SCHEMA }),
+  review => parallel((review?.findings ?? []).map(f => () =>
+    agent(`Adversarially verify: ${f.title}`, { schema: VERDICT_SCHEMA })))
+)
+```
+
+## 3. Barrier when you must dedup / merge first
+
+**When:** the next stage needs the *entire* previous result set in hand — to dedup, merge, or early-exit on a count.
+
+```js
+const all = await parallel(DIMENSIONS.map(d => () => agent(d.prompt, { schema: FINDINGS_SCHEMA })))
+const deduped = dedupeByFileAndLine(all.filter(Boolean).flatMap(r => r.findings))
+const summary = await agent(`Summarize ${deduped.length} unique findings:\n${JSON.stringify(deduped)}`)
+```
+
+## 4. Loop until target count
+
+**When:** discovery with a fixed goal ("find 10 bugs"). Always bound it.
+
+```js
+const bugs = []
+while (bugs.length < 10 && bugs.length < 100 /* hard cap guard */) {
+  const r = await agent(
+    `Find bugs NOT already listed:\n${JSON.stringify(bugs)}`,
+    { schema: BUGS_SCHEMA }
+  )
+  if (!r?.bugs?.length) break
+  bugs.push(...r.bugs)
+}
+```
+
+## 5. Loop until budget runs low
+
+**When:** depth should scale to the user's token target. The `budget` guard is essential.
+
+```js
+const issues = []
+while (budget.total && budget.remaining() > 50_000) {
+  const r = await agent('Find one more issue not yet reported...', { schema: ISSUE_SCHEMA })
+  if (!r?.issues?.length) break
+  issues.push(...r.issues)
+}
+```
+
+## 6. Adversarial verification (skeptic vote)
+
+**When:** a finding will be acted on and a plausible-but-wrong one is costly. Findings survive on majority vote.
+
+```js
+const votes = await parallel(Array.from({ length: 3 }, (_, i) => () =>
+  agent(`Try hard to REFUTE this claim, return { refuted: boolean }:\n${claim}`,
+        { label: `skeptic:${i + 1}`, schema: VERDICT_SCHEMA })))
+const survives = votes.filter(v => v && !v.refuted).length >= 2
+```
+
+## 7. Judge panel
+
+**When:** a wide solution space benefits from several independent attempts, scored and synthesized.
+
+```js
+const drafts = await parallel(ANGLES.map(a => () =>
+  agent(`Produce a plan. Take a strictly ${a} approach.`)))
+const scored = await parallel(drafts.map((d, i) => () =>
+  agent(`Score this plan 1-10 with reasons:\n${d}`, { label: `judge:${i + 1}`, schema: SCORE_SCHEMA })))
+const winner = drafts[scored.indexOf(scored.reduce((a, b) => (a?.score ?? 0) >= (b?.score ?? 0) ? a : b))]
+const final = await agent(`Refine the winning plan:\n${winner}`, { model: 'opus' })
+```
+
+## 8. Loop until dry
+
+**When:** unknown-size discovery that stops after K consecutive rounds with no new findings.
+
+```js
+const found = []
+const seen = new Set()
+let dryRounds = 0
+while (dryRounds < 2 && found.length < 100) {
+  const r = await agent(`Find items not in:\n${JSON.stringify([...seen])}`, { schema: ITEMS_SCHEMA })
+  const fresh = (r?.items ?? []).filter(x => !seen.has(x.id))
+  fresh.forEach(x => seen.add(x.id))
+  found.push(...fresh)
+  dryRounds = fresh.length === 0 ? dryRounds + 1 : 0
+}
+```
+
+## 9. Nested workflow
+
+**When:** a self-contained sub-job lives inside a larger one (one level deep maximum).
+
+```js
+const research = await workflow('research-fanout', ['question one', 'question two'])
+```
+
+## Schema declarations
+
+Schemas are plain JSON Schema objects defined as top-level `const`s and passed via `{ schema }`:
+
+```js
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+          file: { type: 'string' }
+        },
+        required: ['title', 'severity']
+      }
+    }
+  },
+  required: ['findings']
+}
+```
+
+Between stages, stringify structured data into the next prompt (`JSON.stringify(...)`); the schema only shapes what comes *back* from a single `agent()` call.
+
+---
+
+## Sources
+
+1. Ray Amjad — `claude-code-workflow-creator`, `references/patterns.md` (fan-out, pipeline, judge-panel, loop shapes).
+2. Anthropic — Claude Code Workflow tool documentation (`pipeline`/`parallel` semantics).
+3. Anthropic — sub-agent orchestration patterns (Agent tool, fresh-context isolation).
+4. Karpathy — LLM agent loop / file-optimization patterns (loop-until-dry analogue).
+5. Google SRE Workbook — error budgets (loop-until-budget guard).
+6. "LLM-as-a-judge" evaluation literature (judge-panel + scored synthesis).
+7. Ensemble / majority-vote methods in ML (skeptic-vote verification).
+8. JSON Schema specification — structured-output contract for the `schema` option.

--- a/engineering/workflow-builder/skills/workflow-builder/scripts/scaffold_workflow.py
+++ b/engineering/workflow-builder/skills/workflow-builder/scripts/scaffold_workflow.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Scaffold a starter Claude Code workflow (.js) file for a chosen topology.
+
+Emits a runnable skeleton with the meta block, a schema, phase()/log() calls,
+a guarded loop where relevant, and the correct parallel-thunk / pipeline shape.
+Pipe to a file under .claude/workflows/ and then edit the agent prompts.
+
+Stdlib only. Deterministic.
+"""
+import argparse
+import re
+import sys
+
+TOPOLOGIES = ("fan-out", "pipeline", "barrier", "loop", "judge-panel")
+
+
+def _slug(name):
+    s = re.sub(r"[^a-z0-9-]+", "-", name.strip().lower()).strip("-")
+    return s or "my-workflow"
+
+
+def _meta(name, description, phases):
+    phase_lines = ",\n".join(f"    {{ title: '{p}' }}" for p in phases)
+    return (
+        "export const meta = {\n"
+        f"  name: '{_slug(name)}',\n"
+        f"  description: '{description}',\n"
+        "  phases: [\n"
+        f"{phase_lines}\n"
+        "  ]\n"
+        "}\n"
+    )
+
+
+SCHEMA = """const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] }
+        },
+        required: ['title']
+      }
+    }
+  },
+  required: ['findings']
+}
+"""
+
+
+def body_fan_out():
+    return """// Fan-out: independent units in parallel, then one synthesis.
+const ITEMS = args?.items ?? ['item one', 'item two', 'item three']
+
+phase('Fan out')
+const results = await parallel(
+  ITEMS.map((item, i) => () =>
+    agent(`Do the unit of work for:\\n${item}`,
+          { label: `unit:${i + 1}`, model: 'haiku', schema: FINDINGS_SCHEMA }))
+)
+
+phase('Synthesize')
+const clean = results.filter(Boolean)
+const report = await agent(
+  `Synthesize these results into one report:\\n${JSON.stringify(clean)}`,
+  { model: 'opus' }
+)
+log(`Done: synthesized ${clean.length} results.`)
+return report
+"""
+
+
+def body_pipeline():
+    return """// Pipeline: each item flows through stages independently (no barrier).
+const ITEMS = args?.items ?? ['item one', 'item two', 'item three']
+
+const results = await pipeline(
+  ITEMS,
+  // Stage 1 — triage / extract (cheap, high volume).
+  (item, _orig, i) =>
+    agent(`Triage:\\n${item}`, { label: `triage:${i + 1}`, phase: 'Triage', model: 'haiku', schema: FINDINGS_SCHEMA }),
+  // Stage 2 — verify / refine each finding (fewer items, more judgement).
+  (prev) =>
+    parallel((prev?.findings ?? []).map(f => () =>
+      agent(`Verify and refine: ${f.title}`, { phase: 'Verify', model: 'sonnet' })))
+)
+
+log(`Done: processed ${results.filter(Boolean).length} items through the pipeline.`)
+return results.filter(Boolean)
+"""
+
+
+def body_barrier():
+    return """// Barrier: collect the whole set first, then dedup/merge before the next step.
+const SOURCES = args?.sources ?? ['source A', 'source B', 'source C']
+
+phase('Collect')
+const all = await parallel(SOURCES.map((s, i) => () =>
+  agent(`Gather findings from:\\n${s}`, { label: `collect:${i + 1}`, model: 'haiku', schema: FINDINGS_SCHEMA })))
+
+// Merge across the full result set (this is why we need a barrier, not a pipeline).
+const merged = all.filter(Boolean).flatMap(r => r.findings ?? [])
+const seen = new Set()
+const deduped = merged.filter(f => (seen.has(f.title) ? false : (seen.add(f.title), true)))
+
+phase('Synthesize')
+const summary = await agent(
+  `Summarize these ${deduped.length} unique findings:\\n${JSON.stringify(deduped)}`,
+  { model: 'opus' }
+)
+log(`Done: ${deduped.length} unique findings after dedup.`)
+return summary
+"""
+
+
+def body_loop():
+    return """// Loop: discover an unknown number of items. GUARDED against the agent cap.
+const found = []
+const seen = new Set()
+let dryRounds = 0
+const HARD_CAP = 100
+
+phase('Discover')
+while (
+  dryRounds < 2 &&
+  found.length < HARD_CAP &&
+  (!budget.total || budget.remaining() > 50_000)
+) {
+  const r = await agent(
+    `Find items NOT already found:\\n${JSON.stringify([...seen])}`,
+    { model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+  const fresh = (r?.findings ?? []).filter(f => !seen.has(f.title))
+  fresh.forEach(f => seen.add(f.title))
+  found.push(...fresh)
+  dryRounds = fresh.length === 0 ? dryRounds + 1 : 0
+  log(`Round complete: ${fresh.length} new, ${found.length} total.`)
+}
+return found
+"""
+
+
+def body_judge_panel():
+    return """// Judge panel: diverse drafts, scored in parallel, synthesize the winner.
+const ANGLES = args?.angles ?? ['conservative', 'aggressive', 'contrarian']
+
+phase('Draft')
+const drafts = await parallel(ANGLES.map((a, i) => () =>
+  agent(`Produce a plan. Take a strictly ${a} approach.`, { label: `draft:${i + 1}`, model: 'sonnet' })))
+
+phase('Score')
+const SCORE_SCHEMA = { type: 'object', properties: { score: { type: 'number' } }, required: ['score'] }
+const scored = await parallel(drafts.map((d, i) => () =>
+  agent(`Score this plan 1-10 with reasons:\\n${d}`, { label: `judge:${i + 1}`, model: 'haiku', schema: SCORE_SCHEMA })))
+
+let best = 0
+scored.forEach((s, i) => { if ((s?.score ?? 0) > (scored[best]?.score ?? 0)) best = i })
+
+phase('Refine')
+const final = await agent(`Refine the winning plan:\\n${drafts[best]}`, { model: 'opus' })
+log(`Done: winner was angle "${ANGLES[best]}".`)
+return final
+"""
+
+
+PHASES = {
+    "fan-out": ["Fan out", "Synthesize"],
+    "pipeline": ["Triage", "Verify"],
+    "barrier": ["Collect", "Synthesize"],
+    "loop": ["Discover"],
+    "judge-panel": ["Draft", "Score", "Refine"],
+}
+BODIES = {
+    "fan-out": body_fan_out,
+    "pipeline": body_pipeline,
+    "barrier": body_barrier,
+    "loop": body_loop,
+    "judge-panel": body_judge_panel,
+}
+
+
+def scaffold(topology, name, description):
+    parts = [_meta(name, description, PHASES[topology]), "", SCHEMA, "", BODIES[topology]()]
+    return "\n".join(parts)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--topology", choices=TOPOLOGIES, help="orchestration shape to scaffold")
+    p.add_argument("--name", help="workflow name (slugified for meta.name)")
+    p.add_argument("--description", help="one-line meta.description")
+    p.add_argument("--sample", action="store_true", help="emit a built-in pipeline sample")
+    args = p.parse_args(argv)
+
+    if args.sample or not args.topology:
+        if not args.topology and not args.sample:
+            print("No --topology given; emitting --sample (pipeline). Use --help for options.\n", file=sys.stderr)
+        out = scaffold("pipeline", "pr-triage", "Triage open PRs for bugs before merge")
+    else:
+        out = scaffold(args.topology, args.name or args.topology,
+                       args.description or f"A {args.topology} workflow")
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/engineering/workflow-builder/skills/workflow-builder/scripts/validate_workflow.py
+++ b/engineering/workflow-builder/skills/workflow-builder/scripts/validate_workflow.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Linter for Claude Code workflow (.js) files.
+
+Catches the parser-fatal and resume-breaking mistakes before a workflow runs:
+meta-block rules, banned non-deterministic calls, forbidden Node/FS access in
+the orchestrator, parallel()-needs-thunks, unguarded loops, and the script-size
+cap. Reports PASS / WARN / FAIL with line numbers.
+
+Stdlib only. Heuristic (regex/text) — it does not execute the file.
+"""
+import argparse
+import re
+import sys
+
+MAX_SCRIPT_BYTES = 524_288
+AGENT_CAP = 1000
+
+# (severity, label) constants
+FAIL, WARN, PASS = "FAIL", "WARN", "PASS"
+
+
+def _strip_comments(src):
+    """Remove // line and /* */ block comments so they don't trip pattern checks.
+    Keeps line count stable by preserving newlines."""
+    out = []
+    i, n = 0, len(src)
+    in_line = in_block = in_str = False
+    str_ch = ""
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+        if in_line:
+            if c == "\n":
+                in_line = False
+                out.append(c)
+            else:
+                out.append(" ")
+            i += 1
+        elif in_block:
+            if c == "*" and nxt == "/":
+                in_block = False
+                out.append("  ")
+                i += 2
+            else:
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+        elif in_str:
+            out.append(c)
+            if c == "\\":
+                if nxt:
+                    out.append(nxt)
+                    i += 2
+                    continue
+            elif c == str_ch:
+                in_str = False
+            i += 1
+        else:
+            if c == "/" and nxt == "/":
+                in_line = True
+                out.append("  ")
+                i += 2
+            elif c == "/" and nxt == "*":
+                in_block = True
+                out.append("  ")
+                i += 2
+            elif c in "\"'`":
+                in_str = True
+                str_ch = c
+                out.append(c)
+                i += 1
+            else:
+                out.append(c)
+                i += 1
+    return "".join(out)
+
+
+def _lineno(src, idx):
+    return src.count("\n", 0, idx) + 1
+
+
+def check_size(raw, findings):
+    n = len(raw.encode("utf-8"))
+    if n > MAX_SCRIPT_BYTES:
+        findings.append((FAIL, None, f"Script is {n} bytes, over the {MAX_SCRIPT_BYTES}-byte cap (rejected before parsing)."))
+
+
+def check_meta(code, findings):
+    m = re.search(r"export\s+const\s+meta\s*=", code)
+    if not m:
+        findings.append((FAIL, None, "No `export const meta = {...}` declaration found (required, must be first statement)."))
+        return
+    # meta should be the first non-empty, non-import statement.
+    head = code[:m.start()]
+    head_sig = re.sub(r"^\s*import\b.*$", "", head, flags=re.MULTILINE).strip()
+    if head_sig:
+        findings.append((WARN, _lineno(code, m.start()),
+                         "`meta` may not be the first statement — move it above all other code (imports are allowed before it)."))
+    # Extract the meta object body (balanced braces).
+    brace_start = code.find("{", m.end())
+    if brace_start == -1:
+        findings.append((FAIL, _lineno(code, m.start()), "`meta` is not an object literal."))
+        return
+    depth, j = 0, brace_start
+    while j < len(code):
+        if code[j] == "{":
+            depth += 1
+        elif code[j] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        j += 1
+    body = code[brace_start:j + 1]
+    ln = _lineno(code, brace_start)
+    if "name" not in body:
+        findings.append((FAIL, ln, "`meta` is missing the required `name` field."))
+    if "description" not in body:
+        findings.append((FAIL, ln, "`meta` is missing the required `description` field."))
+    # Pure-literal rule: no template strings, spreads, or function calls inside meta.
+    if "`" in body:
+        findings.append((FAIL, ln, "`meta` contains a template string — it must be a pure literal (use plain quoted strings)."))
+    if "..." in body:
+        findings.append((FAIL, ln, "`meta` contains a spread (`...`) — it must be a pure literal."))
+    # function call: an identifier immediately followed by ( that isn't a key.
+    if re.search(r"[A-Za-z_$][\w$]*\s*\(", body):
+        findings.append((FAIL, ln, "`meta` contains a function call — it must be a pure literal (no variables or calls)."))
+    for reserved in ("__proto__", "constructor", "prototype"):
+        if reserved in body:
+            findings.append((FAIL, ln, f"`meta` uses reserved key `{reserved}` (rejected by the parser)."))
+
+
+def check_nondeterminism(code, findings):
+    for pat, msg in [
+        (r"\bMath\.random\s*\(", "Math.random() is banned (non-reproducible, breaks resume) — vary the prompt by index instead."),
+        (r"\bDate\.now\s*\(", "Date.now() is banned (breaks resume) — pass timestamps via `args`."),
+        (r"\bnew\s+Date\s*\(\s*\)", "argless `new Date()` is banned (breaks resume) — use `new Date(specificValue)` or pass via `args`."),
+    ]:
+        for m in re.finditer(pat, code):
+            findings.append((FAIL, _lineno(code, m.start()), msg))
+
+
+def check_node_apis(code, findings):
+    for pat, msg in [
+        (r"\brequire\s*\(", "`require(...)` is unavailable in the orchestrator — do this work inside an agent() call."),
+        (r"\bimport\s+.*\bfrom\s+['\"]fs['\"]", "filesystem access is unavailable in the orchestrator — move it inside an agent()."),
+        (r"\bprocess\.\w+", "`process.*` is unavailable in the orchestrator — move it inside an agent()."),
+        (r"\bfs\.\w+\s*\(", "`fs.*` filesystem calls are unavailable in the orchestrator — move it inside an agent()."),
+        (r"\bfetch\s*\(", "network `fetch(...)` is unavailable in the orchestrator — move it inside an agent()."),
+    ]:
+        for m in re.finditer(pat, code):
+            findings.append((FAIL, _lineno(code, m.start()), msg))
+
+
+def check_parallel_thunks(code, findings):
+    """parallel(...) elements must be thunks: () => ... , not bare agent(...) promises."""
+    for m in re.finditer(r"\bparallel\s*\(", code):
+        # Look at the slice right after the opening paren up to a reasonable window.
+        start = m.end()
+        window = code[start:start + 400]
+        # Common correct forms contain `=>` ; bare-promise misuse is parallel([agent(...) , ...]) or .map(x => agent(...)) without the extra thunk.
+        # Flag .map(...) that returns agent(...) directly without `() =>`.
+        if re.search(r"\.map\s*\(\s*\([^)]*\)\s*=>\s*agent\s*\(", window):
+            findings.append((WARN, _lineno(code, m.start()),
+                             "parallel(items.map(x => agent(...))) passes promises, not thunks — wrap as `x => () => agent(...)`."))
+        elif re.search(r"\[\s*agent\s*\(", window):
+            findings.append((WARN, _lineno(code, m.start()),
+                             "parallel([ agent(...) , ... ]) passes bare promises — use thunks: `[() => agent(...), ...]`."))
+
+
+def check_loops_guarded(code, findings):
+    """Every while/for loop should reference a counter bound or budget.remaining()."""
+    for m in re.finditer(r"\bwhile\s*\(([^)]*)\)", code):
+        cond = m.group(1)
+        ln = _lineno(code, m.start())
+        if "true" in cond and "budget" not in cond:
+            findings.append((WARN, ln, "`while (true)` loop — add a counter or budget.remaining() guard or it hits the 1000-agent cap."))
+        elif "budget" not in cond and not re.search(r"[<>]=?|!==?|===?", cond):
+            findings.append((WARN, ln, "loop condition has no obvious bound — confirm a counter cap or budget guard exists."))
+
+
+def check_filter_boolean(code, findings):
+    """Soft reminder: results of parallel/pipeline should be filtered for nulls before use."""
+    uses_orchestration = re.search(r"\b(parallel|pipeline)\s*\(", code)
+    if uses_orchestration and "filter(Boolean)" not in code and ".filter(" not in code:
+        findings.append((WARN, None,
+                         "No `.filter(Boolean)` found — skipped/failed agents insert `null`; filter results before using them."))
+
+
+def check_agent_present(code, findings):
+    if not re.search(r"\bagent\s*\(", code):
+        findings.append((WARN, None, "No `agent(...)` calls found — a workflow with no sub-agents may not need to be a workflow."))
+
+
+def validate(raw):
+    findings = []
+    check_size(raw, findings)
+    code = _strip_comments(raw)
+    check_meta(code, findings)
+    check_nondeterminism(code, findings)
+    check_node_apis(code, findings)
+    check_parallel_thunks(code, findings)
+    check_loops_guarded(code, findings)
+    check_filter_boolean(code, findings)
+    check_agent_present(code, findings)
+    return findings
+
+
+def verdict(findings):
+    if any(f[0] == FAIL for f in findings):
+        return FAIL
+    if any(f[0] == WARN for f in findings):
+        return WARN
+    return PASS
+
+
+def render(findings, path):
+    v = verdict(findings)
+    icon = {FAIL: "FAIL", WARN: "WARN", PASS: "PASS"}[v]
+    lines = [f"[{icon}] {path}"]
+    if not findings:
+        lines.append("  No issues found. Workflow looks structurally valid.")
+    for sev, ln, msg in sorted(findings, key=lambda f: (f[0] != FAIL, f[1] or 0)):
+        loc = f"line {ln}" if ln else "file"
+        lines.append(f"  {sev} ({loc}): {msg}")
+    return "\n".join(lines)
+
+
+SAMPLE = """export const meta = {
+  name: 'bad-example',
+  description: `template strings not allowed`,
+}
+
+const ts = Date.now()
+while (true) {
+  const r = await parallel([agent('find a bug')])
+  bugs.push(...r)
+}
+"""
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("path", nargs="?", help="path to a workflow .js file")
+    p.add_argument("--json", action="store_true", help="emit JSON findings")
+    p.add_argument("--sample", action="store_true", help="lint a built-in intentionally-broken sample")
+    args = p.parse_args(argv)
+
+    if args.sample or not args.path:
+        if not args.path and not args.sample:
+            print("No path given; linting built-in --sample. Use --help for options.\n", file=sys.stderr)
+        raw, label = SAMPLE, "<sample>"
+    else:
+        try:
+            with open(args.path, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as e:
+            print(f"Could not read {args.path}: {e}", file=sys.stderr)
+            return 2
+        label = args.path
+
+    findings = validate(raw)
+    if args.json:
+        import json
+        print(json.dumps({
+            "path": label,
+            "verdict": verdict(findings),
+            "findings": [{"severity": s, "line": ln, "message": m} for s, ln, m in findings],
+        }, indent=2))
+    else:
+        print(render(findings, label))
+    return 1 if verdict(findings) == FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/engineering/workflow-builder/skills/workflow-builder/scripts/workflow_intake.py
+++ b/engineering/workflow-builder/skills/workflow-builder/scripts/workflow_intake.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Workflow intake recommendation engine.
+
+Turns a (possibly vague) workflow request into a concrete topology proposal:
+recommended topology, model picks, a budget guard, and a one-line rationale for
+every choice. Fills unknown answers with the safest documented default so a
+vague request still yields a presentable "here's what I'd build and why".
+
+Stdlib only. Deterministic: same inputs -> same recommendation.
+"""
+import argparse
+import json
+import re
+import sys
+
+CHOICES_TRI = ("yes", "no", "unknown")
+CHOICES_UNITS = ("known", "unknown", "loop")
+CHOICES_STAGES = ("single", "multiple", "unknown")
+
+# Keyword -> signal. Lowercased substring match on the task description.
+VERB_CHAIN = ("then", "->", "=>", "after", "followed by", "and then")
+PANEL_WORDS = ("best", "compare", "options", "approaches", "alternatives",
+               "candidates", "which", "rank", "score them")
+COSTLY_WORDS = ("critical", "costly", "act on", "production", "security",
+                "verify", "false positive", "high stakes", "merge", "deploy")
+LOOP_WORDS = ("until", "keep", "as many", "all the", "every", "exhaust",
+              "find issues", "discover", "as long as", "budget")
+MERGE_WORDS = ("dedup", "deduplicate", "merge results", "merge findings",
+               "merge them all", "combine all", "consolidate", "aggregate",
+               "count across", "total across")
+LIST_WORDS = ("each", "list of", "set of", "batch", "files", "documents",
+              "questions", "items", "prs", "pull requests", "tickets")
+
+
+def _has(task, words):
+    t = task.lower()
+    return any(w in t for w in words)
+
+
+def classify(task, units, stages, needs_all, structured):
+    """Return (topology, runner_up_or_None, signals_dict)."""
+    t = task.lower()
+    signals = {
+        "verb_chain": bool(re.search(r"\b(then|after)\b", t)) or _has(task, VERB_CHAIN),
+        "panel": _has(task, PANEL_WORDS),
+        "costly": _has(task, COSTLY_WORDS),
+        "loop_like": _has(task, LOOP_WORDS),
+        "merge_like": _has(task, MERGE_WORDS),
+        "list_like": _has(task, LIST_WORDS),
+    }
+
+    # Resolve unknowns with documented defaults (see decision_and_intake_guide.md).
+    if units == "unknown":
+        if signals["loop_like"]:
+            units_eff = "loop"
+        elif signals["list_like"] or signals["merge_like"]:
+            # An explicit list, or a dedup/merge step, both imply a bounded set.
+            units_eff = "known"
+        else:
+            units_eff = "loop"  # safest default when the count is undiscovered
+    else:
+        units_eff = units
+    if stages == "unknown":
+        stages_eff = "multiple" if signals["verb_chain"] else "single"
+    else:
+        stages_eff = stages
+    if needs_all == "unknown":
+        needs_all_eff = "yes" if signals["merge_like"] else "no"
+    else:
+        needs_all_eff = needs_all
+
+    signals["units_effective"] = units_eff
+    signals["stages_effective"] = stages_eff
+    signals["needs_all_effective"] = needs_all_eff
+
+    # Decision tree.
+    runner_up = None
+    if signals["panel"]:
+        topology = "judge-panel"
+        runner_up = "fan-out"
+    elif units_eff == "loop":
+        topology = "loop"
+        runner_up = "fan-out"
+    elif needs_all_eff == "yes":
+        topology = "barrier"
+        runner_up = "pipeline"
+    elif stages_eff == "multiple":
+        topology = "pipeline"
+        runner_up = "barrier"
+    else:
+        topology = "fan-out"
+        runner_up = "pipeline"
+
+    return topology, runner_up, signals
+
+
+def model_plan(topology, signals):
+    """Per-stage model recommendation."""
+    plan = []
+    if topology == "fan-out":
+        plan.append(("fan-out stage", "haiku", "independent, mechanical per-item work is cheap on Haiku"))
+        plan.append(("final synthesis", "opus", "combining many results into one report needs strong reasoning"))
+    elif topology == "pipeline":
+        plan.append(("stage 1 (triage/extract)", "haiku", "first-pass classification is cheap and high-volume"))
+        plan.append(("stage 2 (verify/refine)", "sonnet", "second stage acts on fewer items and needs judgement"))
+    elif topology == "barrier":
+        plan.append(("parallel collection", "haiku", "gather raw results cheaply before the merge"))
+        plan.append(("merge/dedup synthesis", "opus", "reconciling the full set is the hard reasoning step"))
+    elif topology == "loop":
+        plan.append(("per-iteration agent", "sonnet", "each round must reason about what's already found"))
+    elif topology == "judge-panel":
+        plan.append(("draft angles", "sonnet", "diverse drafts need real generation capability"))
+        plan.append(("scoring judges", "haiku", "scoring against a rubric is cheap and parallelizable"))
+        plan.append(("final refine", "opus", "polishing the winning plan rewards the strongest model"))
+    if signals.get("costly"):
+        plan.append(("skeptic-vote verification", "sonnet",
+                     "a wrong result is costly here — add 3 independent refute-attempts, survive on majority"))
+    return plan
+
+
+def budget_guard(signals):
+    if signals["units_effective"] == "loop":
+        return ("budget.remaining() > 50_000 (plus a hard count cap)",
+                "open-ended loop — guard is mandatory or it hits the 1000-agent cap")
+    return ("optional; set budget.total if the user gave a token target",
+            "fixed topology with a known/bounded item count — no runaway risk")
+
+
+def recommend(task, units, stages, needs_all, structured):
+    topology, runner_up, signals = classify(task, units, stages, needs_all, structured)
+    models = model_plan(topology, signals)
+    bguard, bwhy = budget_guard(signals)
+
+    if structured == "unknown":
+        structured_eff = "yes"
+        structured_why = "default on — a small JSON schema makes downstream stages reliable at near-zero cost"
+    else:
+        structured_eff = structured
+        structured_why = ("user asked for structured data back" if structured == "yes"
+                          else "user wants free-text output")
+
+    rationale = {
+        "topology": _topology_reason(topology, signals),
+        "runner_up": runner_up,
+        "structured_output": structured_why,
+        "budget": bwhy,
+    }
+    return {
+        "task": task,
+        "recommended_topology": topology,
+        "runner_up_topology": runner_up,
+        "resolved_signals": {k: v for k, v in signals.items() if k.endswith("effective") or k in
+                             ("panel", "costly", "loop_like", "merge_like", "verb_chain", "list_like")},
+        "model_plan": [{"stage": s, "model": m, "why": w} for s, m, w in models],
+        "structured_output": structured_eff,
+        "budget_guard": bguard,
+        "rationale": rationale,
+        "add_verification": bool(signals.get("costly")),
+    }
+
+
+def _topology_reason(topology, signals):
+    return {
+        "fan-out": "independent units, one pass each, combined at the end -> parallel fan-out then a final synthesis agent",
+        "pipeline": "ordered stages where each item should advance the moment it's ready (no barrier) -> pipeline; faster than parallel-per-stage",
+        "barrier": "a later step needs the whole prior result set (dedup/merge/count) -> parallel barrier, then process",
+        "loop": "item count is undiscovered -> guarded loop (stop on goal, budget, or dryness) with a hard cap",
+        "judge-panel": "wide solution space, want best-of-N -> generate diverse drafts, score in parallel, synthesize the winner",
+    }[topology]
+
+
+def render_human(rec):
+    lines = []
+    lines.append(f"Task: {rec['task']}")
+    lines.append("")
+    lines.append(f"RECOMMENDED TOPOLOGY: {rec['recommended_topology']}")
+    lines.append(f"  why: {rec['rationale']['topology']}")
+    if rec["runner_up_topology"]:
+        lines.append(f"  runner-up if the above doesn't fit: {rec['runner_up_topology']}")
+    lines.append("")
+    lines.append("MODEL PLAN:")
+    for m in rec["model_plan"]:
+        lines.append(f"  - {m['stage']}: {m['model']}  ({m['why']})")
+    lines.append("")
+    lines.append(f"STRUCTURED OUTPUT: {rec['structured_output']}  ({rec['rationale']['structured_output']})")
+    lines.append(f"BUDGET GUARD: {rec['budget_guard']}")
+    lines.append(f"  why: {rec['rationale']['budget']}")
+    if rec["add_verification"]:
+        lines.append("VERIFICATION: add a skeptic-vote pass — a wrong result is costly for this task.")
+    lines.append("")
+    lines.append("Present this to the user as 'here's what I'd build and why', then confirm before scaffolding.")
+    lines.append(f"Next: python scaffold_workflow.py --topology {rec['recommended_topology']} --name <name> --description \"...\"")
+    return "\n".join(lines)
+
+
+SAMPLE = {
+    "task": "review my open PRs for bugs before I merge them",
+    "units": "unknown",
+    "stages": "unknown",
+    "needs_all": "unknown",
+    "structured": "unknown",
+}
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--task", help="free-text description of the task to automate")
+    p.add_argument("--units", choices=CHOICES_UNITS, default="unknown",
+                   help="is the unit count a known list, unknown, or loop-discovered")
+    p.add_argument("--stages", choices=CHOICES_STAGES, default="unknown",
+                   help="single stage or multiple ordered stages")
+    p.add_argument("--needs-all", dest="needs_all", choices=CHOICES_TRI, default="unknown",
+                   help="does a later step need all prior results at once")
+    p.add_argument("--structured", choices=CHOICES_TRI, default="unknown",
+                   help="does any step need structured data back")
+    p.add_argument("--json", action="store_true", help="emit JSON instead of human-readable text")
+    p.add_argument("--sample", action="store_true", help="run with a built-in vague-request sample")
+    args = p.parse_args(argv)
+
+    if args.sample or not args.task:
+        if not args.task and not args.sample:
+            print("No --task given; running --sample. Use --help for options.\n", file=sys.stderr)
+        s = SAMPLE
+        rec = recommend(s["task"], s["units"], s["stages"], s["needs_all"], s["structured"])
+    else:
+        rec = recommend(args.task, args.units, args.stages, args.needs_all, args.structured)
+
+    print(json.dumps(rec, indent=2) if args.json else render_human(rec))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New `engineering/workflow-builder/` plugin — an **intake-first** skill that designs and writes deterministic multi-agent **workflow `.js` files** for Claude Code's Workflow tool (gated behind `CLAUDE_CODE_WORKFLOWS=1`, browsable via `/workflows`, introduced in CC v2.1.147).

The defining behavior (per the task): **every workflow-creation session opens with an intake question set** — what task, what unit of work, known list vs. loop, barrier vs. pipeline, structured output, depth. **When the user is vague, the skill does not stall or interrogate in a loop** — a deterministic recommendation engine infers a topology and presents it *with the reasoning* ("here's what I'd build and why"), then confirms before writing any file.

## What's included (15 files)

- **3 stdlib Python tools**
  - `workflow_intake.py` — classifies a (vague) task → recommended topology (+ runner-up) + per-stage model plan + budget guard + a one-line rationale per choice.
  - `validate_workflow.py` — `.js` linter enforcing the hard rules: pure-literal `meta` (first statement), no `Date.now()`/`Math.random()`/argless `new Date()`, no FS/Node APIs in the orchestrator, `parallel()` thunks, guarded loops, `filter(Boolean)`, 512 KB size cap. PASS / WARN / FAIL with line numbers.
  - `scaffold_workflow.py` — runnable starter generator for 5 topologies (fan-out, pipeline, barrier, loop, judge-panel).
- **3 references** (7-8 sources each): `api_reference.md` (full API surface), `orchestration_patterns.md` (9 copy-paste shapes), `decision_and_intake_guide.md` (question framework + vague-input playbook + worked examples).
- **Assets**: fan-out / pipeline / loop-until-budget templates + a complete `pr-triage.js` example (fan-out → skeptic-vote → synthesize).
- **`cs-workflow-architect`** agent + **`/cs:workflow-build`** command.
- Registered in `.claude-plugin/marketplace.json` (61 → 62 plugins, category `development`).

## Provenance

Conceptually inspired by [Ray Amjad's `claude-code-workflow-creator`](https://github.com/ray-amjad/claude-code-workflow-creator) (credited in `plugin.json` `attribution` + README). The repo has no LICENSE file, so **no text was copied verbatim** — all content was written fresh from Claude Code's publicly-documented Workflow tool API and the user's meta-prompt.

## Test plan

- [x] All 3 scripts pass `--help` and `--sample`, exit 0
- [x] All 4 shipped `.js` files validate PASS; the deliberately-broken validator `--sample` returns FAIL with correct line numbers
- [x] Intake engine classifies fan-out / pipeline / barrier / loop / judge-panel cases correctly (incl. git-merge vs. result-merge disambiguation)
- [x] Skill gates: description **PASS**, structure **PASS** (78 lines ≤ 100), review-checklist **WARN** (only the "skill" vs. "Workflow tool" terminology check — "Workflow tool" is Anthropic's official feature name; justified)
- [x] Karpathy complexity 85/100 (nesting WARN in the comment-tokenizer + classifier, both legitimately stateful); assumption-linter findings are docstring/UI-string false positives
- [x] `marketplace.json` + `plugin.json` valid JSON; `check_plugin_json.py` OK
- [ ] Live run against an actual `CLAUDE_CODE_WORKFLOWS=1` session (feature still gated; cannot execute here)

https://claude.ai/code/session_01Q1kXbgMRodzhdTpgbCqVgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1kXbgMRodzhdTpgbCqVgx)_