### PR TITLE
feat(code-reviewer): add C, C++, Rust, Ruby, PHP, and Dart/Flutter language support (#769)

### DIFF
--- a/.codex/skills-index.json
+++ b/.codex/skills-index.json
@@ -621,7 +621,7 @@
       "name": "code-reviewer",
       "source": "../../engineering-team/skills/code-reviewer",
       "category": "engineering",
-      "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, and Java. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists."
+      "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, Java, C, C++, Rust, Ruby, PHP, and Dart/Flutter. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists."
     },
     {
       "name": "coverage",
@@ -739,15 +739,15 @@
     },
     {
       "name": "review",
-      "source": "../../engineering-team/playwright-pro/skills/review",
-      "category": "engineering",
-      "description": ">-"
-    },
-    {
-      "name": "review",
       "source": "../../engineering-team/self-improving-agent/skills/review",
       "category": "engineering",
       "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics."
+    },
+    {
+      "name": "review",
+      "source": "../../engineering-team/playwright-pro/skills/review",
+      "category": "engineering",
+      "description": ">-"
     },
     {
       "name": "security-pen-testing",

--- a/.codex/skills/review
+++ b/.codex/skills/review
@@ -1,1 +1,1 @@
-../../engineering-team/self-improving-agent/skills/review
+../../engineering-team/playwright-pro/skills/review

--- a/engineering-team/skills/code-reviewer/SKILL.md
+++ b/engineering-team/skills/code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "code-reviewer"
-description: Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, and Java. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.
+description: Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, Java, C, C++, Rust, Ruby, PHP, and Dart/Flutter. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.
 ---
 
 # Code Reviewer
@@ -24,6 +24,12 @@ code-reviewer/
     kotlin.md                     ← Kotlin-specific rules + idioms
     csharp.md                     ← C# / .NET-specific rules + idioms
     java.md                       ← Java-specific rules + idioms
+    c.md                          ← C -specific rules + idioms
+    cpp.md                        ← C++ -specific rules + idioms
+    rust.md                       ← Rust -specific rules + idioms
+    ruby.md                       ← Ruby -specific rules + idioms
+    php.md                        ← PHP-specific rules + idioms
+    dart.md                       ← Dart / Flutter-specific rules + idioms
 ```
 
 ### Loading order for every review
@@ -32,7 +38,7 @@ code-reviewer/
 2. `rules/universal.md` — always, for every language
 3. The matching `languages/*.md` — one file based on the extension table below
 
-That's always exactly **2 additional files**, regardless of scope.
+That is always exactly **2 additional files**, regardless of scope.
 
 | Extension(s) | Load |
 |---|---|
@@ -43,6 +49,12 @@ That's always exactly **2 additional files**, regardless of scope.
 | `.kt`, `.kts` | `languages/kotlin.md` |
 | `.cs`, `.csx`, `.razor`, `.cshtml` | `languages/csharp.md` |
 | `.java` | `languages/java.md` |
+| `.c`, `.h` | `languages/c.md` |
+| `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hh`, `.hxx` | `languages/cpp.md` |
+| `.rs` | `languages/rust.md` |
+| `.rb`, `.rake`, `.gemspec`, `.ru` | `languages/ruby.md` |
+| `.php`, `.phtml` | `languages/php.md` |
+| `.dart` | `languages/dart.md` |
 
 ---
 
@@ -70,6 +82,8 @@ python scripts/pr_analyzer.py /path/to/repo --json
 - Lint / analyzer suppression annotations
 - TODO/FIXME comments
 
+**Language-specific detections** are defined in each `languages/*.md` file.
+
 **Output includes:**
 - Complexity score (1-10)
 - Risk categorization (critical, high, medium, low)
@@ -86,7 +100,8 @@ Analyzes source code for structural issues, code smells, and SOLID violations.
 # Analyze a directory
 python scripts/code_quality_checker.py /path/to/code
 
-# Analyze specific language (valid values: python, typescript, javascript, go, swift, kotlin, csharp, java)
+# Analyze specific language
+# Valid values: python, typescript, javascript, go, swift, kotlin, csharp, java, c, cpp, rust, ruby, php, dart
 python scripts/code_quality_checker.py . --language java
 
 # JSON output

--- a/engineering-team/skills/code-reviewer/languages/c.md
+++ b/engineering-team/skills/code-reviewer/languages/c.md
@@ -1,0 +1,103 @@
+---
+language: c
+extensions: [".c", ".h"]
+---
+
+# C — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only C-specific rules and idioms.
+
+---
+
+## PR Analyzer — C Risk Signals
+
+- `printf` / debug `fprintf(stderr, ...)` statements left in production code
+- `// TODO` / `// FIXME` comments near memory management code — high risk
+- Disabled compiler warnings (`#pragma GCC diagnostic ignore`, `-w` flags in Makefile)
+- Hardcoded credentials or keys in source
+- Use of banned functions: `gets`, `strcpy`, `strcat`, `sprintf`, `scanf` without width limits
+
+---
+
+## Code Quality — C Checks
+
+- Functions longer than 50 lines — C functions tend to grow organically and become hard to reason about
+- Missing `NULL` check after `malloc` / `calloc` / `realloc`
+- Return value of functions ignored without explicit `(void)` cast
+- Global mutable state used across translation units without clear ownership
+- Magic numbers without `#define` or `const` — especially sizes and offsets
+- Mixed `malloc`/`free` ownership — unclear which caller is responsible for freeing
+
+---
+
+## Security
+
+- Flag `gets()` — no bounds checking, always a buffer overflow; replace with `fgets()`
+- Flag `strcpy()` / `strcat()` — use `strncpy()` / `strncat()` with explicit size, or `strlcpy()` / `strlcat()`
+- Flag `sprintf()` — use `snprintf()` with explicit buffer size
+- Flag `scanf("%s", buf)` without a width specifier — unbounded read
+- Flag `strlen()` result used as a signed integer — potential truncation on 64-bit
+- Flag user-controlled data used as a format string (`printf(user_input)`) — format string attack
+- Flag integer arithmetic used as array index without bounds check
+- Flag signed integer overflow — undefined behavior in C
+
+---
+
+## Async / Concurrency
+
+- Flag shared global or `static` variables accessed from multiple threads without a mutex or `_Atomic`
+- Flag `pthread_mutex_t` / `sem_t` not initialized before use
+- Flag signal handlers that call non-async-signal-safe functions (`malloc`, `printf`, etc.)
+- Flag `volatile` used as a substitute for proper synchronization — it is not sufficient
+- Flag lock acquisition order inconsistency across call sites — deadlock risk
+
+---
+
+## Resource Management
+
+- Flag every `malloc` / `calloc` / `realloc` path — verify a matching `free` exists on all exit paths
+- Flag `fopen` without a matching `fclose` on all paths including error paths
+- Flag `dup` / `socket` / `open` file descriptors not closed on all paths
+- Flag stack-allocated VLAs (variable-length arrays) of unbounded size — stack overflow risk
+- Flag `realloc` return value assigned directly to the source pointer — leaks on failure
+
+---
+
+## Exception Handling
+
+- Flag ignored return values from `malloc`, `fopen`, `read`, `write`, `close` — all can fail
+- Flag `errno` checked after a function that doesn't set it, or not checked immediately after one that does
+- Flag `perror` / `strerror` as the sole error handling in library code — propagate errors to callers
+- Flag functions that return `-1` on error without documenting which `errno` values are possible
+- Flag `assert()` used for runtime error handling — disabled by `NDEBUG` in production builds
+
+---
+
+## Performance
+
+- Flag `strlen()` called repeatedly on the same string in a loop — cache the result
+- Flag unnecessary copies of large structs passed by value — pass by pointer
+- Flag `memcpy` / `memset` on overlapping regions — use `memmove` for overlapping
+- Flag repeated heap allocations in a tight loop — consider a pool or stack allocation
+- Flag `volatile` on variables not accessed by hardware or signal handlers — prevents optimization
+
+---
+
+## Idioms and Best Practices
+
+### Memory Safety
+- Every pointer must have a clear owner responsible for freeing it — document ownership in comments
+- Set pointers to `NULL` immediately after `free` to catch use-after-free early
+- Prefer `calloc` over `malloc` + `memset` for zero-initialized allocations
+- Use `const` on pointer parameters that the function does not modify
+
+### Defensive Coding
+- Always check `NULL` returns from allocation functions
+- Use `size_t` for sizes and counts — never `int`
+- Prefer `snprintf` and `fgets` over any unbounded string function
+- Compile with `-Wall -Wextra -Werror` and treat warnings as errors
+
+### Portability
+- Do not assume pointer size equals `int` size — use `intptr_t` / `uintptr_t`
+- Do not rely on undefined behavior for performance — use compiler intrinsics instead
+- Use `stdint.h` types (`uint32_t`, `int64_t`) for fixed-width requirements

--- a/engineering-team/skills/code-reviewer/languages/cpp.md
+++ b/engineering-team/skills/code-reviewer/languages/cpp.md
@@ -1,0 +1,103 @@
+---
+language: cpp
+extensions: [".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"]
+---
+
+# C++ — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only C++-specific rules and idioms.
+
+---
+
+## PR Analyzer — C++ Risk Signals
+
+- Raw `new` / `delete` outside of smart pointer wrappers
+- `reinterpret_cast` — almost always a red flag; require justification
+- Disabled compiler warnings (`#pragma warning(disable:...)`, `-w`)
+- `// TODO` / `// FIXME` near ownership or lifetime code
+- Hardcoded credentials or keys in source
+- Use of deprecated C-style functions: `strcpy`, `sprintf`, `gets`
+
+---
+
+## Code Quality — C++ Checks
+
+- Raw owning pointers (`T*`) used where `unique_ptr` / `shared_ptr` would express ownership
+- `shared_ptr` overused where `unique_ptr` suffices — implies shared ownership unnecessarily
+- `std::endl` used in hot paths — flushes the buffer every call; prefer `'\n'`
+- Implicit conversions between signed and unsigned integers
+- Virtual destructor missing on base classes with virtual methods
+- `catch (...)` swallowing all exceptions without logging or re-throwing
+
+---
+
+## Security
+
+- Flag `reinterpret_cast` on user-controlled data — potential type confusion
+- Flag raw array indexing without bounds check — use `.at()` or assert bounds
+- Flag `std::string` data passed to C APIs without null-termination guarantee — use `.c_str()`
+- Flag hardcoded buffer sizes — derive from `sizeof` or use `std::array<T, N>`
+- Flag `sscanf` / `sprintf` — use `std::istringstream` or `std::format` (C++20)
+- Flag user-controlled data used as a format string
+
+---
+
+## Async / Concurrency
+
+- Flag `std::shared_ptr` accessed from multiple threads — the pointer itself is not thread-safe for write; use `std::atomic<std::shared_ptr<T>>` (C++20) or external locking
+- Flag `std::vector` / `std::map` mutated from multiple threads without a mutex
+- Flag `std::mutex` locked twice in the same thread without `std::recursive_mutex` — deadlock
+- Flag detached threads (`std::thread::detach`) with no lifetime coordination
+- Flag `volatile` used instead of `std::atomic` for inter-thread communication
+
+---
+
+## Resource Management
+
+- Flag raw `new` returning an owning pointer — wrap immediately in `std::make_unique` or `std::make_shared`
+- Flag `delete` called manually outside of a destructor or smart pointer — ownership confusion
+- Flag RAII violations — resources acquired in constructor but not released via destructor
+- Flag `std::ifstream` / `std::ofstream` not checked for open failure before use
+- Flag exceptions thrown from destructors — causes `std::terminate` if thrown during stack unwinding
+
+---
+
+## Exception Handling
+
+- Flag `catch (...)` that swallows exceptions without logging or re-throwing
+- Flag exceptions thrown from destructors — wrap in `try/catch` inside the destructor
+- Flag `noexcept` on functions that can actually throw — causes `std::terminate`
+- Flag exception specifications (`throw(...)`) — deprecated since C++11, removed in C++17
+- Flag using exceptions for control flow in performance-critical paths
+
+---
+
+## Performance
+
+- Flag pass-by-value for non-trivial types where pass-by-const-reference suffices
+- Flag `std::vector::push_back` in a loop without `reserve` when size is known — repeated reallocations
+- Flag `std::map` used where `std::unordered_map` would give O(1) lookup
+- Flag `std::endl` in loops — prefer `'\n'` to avoid repeated buffer flushes
+- Flag unnecessary copies from missing `std::move` on local temporaries being returned or passed
+
+---
+
+## Idioms and Best Practices
+
+### Ownership and Lifetime
+- Prefer `std::unique_ptr` for sole ownership, `std::shared_ptr` only for shared ownership
+- Prefer `std::make_unique` / `std::make_shared` over `new` — exception-safe
+- Use `std::weak_ptr` to break `shared_ptr` cycles
+- Never use raw owning pointers in new code — they are for non-owning observation only
+
+### Modern C++ (17/20)
+- Prefer `std::optional<T>` over sentinel values or nullable pointers for optional returns
+- Prefer `std::variant` over tagged unions
+- Prefer `std::string_view` over `const std::string&` for read-only string parameters
+- Prefer range-based `for` loops over index loops where the index isn't needed
+- Prefer `if constexpr` over `#ifdef` for compile-time branching
+
+### Type Safety
+- Prefer `static_cast` over C-style casts — explicit and auditable
+- Avoid `reinterpret_cast` except in low-level I/O or FFI code with a comment
+- Use `enum class` over plain `enum` to avoid implicit integer conversions

--- a/engineering-team/skills/code-reviewer/languages/dart.md
+++ b/engineering-team/skills/code-reviewer/languages/dart.md
@@ -1,0 +1,108 @@
+---
+language: dart
+extensions: [".dart"]
+---
+
+# Dart / Flutter — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Dart and Flutter-specific rules and idioms.
+
+---
+
+## PR Analyzer — Dart / Flutter Risk Signals
+
+- `print()` statements left in production code — use a logging package
+- `// ignore:` lint suppression comments — verify they are justified
+- `!` null assertion operator used broadly without justification
+- Hardcoded API keys, tokens, or URLs in Dart source — use environment variables or a secrets package
+- `TODO` / `FIXME` near widget lifecycle or state management code
+
+---
+
+## Code Quality — Dart Checks
+
+- `dynamic` used where a concrete type is known — defeats static analysis
+- `!` (null assertion) used broadly — prefer null-safe patterns
+- `StatefulWidget` used where `StatelessWidget` suffices — prefer stateless
+- `setState` called with heavy computation inside — offload before calling
+- `BuildContext` used across async gaps without checking `mounted`
+- Missing `const` constructor on widgets that could be constant
+
+---
+
+## Security
+
+- Flag API keys or secrets hardcoded in Dart source or `pubspec.yaml` — use `--dart-define` or a secrets manager
+- Flag `http` package used without certificate validation disabled intentionally
+- Flag `SharedPreferences` used to store sensitive data — use `flutter_secure_storage`
+- Flag user-controlled input used in `dart:io` file path operations without sanitization
+- Flag `WebView` loading arbitrary user-supplied URLs without validation
+- Flag deep link / URL scheme handlers that don't validate the incoming URL before acting on it
+
+---
+
+## Async / Concurrency
+
+- Flag `BuildContext` used after an `await` without checking `if (!mounted) return` — context may be invalid
+- Flag `Future` returned but not `await`-ed and without `.catchError()` or `unawaited()` — floating future
+- Flag `Isolate.spawn` without a clear message-passing protocol
+- Flag heavy computation on the main isolate — offload with `compute()` or `Isolate.run()`
+- Flag `StreamController` not closed when the owning widget is disposed — memory leak
+- Flag `async*` / `yield*` generators with no error handling on the stream consumer side
+
+---
+
+## Resource Management
+
+- Flag `StreamController` not closed in `dispose()`
+- Flag `AnimationController` not disposed in `dispose()`
+- Flag `TextEditingController` / `FocusNode` / `ScrollController` not disposed in `dispose()`
+- Flag `Timer` not cancelled in `dispose()`
+- Flag listeners added to `ChangeNotifier` / `ValueNotifier` without a corresponding `removeListener`
+
+---
+
+## Exception Handling
+
+- Flag empty `catch` blocks — swallowed errors
+- Flag `catchError` with no handler body — silent failure
+- Flag `Future.error` not surfaced to the UI — show an error state
+- Flag `FlutterError.onError` overridden without calling the original handler
+- Prefer typed `on ExceptionType catch (e)` over generic `catch (e)` where the exception type is known
+
+---
+
+## Performance
+
+- Flag `setState` called for changes that only affect a small subtree — use `ValueNotifier` / `provider` / `Riverpod` to scope rebuilds
+- Flag expensive computation inside `build()` — move to `initState`, a controller, or a `FutureBuilder`
+- Flag `ListView` without `ListView.builder` for long or infinite lists — builds all children at once
+- Flag missing `const` on widgets that never change — prevents unnecessary rebuilds
+- Flag `Image.network` without a caching package in a list — re-downloads on every scroll
+- Flag `RepaintBoundary` missing around frequently-repainted widgets (animations, counters)
+
+---
+
+## Idioms and Best Practices
+
+### Null Safety
+- Prefer `?.` safe navigation and `??` null coalescing over `!` assertions
+- Use `late` only when initialization is guaranteed before first access — document why
+- Prefer early returns over deeply nested null checks
+
+### Flutter Widget Patterns
+- Prefer `StatelessWidget` + external state management over `StatefulWidget` for business logic
+- Keep `build()` methods pure — no side effects, no heavy computation
+- Extract repeated widget subtrees into named widget classes, not just methods, for better rebuild granularity
+- Use `const` constructors wherever possible — compile-time constant widgets skip rebuilds entirely
+
+### State Management
+- Do not mix multiple state management approaches in the same feature
+- Flag business logic inside `build()` — it belongs in a ViewModel, Notifier, or BLoC
+- Prefer `Riverpod` / `provider` / `BLoC` over raw `setState` for anything beyond local UI state
+
+### Modern Dart (3.x)
+- Prefer `sealed` classes for exhaustive pattern matching on domain types
+- Use records (`(int, String)`) for lightweight multi-value returns instead of ad hoc classes
+- Use `switch` expressions with pattern matching instead of long `if/else` chains
+- Prefer `final` for local variables — immutability by default

--- a/engineering-team/skills/code-reviewer/languages/php.md
+++ b/engineering-team/skills/code-reviewer/languages/php.md
@@ -1,0 +1,109 @@
+---
+language: php
+extensions: [".php", ".phtml", ".php3", ".php4", ".php5", ".phps"]
+---
+
+# PHP — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only PHP-specific rules and idioms.
+
+---
+
+## PR Analyzer — PHP Risk Signals
+
+- `var_dump` / `print_r` / `echo` debug statements left in production code
+- `@` error suppression operator — masks real errors; verify it is justified
+- `// phpcs:ignore` / `// phpstan-ignore` comments — verify they are justified
+- Hardcoded credentials, database passwords, or API keys in source
+- `eval()` anywhere — almost always a security issue
+- `$_GET` / `$_POST` / `$_REQUEST` / `$_COOKIE` used without sanitization
+
+---
+
+## Code Quality — PHP Checks
+
+- Missing type declarations on function parameters and return types
+- `mixed` return type used broadly — tighten to specific types
+- Global variables (`global $var`) — pass dependencies explicitly
+- Long functions (>50 lines) — PHP functions tend to accumulate logic
+- `isset()` / `empty()` used to mask type errors instead of fixing the root cause
+- Missing `strict_types=1` declaration at the top of the file
+
+---
+
+## Security
+
+- Flag `$_GET` / `$_POST` / `$_REQUEST` used directly in SQL queries — require PDO prepared statements
+- Flag `mysqli_query($conn, "SELECT ... WHERE id = " . $_GET['id'])` — SQL injection
+- Flag `echo $_GET['name']` or any unescaped output — XSS; use `htmlspecialchars()` with `ENT_QUOTES`
+- Flag `include` / `require` with user-controlled paths — local/remote file inclusion
+- Flag `eval()` — remote code execution risk; no legitimate use in application code
+- Flag `shell_exec` / `exec` / `system` / `passthru` with user-controlled input — command injection
+- Flag `unserialize()` on untrusted data — arbitrary object instantiation and code execution
+- Flag `move_uploaded_file` without MIME type validation and extension whitelist — file upload attack
+- Flag `header("Location: " . $_GET['url'])` without validation — open redirect
+- Flag missing CSRF token validation on state-changing form endpoints
+
+---
+
+## Async / Concurrency
+
+- Flag long-running synchronous operations in a request cycle — offload to a queue (Laravel Queue, RabbitMQ)
+- Flag `sleep()` used inside a request handler — blocks the PHP-FPM worker
+- Flag shared mutable state in `static` properties accessed across requests in long-running processes (Swoole, RoadRunner)
+- Flag missing idempotency in queued jobs — jobs can be retried on failure
+
+---
+
+## Resource Management
+
+- Flag database connections not closed or returned to the pool (`$pdo = null` or `$conn->close()`)
+- Flag `fopen` / `fwrite` without a matching `fclose` on all paths
+- Flag `curl_init` without `curl_close` — leaks the curl handle
+- Flag unbounded file uploads with no size or type restriction
+- Flag sessions not explicitly closed (`session_write_close()`) before long operations — session locking blocks other requests
+
+---
+
+## Exception Handling
+
+- Flag empty `catch` blocks — swallowed exceptions
+- Flag `catch (Exception $e) {}` without logging — silent failure
+- Flag `die()` / `exit()` used for error handling in library code — use exceptions
+- Flag `@` operator used to suppress errors from functions that can fail — check return values instead
+- Flag `trigger_error` used in new code — prefer exceptions
+
+---
+
+## Performance
+
+- Flag N+1 Eloquent / Doctrine queries — use eager loading (`with()`, `load()`, `join`)
+- Flag `count($array)` called repeatedly in a loop condition — cache the result
+- Flag `array_push($arr, $val)` — use `$arr[] = $val` which is faster
+- Flag `in_array` on large arrays without the strict third argument — use `isset` on a flipped array for O(1) lookup
+- Flag `file_get_contents` on remote URLs in a request cycle — use an HTTP client with timeout and async where possible
+- Flag Eloquent `all()` without pagination — loads entire table into memory
+
+---
+
+## Idioms and Best Practices
+
+### Type Safety
+- Always declare `declare(strict_types=1)` at the top of every file
+- Use union types (`int|string`) and nullable types (`?string`) rather than `mixed`
+- Use typed properties on classes — avoid untyped `public $foo`
+- Use constructor promotion for simple value objects
+
+### Modern PHP (8.x)
+- Prefer `match` expressions over `switch` — strict comparison, no fall-through
+- Use named arguments for functions with many optional parameters
+- Use `enum` for fixed sets of values instead of class constants
+- Use `readonly` properties for immutable data
+- Use nullsafe operator (`?->`) instead of nested `isset` checks
+- Use `first-class callable syntax` (`strlen(...)`) instead of string references
+
+### Laravel / Symfony Specific
+- Keep controllers thin — logic belongs in service classes or action classes
+- Use form requests for validation — never validate in the controller directly
+- Prefer Eloquent relationships over manual joins for readability
+- Flag raw queries where the ORM can express the same intent safely

--- a/engineering-team/skills/code-reviewer/languages/ruby.md
+++ b/engineering-team/skills/code-reviewer/languages/ruby.md
@@ -1,0 +1,105 @@
+---
+language: ruby
+extensions: [".rb", ".rake", ".gemspec", ".ru"]
+---
+
+# Ruby — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Ruby-specific rules and idioms.
+
+---
+
+## PR Analyzer — Ruby Risk Signals
+
+- `puts` / `p` / `pp` debug statements left in production code
+- `# rubocop:disable` comments — verify they are justified
+- `eval` / `instance_eval` / `class_eval` with user-controlled input
+- Hardcoded credentials, tokens, or `SECRET_KEY_BASE` in source
+- `binding.pry` / `byebug` / `debugger` left in code
+
+---
+
+## Code Quality — Ruby Checks
+
+- Methods longer than 15 lines — Ruby idioms favor very small methods
+- Classes with more than 10 public methods — possible god object
+- `rescue Exception` — catches `SignalException` and `SystemExit`; use `rescue StandardError` or more specific types
+- `method_missing` implemented without `respond_to_missing?`
+- Deeply nested blocks (>3 levels) — extract to methods
+- String interpolation used where a symbol would suffice (hash keys, etc.)
+
+---
+
+## Security
+
+- Flag `eval` / `instance_eval` with user-controlled strings — remote code execution
+- Flag `system()` / `exec()` / backtick calls with user-controlled input — shell injection
+- Flag `YAML.load` on untrusted data — use `YAML.safe_load`
+- Flag `Marshal.load` on untrusted data — arbitrary code execution
+- Flag raw SQL string interpolation in ActiveRecord — use parameterized queries (`where("name = ?", name)`)
+- Flag `params` passed directly to `redirect_to` without validation — open redirect
+- Flag `render inline:` with user data — XSS via ERB
+- Flag missing `strong_parameters` in Rails controllers — mass assignment vulnerability
+
+---
+
+## Async / Concurrency
+
+- Flag shared mutable state accessed from multiple threads without a `Mutex`
+- Flag `Thread.new` without storing the thread reference — exceptions are silently swallowed
+- Flag `sleep` used as a synchronization mechanism in threaded code
+- Flag `@@class_variables` mutated in multi-threaded contexts — not thread-safe
+- Flag Sidekiq / ActiveJob workers that are not idempotent — jobs can be retried
+
+---
+
+## Resource Management
+
+- Flag `File.open` without a block form — the block form guarantees `close`
+- Flag database connections or HTTP clients not released in `ensure` blocks
+- Flag `ActiveRecord` queries inside loops — N+1 pattern; use `includes` / `preload` / `eager_load`
+- Flag `ObjectSpace` usage in production — memory and performance impact
+
+---
+
+## Exception Handling
+
+- Flag `rescue Exception` — use `rescue StandardError` or a specific exception class
+- Flag empty `rescue` blocks — swallowed errors
+- Flag `rescue` used for control flow (e.g. rescuing `ActiveRecord::RecordNotFound` instead of using `find_by`)
+- Flag re-raising with `raise e` instead of bare `raise` — loses the original backtrace
+- Flag `ensure` blocks that can raise — masks the original exception
+
+---
+
+## Performance
+
+- Flag N+1 ActiveRecord queries — use `includes`, `preload`, or `eager_load`
+- Flag `Array#each` with string concatenation — use `map` + `join`
+- Flag `select` + `map` that could be a single `filter_map`
+- Flag `.count` on an ActiveRecord relation inside a view or loop — triggers a query each time
+- Flag `require` inside a method body — constant overhead on every call
+- Flag `Hash#merge` in a loop — use `merge!` or `each_with_object`
+
+---
+
+## Idioms and Best Practices
+
+### Ruby Style
+- Prefer `map` / `select` / `reject` / `reduce` over manual `each` + accumulator
+- Prefer `&method(:name)` over `{ |x| some_method(x) }` for method reference blocks
+- Prefer `freeze` on string constants to avoid repeated object allocation
+- Use `attr_reader` / `attr_writer` / `attr_accessor` instead of manual getter/setter methods
+- Prefer `Symbol#to_proc` (`&:method_name`) for simple single-method blocks
+
+### Rails-Specific
+- Keep controllers thin — logic belongs in service objects, models, or concerns
+- Use `before_action` for authentication/authorization checks — never inline
+- Prefer `find_by` over `where(...).first` — more intent-revealing
+- Flag `after_commit` callbacks with side effects that should be in a service object
+- Prefer `respond_to` blocks over separate controller actions for format variants
+
+### Modern Ruby (3.x)
+- Prefer pattern matching (`case/in`) for complex data destructuring
+- Use numbered block parameters (`_1`, `_2`) only for very short, obvious blocks
+- Prefer `Data.define` for simple immutable value objects (Ruby 3.2+)

--- a/engineering-team/skills/code-reviewer/languages/rust.md
+++ b/engineering-team/skills/code-reviewer/languages/rust.md
@@ -1,0 +1,99 @@
+---
+language: rust
+extensions: [".rs"]
+---
+
+# Rust — Language-Specific Review Notes
+
+Load this file alongside `rules/universal.md`. Universal rules are not repeated here — only Rust-specific rules and idioms.
+
+---
+
+## PR Analyzer — Rust Risk Signals
+
+- `unsafe { }` blocks — require explicit justification and sign-off
+- `#[allow(...)]` attributes suppressing lints — verify they are justified
+- `.unwrap()` / `.expect("")` on `Option` or `Result` outside of tests or prototypes
+- Hardcoded credentials or tokens in source
+- `TODO` / `FIXME` comments near `unsafe` or ownership code
+
+---
+
+## Code Quality — Rust Checks
+
+- `.unwrap()` used broadly in production code — prefer `?`, `if let`, or `match`
+- `clone()` called excessively — may indicate ownership design issues
+- `Arc<Mutex<T>>` used where a simpler ownership model would work
+- `Box<dyn Trait>` used where generics (`impl Trait`) would avoid heap allocation
+- `pub` fields on structs that should enforce invariants — use accessor methods
+
+---
+
+## Security
+
+- Flag `unsafe` blocks accessing raw pointers without clear safety invariant documented in a comment
+- Flag `std::mem::transmute` — almost always a logic error or undefined behavior; require strong justification
+- Flag `from_utf8_unchecked` on user-controlled data — use `from_utf8` with error handling
+- Flag `unwrap()` on user-supplied input parsing — panics are a denial-of-service vector in server code
+- Flag hardcoded secrets — use environment variables or a secrets crate
+
+---
+
+## Async / Concurrency
+
+- Flag `std::sync::Mutex` used in async code — use `tokio::sync::Mutex` to avoid blocking the async runtime
+- Flag `.await` inside a `std::sync::MutexGuard` scope — holds the lock across an await point, blocking other tasks
+- Flag `spawn` without storing the `JoinHandle` — panics in the spawned task are silently ignored
+- Flag `Arc<Mutex<T>>` cloned excessively — consider message passing via channels instead
+- Flag blocking I/O calls (`std::fs`, `std::net`) inside async functions — use async equivalents
+
+---
+
+## Resource Management
+
+- Flag manual `drop` called explicitly where the natural scope boundary suffices
+- Flag `Rc<T>` used in multi-threaded code — use `Arc<T>`; the compiler catches this but flag in review for architecture discussion
+- Flag `Vec` or `String` with large pre-allocated capacity never trimmed — call `.shrink_to_fit()` if long-lived
+- Flag `impl Drop` that can panic — causes `abort` during stack unwinding
+
+---
+
+## Exception Handling
+
+- Flag `.unwrap()` in production code outside of tests — use `?` to propagate or handle explicitly
+- Flag `.expect("todo")` or `.expect("")` — messages must explain the invariant that guarantees safety
+- Flag `panic!` used for recoverable errors — use `Result<T, E>`
+- Flag `unwrap_or_default()` where the default silently masks a real error
+- Prefer typed error enums (`thiserror`) over `Box<dyn Error>` for library crates
+- Prefer `anyhow` for application-level error context; `thiserror` for library error types
+
+---
+
+## Performance
+
+- Flag `.clone()` on large types in hot paths — review whether a reference or `Cow<T>` would work
+- Flag `format!` used only to create a `String` from a literal — use `.to_string()` or `String::from`
+- Flag `collect::<Vec<_>>()` followed immediately by `.iter()` — chain iterators instead
+- Flag `Box<T>` for small types where stack allocation is fine
+- Flag `Mutex` contention on a hot path — consider `RwLock` for read-heavy workloads or sharding
+
+---
+
+## Idioms and Best Practices
+
+### Ownership
+- Prefer borrowing (`&T`, `&mut T`) over cloning wherever the lifetime allows
+- Use `Cow<'_, str>` for functions that sometimes need to own and sometimes borrow
+- Prefer `impl Trait` in function signatures over `Box<dyn Trait>` for static dispatch
+
+### Error Handling
+- Use `?` operator to propagate errors — avoid manual `match Err(e) => return Err(e)`
+- Define domain error types with `thiserror` in libraries; use `anyhow` in binaries
+- Never use `.unwrap()` in library code — it panics the caller's thread
+
+### Modern Rust
+- Prefer `if let` / `while let` for single-variant matches over full `match`
+- Prefer `?` over `unwrap` everywhere errors are recoverable
+- Use `#[derive(Debug, Clone, PartialEq)]` consistently on data types
+- Prefer `iter()` chains over manual loops — they compose and optimize well
+- Use `clippy` and treat its lints as required — flag any `#[allow(clippy::...)]` in review


### PR DESCRIPTION
Adds 6 new language files to the code-reviewer skill, expanding coverage from 7 to 13 languages. Each file follows the established hybrid structure — language-specific rules inline, universal rules in rules/universal.md.

Files added:
- languages/c.md — memory safety, banned functions, pointer ownership, buffer bounds, UB
- languages/cpp.md — smart pointers, RAII, reinterpret_cast, virtual destructors, C++17/20
- languages/rust.md — unsafe blocks, .unwrap() in production, Tokio pitfalls, clippy
- languages/ruby.md — Rails-aware N+1, strong_parameters, YAML.safe_load, Marshal.load
- languages/php.md — SQLi, unserialize, eval, file inclusion, CSRF, XSS, PHP 8.x
- languages/dart.md — Dart + Flutter: dispose(), BuildContext across async, const widgets

SKILL.md dispatch table and --language valid values updated accordingly.