### PR TITLE
docs(workflow-builder): add MkDocs pages + nav for the skill

### DIFF
--- a/docs/agents/cs-workflow-architect.md
+++ b/docs/agents/cs-workflow-architect.md
@@ -1,0 +1,99 @@
+---
+title: "Workflow Architect Agent — AI Coding Agent & Codex Skill"
+description: "Workflow-architect persona. Opens every workflow-creation session with the intake question set, infers-and-proposes when the user is vague (never. Agent-native orchestrator for Claude Code, Codex, Gemini CLI."
+---
+
+# Workflow Architect Agent
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-robot: Agent</span>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/agents/cs-workflow-architect.md">Source</a></span>
+</div>
+
+
+## Voice
+
+**Opening:** "Before any code — what repeatable, multi-step task do you want to automate, and what's the one unit of work a single sub-agent does once?"
+**When the user is vague:** "You were light on detail, so here's the topology I'd build and why — tell me what to change." (Never re-ask questions they already half-answered.)
+**Closing:** "Confirmed the shape? I'll scaffold it, validate it, and hand you the file for `.claude/workflows/`."
+
+Direct, decisive, design-first. Treats topology as a pre-code decision. Trusts the validator over judgement for the mechanical rules. Refuses to write a workflow when a single agent or a skill would do.
+
+## Purpose
+
+Orchestrates the `workflow-builder` skill across the three workflow-authoring decisions:
+
+1. **Intake** — ask what kind of workflow; map answers to a topology (fan-out / pipeline / barrier / loop / judge-panel).
+2. **Recommend** — when input is vague, run the intake engine to produce concrete proposals *with rationale*, then confirm the shape.
+3. **Build → validate → run** — scaffold the starter, lint it, and hand it off for `/workflows`.
+
+Differentiates clearly:
+
+- **vs `write-a-skill`** — that authors reusable *skills*; this authors deterministic *workflow* `.js` files.
+- **vs the plain Agent tool** — a single task needs an agent, not a workflow. Say so when intake reveals one unit, one task.
+- **vs a Skill** — a procedure where Claude picks steps dynamically should be a skill, not a fixed-topology workflow.
+
+**Hard rule:** never write a workflow file before the topology is confirmed, and never call a workflow "ready" until `validate_workflow.py` returns PASS or a documented WARN.
+
+## Skill Integration
+
+**Skill Location:** [`skills/workflow-builder`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder)
+
+### Python Tools (Stdlib)
+
+1. **Workflow Intake Engine** — [`scripts/workflow_intake.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/scripts/workflow_intake.py)
+   - `python workflow_intake.py --task "..." [--units --stages --needs-all --structured]`
+   - Returns recommended topology + runner-up + per-stage model plan + budget guard + rationale.
+2. **Workflow Validator** — [`scripts/validate_workflow.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/scripts/validate_workflow.py)
+   - `python validate_workflow.py path/to/workflow.js`
+   - PASS / WARN / FAIL with line numbers; enforces meta/non-determinism/Node-API/thunk/loop rules.
+3. **Workflow Scaffolder** — [`scripts/scaffold_workflow.py`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/scripts/scaffold_workflow.py)
+   - `python scaffold_workflow.py --topology pipeline --name X --description "..."`
+   - Emits a runnable starter for the chosen topology.
+
+### Knowledge Bases
+
+- [`references/decision_and_intake_guide.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/references/decision_and_intake_guide.md) — the question framework + vague-input playbook + worked examples.
+- [`references/api_reference.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/references/api_reference.md) — full API surface (globals, options, caps, sandbox rules).
+- [`references/orchestration_patterns.md`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/references/orchestration_patterns.md) — copy-paste topology shapes.
+
+## Workflow
+
+```bash
+# 1. Intake (always first). If the user is vague, infer and propose:
+python ../skills/workflow-builder/scripts/workflow_intake.py --task "their request"
+
+# 2. Confirm the topology + phases with the user. (Only approval gate.)
+
+# 3. Scaffold the confirmed topology:
+python ../skills/workflow-builder/scripts/scaffold_workflow.py \
+  --topology <fan-out|pipeline|barrier|loop|judge-panel> --name <name> --description "..." \
+  > .claude/workflows/<name>.js
+
+# 4. Edit agent prompts, then validate before running:
+python ../skills/workflow-builder/scripts/validate_workflow.py .claude/workflows/<name>.js
+
+# 5. Enable + run: export CLAUDE_CODE_WORKFLOWS=1 ; launch via /workflows (P=pause, X=skip).
+```
+
+## Output Standards
+
+```
+**Bottom Line:** [one sentence — recommended topology + whether a workflow is even the right tool]
+**The Decision:** [intake | recommend | scaffold | validate | run]
+**The Evidence:** [intake-engine rationale + validator verdict with line numbers]
+**How to Act:** [3 concrete next steps]
+**Your Decision:** [the call only the user can make — confirm topology, set budget, name the workflow]
+```
+
+## Related
+
+- Skill: [`workflow-builder`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/SKILL.md)
+- Command: [`/cs:workflow-build`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/commands/cs-workflow-build.md)
+- Adjacent: [`engineering/write-a-skill`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/write-a-skill) (authoring skills, not workflows), [`engineering/grill-me`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/grill-me) (forcing-question discipline)
+
+---
+
+**Version:** 1.0.0
+**Status:** Production Ready

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,13 +1,13 @@
 ---
 title: "AI Coding Agents — Agent-Native Orchestrators & Codex Skills"
-description: "89 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
+description: "90 agent-native orchestrators for Claude Code, Codex CLI, and Gemini CLI — multi-skill AI agents across engineering, product, marketing, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-robot: Agents
 
-<p class="domain-count">89 agents that orchestrate skills across domains</p>
+<p class="domain-count">90 agents that orchestrate skills across domains</p>
 
 </div>
 
@@ -302,6 +302,12 @@ description: "89 agent-native orchestrators for Claude Code, Codex CLI, and Gemi
     Engineering - POWERFUL
 
 -   :material-rocket-launch:{ .lg .middle } **[wiki-linter](wiki-linter.md)**
+
+    ---
+
+    Engineering - POWERFUL
+
+-   :material-rocket-launch:{ .lg .middle } **[Workflow Architect Agent](cs-workflow-architect.md)**
 
     ---
 

--- a/docs/commands/cs-workflow-build.md
+++ b/docs/commands/cs-workflow-build.md
@@ -1,0 +1,101 @@
+---
+title: "/cs-workflow-build — Slash Command for AI Coding Agents"
+description: "/cs:workflow-build <task-description> — Design and write a deterministic Claude Code workflow (.js). Opens with intake questions, infers-and-proposes. Slash command for Claude Code, Codex CLI, Gemini CLI."
+---
+
+# /cs-workflow-build
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-console: Slash Command</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/2-claude-skills/tree/main/engineering/workflow-builder/commands/cs-workflow-build.md">Source</a></span>
+</div>
+
+
+**Command:** `/cs:workflow-build <task-description>`
+
+Designs a deterministic multi-agent workflow for Claude Code's Workflow tool. Always opens with intake; never writes a file before the topology is confirmed.
+
+## When to Run
+
+- Building a new `.claude/workflows/*.js` file
+- Automating a repeatable, multi-step task across fresh-context sub-agents
+- Deciding whether a task even warrants a workflow (vs. a single agent or a skill)
+
+## Step 1 — Intake (always first)
+
+Ask the opening question set. Lead with #1.
+
+1. What repeatable, multi-step task do you want to automate?
+2. What is the one unit of work a single sub-agent does once?
+3. How many units — a known list, or discovered by looping?
+4. Do later steps need *all* prior results at once, or can each item flow on its own?
+5. Does any step need structured data back (a verdict, a list, scores)?
+6. Roughly how deep / how many tokens?
+
+## Step 2 — If the user is vague, infer and propose (don't loop on questions)
+
+```bash
+python ../skills/workflow-builder/scripts/workflow_intake.py --task "<their request>" \
+  --units unknown --stages unknown --needs-all unknown --structured unknown
+```
+
+Present the result as "here's what I'd build and why": recommended topology (+ runner-up), per-stage model picks, a budget guard, and the rationale for each choice. Then ask only "what should I change?"
+
+## Step 3 — Confirm the shape, then scaffold
+
+```bash
+python ../skills/workflow-builder/scripts/scaffold_workflow.py \
+  --topology <fan-out|pipeline|barrier|loop|judge-panel> --name <name> --description "..." \
+  > .claude/workflows/<name>.js
+```
+
+## Step 4 — Validate before running
+
+```bash
+python ../skills/workflow-builder/scripts/validate_workflow.py .claude/workflows/<name>.js
+```
+
+Fix every FAIL. WARNs need a one-line justification.
+
+## Step 5 — Run
+
+```bash
+export CLAUDE_CODE_WORKFLOWS=1   # the feature is off by default
+# Save under .claude/workflows/, then launch + monitor via /workflows.
+# P = pause/resume, X = skip a sub-agent. Failed agents retry automatically.
+```
+
+## The Hard Rules (validator enforces)
+
+1. `meta` is a pure literal and the first statement — no variables, spreads, template strings, or calls.
+2. No `Date.now()`, `Math.random()`, or argless `new Date()` — they break resume.
+3. No filesystem / Node APIs in the orchestrator — that work goes inside `agent()`.
+4. `parallel()` takes thunks (`() => agent(...)`); default to `pipeline()` unless a stage needs the whole prior set.
+5. Guard every open-ended loop with a counter or `budget.remaining()`.
+6. `results.filter(Boolean)` before using parallel/pipeline output.
+
+## Output Format
+
+```markdown
+# Workflow Build: <name>
+## The Decision
+[intake | recommend | scaffold | validate | run]
+## Recommended Topology
+[fan-out | pipeline | barrier | loop | judge-panel] — why
+## Model Plan
+[per-stage model + reason]
+## Validator Verdict
+🟢 PASS | 🟡 WARN (justified) | 🔴 FAIL (with line numbers)
+## Next Steps
+[3 concrete actions]
+```
+
+## Related
+
+- Agent: [`cs-workflow-architect`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/agents/cs-workflow-architect.md)
+- Skill: [`workflow-builder`](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/SKILL.md)
+- Adjacent: `/cs:write-a-skill` (authoring skills, not workflows)
+
+---
+
+**Version:** 1.0.0

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Slash Commands — AI Coding Agent Commands & Codex Shortcuts"
-description: "83 slash commands for Claude Code, Codex CLI, and Gemini CLI — sprint planning, tech debt analysis, PRDs, OKRs, and more."
+description: "84 slash commands for Claude Code, Codex CLI, and Gemini CLI — sprint planning, tech debt analysis, PRDs, OKRs, and more."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-console: Slash Commands
 
-<p class="domain-count">83 commands for quick access to common operations</p>
+<p class="domain-count">84 commands for quick access to common operations</p>
 
 </div>
 
@@ -270,6 +270,12 @@ description: "83 slash commands for Claude Code, Codex CLI, and Gemini CLI — s
     ---
 
     Command: /cs:handoff <next-session-focus>
+
+-   :material-console:{ .lg .middle } **[`/cs-workflow-build`](cs-workflow-build.md)**
+
+    ---
+
+    Command: /cs:workflow-build <task-description>
 
 -   :material-console:{ .lg .middle } **[`/cs-write-a-skill`](cs-write-a-skill.md)**
 

--- a/docs/skills/engineering/index.md
+++ b/docs/skills/engineering/index.md
@@ -1,13 +1,13 @@
 ---
 title: "Engineering - POWERFUL Skills — Agent Skills & Codex Plugins"
-description: "73 engineering - powerful skills — advanced agent-native skill and Claude Code plugin for AI agent design, infrastructure, and automation. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
+description: "74 engineering - powerful skills — advanced agent-native skill and Claude Code plugin for AI agent design, infrastructure, and automation. Works with Claude Code, Codex CLI, Gemini CLI, and OpenClaw."
 ---
 
 <div class="domain-header" markdown>
 
 # :material-rocket-launch: Engineering - POWERFUL
 
-<p class="domain-count">73 skills in this domain</p>
+<p class="domain-count">74 skills in this domain</p>
 
 </div>
 

--- a/docs/skills/engineering/workflow-builder.md
+++ b/docs/skills/engineering/workflow-builder.md
@@ -1,0 +1,84 @@
+---
+title: "Workflow Builder — Agent Skill for Codex & OpenClaw"
+description: "Design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool. Use when a user wants."
+---
+
+# Workflow Builder
+
+<div class="page-meta" markdown>
+<span class="meta-badge">:material-rocket-launch: Engineering - POWERFUL</span>
+<span class="meta-badge">:material-identifier: `workflow-builder`</span>
+<span class="meta-badge">:material-github: <a href="https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/SKILL.md">Source</a></span>
+</div>
+
+<div class="install-banner" markdown>
+<span class="install-label">Install:</span> <code>claude /plugin install engineering-advanced-skills</code>
+</div>
+
+
+Author runnable workflow scripts for Claude Code's Workflow tool: deterministic multi-agent orchestration files (`.js`) that fan work out to fresh-context sub-agents under plain JavaScript control flow. Only leaf `agent()` calls spend tokens, so the main session stays clean and the whole run is resumable.
+
+## ALWAYS start every session with intake (non-negotiable)
+
+Before proposing or writing any workflow, run the intake. Do not skip to code.
+
+1. **Ask what kind of workflow they want.** Use this opening question set:
+   - What repeatable, multi-step task do you want to automate?
+   - What is the one unit of work a single sub-agent does once?
+   - How many units — a known list, or discovered by looping?
+   - Do later steps need *all* prior results at once, or can each item flow on its own?
+   - Does any step need structured data back (a verdict, a list, scores)?
+   - Roughly how many tokens / how deep should it go?
+
+2. **If the user is vague, do NOT stall.** Run the recommendation engine to turn whatever you have into 1-2 concrete proposals, then present them *with the reasoning*:
+   ```bash
+   python scripts/workflow_intake.py --task "their description" \
+     --units unknown --stages unknown --needs-all unknown --structured unknown
+   ```
+   The engine returns a recommended topology (fan-out / pipeline / loop / barrier / judge-panel), model picks, a budget guard, and a one-line rationale per choice. Present those as "Here's what I'd build and why" — never ask the user to re-answer questions they already half-answered.
+
+3. **Confirm the shape with the user** (topology + phases + parallel-vs-pipeline) before writing the file. This is the only approval gate.
+
+See [references/decision_and_intake_guide.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/references/decision_and_intake_guide.md) for the full question framework, the vague-input playbook, and worked recommendation examples.
+
+## Decide if a workflow is even the right tool
+
+| Scenario | Use |
+|----------|-----|
+| Single sub-agent, one task | plain Agent tool |
+| Reusable procedure, Claude picks steps dynamically | a Skill |
+| Many sub-agents in a fixed topology, deterministic + resumable | **Workflow** ✓ |
+
+Workflows earn their cost when work is parallel or multi-stage, must be reproducible, long enough to fail halfway (so resume matters), or benefits from isolating each step in its own context window. For one-off tasks, just use Claude directly.
+
+## Build → validate → run loop
+
+1. **Scaffold** a starter from the confirmed topology:
+   ```bash
+   python scripts/scaffold_workflow.py --topology pipeline --name pr-triage \
+     --description "Triage open PRs" > .claude/workflows/pr-triage.js
+   ```
+2. **Edit** the file: `meta` block first (pure literal, first statement), then the async body using the injected globals — `agent()`, `pipeline()`, `parallel()`, `phase()`, `log()`, `budget`, `args`, `workflow()`. Full surface in [references/api_reference.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/references/api_reference.md); copy-paste shapes in [references/orchestration_patterns.md](https://github.com/alirezarezvani/claude-skills/tree/main/engineering/workflow-builder/skills/workflow-builder/references/orchestration_patterns.md).
+3. **Validate** before running — catches the parser-fatal mistakes:
+   ```bash
+   python scripts/validate_workflow.py .claude/workflows/pr-triage.js
+   ```
+4. **Run** it: enable the feature with `export CLAUDE_CODE_WORKFLOWS=1`, save the file under `.claude/workflows/`, then use `/workflows` to launch and watch it live. Press **P** to pause/resume, **X** to skip a sub-agent. Failed agents retry automatically.
+
+## Hard rules (validator enforces these)
+
+- `meta` is a **pure literal** and the **first statement** — no variables, spreads, template strings, or function calls inside it.
+- **No non-determinism:** `Date.now()`, `Math.random()`, argless `new Date()` break resume — pass timestamps via `args`.
+- **No filesystem / Node APIs** (`require`, `fs`, `process`, network) in the orchestrator — that work belongs *inside* `agent()` prompts.
+- `parallel()` takes **thunks** (`() => agent(...)`), not bare promises. Default to `pipeline()` unless a stage needs the whole prior result set.
+- **Guard every open-ended loop** with a counter or `budget.remaining()` check — unguarded loops hit the 1000-agent cap.
+- Filter skipped/failed agents: `results.filter(Boolean)`.
+
+## Tooling
+
+- `scripts/workflow_intake.py` — intake recommendation engine (topology + model + budget + rationale from vague input).
+- `scripts/validate_workflow.py` — stdlib linter for the rules above; PASS / WARN / FAIL with line numbers.
+- `scripts/scaffold_workflow.py` — generate a starter `.js` for any topology.
+- `assets/templates/` — fan-out, pipeline, loop-until-budget starters. `assets/examples/` — a complete runnable workflow.
+
+All scripts run with `--sample` (no args) and `--help`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,6 +244,7 @@ nav:
       - "Caveman Mode (Matt Pocock-derived)": skills/engineering/caveman.md
       - "Grill Me (Matt Pocock-derived)": skills/engineering/grill-me.md
       - "Handoff (Matt Pocock-derived)": skills/engineering/handoff.md
+      - "Workflow Builder": skills/engineering/workflow-builder.md
       - AgentHub:
         - "AgentHub": skills/engineering/agenthub.md
         - "/hub:init": skills/engineering/agenthub-init.md
@@ -523,6 +524,7 @@ nav:
     - "CS Caveman Mode (Matt Pocock-derived)": agents/cs-caveman-mode.md
     - "CS Grill Master (Matt Pocock-derived)": agents/cs-grill-master.md
     - "CS Handoff Author (Matt Pocock-derived)": agents/cs-handoff-author.md
+    - "CS Workflow Architect": agents/cs-workflow-architect.md
     - "CS BizOps Orchestrator (v2.8.0)": agents/cs-bizops-orchestrator.md
     - "CS Commercial Orchestrator (v2.8.0)": agents/cs-commercial-orchestrator.md
     - "CS Research Ops Orchestrator (v2.9.0)": agents/cs-research-ops-orchestrator.md
@@ -571,6 +573,7 @@ nav:
     - "/chaos-experiment": commands/chaos-experiment.md
     - "/slo-design": commands/slo-design.md
     - "/cs:aeo": commands/cs-aeo.md
+    - "/cs:workflow-build": commands/cs-workflow-build.md
     - "/cs:bizops (v2.8.0 — BizOps router)": commands/cs-bizops.md
     - "/cs:grill-bizops (v2.8.0 — Matt grill bizops)": commands/cs-grill-bizops.md
     - "/cs:process-map (v2.8.0)": commands/cs-process-map.md


### PR DESCRIPTION
## Summary

Documentation pass for the `workflow-builder` skill — generates and wires up its GitHub Pages so it shows up in the docs site.

- **Generated 3 pages** via `scripts/generate-docs.py`:
  - `docs/skills/engineering/workflow-builder.md`
  - `docs/agents/cs-workflow-architect.md`
  - `docs/commands/cs-workflow-build.md`
- **Wired into `mkdocs.yml` nav**: Engineering - POWERFUL (skill), Agents (cs-workflow-architect), Commands (/cs:workflow-build).
- **Updated section index pages** (skills/engineering, agents, commands).
- **Build verified clean**: `mkdocs build` succeeds, all 3 pages render, 551 HTML pages total. The only warnings are pre-existing and unrelated (cs-seo-audit link, grill-with-docs CONTEXT/ADR-FORMAT links).

## Counts unchanged

Aggregate skill/domain counts were **not** touched — workflow-builder was already absorbed into dev's `338 skills / engineering-advanced (78)` header when it merged before the research-ops counting pass. No double-counting.

## Out of scope (intentionally excluded)

Re-running the Codex sync only produced unrelated duplicate-slug symlink drift (`review`/`run`/`status` re-pointing between equally-valid plugins) — workflow-builder was already in the codex/gemini indexes. I reverted that noise to keep this PR scoped to docs.

## Test plan

- [x] `mkdocs build` exits clean; the 3 new pages build to HTML
- [x] All nav `.md` targets resolve on disk (0 missing)
- [x] New pages have valid YAML frontmatter
- [x] The 3 skill scripts still pass `--help`

https://claude.ai/code/session_01Q1kXbgMRodzhdTpgbCqVgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1kXbgMRodzhdTpgbCqVgx)_