### PR TITLE
chore(versioning): unify remaining 20 plugins to 2.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
       "name": "marketing-skills",
       "source": "./marketing-skill",
       "description": "44 marketing skills across 7 pods: Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs.",
-      "version": "2.7.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -248,7 +248,7 @@
       "name": "engineering-skills",
       "source": "./engineering-team",
       "description": "32 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit (WCAG 2.2), Azure cloud architect, GCP cloud architect, security pen testing, Snowflake development, adversarial-reviewer, ai-security, cloud-security, incident-response, red-team, threat-detection. v2.8.1 audits senior-fullstack / senior-frontend / senior-backend against karpathy-coder + Matt Pocock — each ships a 7-question forcing-question library, 4 customization profiles (JSON), deterministic decision engine, composition map into POWERFUL specialists, plus cs-fullstack-engineer / cs-frontend-engineer / cs-backend-engineer orchestrator agents (context: fork) + /cs:fullstack-review, /cs:frontend-review, /cs:backend-review, /cs:engineer-grill slash commands.",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -920,7 +920,7 @@
       "name": "capture-skill",
       "source": "./productivity/capture",
       "description": "Brain-dump-to-action workspace skill. Routes vague captures into discoverable actions via classify→cluster→connect→clarify intake. Path-B from megaprompt 05.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -938,7 +938,7 @@
       "name": "email-pair",
       "source": "./productivity/email",
       "description": "Email-workflow skill pair: inbox-setup builds your taxonomy/KB; inbox-triage classifies + drafts (drafts-only, never auto-send). KB-file contract between them. Path-B from megaprompts 06+07.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -957,7 +957,7 @@
       "name": "reflect-skill",
       "source": "./productivity/reflect",
       "description": "Light-prompt reflection skill. Single forcing question + structured journal capture. Path-B sibling of capture from megaprompt 08.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -974,7 +974,7 @@
       "name": "handoff-productivity",
       "source": "./productivity/handoff",
       "description": "Compact the current conversation into a handoff document for another agent to pick up. Configurable save location, redaction enforcement, SessionStart auto-load + SessionEnd reminder, self-check fidelity script, --refresh flag, mtime-guarded cleanup. Inspired by Matt Pocock's handoff (MIT).",
-      "version": "2.8.2",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -994,7 +994,7 @@
       "name": "andreessen",
       "source": "./productivity/andreessen",
       "description": "Marc Andreessen-mode decision and productivity skill. Market-first operator that pressure-tests ventures/ideas/features/bets (market > team > product; product/market fit is the only milestone; bias to build) and runs the 3x5-card + Anti-Todo routine. Fixed anti-sycophancy operating prompt: counterargument first, no disclaimers, explicit confidence levels, no capitulation. Issues hard verdicts backed by deterministic stdlib tools.",
-      "version": "2.8.4",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1014,7 +1014,7 @@
       "name": "landing",
       "source": "./marketing/landing",
       "description": "Single-file HTML landing-page generator with 4 design styles, brand palette validation, GSAP animation patterns, kebab-slug URL hygiene. Path-B from megaprompt 04.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1033,7 +1033,7 @@
       "name": "pulse",
       "source": "./research/pulse",
       "description": "Multi-source recency research. Reddit/HN/X/web sentiment + trending. Research-pack convention (1 q/sec, three-count tracking). Path-B from megaprompt 01.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1053,7 +1053,7 @@
       "name": "litreview",
       "source": "./research/litreview",
       "description": "Academic literature orientation skill. PICO/SPIDER frameworks, systematic review structure, 8-section DOCX guide. Research-pack convention. Path-B from megaprompt 09.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1073,7 +1073,7 @@
       "name": "grants",
       "source": "./research/grants",
       "description": "NIH grant-funding intelligence skill. RePORTER/NOSI/study-section navigation, R01/R21/K-award strategy. Research-pack convention. Path-B from megaprompt 11.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1094,7 +1094,7 @@
       "name": "dossier",
       "source": "./research/dossier",
       "description": "Decision-grade entity research. Due-diligence/background-check/competitor-prep with tier-weighted verdict + citation tracker. Research-pack convention. Path-B from megaprompt 02.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1114,7 +1114,7 @@
       "name": "patent",
       "source": "./research/patent",
       "description": "Patent prior-art + IP landscape skill. FTO/novelty/family-resolver via 3-pass Jaccard heuristic. Research-pack convention. Path-B from megaprompt 12.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1134,7 +1134,7 @@
       "name": "syllabus",
       "source": "./research/syllabus",
       "description": "Course supplementary-reading skill. Topic-grouper + bundled Node.js DOCX generator for syllabus-anchored reading lists. Research-pack convention. Path-B from megaprompt 10.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1154,7 +1154,7 @@
       "name": "notebooklm",
       "source": "./research/notebooklm",
       "description": "Google NotebookLM browser-automation skill. 4 actions (read/extract, add-source, Studio outputs, create notebook). Screenshot-first + find-before-click + fire-and-notify async discipline. Path-B from megaprompt 03.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1174,7 +1174,7 @@
       "name": "research-orchestrator",
       "source": "./research/research",
       "description": "Research orchestrator (hybrid router + fallback). Deterministic SIGNALS classification routes to 6 specialists (pulse/litreview/grants/dossier/patent/syllabus) at >=2 signals, else runs own 8-step plan-decompose-search-synthesize-cite fallback. Routing transparency mandatory. Path-B from megaprompt 13.",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1194,7 +1194,7 @@
       "name": "aeo",
       "source": "./marketing-skill/skills/aeo",
       "description": "Answer Engine Optimization (AEO) skill — optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO (which optimizes for search rankings), AEO optimizes for citation in LLM-generated responses. 3 stdlib Python tools (aeo_audit, aeo_optimizer, citation_tracker), 3 references citing 8 sources each, industry-aware thresholds for 8 industries (saas/healthcare/finance/legal/ecommerce/b2b/media/education). Ported from alirezarezvani/aeo-box.",
-      "version": "2.7.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1216,7 +1216,7 @@
       "name": "security-guidance",
       "source": "./engineering/security-guidance",
       "description": "PreToolUse security reminder hook for Claude Code. Catches 12 common security anti-patterns in Edit/Write/MultiEdit operations BEFORE they happen — command injection (exec, os.system, subprocess shell=True), XSS (innerHTML, dangerouslySetInnerHTML, document.write), SQL injection (f-string queries, .format), unsafe deserialization (pickle, yaml.unsafe_load), code injection (eval, new Function), and GitHub Actions workflow injection. Session-state caching prevents duplicate warnings; 30-day auto-cleanup. Disable per-session with ENABLE_SECURITY_REMINDER=0. Ported from David Dworken at Anthropic.",
-      "version": "2.7.3",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1238,7 +1238,7 @@
       "name": "business-operations-skills",
       "source": "./business-operations",
       "description": "Internal BizOps domain. v2.8.0 ships 7 skills: orchestrator + process-mapper (BPMN/bottleneck/cycle-time, Lean+TOC) + vendor-management (scorecard+SLA+3rd-party risk, NIST SP 800-161/ISO 27036) + capacity-planner (Erlang-C queueing math for ops teams, NOT engineering) + internal-comms (ADKAR+Kotter 8-step, NOT marketing) + knowledge-ops (SOP+runbook+KB hygiene with 5W2H, context: fork) + procurement-optimizer (UNSPSC spend categorization + supplier consolidation). Orchestrator uses context: fork to route inquiries via Matt Pocock grill discipline (one question per turn, recommended answer, canon-cited challenge). Every SKILL.md ships a Forcing-question library section. 18 stdlib Python tools, 24+ reference docs. Distinct from business-growth (external sales) and c-level-advisor (strategic).",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },
@@ -1277,7 +1277,7 @@
       "name": "commercial-skills",
       "source": "./commercial",
       "description": "Per-deal-and-packaging Commercial domain. v2.8.0 ships 8 skills: orchestrator + pricing-strategist (model picker + Van Westendorp WTP + packaging) + deal-desk (deal scorer + discount approval routing + redline) + partnerships-architect (5-tier classifier + joint GTM + revshare modeler) + channel-economics (cost-to-serve + ROI + mix optimizer) + commercial-policy (data-backed discount matrix + exception flow + linter) + rfp-responder (Shipley structured RFP/RFI/RFQ + win-theme + winrate predictor, context: fork) + commercial-forecaster (4Q-weighted bookings + cohort NRR/GRR + funnel-confidence with mandatory assumption disclosure). Hard rules: pricing outputs model+range (never a single number), deal outputs route to named human approver (never auto-approve), forecast outputs surface conversion assumption, RFP never invents claims for GAP requirements. 21 stdlib Python tools, 28+ reference docs. Distinct from business-growth (sales execution), c-level-advisor/cro-advisor (strategic), finance (close+report).",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "author": {
         "name": "Alireza Rezvani"
       },

--- a/business-operations/.claude-plugin/plugin.json
+++ b/business-operations/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-operations-skills",
   "description": "6 BizOps skills + 1 orchestrator: process-mapper (BPMN + bottleneck + cycle-time), vendor-management (SLA + risk + scorecard), capacity-planner (Erlang-C queueing math for ops teams), internal-comms (ADKAR + Kotter 8-step change comms), knowledge-ops (SOP + runbook authoring with 5W2H validation, context: fork), procurement-optimizer (UNSPSC-aligned spend categorization + supplier consolidation). Orchestrator skill uses context: fork to route inquiries to the right sub-skill via Matt Pocock grill discipline. 18 stdlib-only Python tools, 24+ reference docs each citing ≥7 authoritative sources, asset templates per skill. Distinct from business-growth (external sales) and c-level-advisor (strategic).",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/commercial/.claude-plugin/plugin.json
+++ b/commercial/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commercial-skills",
   "description": "7 Commercial skills + 1 orchestrator: pricing-strategist (Van Westendorp WTP + packaging + model picker), deal-desk (margin + discount routing + redline scoring), partnerships-architect (5-tier classifier + joint GTM + revshare modeler), channel-economics (cost-to-serve + ROI + channel mix optimizer), commercial-policy (data-backed discount matrix + exception flow + policy linter), rfp-responder (Shipley-method structured RFP/RFI/RFQ response + win-theme + winrate predictor; context: fork for heavy intake), commercial-forecaster (4Q-weighted bookings + cohort NRR/GRR + funnel-confidence with mandatory assumption disclosure). Orchestrator skill uses context: fork. 21 stdlib-only Python tools, 28+ reference docs. Distinct from business-growth (sales execution), c-level-advisor/cro-advisor (strategic CRO), finance (close-and-report).",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering-team/.claude-plugin/plugin.json
+++ b/engineering-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engineering-skills",
   "description": "32 production-ready engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright, self-improving agent, security suite (adversarial-reviewer, ai-security, cloud-security, incident-response, red-team, threat-detection), Stripe integration, TDD guide, Google Workspace CLI, a11y audit, Snowflake development, and more. v2.8.1 augments senior-fullstack / senior-frontend / senior-backend with karpathy-coder + Matt Pocock discipline: each ships a 7-question forcing-question library, 4 customization profiles (JSON, swappable), a deterministic decision engine, a composition map into POWERFUL specialists, plus cs-fullstack-engineer / cs-frontend-engineer / cs-backend-engineer orchestrator agents (context: fork) invokable by other agents via /cs:fullstack-review, /cs:frontend-review, /cs:backend-review, /cs:engineer-grill. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/engineering/security-guidance/.claude-plugin/plugin.json
+++ b/engineering/security-guidance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-guidance",
   "description": "PreToolUse security reminder hook for Claude Code. Catches 12 common security anti-patterns in Edit/Write/MultiEdit operations BEFORE they happen — command injection (exec, os.system, subprocess shell=True), XSS (innerHTML, dangerouslySetInnerHTML, document.write), SQL injection (f-string queries, .format), unsafe deserialization (pickle, yaml.unsafe_load), code injection (eval, new Function), and GitHub Actions workflow injection. Session-state caching prevents duplicate warnings; 30-day auto-cleanup of stale state files. Disable per-session with ENABLE_SECURITY_REMINDER=0. Ported from David Dworken's MIT-licensed plugin at github.com/alirezarezvani/aeo-box.",
-  "version": "2.7.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/marketing-skill/.claude-plugin/plugin.json
+++ b/marketing-skill/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "45 production-ready marketing skills across 8 pods: Content (copywriting, content strategy, content production), SEO + AEO (traditional audits, schema markup, programmatic SEO, site architecture, plus Answer Engine Optimization for LLM citation in ChatGPT/Perplexity/Claude/Gemini/Mistral), CRO (A/B testing, forms, popups, signup flows, pricing, onboarding), Channels (email sequences, social media, paid ads, cold email, X/Twitter growth), Growth (launch strategy, referral programs, free tools), Intelligence (competitor analysis, marketing psychology, analytics tracking), and Sales enablement. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
-  "version": "2.7.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/marketing-skill/skills/aeo/.claude-plugin/plugin.json
+++ b/marketing-skill/skills/aeo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aeo",
   "description": "Answer Engine Optimization (AEO) skill — optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO (which optimizes for search rankings), AEO optimizes for citation in LLM-generated responses. Ships 3 stdlib Python tools (aeo_audit.py for E-E-A-T + structure scoring, aeo_optimizer.py for content rewriting in conservative/balanced/aggressive modes, citation_tracker.py for local-first citation ledger), 3 references citing 7+ authoritative sources each (E-E-A-T methodology, per-LLM citation patterns, AEO-vs-SEO strategy), and industry-aware thresholds for 8 industries (saas/healthcare/finance/legal/ecommerce/b2b/media/education) with stricter YMYL calibration. Triggers — 'AEO audit', 'optimize for ChatGPT', 'get cited by Perplexity', 'E-E-A-T audit', 'LLM citation strategy', 'answer engine optimization'.",
-  "version": "2.7.3",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/marketing/landing/.claude-plugin/plugin.json
+++ b/marketing/landing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "landing",
   "description": "Premium single-file HTML landing page generator with GSAP 3D animations, scroll-triggered effects, and mouse-parallax depth. Forcing 3-4 question grill-me intake (product+pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written. Outputs a single self-contained HTML file (Claude Code) or HTML artifact (Claude.ai) with all CSS/JS inline \u2014 only externals are Google Fonts + GSAP via CDN. Configurable brand colors via CSS custom property overrides. Source spec: megaprompts/04-landing-megaprompt.md (PR #657). Distinct from product-team/skills/landing-page-generator (which outputs Next.js TSX for conversion-optimized lead-gen) \u2014 this skill is for premium visual one-pagers with motion design.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/productivity/andreessen/.claude-plugin/plugin.json
+++ b/productivity/andreessen/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "andreessen",
   "description": "Marc Andreessen-mode decision and productivity skill. A blunt, market-first operator that pressure-tests ventures, ideas, features, and career bets through Andreessen's documented frameworks (market > team > product; product/market fit is the only milestone that matters; bias to build) and runs his 3x5-card + Anti-Todo daily routine. Runs on a fixed anti-sycophancy operating prompt: leads with the strongest counterargument, never validates premises, no disclaimers, explicit confidence levels, never apologizes for disagreeing. Issues hard verdicts (BUILD-POUR-FUEL / MARKET-FIRST-DERISK / KILL-OR-REPICK-MARKET) backed by deterministic stdlib tools.",
-  "version": "2.8.4",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/productivity/capture/.claude-plugin/plugin.json
+++ b/productivity/capture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "capture",
   "description": "Brain-dump organizer. Ingests an unstructured stream of mixed thoughts, tasks, ideas and transforms it into a clean four-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help) with zero information loss. Fast-to-action by design \u2014 no upfront intake. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project. Workspace detection is real (Glob/Grep) \u2014 never fabricates connections. Source spec: megaprompts/05-capture-megaprompt.md (PR #657).",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/productivity/email/.claude-plugin/plugin.json
+++ b/productivity/email/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "email",
   "description": "Email triage system \u2014 paired skills (inbox-setup + inbox-triage) for personalized recurring email triage. inbox-setup runs once via interactive interview to build a knowledge base of 7 files (taxonomy, patterns, evaluation-framework, rate-card, blocklist, tracker, triage-log/) in ${WORKSPACE}/Email/. inbox-triage runs on recurring cadence (1-3x daily) or on demand: classifies recent emails, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report, and updates the KB with learnings. The two skills share a strict file contract \u2014 PR #657's cross-skill consistency audit verified the 7 KB filenames align verbatim between the two megaprompts. Source specs: megaprompts/06-inbox-setup-megaprompt.md + megaprompts/07-inbox-triage-megaprompt.md.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/productivity/handoff/.claude-plugin/plugin.json
+++ b/productivity/handoff/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handoff",
   "description": "Compact the current conversation into a handoff document for another agent to pick up. Save to a user-configured location (OS temp, home folder, or per-project .handoff/), redact secrets before write, suggest skills for the next session, and auto-load the latest handoff on the next SessionStart. First-run setup asks where to save so the project folder never gets cluttered. Use when the user says 'hand this off', 'handoff doc', 'summarize this for a new session', 'compact this conversation', 'I'm ending this session', or any variation signaling intent to pass work to a fresh agent.",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/productivity/reflect/.claude-plugin/plugin.json
+++ b/productivity/reflect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reflect",
   "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck \u2014 that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/dossier/.claude-plugin/plugin.json
+++ b/research/dossier/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dossier",
   "description": "Decision-grade entity research skill \u2014 produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a generic profile. Forcing intake makes the user state their hypothesis upfront (what they already believe and want to verify or disprove) so the dossier tests it rather than confirms it. Output is an editable Word document (.docx) with verdict on the hypothesis, identity facts, 12-month activity timeline, network signals, reputation signals, red flags, 3-5 conversation hooks tied to specific findings, and source-provenance audit log. Uses WebSearch + WebFetch + free APIs (SEC EDGAR, GitHub, ProPublica Nonprofit Explorer) as workhorses; optional BYOK MCPs (LinkedIn, Crunchbase, Apollo, Pitchbook, SimilarWeb) enhance coverage. Triggers: 'research [company]', 'dossier on [person/company]', 'background check on [entity]', 'prep me for a meeting with [person/company]', 'due diligence on [company]', 'what should I know about [entity]', 'research [person] before I [meet/hire/invest]', 'competitor research on [company]', 'investor diligence [company]', 'interview prep for [company]'. Honors sensitivity exclusions for journalism + personal-vetting contexts.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/grants/.claude-plugin/plugin.json
+++ b/research/grants/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grants",
   "description": "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission posture + known institute targets) locks down the funding strategy before any search runs. Runs a 5-facet Consensus positioning analysis (with draft Significance/Innovation language), maps the research to the right NIH institutes and study sections via RePORTER, finds NOSIs and funded overlap, and produces an editable Word document (.docx) with budget/scope-aware mechanism recommendations, submission timelines, and a mandatory program officer recommendation. Triggers: 'grants for [topic]', 'find grants for my research idea', 'what grants match my research', 'help me find NIH funding', 'grant opportunities for my research', or any grant-related request. NIH-only scope \u2014 non-NIH funders (PCORI, DOD CDMRP, VA, foundations) are out of scope and flagged at intake.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/litreview/.claude-plugin/plugin.json
+++ b/research/litreview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "litreview",
   "description": "Academic literature orientation skill. Turns a research question into a strategically planned mini literature review, delivered as a researcher-friendly Word document (.docx). Grill-me intake (research question + framework hint + tentative depth) before recon search; second forcing checkpoint after Phase 2 confirms framework + sub-areas + depth. Configurable depth (5/10/20 Consensus queries) controls coverage vs. speed. Output is a 'launching pad' \u2014 orientation guide, not a finished review. Implements research-pack Agent Integrity Rules: 1 q/sec Consensus rate limit, sequential execution, plan-tier detection, three-count tracking (sent/received/cited). Source spec: megaprompts/09-litreview-megaprompt.md (PR #657). Sibling of pulse (research-pack shape).",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/notebooklm/.claude-plugin/plugin.json
+++ b/research/notebooklm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "notebooklm",
   "description": "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube links, synthesized content), generating Studio outputs (Audio Overview, infographics, slide decks, study guides, briefing docs, mind maps, timelines, FAQs), and creating new notebooks. Triggers on any phrase involving NotebookLM \u2014 'open NotebookLM', 'check my [name] notebook', 'pull info from NotebookLM', 'ask my notebook about X', 'add [source] to NotebookLM', 'create an infographic in NotebookLM', 'use NotebookLM Studio', 'generate a slide deck from my notebook', or any variation where the goal involves NotebookLM. Requires browser automation environment \u2014 fails gracefully when unavailable.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/patent/.claude-plugin/plugin.json
+++ b/research/patent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "patent",
   "description": "Patent prior-art and landscape intelligence skill \u2014 not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-resolved hits, geographic coverage, FTO flags where applicable, strategy recommendations, and full audit log. Triggers: 'prior art search for [invention]', 'patent search on [topic]', 'freedom to operate analysis', 'FTO for [product]', 'patent landscape for [field]', 'is [invention] novel', 'patents on [topic]', 'competitive patent analysis', 'prior art for litigation', 'patent diligence on [company]'. Produces search signal, not legal advice \u2014 always recommends consulting a patent attorney before filing or licensing decisions. Trademark, copyright, and trade-secret questions are out of scope.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/pulse/.claude-plugin/plugin.json
+++ b/research/pulse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulse",
   "description": "Multi-source recency research skill. Takes the pulse of any topic across Reddit, Hacker News, the open web, and (optionally) X/Twitter within a configurable recent window (default 30 days). Forcing 2\u20134 question grill-me intake clarifies topic specificity, angle (trend/sentiment/problems/opportunities/comparison), time window, and platform scope before searching. Phases 1\u20133 run in parallel per the research-pack convention. Returns a synthesized briefing with citations, engagement metrics, and cross-platform pattern analysis. Source spec: megaprompts/01-pulse-megaprompt.md (PR #657). Implements the Agent Integrity Rules block locked down by PR #657 audit: 1 q/sec per platform, three-count tracking (sent/received/cited), retry-once-after-3s, stop-after-3-consecutive-failures.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/research/.claude-plugin/plugin.json
+++ b/research/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research",
   "description": "Default entry point for any research request \u2014 a hybrid router that classifies the question deterministically and either delegates to a specialist research skill (pulse for trends/sentiment, grants for NIH funding, litreview for academic literature, syllabus for course reading, patent for prior-art + IP landscape, dossier for entity research) or runs its own plan-decompose-multi-source-search-synthesize-cite fallback workflow when no specialist matches. Always surfaces the routing decision so users can override. Triggers: 'research [topic]', 'look into [topic]', 'what do we know about [topic]', 'investigate [topic]', 'find me information on [topic]', 'do some research on [topic]', 'I need to understand [topic]', or any research request that doesn't obviously match a more-specific specialist skill. Output is a markdown briefing (default) or .docx document (on request) with full citations and an audit log.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"

--- a/research/syllabus/.claude-plugin/plugin.json
+++ b/research/syllabus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syllabus",
   "description": "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format + course audience + year range) plus a grouping forcing-options checkpoint before any search runs \u2014 so the reading list matches the course's level and recency need. Parses the syllabus to extract topics and learning outcomes, searches Consensus for recent peer-reviewed papers per topic, and produces a professionally formatted .docx with clickable Consensus links, plain-language summaries calibrated to audience level, and Bloom-higher-order discussion questions tied to course learning goals. Triggers whenever a user uploads a syllabus, course outline, or curriculum document and wants supplementary readings. Also triggers on: 'syllabus reading list', 'find papers for my course', 'create a reading list from this syllabus', 'recent research for my class', 'supplementary readings', 'find journal articles for these topics', 'what recent papers cover this material', 'any new research on these course topics', 'update my syllabus with recent papers'. Even casual mentions when a syllabus is attached should trigger this skill.",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"


### PR DESCRIPTION
## Summary

Follow-up to #756. That PR normalized most marketplace versions to `2.9.0`, but **20 newer plugins** (added after the normalization pass) were still on their own versions — consistently on *both* `marketplace.json` and their `plugin.json`. This bumps all 20 to `2.9.0` so the registry advertises **one unified release version**.

After this change: **62/62** marketplace entries at `2.9.0`, with `marketplace.json` and every `plugin.json` fully in sync (0 mismatches).

### Plugins bumped to 2.9.0
- `marketing-skills`, `aeo`, `security-guidance` (2.7.3)
- `engineering-skills` (2.8.1)
- `business-operations-skills`, `commercial-skills` (2.8.0)
- `handoff-productivity` (2.8.2), `andreessen` (2.8.4)
- `capture-skill`, `email-pair`, `reflect-skill`, `landing`, `pulse`, `litreview`, `grants`, `dossier`, `patent`, `syllabus`, `notebooklm`, `research-orchestrator` (2.7.0)

### Note on #756
On the current `dev` state, #756 + the earlier `2.9.0` normalization left `marketplace.json` and `plugin.json` **fully consistent** for every plugin they touched. This PR only closes the gap for the stragglers — no mismatch correction was needed.

## Type of Change
- [x] Bug fix / Infrastructure

## Testing
- `scripts/check_plugin_json.py --all` → all OK
- Verified 62/62 marketplace entries at `2.9.0` and 0 marketplace-vs-`plugin.json` mismatches
- All modified JSON files parse cleanly

https://claude.ai/code/session_01JGwZR83iSg59EAtpTSCBjH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGwZR83iSg59EAtpTSCBjH)_