### PR TITLE
fix(code-reviewer): wire 6 new languages into deterministic analyzer

### DIFF
--- a/engineering-team/skills/code-reviewer/scripts/code_quality_checker.py
+++ b/engineering-team/skills/code-reviewer/scripts/code_quality_checker.py
@@ -19,7 +19,9 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 
-# Language-specific file extensions
+# Language-specific file extensions.
+# `c` is declared before `cpp` so plain `.h` resolves to C, matching the
+# dispatch table in SKILL.md. C++ headers use `.hpp` / `.hh` / `.hxx`.
 LANGUAGE_EXTENSIONS = {
     "python": [".py"],
     "typescript": [".ts", ".tsx"],
@@ -29,6 +31,12 @@ LANGUAGE_EXTENSIONS = {
     "kotlin": [".kt", ".kts"],
     "csharp": [".cs", ".csx", ".razor", ".cshtml"],
     "java": [".java"],
+    "c": [".c", ".h"],
+    "cpp": [".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"],
+    "rust": [".rs"],
+    "ruby": [".rb", ".rake", ".gemspec", ".ru"],
+    "php": [".php", ".phtml"],
+    "dart": [".dart"],
 }
 
 # Code smell thresholds
@@ -143,6 +151,48 @@ def find_functions(content: str, language: str) -> List[Dict]:
             r"synchronized|native|default|strictfp)\s+)+"
             r"(?:[\w<>?,\s\[\]\.]+?\s+)?(\w+)\s*\(([^)]*)\)"
         ),
+        # C: require an opening brace after the parens so prototypes and
+        # call sites don't get matched. Return type / qualifiers come first.
+        # Skip C control-flow keywords that look like function calls.
+        "c": (
+            r"^(?:static\s+|inline\s+|extern\s+|const\s+|unsigned\s+|"
+            r"signed\s+|volatile\s+|register\s+)*"
+            r"(?:[\w\*]+\s+\**)+"
+            r"(?!(?:if|while|for|switch|return|sizeof)\b)"
+            r"(\w+)\s*\(([^)]*)\)\s*\{"
+        ),
+        # C++: like C but also catches `ClassName::method(...)` definitions
+        # and template return types like `std::vector<int>`.
+        "cpp": (
+            r"^(?:static\s+|inline\s+|extern\s+|const\s+|virtual\s+|"
+            r"explicit\s+|constexpr\s+|noexcept\s+)*"
+            r"(?:[\w:\*<>&,\s]+\s+\**)+"
+            r"(?!(?:if|while|for|switch|return|sizeof)\b)"
+            r"(\w+)(?:::\w+)?\s*\(([^)]*)\)\s*(?:const\s*)?"
+            r"(?:noexcept\s*)?(?:override\s*)?(?:final\s*)?\{"
+        ),
+        # Rust: `fn` keyword is always present and unambiguous.
+        "rust": (
+            r"(?:pub(?:\([^)]+\))?\s+)?(?:async\s+)?(?:unsafe\s+)?"
+            r"(?:extern\s+\"[^\"]+\"\s+)?fn\s+(\w+)\s*"
+            r"(?:<[^>]+>)?\s*\(([^)]*)\)"
+        ),
+        # Ruby: `def` keyword; params may be parenthesised or bare.
+        "ruby": (
+            r"def\s+(?:self\.)?(\w+[?!=]?)(?:\s*\(([^)]*)\)|\s*$|\s+\w)"
+        ),
+        # PHP: `function` keyword is always present.
+        "php": (
+            r"(?:(?:public|private|protected|static|abstract|final)\s+)*"
+            r"function\s+(\w+)\s*\(([^)]*)\)"
+        ),
+        # Dart: typed return followed by name and parens. Constructors
+        # (where name matches enclosing class) are not specially handled.
+        "dart": (
+            r"^\s*(?:static\s+|external\s+)*"
+            r"(?:Future<[^>]*>|Stream<[^>]*>|void|[\w<>?,\s]+?)\s+"
+            r"(\w+)\s*\(([^)]*)\)\s*(?:async\*?\s*|sync\*?\s*)?\{"
+        ),
     }
 
     pattern = patterns.get(language, patterns["python"])
@@ -192,6 +242,22 @@ def find_classes(content: str, language: str) -> List[Dict]:
         "kotlin": r"class\s+(\w+)",
         "csharp": r"(?:class|struct|record|interface)\s+(\w+)",
         "java": r"(?:class|interface|enum|record)\s+(\w+)",
+        # C has no classes; `struct` and `typedef struct` are the closest.
+        "c": r"(?:typedef\s+)?struct\s+(\w+)",
+        "cpp": r"(?:class|struct)\s+(\w+)",
+        # Rust uses `struct`, `enum`, `trait`, `union` for type definitions.
+        # `impl` blocks attach methods but are not type defs themselves.
+        "rust": r"(?:pub(?:\([^)]+\))?\s+)?(?:struct|enum|trait|union)\s+(\w+)",
+        "ruby": r"(?:class|module)\s+(\w+)",
+        "php": (
+            r"(?:abstract\s+|final\s+)?"
+            r"(?:class|interface|trait|enum)\s+(\w+)"
+        ),
+        # Dart 3 class modifiers: final / interface / base / sealed / mixin.
+        "dart": (
+            r"(?:abstract\s+|sealed\s+|final\s+|base\s+|interface\s+)?"
+            r"(?:class|mixin|enum|extension)\s+(\w+)"
+        ),
     }
 
     pattern = patterns.get(language, patterns["python"])
@@ -226,6 +292,33 @@ def find_classes(content: str, language: str) -> List[Dict]:
                 r"(?:(?:public|private|protected|static|final|abstract|"
                 r"synchronized|native|default|strictfp)\s+)+"
                 r"(?:[\w<>?,\s\[\]\.]+?\s+)?\w+\s*\("
+            ),
+            # C has no classes; struct members are typically function pointers
+            # rather than methods. Use the function definition pattern.
+            "c": (
+                r"^(?:static\s+|inline\s+)*(?:[\w\*]+\s+\**)+"
+                r"(?!(?:if|while|for|switch|return|sizeof)\b)"
+                r"\w+\s*\([^)]*\)\s*\{"
+            ),
+            "cpp": (
+                r"^(?:static\s+|inline\s+|virtual\s+|explicit\s+|"
+                r"constexpr\s+)*(?:[\w:\*<>&,\s]+\s+\**)+"
+                r"(?!(?:if|while|for|switch|return|sizeof)\b)"
+                r"\w+(?:::\w+)?\s*\([^)]*\)"
+            ),
+            "rust": (
+                r"(?:pub(?:\([^)]+\))?\s+)?(?:async\s+)?(?:unsafe\s+)?"
+                r"fn\s+\w+"
+            ),
+            "ruby": r"def\s+(?:self\.)?\w+[?!=]?",
+            "php": (
+                r"(?:(?:public|private|protected|static|abstract|final)\s+)*"
+                r"function\s+\w+\s*\("
+            ),
+            "dart": (
+                r"^\s*(?:static\s+|external\s+)*"
+                r"(?:Future<[^>]*>|Stream<[^>]*>|void|[\w<>?,\s]+?)\s+"
+                r"\w+\s*\([^)]*\)\s*(?:async\*?\s*|sync\*?\s*)?\{"
             ),
         }
         method_pattern = method_patterns.get(language, method_patterns["python"])


### PR DESCRIPTION
## Why

Post-merge audit of PR #769 surfaced a gap: the dispatch table in `SKILL.md` and the `--language` help text both advertise coverage for **C, C++, Rust, Ruby, PHP, and Dart/Flutter** — but `scripts/code_quality_checker.py` was never updated. Files in those 6 languages were silently skipped by the deterministic analyzer (see `analyze_directory` filtering by `LANGUAGE_EXTENSIONS.keys()` at the existing line). The skill effectively offered agent-driven review only for the 6 new languages, while the manifest promised both.

This PR closes that gap. Phase 1 of the broader audit punch list — minimal scope, no new dependencies.

## What changed

One file: `engineering-team/skills/code-reviewer/scripts/code_quality_checker.py` (+94 / -1).

Three structures extended in parallel:

1. **`LANGUAGE_EXTENSIONS`** — 6 new dict entries matching `SKILL.md` exactly. `c` is declared before `cpp` so plain `.h` resolves to C per the dispatch-table contract.
2. **`find_functions` patterns** — language-aware function regexes. C/C++ require a trailing `{` (filters prototypes and call sites) and a negative-lookahead for control-flow keywords (`if`/`while`/`for`/`switch`/`return`/`sizeof`). Rust uses the unambiguous `fn` keyword. Ruby handles `def`, `def self.x`, predicate (`?`) and bang (`!`) suffixes, and parenthesised-or-bare params. PHP requires the `function` keyword. Dart matches typed-return-then-name with optional `async`/`async*`/`sync*` markers.
3. **`find_classes` patterns + nested `method_patterns`** — type-def regexes for class-like constructs:
   - C: `struct` / `typedef struct`
   - C++: `class` / `struct`
   - Rust: `struct` / `enum` / `trait` / `union` (with `pub` modifier)
   - Ruby: `class` / `module`
   - PHP: `class` / `interface` / `trait` / `enum` (with `abstract`/`final` modifiers)
   - Dart 3: `class` / `mixin` / `enum` / `extension` with all 5 class modifiers (`abstract`/`sealed`/`final`/`base`/`interface`)

This matches the discipline already used for Java and C#: function patterns require strong syntactic markers to avoid misclassifying invocations as definitions.

## Verification

**`--help` regression** — all 14 languages now appear:
```
--language {python,typescript,javascript,go,swift,kotlin,csharp,java,c,cpp,rust,ruby,php,dart}
```

**Smoke test against one minimal sample per new language** (full source in `/tmp/codereviewer-smoke/`):

| Language | Functions detected | Classes detected | Score | Errors |
|---|---|---|---|---|
| C | 2 | 1 | 100/A | 0 |
| C++ | 2 | 1 | 100/A | 0 |
| Rust | 3 | 2 | 100/A | 0 |
| Ruby | 5 | 2 | 100/A | 0 |
| PHP | 4 | 3 | 100/A | 0 |
| Dart | 3 | 4 | 100/A | 0 |

Counts manually verified against each sample. No `"Unsupported file type"` errors.

**Regression on existing languages** — all 4 bundled fixtures still match their committed `expected_outputs/*.json` byte-for-byte:

```
PASS  assets/sample_csharp_smells.cs
PASS  assets/sample_csharp_clean.cs
PASS  assets/sample_java_smells.java
PASS  assets/sample_java_clean.java
```

## Not in this PR (Phase 2 of the audit, separate PRs)

- **Language-specific `check_<name>_specific_smells` detectors.** Only C# and Java have these today. Audit ranked C / C++ / Rust as the highest-leverage next adds (memory safety, `unsafe` block discipline, smart pointer ownership). ~3-4h per language.
- **Asset fixtures + `expected_outputs/*.json`** for the 6 new languages as regression guards (per the optional Step 6 in `SKILL.md`'s "Adding a New Language" guide).
- **Modernity / version-anchor sweep** on the 13 language markdown files (Java 21 virtual threads, Swift 6 strict concurrency, Dart 3 class modifiers in the markdown, etc.).
- **New languages.** Audit's Tier 1 candidates (high-value, zero overlap with existing files): Bash, SQL, Terraform/HCL, Solidity.

## Checklist

- [x] Target branch is `dev`
- [x] No hardcoded secrets, tokens, or credentials
- [x] No new dependencies (stdlib-only — `re`, `argparse`, `json`)
- [x] Existing tests / regression fixtures still pass

https://claude.ai/code/session_01SnXMhpyuAwrws26Wy4fizz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnXMhpyuAwrws26Wy4fizz)_