### PR TITLE
feat(code-reviewer): C-specific smell detector + fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the Claude Skills Library will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — code-reviewer: C-specific smell detector + fixtures
+
+### Added — language-specific smell pack for C (this PR)
+
+Closes Phase 2 / Tier 1 of the post-#769 audit: brings C onto the same footing as C# and Java for deterministic detection. Until now, `code_quality_checker.py` only had `check_<name>_specific_smells` for C# and Java; C / C++ / Rust / Ruby / PHP / Dart all fell through to generic checks.
+
+- **`check_c_specific_smells()`** in `scripts/code_quality_checker.py` (~110 lines). Detects:
+  - **Banned functions** — `gets`, `strcpy`, `strcat`, `sprintf`, `vsprintf` (all no-bounds; CWE-242 and CWE-120 family).
+  - **Format-string vulnerability** — `printf(var)` / `syslog(var)` with a bare identifier as the format argument (CWE-134). Skips literal-string first args.
+  - **Unbounded `scanf`** — `%s` specifier without a width (CWE-120). Suppressed when a width is present (`%31s`, etc.).
+  - **`malloc`/`calloc`/`realloc` without NULL check** — result variable not checked within 5 lines (CWE-690 NULL pointer dereference). Recognises `if (p == NULL)`, `if (NULL == p)`, `if (!p)`, `if (p != NULL)`.
+  - **`free()` without zeroing** — pointer not set to `NULL` on the next real line (CWE-416 use-after-free guardrail). Low severity since some style guides skip it.
+  - **`system()` with non-literal argument** — command-injection surface (CWE-78). Suppressed when the argument is a string literal or `NULL`.
+- Wired into `analyze_file()` after the C# and Java dispatchers.
+- **`assets/sample_c_smells.c`** + **`assets/sample_c_clean.c`** — labelled fixtures; every smell is annotated inline with the CWE it maps to. Smells fixture has 10 C-specific detector hits (some rules fire more than once); clean fixture has 0 hits and scores 100/A.
+- **`expected_outputs/sample_c_smells_quality.json`** + **`expected_outputs/sample_c_clean_quality.json`** — regression-detection harness following the C# / Java pattern.
+- Documentation refreshed: `README.md` adds C to the "Language-specific smell packs" line and the bundled-fixtures table; `SKILL.md` and `docs/skills/engineering-team/code-reviewer.md` update the "Adding a New Language" guide and "Regression Fixtures" section to reference C# + Java + C.
+
+Verification: all 6 fixtures (C# / Java / C × smells / clean) match their committed `expected_outputs/*.json` byte-for-byte. C smells fixture scores 4/100 (F); C clean fixture scores 100/100 (A).
+
+**Not yet (separate PRs):** `check_<name>_specific_smells` for C++, Rust, Python, Kotlin, PHP, Ruby, Dart, Go, Swift, TypeScript, JavaScript (audit-ranked sequence). C++ and Rust are next — security delta is highest there (smart-pointer ownership, `unsafe` block discipline).
+
+---
+
 ## [Unreleased] — code-reviewer: 6 new languages + analyzer wiring + doc sync
 
 ### Added — language coverage 7 → 13 (PR #769)

--- a/docs/skills/engineering-team/code-reviewer.md
+++ b/docs/skills/engineering-team/code-reviewer.md
@@ -175,7 +175,7 @@ score the new language:
 
 3. Add the extensions to `LANGUAGE_EXTENSIONS` in `scripts/code_quality_checker.py` (this also adds the `--language` choice).
 4. Add `function` / `class` / `method` regex entries for the language in the same file; otherwise it falls back to the Python patterns.
-5. Optionally add a `check_<name>_specific_smells(...)` detector (see the C# and Java ones) and call it from `analyze_file`.
+5. Optionally add a `check_<name>_specific_smells(...)` detector (see the C#, Java, and C ones) and call it from `analyze_file`.
 6. Add `assets/sample_<name>_smells.<ext>` + `_clean` fixtures and commit the expected `--json` output under `expected_outputs/` as a regression guard.
 
 ---
@@ -183,7 +183,7 @@ score the new language:
 ## Regression Fixtures
 
 Labelled fixtures live in `assets/` with their committed `--json` output in
-`expected_outputs/` (C# and Java). Drift from the committed JSON signals a
+`expected_outputs/` (C#, Java, and C). Drift from the committed JSON signals a
 behaviour change in the analyzer:
 
 ```bash

--- a/engineering-team/skills/code-reviewer/README.md
+++ b/engineering-team/skills/code-reviewer/README.md
@@ -59,6 +59,8 @@ Outputs: review verdict (approve / request changes / block), score, prioritized 
 | [`assets/sample_csharp_clean.cs`](./assets/sample_csharp_clean.cs) | Same code refactored per `rules/universal.md` + `languages/csharp.md` |
 | [`assets/sample_java_smells.java`](./assets/sample_java_smells.java) | Java file with every Java-specific pattern this skill detects, labelled inline |
 | [`assets/sample_java_clean.java`](./assets/sample_java_clean.java) | Same code refactored per `rules/universal.md` + `languages/java.md` |
+| [`assets/sample_c_smells.c`](./assets/sample_c_smells.c) | C file with every C-specific pattern this skill detects, labelled inline |
+| [`assets/sample_c_clean.c`](./assets/sample_c_clean.c) | Same code refactored per `rules/universal.md` + `languages/c.md` |
 | [`expected_outputs/*.json`](./expected_outputs/) | Expected `code_quality_checker.py --json` output for each fixture |
 
 Use them as a regression-detection harness:
@@ -76,7 +78,7 @@ diff /tmp/check.json expected_outputs/sample_java_smells_quality.json
 See [`SKILL.md`](./SKILL.md) for the full pattern list, severity tiers, and references. Quick summary:
 
 - **PR Analyzer** (`scripts/pr_analyzer.py`): hardcoded secrets / connection strings, SQL injection, debug statements (`console.*` / `System.out` / `printStackTrace`), analyzer suppressions (ESLint / Roslyn / `@SuppressWarnings`), `any` / `dynamic` overuse, TODO/FIXME, `unsafe` blocks, null-forgiving `!`, `async void`, blocking on `Task`.
-- **Code Quality Checker** (`scripts/code_quality_checker.py`): long methods, large files, god classes, deep nesting, too many parameters, high cyclomatic complexity, swallowed exceptions, missing `await`, undisposed `IDisposable`, `new HttpClient()` in method body, unused `using` directives. Language-specific smell packs for C# and Java (e.g. empty catch, `printStackTrace`, swallowed `InterruptedException`, unclosed resources, per-call `ObjectMapper` / `Gson`).
+- **Code Quality Checker** (`scripts/code_quality_checker.py`): long methods, large files, god classes, deep nesting, too many parameters, high cyclomatic complexity, swallowed exceptions, missing `await`, undisposed `IDisposable`, `new HttpClient()` in method body, unused `using` directives. Language-specific smell packs for C# (`async void`, blocking on `Task`), Java (empty catch, `printStackTrace`, swallowed `InterruptedException`, unclosed resources, per-call `ObjectMapper` / `Gson`), and C (banned functions `gets`/`strcpy`/`strcat`/`sprintf`/`vsprintf`, format-string vulnerability `printf(var)`, unbounded `scanf("%s")`, malloc-without-NULL-check, free-without-zeroing, `system()` with non-literal argument).
 - **Review Report Generator** (`scripts/review_report_generator.py`): combines the above into a single markdown or JSON verdict.
 
 ---

--- a/engineering-team/skills/code-reviewer/SKILL.md
+++ b/engineering-team/skills/code-reviewer/SKILL.md
@@ -166,7 +166,7 @@ score the new language:
 
 3. Add the extensions to `LANGUAGE_EXTENSIONS` in `scripts/code_quality_checker.py` (this also adds the `--language` choice).
 4. Add `function` / `class` / `method` regex entries for the language in the same file; otherwise it falls back to the Python patterns.
-5. Optionally add a `check_<name>_specific_smells(...)` detector (see the C# and Java ones) and call it from `analyze_file`.
+5. Optionally add a `check_<name>_specific_smells(...)` detector (see the C#, Java, and C ones) and call it from `analyze_file`.
 6. Add `assets/sample_<name>_smells.<ext>` + `_clean` fixtures and commit the expected `--json` output under `expected_outputs/` as a regression guard.
 
 ---
@@ -174,7 +174,7 @@ score the new language:
 ## Regression Fixtures
 
 Labelled fixtures live in `assets/` with their committed `--json` output in
-`expected_outputs/` (C# and Java). Drift from the committed JSON signals a
+`expected_outputs/` (C#, Java, and C). Drift from the committed JSON signals a
 behaviour change in the analyzer:
 
 ```bash

--- a/engineering-team/skills/code-reviewer/assets/sample_c_clean.c
+++ b/engineering-team/skills/code-reviewer/assets/sample_c_clean.c
@@ -1,0 +1,71 @@
+/*
+ * sample_c_clean.c — sample_c_smells.c refactored per
+ * rules/universal.md + languages/c.md. Same surface area, zero
+ * detector hits.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+void safe_input(void) {
+    char buf[64];
+
+    /* fgets is bounds-aware */
+    if (fgets(buf, sizeof(buf), stdin) == NULL) {
+        return;
+    }
+
+    char dest[10];
+    /* strncpy with explicit bound + manual null-terminate */
+    strncpy(dest, buf, sizeof(dest) - 1);
+    dest[sizeof(dest) - 1] = '\0';
+
+    /* strncat with remaining-space bound */
+    size_t room = sizeof(dest) - strlen(dest) - 1;
+    strncat(dest, "world", room);
+
+    char msg[100];
+    /* snprintf is bounds-aware */
+    snprintf(msg, sizeof(msg), "%s says hello", buf);
+
+    /* Format string is a literal; buf is an argument */
+    printf("%s\n", buf);
+
+    char name[32];
+    /* %s with explicit width prevents overflow */
+    scanf("%31s", name);
+}
+
+
+void checked_alloc(int n) {
+    /* malloc result is NULL-checked before any dereference */
+    char *buf = malloc(n);
+    if (buf == NULL) {
+        return;
+    }
+    buf[0] = 'x';
+    buf[1] = 'y';
+    strncpy(buf, "ok", n - 1);
+
+    free(buf);
+    buf = NULL;
+    printf("done\n");
+}
+
+
+void run_safe_cmd(void) {
+    /* system() with a string literal — no command-injection surface */
+    system("ls -la");
+}
+
+
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    safe_input();
+    checked_alloc(100);
+    run_safe_cmd();
+    return 0;
+}

--- a/engineering-team/skills/code-reviewer/assets/sample_c_smells.c
+++ b/engineering-team/skills/code-reviewer/assets/sample_c_smells.c
@@ -1,0 +1,66 @@
+/*
+ * sample_c_smells.c — labelled instances of every C-specific pattern
+ * the code-reviewer skill flags. Every smell is annotated inline with
+ * its CWE and the rule from languages/c.md.
+ *
+ * Refactored counterpart: sample_c_clean.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+void unsafe_input(void) {
+    char buf[64];
+
+    /* RULE: banned function gets() — CWE-242, no bounds check */
+    gets(buf);
+
+    char dest[10];
+    /* RULE: banned function strcpy() — no bounds check */
+    strcpy(dest, buf);
+
+    /* RULE: banned function strcat() — no bounds check */
+    strcat(dest, "world");
+
+    char msg[100];
+    /* RULE: banned function sprintf() — no bounds check */
+    sprintf(msg, "%s says hello", buf);
+
+    /* RULE: format-string vulnerability — CWE-134, buf controls format */
+    printf(buf);
+
+    char name[32];
+    /* RULE: unbounded scanf — %s without width, CWE-120 */
+    scanf("%s", name);
+}
+
+
+void leaky_alloc(int n) {
+    /* RULE: malloc result not NULL-checked within 5 lines — CWE-690 */
+    char *buf = malloc(n);
+    buf[0] = 'x';
+    buf[1] = 'y';
+    strcpy(buf, "leak");
+
+    /* RULE: free without zeroing pointer — CWE-416 dangling */
+    free(buf);
+    printf("done\n");
+}
+
+
+void run_user_cmd(const char *cmd_from_user) {
+    /* RULE: system() with non-literal argument — CWE-78 command injection */
+    system(cmd_from_user);
+}
+
+
+int main(int argc, char *argv[]) {
+    if (argc > 1) {
+        unsafe_input();
+        leaky_alloc(100);
+        run_user_cmd(argv[1]);
+    }
+    return 0;
+}

--- a/engineering-team/skills/code-reviewer/expected_outputs/sample_c_clean_quality.json
+++ b/engineering-team/skills/code-reviewer/expected_outputs/sample_c_clean_quality.json
@@ -1,0 +1,65 @@
+{
+  "file": "/home/user/claude-skills/engineering-team/skills/code-reviewer/assets/sample_c_clean.c",
+  "language": "c",
+  "metrics": {
+    "lines": {
+      "total": 72,
+      "code": 43,
+      "blank": 17,
+      "comment": 12
+    },
+    "functions": 4,
+    "classes": 0,
+    "avg_complexity": 1.8
+  },
+  "quality_score": 100,
+  "grade": "A",
+  "smells": [
+    {
+      "type": "long_function",
+      "severity": "medium",
+      "message": "Function 'safe_input' has 61 lines (max: 50)",
+      "location": "safe_input"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 100 should be a named constant",
+      "location": "line 29"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 100 should be a named constant",
+      "location": "line 68"
+    }
+  ],
+  "solid_violations": [],
+  "function_details": [
+    {
+      "name": "safe_input",
+      "parameters": 1,
+      "lines": 61,
+      "complexity": 3
+    },
+    {
+      "name": "checked_alloc",
+      "parameters": 1,
+      "lines": 31,
+      "complexity": 2
+    },
+    {
+      "name": "run_safe_cmd",
+      "parameters": 1,
+      "lines": 15,
+      "complexity": 1
+    },
+    {
+      "name": "main",
+      "parameters": 2,
+      "lines": 9,
+      "complexity": 1
+    }
+  ],
+  "class_details": []
+}

--- a/engineering-team/skills/code-reviewer/expected_outputs/sample_c_smells_quality.json
+++ b/engineering-team/skills/code-reviewer/expected_outputs/sample_c_smells_quality.json
@@ -1,0 +1,155 @@
+{
+  "file": "/home/user/claude-skills/engineering-team/skills/code-reviewer/assets/sample_c_smells.c",
+  "language": "c",
+  "metrics": {
+    "lines": {
+      "total": 67,
+      "code": 37,
+      "blank": 17,
+      "comment": 13
+    },
+    "functions": 4,
+    "classes": 0,
+    "avg_complexity": 2.0
+  },
+  "quality_score": 4,
+  "grade": "F",
+  "smells": [
+    {
+      "type": "long_function",
+      "severity": "medium",
+      "message": "Function 'unsafe_input' has 54 lines (max: 50)",
+      "location": "unsafe_input"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 242 should be a named constant",
+      "location": "line 17"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 100 should be a named constant",
+      "location": "line 27"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 134 should be a named constant",
+      "location": "line 31"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 120 should be a named constant",
+      "location": "line 35"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 690 should be a named constant",
+      "location": "line 41"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 416 should be a named constant",
+      "location": "line 47"
+    },
+    {
+      "type": "magic_number",
+      "severity": "low",
+      "message": "Magic number 100 should be a named constant",
+      "location": "line 62"
+    },
+    {
+      "type": "c_banned_gets",
+      "severity": "high",
+      "message": "'gets()' is unsafe: no bounds check, removed from C11 (CWE-242)",
+      "location": "offset 117"
+    },
+    {
+      "type": "c_banned_strcpy",
+      "severity": "high",
+      "message": "'strcpy()' is unsafe: no bounds check \u2014 prefer strncpy or strlcpy",
+      "location": "offset 157"
+    },
+    {
+      "type": "c_banned_strcpy",
+      "severity": "high",
+      "message": "'strcpy()' is unsafe: no bounds check \u2014 prefer strncpy or strlcpy",
+      "location": "offset 447"
+    },
+    {
+      "type": "c_banned_strcat",
+      "severity": "high",
+      "message": "'strcat()' is unsafe: no bounds check \u2014 prefer strncat or strlcat",
+      "location": "offset 186"
+    },
+    {
+      "type": "c_banned_sprintf",
+      "severity": "high",
+      "message": "'sprintf()' is unsafe: no bounds check \u2014 prefer snprintf",
+      "location": "offset 238"
+    },
+    {
+      "type": "c_format_string",
+      "severity": "high",
+      "message": "'printf(buf)' uses a non-literal format string \u2014 CWE-134 format string vulnerability",
+      "location": "offset 284"
+    },
+    {
+      "type": "c_unbounded_scanf",
+      "severity": "high",
+      "message": "scanf '%s' without a width specifier \u2014 unbounded read can overflow the destination buffer",
+      "location": "offset 326"
+    },
+    {
+      "type": "c_malloc_unchecked",
+      "severity": "medium",
+      "message": "'buf' from malloc/calloc/realloc is not NULL-checked within 5 lines \u2014 dereferencing NULL is UB (CWE-690)",
+      "location": "line 36"
+    },
+    {
+      "type": "c_free_without_null",
+      "severity": "low",
+      "message": "'free(buf)' not followed by 'buf = NULL;' \u2014 dangling pointer can be reused (CWE-416)",
+      "location": "line 42"
+    },
+    {
+      "type": "c_system_non_literal",
+      "severity": "high",
+      "message": "'system(cmd_from_user)' with a non-literal argument \u2014 command injection (CWE-78); use execve with validated args",
+      "location": "offset 571"
+    }
+  ],
+  "solid_violations": [],
+  "function_details": [
+    {
+      "name": "unsafe_input",
+      "parameters": 1,
+      "lines": 54,
+      "complexity": 2
+    },
+    {
+      "name": "leaky_alloc",
+      "parameters": 1,
+      "lines": 28,
+      "complexity": 2
+    },
+    {
+      "name": "run_user_cmd",
+      "parameters": 1,
+      "lines": 15,
+      "complexity": 2
+    },
+    {
+      "name": "main",
+      "parameters": 2,
+      "lines": 9,
+      "complexity": 2
+    }
+  ],
+  "class_details": []
+}

--- a/engineering-team/skills/code-reviewer/scripts/code_quality_checker.py
+++ b/engineering-team/skills/code-reviewer/scripts/code_quality_checker.py
@@ -607,6 +607,138 @@ def check_java_specific_smells(content: str) -> List[Dict]:
     return smells
 
 
+def check_c_specific_smells(content: str) -> List[Dict]:
+    """C-specific code smells documented in languages/c.md.
+
+    Focuses on memory-safety and command/format-string patterns that the
+    CERT C Coding Standard and the CWE catalogue rank as the
+    highest-impact footguns. C uses the same line/block comment syntax as
+    C# and Java, so the existing comment stripper applies.
+    """
+    smells: List[Dict] = []
+    content = _strip_csharp_comments(content)
+
+    # 1. Banned functions — no bounds check on any of them.
+    banned = {
+        "gets": "no bounds check, removed from C11 (CWE-242)",
+        "strcpy": "no bounds check — prefer strncpy or strlcpy",
+        "strcat": "no bounds check — prefer strncat or strlcat",
+        "sprintf": "no bounds check — prefer snprintf",
+        "vsprintf": "no bounds check — prefer vsnprintf",
+    }
+    for fn, reason in banned.items():
+        for m in re.finditer(rf"\b{fn}\s*\(", content):
+            smells.append({
+                "type": f"c_banned_{fn}",
+                "severity": "high",
+                "message": f"'{fn}()' is unsafe: {reason}",
+                "location": f"offset {m.start()}",
+            })
+
+    # 2. Format-string vulnerability — printf/syslog called with a bare
+    # identifier as the format argument (CWE-134). Skip when the first
+    # arg is a string literal.
+    for fn in ("printf", "syslog"):
+        pattern = rf"\b{fn}\s*\(\s*(?!\")(\w+)\s*[,\)]"
+        for m in re.finditer(pattern, content):
+            smells.append({
+                "type": "c_format_string",
+                "severity": "high",
+                "message": (
+                    f"'{fn}({m.group(1)})' uses a non-literal format string "
+                    "— CWE-134 format string vulnerability"
+                ),
+                "location": f"offset {m.start()}",
+            })
+
+    # 3. Unbounded scanf — `%s` without a width specifier invites overflow.
+    scanf_call = re.compile(
+        r"\b(?:scanf|fscanf|sscanf)\s*\(\s*[^)]*?\"([^\"]*)\""
+    )
+    for m in scanf_call.finditer(content):
+        fmt = m.group(1)
+        if "%s" in fmt and not re.search(r"%\d+s", fmt):
+            smells.append({
+                "type": "c_unbounded_scanf",
+                "severity": "high",
+                "message": (
+                    "scanf '%s' without a width specifier — unbounded read "
+                    "can overflow the destination buffer"
+                ),
+                "location": f"offset {m.start()}",
+            })
+
+    # 4. malloc / calloc / realloc result dereferenced without a NULL check
+    # within 5 lines. CWE-690.
+    lines = content.split("\n")
+    malloc_assign = re.compile(
+        r"^\s*(?:[\w\*]+\s+)?\*?(\w+)\s*=\s*\(?[\w\s\*]*\)?\s*"
+        r"(?:m|c|re)alloc\s*\("
+    )
+    for i, line in enumerate(lines):
+        m = malloc_assign.match(line)
+        if not m:
+            continue
+        var = m.group(1)
+        window = "\n".join(lines[i + 1 : i + 6])
+        null_check = re.compile(
+            rf"\bif\s*\([^)]*(?:{re.escape(var)}\s*==\s*NULL"
+            rf"|NULL\s*==\s*{re.escape(var)}"
+            rf"|!\s*{re.escape(var)}\b"
+            rf"|{re.escape(var)}\s*!=\s*NULL)"
+        )
+        if not null_check.search(window):
+            smells.append({
+                "type": "c_malloc_unchecked",
+                "severity": "medium",
+                "message": (
+                    f"'{var}' from malloc/calloc/realloc is not NULL-checked "
+                    "within 5 lines — dereferencing NULL is UB (CWE-690)"
+                ),
+                "location": f"line {i + 1}",
+            })
+
+    # 5. free(p) without setting p to NULL on the next real line.
+    # CWE-416 use-after-free guardrail.
+    free_call = re.compile(r"^\s*free\s*\(\s*(\w+)\s*\)\s*;")
+    for i, line in enumerate(lines):
+        m = free_call.match(line)
+        if not m:
+            continue
+        var = m.group(1)
+        for j in range(i + 1, min(i + 3, len(lines))):
+            nxt = lines[j].strip()
+            if not nxt:
+                continue
+            if re.match(rf"^{re.escape(var)}\s*=\s*NULL\s*;", nxt):
+                break
+            smells.append({
+                "type": "c_free_without_null",
+                "severity": "low",
+                "message": (
+                    f"'free({var})' not followed by '{var} = NULL;' — "
+                    "dangling pointer can be reused (CWE-416)"
+                ),
+                "location": f"line {i + 1}",
+            })
+            break
+
+    # 6. system() with a non-string-literal argument — command injection.
+    system_pattern = re.compile(r"\bsystem\s*\(\s*(?!\"|NULL\b)(\w+)\s*\)")
+    for m in system_pattern.finditer(content):
+        smells.append({
+            "type": "c_system_non_literal",
+            "severity": "high",
+            "message": (
+                f"'system({m.group(1)})' with a non-literal argument — "
+                "command injection (CWE-78); use execve with validated args"
+            ),
+            "location": f"offset {m.start()}",
+        })
+
+    return smells
+
+
 def check_solid_violations(content: str) -> List[Dict]:
     """Check for potential SOLID principle violations."""
     violations = []
@@ -719,6 +851,8 @@ def analyze_file(filepath: Path) -> Dict:
         smells.extend(check_csharp_specific_smells(content))
     if language == "java":
         smells.extend(check_java_specific_smells(content))
+    if language == "c":
+        smells.extend(check_c_specific_smells(content))
     violations = check_solid_violations(content)
     score = calculate_quality_score(line_metrics, functions, classes, smells, violations)
 


### PR DESCRIPTION
## Why

Phase 2 / Tier 1 of the post-#769 audit. Until now, `scripts/code_quality_checker.py` only had language-specific smell detectors for **C# and Java** — the other 12 supported languages fell through to generic checks. The audit ranked C/C++/Rust as the highest-leverage next adds because the security delta is largest for memory-unsafe languages.

This PR ships C. C++ and Rust follow in subsequent PRs.

## What's detected

Six pattern families anchored to CERT C + the CWE catalogue:

| Rule | Severity | CWE | Notes |
|---|---|---|---|
| Banned function `gets` / `strcpy` / `strcat` / `sprintf` / `vsprintf` | high | 242 / 120 | All five are no-bounds, removed from C11 or recommended replacements exist |
| Format-string vulnerability — `printf(var)` / `syslog(var)` | high | 134 | First-arg bare identifier instead of a literal. Suppressed when first arg is a string literal |
| Unbounded `scanf` — `%s` without width | high | 120 | Suppressed when a width is present (`%31s`) |
| `malloc` / `calloc` / `realloc` result not NULL-checked within 5 lines | medium | 690 | Recognises `if (p == NULL)`, `if (NULL == p)`, `if (!p)`, `if (p != NULL)` |
| `free(p)` not followed by `p = NULL;` | low | 416 guardrail | Low severity since some style guides skip the zeroing convention |
| `system()` with a non-literal argument | high | 78 | Suppressed when arg is a string literal or `NULL` |

## Implementation

- New `check_c_specific_smells()` in `scripts/code_quality_checker.py` (~110 lines), placed after `check_java_specific_smells()`.
- Reuses the existing `_strip_csharp_comments` helper — C, C#, and Java share `//` and `/* */` syntax.
- Wired into `analyze_file()` via the existing dispatcher pattern:
  ```python
  if language == "c":
      smells.extend(check_c_specific_smells(content))
  ```

## Fixtures (regression-detection harness)

Mirrors the C# / Java pattern already in `assets/` + `expected_outputs/`.

- **`assets/sample_c_smells.c`** (67 lines) — every detector pattern labelled inline with its CWE. **10 C-specific hits**, score 4/100 (F). `strcpy` fires twice intentionally (once per function).
- **`assets/sample_c_clean.c`** — same surface refactored per `rules/universal.md` + `languages/c.md`. **0 C-specific hits**, score 100/100 (A). Demonstrates the safe equivalents (`fgets` / `strncpy` + manual null-term / `snprintf` / `%31s` / NULL-check / `system("literal")`).
- **`expected_outputs/sample_c_smells_quality.json`** + **`expected_outputs/sample_c_clean_quality.json`** — committed JSON output, follows the C# / Java naming convention.

## Documentation updates

| File | What changed |
|---|---|
| `engineering-team/skills/code-reviewer/README.md` | "Language-specific smell packs" line extended to enumerate the 6 C-pack patterns alongside existing C# and Java packs. Bundled-fixtures table adds 2 new C rows. |
| `engineering-team/skills/code-reviewer/SKILL.md` | "Adding a New Language" step 5 + "Regression Fixtures" paragraph: "C# and Java" → "C#, Java, and C". |
| `docs/skills/engineering-team/code-reviewer.md` | Same SKILL.md updates mirrored to the MkDocs page. |
| `CHANGELOG.md` | New `[Unreleased]` section above the existing code-reviewer entry, documenting the detector + fixtures. |

## Verification

```bash
$ for fixture in assets/sample_csharp_smells.cs assets/sample_csharp_clean.cs \
                 assets/sample_java_smells.java assets/sample_java_clean.java \
                 assets/sample_c_smells.c assets/sample_c_clean.c; do
    base=$(basename "$fixture"); stem="${base%.*}"
    diff <(python3 scripts/code_quality_checker.py "$fixture" --json) \
         "expected_outputs/${stem}_quality.json" \
      && echo "PASS  $fixture" || echo "FAIL  $fixture"
  done
PASS  assets/sample_csharp_smells.cs
PASS  assets/sample_csharp_clean.cs
PASS  assets/sample_java_smells.java
PASS  assets/sample_java_clean.java
PASS  assets/sample_c_smells.c
PASS  assets/sample_c_clean.c
```

All 6 fixtures pass byte-for-byte. No drift in existing C# or Java detector behaviour.

## Out of scope (subsequent PRs)

- `check_<name>_specific_smells` for **C++**, **Rust** (next in audit order — security delta still highest), then Python, Kotlin, PHP, Ruby, Dart, Go, Swift, TypeScript, JavaScript.
- Modernity / version-anchor sweep on the 13 language markdown files.
- New languages from the audit's Tier 1 list: Bash, SQL, Terraform/HCL, Solidity.

## Checklist

- [x] Target branch is `dev`
- [x] No hardcoded secrets, tokens, or credentials
- [x] No new dependencies (stdlib-only — `re`, `argparse`, `json`)
- [x] All 6 regression fixtures pass

https://claude.ai/code/session_01SnXMhpyuAwrws26Wy4fizz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnXMhpyuAwrws26Wy4fizz)_