### PR TITLE
chore(workflow-builder): apply plugin-audit fixes

### DIFF
--- a/.gemini/skills-index.json
+++ b/.gemini/skills-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "gemini-cli-skills",
-  "total_skills": 409,
+  "total_skills": 410,
   "skills": [
     {
       "name": "README",
@@ -1474,6 +1474,11 @@
       "description": "Terraform infrastructure-as-code agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Covers module design patterns, state management strategies, provider configuration, security hardening, policy-as-code with Sentinel/OPA, and CI/CD plan/apply workflows. Use when: user wants to design Terraform modules, manage state backends, review Terraform security, implement multi-region deployments, or follow IaC best practices."
     },
     {
+      "name": "workflow-builder",
+      "category": "engineering-advanced",
+      "description": "Design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool. Use when a user wants to build, create, author, scaffold, or run a custom Claude Code workflow, orchestrate sub-agents (fan-out, pipeline, loop, judge-panel), or automate a repeatable multi-step task across fresh-context agents."
+    },
+    {
       "name": "write-a-skill",
       "category": "engineering-advanced",
       "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, build, or author a new skill."
@@ -2083,7 +2088,7 @@
       "description": "Engineering resources"
     },
     "engineering-advanced": {
-      "count": 78,
+      "count": 79,
       "description": "Engineering-advanced resources"
     },
     "finance": {

--- a/.gemini/skills/workflow-builder/SKILL.md
+++ b/.gemini/skills/workflow-builder/SKILL.md
@@ -1,0 +1,1 @@
+../../../engineering/workflow-builder/skills/workflow-builder/SKILL.md

--- a/engineering/workflow-builder/skills/workflow-builder/README.md
+++ b/engineering/workflow-builder/skills/workflow-builder/README.md
@@ -1,0 +1,33 @@
+# workflow-builder (skill)
+
+Intake-first authoring of deterministic multi-agent **workflow `.js` files** for Claude Code's Workflow tool (`CLAUDE_CODE_WORKFLOWS=1`, `/workflows`). See the plugin root [README](../../README.md) for the full overview and attribution.
+
+## Tools (`scripts/`)
+
+| Tool | Purpose |
+|---|---|
+| `workflow_intake.py` | Classify a (vague) task → recommended topology + runner-up + per-stage model plan + budget guard + rationale. |
+| `validate_workflow.py` | Lint a workflow `.js`: pure-literal `meta`, no non-determinism, no Node/FS APIs, `parallel()` thunks, guarded loops, `filter(Boolean)`, size cap. PASS / WARN / FAIL with line numbers. |
+| `scaffold_workflow.py` | Emit a runnable starter for any of 5 topologies (fan-out, pipeline, barrier, loop, judge-panel). |
+
+All three run with `--sample` (no args) and `--help`.
+
+## Quick start
+
+```bash
+python scripts/workflow_intake.py --task "review my open PRs for bugs"
+python scripts/scaffold_workflow.py --topology pipeline --name pr-triage \
+  --description "Triage open PRs" > /tmp/pr-triage.js
+python scripts/validate_workflow.py /tmp/pr-triage.js
+```
+
+## Layout
+
+- `references/` — API surface, orchestration patterns, decision + intake guide.
+- `assets/templates/` — fan-out / pipeline / loop-until-budget starters.
+- `assets/examples/` — a complete PR-triage workflow.
+- `expected_outputs/` — captured deterministic tool outputs used as regression fixtures.
+
+## License
+
+MIT.

--- a/engineering/workflow-builder/skills/workflow-builder/expected_outputs/intake_pr_review.json
+++ b/engineering/workflow-builder/skills/workflow-builder/expected_outputs/intake_pr_review.json
@@ -1,0 +1,37 @@
+{
+  "task": "review my open PRs for bugs",
+  "recommended_topology": "fan-out",
+  "runner_up_topology": "pipeline",
+  "resolved_signals": {
+    "verb_chain": false,
+    "panel": false,
+    "costly": false,
+    "loop_like": false,
+    "merge_like": false,
+    "list_like": true,
+    "units_effective": "known",
+    "stages_effective": "single",
+    "needs_all_effective": "no"
+  },
+  "model_plan": [
+    {
+      "stage": "fan-out stage",
+      "model": "haiku",
+      "why": "independent, mechanical per-item work is cheap on Haiku"
+    },
+    {
+      "stage": "final synthesis",
+      "model": "opus",
+      "why": "combining many results into one report needs strong reasoning"
+    }
+  ],
+  "structured_output": "yes",
+  "budget_guard": "optional; set budget.total if the user gave a token target",
+  "rationale": {
+    "topology": "independent units, one pass each, combined at the end -> parallel fan-out then a final synthesis agent",
+    "runner_up": "pipeline",
+    "structured_output": "default on \u2014 a small JSON schema makes downstream stages reliable at near-zero cost",
+    "budget": "fixed topology with a known/bounded item count \u2014 no runaway risk"
+  },
+  "add_verification": false
+}

--- a/engineering/workflow-builder/skills/workflow-builder/expected_outputs/scaffold_pipeline.js
+++ b/engineering/workflow-builder/skills/workflow-builder/expected_outputs/scaffold_pipeline.js
@@ -1,0 +1,46 @@
+export const meta = {
+  name: 'pr-triage',
+  description: 'Triage open PRs for bugs',
+  phases: [
+    { title: 'Triage' },
+    { title: 'Verify' }
+  ]
+}
+
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] }
+        },
+        required: ['title']
+      }
+    }
+  },
+  required: ['findings']
+}
+
+
+// Pipeline: each item flows through stages independently (no barrier).
+const ITEMS = args?.items ?? ['item one', 'item two', 'item three']
+
+const results = await pipeline(
+  ITEMS,
+  // Stage 1 — triage / extract (cheap, high volume).
+  (item, _orig, i) =>
+    agent(`Triage:\n${item}`, { label: `triage:${i + 1}`, phase: 'Triage', model: 'haiku', schema: FINDINGS_SCHEMA }),
+  // Stage 2 — verify / refine each finding (fewer items, more judgement).
+  (prev) =>
+    parallel((prev?.findings ?? []).map(f => () =>
+      agent(`Verify and refine: ${f.title}`, { phase: 'Verify', model: 'sonnet' })))
+)
+
+log(`Done: processed ${results.filter(Boolean).length} items through the pipeline.`)
+return results.filter(Boolean)
+

--- a/engineering/workflow-builder/skills/workflow-builder/expected_outputs/validate_sample.txt
+++ b/engineering/workflow-builder/skills/workflow-builder/expected_outputs/validate_sample.txt
@@ -1,0 +1,6 @@
+[FAIL] <sample>
+  FAIL (line 1): `meta` contains a template string — it must be a pure literal (use plain quoted strings).
+  FAIL (line 6): Date.now() is banned (breaks resume) — pass timestamps via `args`.
+  WARN (file): No `.filter(Boolean)` found — skipped/failed agents insert `null`; filter results before using them.
+  WARN (line 7): `while (true)` loop — add a counter or budget.remaining() guard or it hits the 1000-agent cap.
+  WARN (line 8): parallel([ agent(...) , ... ]) passes bare promises — use thunks: `[() => agent(...), ...]`.

--- a/engineering/workflow-builder/skills/workflow-builder/scripts/scaffold_workflow.py
+++ b/engineering/workflow-builder/skills/workflow-builder/scripts/scaffold_workflow.py
@@ -149,8 +149,8 @@ def body_judge_panel():
 const ANGLES = args?.angles ?? ['conservative', 'aggressive', 'contrarian']
 
 phase('Draft')
-const drafts = await parallel(ANGLES.map((a, i) => () =>
-  agent(`Produce a plan. Take a strictly ${a} approach.`, { label: `draft:${i + 1}`, model: 'sonnet' })))
+const drafts = (await parallel(ANGLES.map((a, i) => () =>
+  agent(`Produce a plan. Take a strictly ${a} approach.`, { label: `draft:${i + 1}`, model: 'sonnet' })))).filter(Boolean)
 
 phase('Score')
 const SCORE_SCHEMA = { type: 'object', properties: { score: { type: 'number' } }, required: ['score'] }


### PR DESCRIPTION
## Summary

Follow-ups from running the 8-phase plugin audit on `engineering/workflow-builder` (verdict: **PASS WITH WARNINGS**). All changes are non-functional improvements + one real null-safety fix:

1. **`scaffold_workflow.py`** — added `.filter(Boolean)` to the judge-panel `drafts` (a skipped draft agent inserts `null`, so `drafts[best]` could be null). All 5 topologies now scaffold to validator-**PASS** output (judge-panel was the lone WARN).
2. **inner `skills/workflow-builder/README.md`** — matches the handoff/andreessen precedent.
3. **`expected_outputs/`** — 3 captured deterministic fixtures (intake JSON, scaffolded pipeline, validator sample) as regression tests + stability evidence.
4. **Gemini sync** — `workflow-builder` was missing from `.gemini/skills-index.json` (peers write-a-skill/handoff/caveman were present); re-ran the sync (1 created, 409 unchanged).

## Audit results

| Phase | Result |
|---|---|
| Structure | 81.8 → **87.0** (GOOD) |
| Quality | 50.0 → **60.4** (C, above the 60 bar) |
| Scripts | 3/3 functional (2 pass, 1 partial), PASS |
| Security | PASS (0 critical, 0 high) |
| Marketplace | plugin.json valid, entry matches |
| Ecosystem | codex ✓, gemini ✓ (fixed), agent + command ✓ |

### Known warnings (not defects)
- **Quality Documentation dimension** stays low because the scorer rewards the older POWERFUL-tier format (100+ line SKILL.md, Tier/Category/Features/Usage sections); this skill follows the modern write-a-skill convention (≤100 lines) that the binding validators already pass. 60.4 clears the threshold without bloating the file.
- **plugin.json** keeps `version: 1.0.0` + the `attribution` field — both repo-compliant (the audit template's "2.1.2 / no extra fields" rule is stale).

## Test plan

- [x] Intake 5/5 topology classifications correct
- [x] All 5 topologies scaffold → validator PASS
- [x] Validator flags every hard rule (template-string meta, Date.now, unguarded loop, bare-promise parallel, missing filter)
- [x] `workflow-builder` present in both `.codex` and `.gemini` indexes

https://claude.ai/code/session_01Q1kXbgMRodzhdTpgbCqVgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1kXbgMRodzhdTpgbCqVgx)_