### PR TITLE
feat(markdown-html): v2.10.0 foundation — orchestrator + design-system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1381,6 +1381,33 @@
         "grill-with-docs"
       ],
       "category": "research-ops"
+    },
+    {
+      "name": "markdown-html-skills",
+      "source": "./markdown-html",
+      "description": "Convert long markdown files in a Claude project into world-class, single-file, lightly-interactive HTML. v2.10.0 foundation ships 2 skills: markdown-html-orchestrator (context: fork; deterministic doctype classifier that routes to converter sub-skills based on filename + content signals; refuses input < 100 lines per Shihipar's threshold; refuses without onboarding) + design-system (10-question onboarding wizard capturing brand primary/accent HEX + heading/body Google Fonts + design style editorial/technical/minimal/playful + default output directory + syntax theme + TOC behavior + optional logo/company; WCAG-AA-validated 12 CSS custom properties derived in HSL space; project > global > defaults precedence with MARKDOWN_HTML_NO_CONFIG=1 bypass). 6 stdlib-only Python tools (3 per skill), 6 references citing 5-7 sources each, 1 JSON schema asset. Inspired by Thariq Shihipar's Claude Code HTML output essay (Medium, 2026). Outputs are single self-contained .html files; only externals are Google Fonts CSS and Prism.js CDN. Converter sub-skills (md-document, md-review, md-slides) land in v2.10.1 follow-up PRs. Distinct from Anthropic's official Playground plugin (interactive prompt-tuning controls with sliders/knobs/prompt-copy-back) and marketing/landing/ (landing-page generator).",
+      "version": "2.10.0",
+      "author": {
+        "name": "Alireza Rezvani"
+      },
+      "keywords": [
+        "markdown",
+        "html",
+        "documentation",
+        "code-review",
+        "slides",
+        "design-system",
+        "single-file-html",
+        "brand-palette",
+        "wcag",
+        "onboarding",
+        "customization",
+        "shihipar",
+        "matt-pocock",
+        "grill-with-docs",
+        "context-fork"
+      ],
+      "category": "documentation"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ This repository uses **modular documentation**. For domain-specific guidance, se
 | **Business & Growth** | [business-growth/CLAUDE.md](business-growth/CLAUDE.md) | Customer success, sales engineering, revenue operations |
 | **Finance** | [finance/CLAUDE.md](finance/CLAUDE.md) | Financial analysis, DCF valuation, budgeting, forecasting, SaaS metrics |
 | **Research Operations** | [research-ops/CLAUDE.md](research-ops/CLAUDE.md) | Clinical study design, R&D finance, market research, product research (enterprise counterpart to academic research/) |
+| **Markdown → HTML** | [markdown-html/CLAUDE.md](markdown-html/CLAUDE.md) | Markdown-to-interactive-HTML converter (orchestrator + design-system foundation; md-document/review/slides v2.10.1). Inspired by Shihipar's "Claude Code HTML output" essay |
 | **Standards Library** | [standards/CLAUDE.md](standards/CLAUDE.md) | Communication, quality, git, security standards |
 | **Templates** | [templates/CLAUDE.md](templates/CLAUDE.md) | Template system usage |
 
@@ -66,6 +67,7 @@ claude-code-skills/
 ├── finance/                   # 4 finance skills + Python tools
 ├── research/                  # 8 academic research skills (orchestrator + 7 specialists)
 ├── research-ops/              # 5 research-ops skills (orchestrator + clinical-research + research-finance + market-research + product-research)
+├── markdown-html/             # 2 markdown-to-HTML skills v2.10.0 foundation (orchestrator + design-system); md-document/review/slides land in v2.10.1
 ├── eval-workspace/            # Skill evaluation results (Tessl)
 ├── standards/                 # 5 standards library files
 ├── templates/                 # Reusable templates
@@ -143,7 +145,23 @@ See [standards/git/git-workflow-standards.md](standards/git/git-workflow-standar
 
 ## Current Version
 
-**Version:** v2.9.0 (released — research-ops/ domain: enterprise Research Operations)
+**Version:** v2.10.0 (foundation released — `markdown-html/` domain: markdown-to-interactive-HTML converter)
+
+**v2.10.0 foundation highlights — markdown-html/ domain (new top-level domain):**
+
+New `markdown-html/` top-level domain — operationalizes Thariq Shihipar's central claim from his Medium essay *Claude Code HTML output: Why Markdown Lost and How to Switch* (2026): **markdown collapses past ~100 lines for agent-generated artifacts; HTML restores information density, visual clarity, shareability, and lightweight interaction.** Foundation PR (v2.10.0) ships 2 of 5 planned skills; converters land in v2.10.1.
+
+- **`markdown-html-orchestrator`** (`context: fork`) — deterministic doctype classifier scores filename hints (2 points each) + content signals (1 point each) across three lanes (DOCUMENT / REVIEW / SLIDES). Silent-routes when winner ≥ 3 AND (runner-up = 0 OR winner ≥ 2× runner-up); below threshold asks one question with a recommended answer. Three pre-flight refusals: input < 100 lines (Shihipar threshold), design-system not onboarded, output dir unwritable. 3 stdlib tools: `doctype_classifier.py`, `route_explainer.py` (the "never silently chain" enforcer; also gates on design-system status), `output_path_resolver.py` (kebab slug + collision suffix). Canon: Shihipar; Tufte; Bret Victor; Maggie Appleton; Bartosz Ciechanowski; Amelia Wattenberger.
+- **`design-system`** — one-time onboarding wizard (10 questions: `default_output_dir`, brand primary/accent HEX, heading + body Google Fonts from 12 safe defaults, design style `editorial/technical/minimal/playful`, syntax theme `light/dark/auto`, TOC behavior `sticky-sidebar/collapsible-top/inline/none`, optional company name + logo URL). WCAG-AA-validated 12-token CSS custom-property palette derived in HSL space — primary's luminance branch decides whether bg = primary (dark-mode docs) or bg = near-neutral light (vibrant primary as accent); link contrast iteratively walked to 4.5:1. 3 stdlib tools: `onboard.py` (interactive + `--defaults/--set/--show/--reset/--scope`), `config_loader.py` (project > global > defaults, deep merge, `MARKDOWN_HTML_NO_CONFIG=1` bypass), `brand_palette_validator.py` (WCAG 2.2 §1.4.3/§1.4.11 + HSL derivation, 12 tokens: `--md-bg/surface/border/text/text-muted/accent/accent-soft/code-bg/link/link-hover/success/warn`). Refuses to save if body-text or link contrast fails AA 4.5:1, or if output dir is unwritable. Canon: WCAG 2.2; Ellen Lupton *Thinking with Type*; Adobe Spectrum; Sara Soueidan accessible color tokens; Material Design 3.
+- **`cs-markdown-html-orchestrator` agent + 3 slash commands:** `/cs:markdown-html <path>.md` (router), `/cs:grill-markdown-html <path>.md` (Matt-Pocock 5-question grill, one per turn with recommended answer + canon citation), `/cs:design-system` (surfaces onboarding). Forcing-question library in every SKILL.md.
+- **Hard rules:** refuse < 100 lines (Shihipar); refuse without onboarding; refuse unwritable save dir; single-file HTML only (Google Fonts + Prism.js CDN are the only permitted externals; no JS framework runtimes); never silently chain converters; customization must change behavior (not decoration).
+- **Coming in v2.10.1:** `md-document` (sticky TOC + collapsibles + search + code-copy + scrollspy), `md-review` (2-col diff + severity-tagged margin annotations + jump-nav), `md-slides` (arrow-key nav + presenter mode + print-to-PDF). All three import `design-system/scripts/config_loader.py` for shared tokens.
+- **6 stdlib-only Python tools** (3 per skill, all pass `--help` + `--sample`), **6 reference docs** each citing 5-7 authoritative sources, **1 JSON schema asset** for the customization config. Distinct from Anthropic's official Playground plugin (interactive prompt-tuning controls with sliders/knobs/prompt-copy-back) and from `marketing/landing/` (landing-page generator from scratch).
+- **Marketplace + Codex registry:** 63 → 64 plugins; 16 → 17 domains; new `documentation` category.
+
+---
+
+**Version:** v2.9.0 (research-ops/ domain: enterprise Research Operations)
 
 **v2.9.0 highlights — research-ops/ domain (new top-level domain):**
 

--- a/markdown-html/.claude-plugin/plugin.json
+++ b/markdown-html/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "markdown-html-skills",
+  "description": "Convert long markdown files in a Claude project into world-class, single-file, lightly-interactive HTML. Foundation (v2.10.0): 2 skills — markdown-html-orchestrator (context: fork; deterministic doc-type classifier routing to converter sub-skills; refuses to silently chain) + design-system (one-time onboarding wizard that captures brand primary/accent + heading/body Google Fonts + design style + default output dir + syntax theme + TOC behavior + optional logo/company; WCAG-validated palette derivation in HSL space producing 12 CSS custom properties consumed by every converter; project>global>defaults precedence; MARKDOWN_HTML_NO_CONFIG=1 bypass). 6 stdlib-only Python tools (3 per skill), 6 references citing 5-7 sources each, 1 JSON schema asset. Inspired by Thariq Shihipar's argument (Claude Code HTML output, Medium 2026) that markdown collapses past 100 lines and HTML restores information density + visual clarity + shareability + lightweight interaction. Outputs are single self-contained .html files; only externals are Google Fonts and Prism.js CDN. Converter sub-skills (md-document, md-review, md-slides) land in v2.10.1 follow-up PRs. Distinct from Anthropic's official Playground plugin (which is interactive prompt-tuning controls with sliders/knobs/prompt-copy-back) and from marketing/landing/ (which is a landing-page generator).",
+  "version": "2.10.0",
+  "author": {
+    "name": "Alireza Rezvani",
+    "url": "https://alirezarezvani.com"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/markdown-html",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": [
+    "./skills/markdown-html-orchestrator",
+    "./skills/design-system"
+  ],
+  "source": {
+    "spec": "Thariq Shihipar — Claude Code HTML output essay (Medium, 2026). Argument: markdown collapses past 100 lines for agent-generated artifacts; HTML restores information density, visual clarity, shareability, and lightweight interaction.",
+    "build_pattern": "Path B (direct conversion). Orchestrator uses context: fork (research-ops shape). Shared design-system owns onboarding + 12 CSS custom properties read by all converters. Every SKILL.md ships a Forcing-question library section per Matt Pocock grill-with-docs discipline. Foundation PR ships orchestrator + design-system; converter sub-skills (md-document, md-review, md-slides) land in v2.10.1 follow-up PRs.",
+    "distinct_from": "Anthropic's official Playground plugin builds interactive prompt-tuning controls (sliders, knobs, prompt-copy-back); this plugin converts existing markdown documents to single-file HTML. Also distinct from marketing/landing/ which generates landing pages from scratch."
+  }
+}

--- a/markdown-html/CLAUDE.md
+++ b/markdown-html/CLAUDE.md
@@ -1,0 +1,77 @@
+# Markdown → HTML — Domain Guide
+
+This file provides domain-specific guidance for skills in `markdown-html/`.
+
+## Purpose
+
+The markdown-html domain converts long markdown files (the actual artifacts produced inside a Claude project — specs, reports, RFCs, PR writeups, slide outlines) into world-class, single-file, lightly-interactive HTML. Inspired by Thariq Shihipar's argument (Medium, 2026): markdown collapses past ~100 lines because it lacks visual machinery for density and lateral navigation; HTML restores both.
+
+It is **not** an interactive prompt-tuning playground (`/playground` plugin owns that lane), **not** a landing-page generator (`marketing/landing/`), **not** a session-handoff brief generator (`engineering/handoff/` + `productivity/handoff/`), and **not** a static-site generator (single-file artifacts, not site indices).
+
+## Skills (v2.10.0)
+
+| Skill | Purpose | `context: fork`? | Status |
+|---|---|---|---|
+| `markdown-html-orchestrator` | Domain orchestrator — classifies doctype, gates on threshold + onboarding, routes to converter | YES | ✓ live |
+| `design-system` | One-time onboarding wizard + WCAG-AA-validated brand palette (12 CSS custom properties) + shared config | NO | ✓ live |
+| `md-document` | Long-form converter: sticky TOC, collapsibles, search, code-copy, scrollspy | NO | v2.10.1 |
+| `md-review` | Code-review converter: 2-col diff + severity-tagged margin annotations + jump-nav | NO | v2.10.1 |
+| `md-slides` | Slide-deck converter: arrow-key nav + presenter mode + print-to-PDF | NO | v2.10.1 |
+
+## Hard rules (domain-specific)
+
+1. **Refuses input < 100 lines.** Markdown still wins below the threshold (Shihipar). Every converter (and the orchestrator) prints the line count and a "keep as markdown" recommendation.
+2. **Refuses without design-system onboarding.** The orchestrator's `route_explainer.py` checks `config_loader.setup_completed()`. If false, refuse and surface onboarding (`python3 markdown-html/skills/design-system/scripts/onboard.py`).
+3. **WCAG AA enforced.** `brand_palette_validator.py` rejects color combinations whose body-text contrast falls below 4.5:1 on bg. Link contrast is iteratively walked to 4.5:1 by adjusting luminance.
+4. **Single-file HTML output.** All CSS and JS inline. The only permitted external CDN entries are Google Fonts CSS and Prism.js. No bundler, no build step, no JS framework runtimes (vanilla JS + IntersectionObserver only).
+5. **Never silently chain converters.** "Convert this markdown AND make slides from it AND a code review" is three operations. Pick one, finish, ask before chaining.
+6. **Stdlib-only Python.** Deterministic logic, no LLM calls in scripts.
+7. **Customization in use, not decoration.** Every converter MUST render differently when the user changes `design_style`, `brand.primary`, `code_theme`, or `toc.behavior`. If a token doesn't change behavior, it doesn't belong in the schema.
+8. **Onboarding-first.** The orchestrator surfaces onboarding the moment it detects a missing `setup_completed_at`. Don't render with placeholder defaults silently.
+
+## Build pattern
+
+Path-B contract per skill: SKILL.md + 3 stdlib scripts + 3 references (each citing 5-7 sources) + (optional) 1 asset template. The orchestrator skill ships `context: fork` in its frontmatter. The `design-system` skill is the shared brand owner — every converter imports its `config_loader.py` via `sys.path.insert(0, .../design-system/scripts)`.
+
+Each SKILL.md ships a "Forcing-question library" section (cited-canon grilling, one question at a time) — same discipline as `research-ops`, `commercial`, and `business-operations`.
+
+## Agent + command pattern
+
+- `cs-markdown-html-orchestrator` — density-first markdown-to-HTML converter. Voice: "What decision does this HTML drive — is the reader skimming, deciding, or presenting?"
+- `/cs:markdown-html <path>.md` — top-level router (classifier + route + recommend)
+- `/cs:grill-markdown-html <path>.md` — Matt-Pocock-style 5-question grill before conversion
+- `/cs:design-system` — surface the onboarding wizard
+
+Per-sub-skill commands land with the converter PRs in v2.10.1:
+- `/cs:md-document`, `/cs:md-review`, `/cs:md-slides`
+
+## Anti-patterns (domain-level)
+
+- ❌ Converting markdown < 100 lines — markdown still wins. Refuse + cite Shihipar.
+- ❌ Skipping onboarding because "the user wants it done now." Surface onboarding — it's 60 seconds.
+- ❌ Multi-file output (separate CSS / JS / image folders). Single file or nothing.
+- ❌ External JS framework runtimes (React, Vue, Svelte, Alpine). Vanilla JS + IntersectionObserver only.
+- ❌ Silently overwriting existing output files. `output_path_resolver.py` suffixes `-2`, `-3`, … by default.
+- ❌ Setting `MARKDOWN_HTML_NO_CONFIG=1` silently for an interactive user.
+- ❌ Decorative tokens — every token must change at least one converter's output.
+- ❌ Inventing brand colors when the user hasn't onboarded.
+- ❌ A skill that overlaps Anthropic's official Playground plugin (sliders/knobs/prompt-copy-back).
+- ❌ A skill that overlaps `marketing/landing/` (landing-page generation from scratch).
+
+## Customization pipeline
+
+1. User runs `python3 markdown-html/skills/design-system/scripts/onboard.py`.
+2. Wizard validates brand colors via `brand_palette_validator.py`, derives 12-token palette.
+3. Result written to `~/.config/markdown-html/design-system.json` (or `./.markdown-html/design-system.json` with `--scope project`).
+4. Every converter sub-skill imports `config_loader.py` and calls `load_config()` to read project > global > defaults.
+5. Each converter's renderer emits a single `<style>` block with `:root { --md-bg: ...; }` for all 12 tokens, then references those variables throughout the CSS.
+6. Result: change a single field via `--set brand.primary=#FF6B35` → next conversion re-renders with the new brand.
+
+## References
+
+- Spec: Thariq Shihipar — *Claude Code HTML output: Why Markdown Lost and How to Switch* (Medium, 2026)
+- Forking pattern source: `research-ops/skills/research-ops-skills/SKILL.md` (`context: fork`, two-signal routing)
+- Onboarding pattern source: `research-ops/skills/clinical-research/scripts/onboard.py` + `config_loader.py`
+- Brand palette math source: `marketing/landing/skills/landing/scripts/brand_palette_validator.py`
+- Matt Pocock grill-with-docs: `engineering/grill-with-docs`
+- Single-file HTML discipline source: `marketing/landing/skills/landing/SKILL.md`

--- a/markdown-html/README.md
+++ b/markdown-html/README.md
@@ -1,0 +1,104 @@
+# markdown-html — Markdown to interactive HTML converter
+
+> "I generated a 200-line implementation plan in Claude Code last month. Markdown. … I skimmed the first 20 lines, scrolled past the diagram I could not actually parse, and closed the file. I never read the rest."
+> — Thariq Shihipar, *Claude Code HTML output* (Medium, 2026)
+
+Convert long markdown files in a Claude project into single-file, lightly-interactive HTML that respects your brand. One-time design-system onboarding captures brand primary + accent + typography + layout style + default save location. Every conversion reads that config and renders consistently.
+
+## Status — v2.10.0 (foundation)
+
+| Skill | Purpose | Status |
+|---|---|---|
+| `markdown-html-orchestrator` | Routes long markdown → converter sub-skill (`context: fork`) | ✓ live |
+| `design-system` | Onboarding wizard + WCAG-AA-validated brand palette + shared config | ✓ live |
+| `md-document` | Long-form: sticky TOC + collapsibles + search + code-copy + scrollspy | v2.10.1 (next PR) |
+| `md-review` | Code review: 2-col diff + severity-tagged margin annotations + jump-nav | v2.10.1 (next PR) |
+| `md-slides` | Slide deck: arrow-key nav + presenter mode + print-to-PDF | v2.10.1 (next PR) |
+
+## Quick start
+
+```bash
+# 1. One-time onboarding (10 questions, ~60 seconds)
+python3 markdown-html/skills/design-system/scripts/onboard.py
+
+# 2. (or zero-touch defaults for first-test)
+python3 markdown-html/skills/design-system/scripts/onboard.py --defaults
+
+# 3. Inspect the saved config
+python3 markdown-html/skills/design-system/scripts/config_loader.py --status
+
+# 4. Classify a markdown file and see the routing decision
+python3 markdown-html/skills/markdown-html-orchestrator/scripts/doctype_classifier.py \
+    --input ./my-report.md --output json \
+  | python3 markdown-html/skills/markdown-html-orchestrator/scripts/route_explainer.py
+
+# 5. Resolve where it would save (foundation; converters in v2.10.1)
+python3 markdown-html/skills/markdown-html-orchestrator/scripts/output_path_resolver.py \
+    --input ./my-report.md --doctype document
+```
+
+## Slash commands
+
+- `/cs:markdown-html <path>.md` — top-level router (classify + route + recommend)
+- `/cs:grill-markdown-html <path>.md` — Matt-style 5-question grill before conversion
+- `/cs:design-system` — surface the onboarding wizard
+
+## Hard rules
+
+1. **Refuses input < 100 lines** — markdown still wins below the threshold (Shihipar). Keep short docs as markdown.
+2. **Refuses without onboarding** — without a captured brand, output renders with placeholder defaults. Run onboarding once.
+3. **Refuses unwritable save location** — onboarding asks where to save; the orchestrator honors it; collisions get suffixed (`-2`, `-3`, …).
+4. **Single-file HTML only** — all CSS + JS inline. The only external CDN entries are Google Fonts + Prism.js. No build step, no bundler, no JS framework.
+5. **Never silently chain** — "convert this AND make slides AND a code review" is three operations, asked explicitly.
+6. **WCAG AA enforced** — body-text contrast must reach 4.5:1. Onboarding refuses any combination that fails.
+
+## Distinct from
+
+- **Anthropic Playground plugin** (`/playground`) — builds interactive prompt-tuning controls (sliders, knobs, prompt-copy-back). Different tool entirely.
+- **`marketing/landing/`** — generates landing pages from scratch. Doesn't take markdown input.
+- **`engineering/handoff/` + `productivity/handoff/`** — session continuity briefs. Different artifact type.
+
+## File layout
+
+```
+markdown-html/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   └── cs-markdown-html-orchestrator.md
+├── commands/
+│   ├── cs-markdown-html.md          # router
+│   ├── cs-design-system.md          # onboarding surface
+│   └── cs-grill-markdown-html.md    # 5-question grill
+└── skills/
+    ├── markdown-html-orchestrator/  # context: fork
+    │   ├── SKILL.md
+    │   ├── scripts/
+    │   │   ├── doctype_classifier.py
+    │   │   ├── route_explainer.py
+    │   │   └── output_path_resolver.py
+    │   └── references/
+    │       ├── information_density_canon.md
+    │       ├── orchestrator_routing_patterns.md
+    │       └── single_file_html_discipline.md
+    └── design-system/
+        ├── SKILL.md
+        ├── scripts/
+        │   ├── onboard.py
+        │   ├── config_loader.py
+        │   └── brand_palette_validator.py
+        ├── references/
+        │   ├── design_token_canon.md
+        │   ├── wcag_accessibility.md
+        │   └── typography_pairing.md
+        └── assets/
+            └── design_system_schema.json
+```
+
+## License
+
+MIT. See repo `LICENSE`.
+
+## Spec
+
+Thariq Shihipar — *Claude Code HTML output: Why Markdown Lost and How to Switch* (Medium, 2026). The plugin operationalizes the article's central claim — markdown collapses past ~100 lines for agent-generated artifacts; HTML restores density, clarity, shareability, and lightweight interaction.

--- a/markdown-html/agents/cs-markdown-html-orchestrator.md
+++ b/markdown-html/agents/cs-markdown-html-orchestrator.md
@@ -1,0 +1,100 @@
+---
+name: cs-markdown-html-orchestrator
+description: Density-first markdown-to-HTML converter. Routes long markdown files (≥ 100 lines per Shihipar's threshold) to one of three converter sub-skills (md-document / md-review / md-slides) via the markdown-html-orchestrator skill. Refuses below threshold or when the design-system isn't onboarded. Forks context so the full markdown body, diffs, and slide content stay out of the parent thread. Signature forcing question — "What decision does this HTML drive — is the reader skimming, deciding, or presenting?"
+tools: Read, Write, Edit, Glob, Grep, Bash, Skill
+model: sonnet
+---
+
+# cs-markdown-html-orchestrator — Density-first markdown-to-HTML converter
+
+You are a density-first document specialist. You convert long markdown files in a user's Claude project into single-file, lightly-interactive HTML that respects their brand. You don't render short markdown — you tell the user to keep it as markdown. You don't render without a design system in place — you point them at onboarding. You don't silently chain converters — you ask before doing two operations.
+
+## Voice
+
+Allergic to:
+- Long markdown that should have been HTML (the reader will stop scrolling at line 100)
+- Short markdown forced into HTML (overhead with no payoff under 100 lines)
+- HTML that doesn't carry the user's brand (placeholder defaults are honesty about a missing step, not an output)
+- "Convert this and also make slides from it" (two operations, asked explicitly)
+
+Your signature opener: **"What decision does this HTML drive — is the reader skimming, deciding, or presenting? That tells me which density to render at."**
+
+The trap you protect against: an agent silently rendering an unbranded, overstuffed, or wrong-doctype HTML and shipping it to a stakeholder.
+
+## Your three lanes
+
+You route every inquiry to one of three converter sub-skills via the `markdown-html-orchestrator` skill (`context: fork`):
+
+| Lane | Sub-skill | When |
+|---|---|---|
+| Document | `md-document` | Long-form: specs, RFCs, reports, explainers (90% of inputs) |
+| Review | `md-review` | Code review / PR writeup with diff blocks and severity annotations |
+| Slides | `md-slides` | Slide deck with `---` boundaries or H1 cadence + presenter notes |
+
+Each sub-skill ships in v2.10.1 follow-up PRs. Until they land (v2.10.0 foundation), you run the classifier + design-system gate and hand the rendering brief back to Claude.
+
+## Pre-flight gates (refuse and surface, never override)
+
+1. **Input < 100 lines.** Per Shihipar's threshold, markdown wins below that. Refuse with the line count and tell the user to keep it as markdown.
+2. **Design-system not onboarded.** No `~/.config/markdown-html/design-system.json` (or `setup_completed_at` is null). Refuse with: `python3 markdown-html/skills/design-system/scripts/onboard.py` (or `--defaults` for zero-touch). Re-prompt after they've run it.
+3. **Output directory unwritable.** `output_path_resolver.py` refuses. Don't override — let the user fix the path or re-onboard.
+
+## Routing logic
+
+1. **Classify the input.**
+   ```bash
+   python3 markdown-html/skills/markdown-html-orchestrator/scripts/doctype_classifier.py \
+       --input <path>.md --output json \
+     | python3 markdown-html/skills/markdown-html-orchestrator/scripts/route_explainer.py
+   ```
+2. **Read the verdict.** One of: `ROUTE_SILENTLY`, `ASK_USER one question`, `REFUSE — fix the issues above`.
+3. **Act on it.** Never override `REFUSE`. Never invent a verdict the classifier didn't produce.
+
+## How you communicate (Matt Pocock grill discipline)
+
+Adopt the five rules from `engineering/grill-with-docs` (Matt Pocock, MIT):
+
+1. **One question per turn.** Never bundle.
+2. **Always recommend an answer.** Format: "Recommended: <answer>, because <canon-cited rationale>".
+3. **Explore before asking.** Read the markdown header and filename before asking the user what type it is.
+4. **Walk the tree depth-first.** Finish a conversion before starting another.
+5. **Track dependencies.** Onboarding → classification → routing → conversion. Don't skip steps.
+
+After running a conversion, return a **≤ 100-word digest**:
+- Input lines, doctype, output path
+- Design style + brand primary applied
+- Top 3 features used (sticky TOC, scrollspy, code-copy, severity badges, presenter mode, etc.)
+- **One forcing question** for the user (citing canon: Shihipar, WCAG, Lupton, etc.)
+
+## Anti-patterns
+
+- ❌ Converting markdown < 100 lines just because the user asked. Refuse + cite Shihipar.
+- ❌ Skipping onboarding because "the user wants it done now." Surface onboarding — it's 60 seconds.
+- ❌ Multi-file output (separate CSS / JS / image folders). Single file only.
+- ❌ External JS framework runtimes. Vanilla JS + IntersectionObserver only; Prism.js CDN is the one exception.
+- ❌ Silently chaining "convert AND make slides AND also a code review." One operation per turn, ask before chaining.
+- ❌ Inventing brand colors when the user hasn't onboarded. Refuse; surface onboarding.
+
+## Available commands
+
+- `/cs:markdown-html <markdown-file-path>` — top-level router (classifier + route + recommend)
+- `/cs:grill-markdown-html <markdown-file-path>` — Matt-style grilling before conversion
+- `/cs:design-system` — surface the onboarding wizard
+
+Once converter sub-skills ship in v2.10.1:
+- `/cs:md-document <markdown-file-path>`
+- `/cs:md-review <markdown-file-path>`
+- `/cs:md-slides <markdown-file-path>`
+
+## When to escalate
+
+- Interactive prompt-tuning with sliders/knobs → Anthropic's official `playground` plugin (`/playground`)
+- Landing-page generation from scratch → `marketing/landing/`
+- PDF generation pipeline → out of scope; users can print-to-PDF from the rendered HTML
+- Diagram generation (architecture diagrams, sequence diagrams) → for now, suggest inline SVG written by Claude; future skill TBD
+
+## Distinct from
+
+- **Anthropic Playground plugin** — interactive prompt-tuning controls. Different tool entirely.
+- **`marketing/landing/`** — generates landing pages from scratch (Phase-0 intake → 3 sections → branded HTML). Doesn't take markdown input.
+- **`engineering/handoff/`** + **`productivity/handoff/`** — session continuity briefs. Different artifact type.

--- a/markdown-html/commands/cs-design-system.md
+++ b/markdown-html/commands/cs-design-system.md
@@ -1,0 +1,57 @@
+---
+description: Run the one-time markdown-html design-system onboarding wizard. Captures brand primary/accent (HEX) + heading/body Google Fonts + design style (editorial/technical/minimal/playful) + default output directory + syntax theme + TOC behavior + optional logo/company. WCAG-AA validates body-text contrast; refuses if it fails. Stores at ~/.config/markdown-html/design-system.json (or project-scoped with --scope project). Every converter reads this config via config_loader.py before rendering.
+argument-hint: "[--defaults | --show | --reset | --set key=value | --scope global|project]"
+---
+
+# /cs:design-system — Markdown-HTML design-system onboarding
+
+Run the design-system wizard:
+
+```bash
+python3 markdown-html/skills/design-system/scripts/onboard.py $ARGUMENTS
+```
+
+## Modes
+
+| Flag | Behavior |
+|---|---|
+| (no flag) | Interactive — walks 10 questions one at a time. Default. |
+| `--defaults` | Zero-touch: writes built-in defaults (`#0A1628` navy + `#00D4AA` teal + Inter + technical + sticky TOC + `./markdown-html-out/`) without prompting. Useful for CI or first-test. |
+| `--set key=value` | Non-interactive override (repeatable). Dotted keys supported: `brand.primary=#FF6B35`, `typography.heading_font=Lora`, `design_style=editorial`. |
+| `--show` | Print the 10 questions + the current effective config (project > global > defaults). |
+| `--reset` | Delete the saved config at the chosen scope. |
+| `--scope project` | Save to `./.markdown-html/design-system.json` (per-repo override) instead of global `~/.config/markdown-html/design-system.json`. |
+
+## The 10 questions
+
+1. Default output directory (path; must be writable)
+2. Brand primary HEX
+3. Brand accent HEX (optional; auto-derives if blank)
+4. Heading Google Font (12 safe defaults)
+5. Body Google Font
+6. Design style: editorial / technical / minimal / playful
+7. Syntax-highlighting theme: light / dark / auto
+8. TOC behavior: sticky-sidebar / collapsible-top / inline / none
+9. Company / project name (optional, shows in footer)
+10. Logo URL (optional, base64-embedded at render time)
+
+## Hard refusals
+
+- `default_output_dir` empty or unwritable → exit 3. Pick a path you control.
+- WCAG AA body-text contrast fails (< 4.5:1) → exit 4. Pick a darker primary, blank `brand.bg`/`brand.text` to let derivation pick a passing pair, or override `brand.text` explicitly.
+- WCAG link contrast walked iteratively; falls back to a passing color if accent on bg can't reach 4.5:1.
+
+## After onboarding
+
+Inspect the effective config:
+
+```bash
+python3 markdown-html/skills/design-system/scripts/config_loader.py --show
+python3 markdown-html/skills/design-system/scripts/config_loader.py --status
+```
+
+Then convert markdown via `/cs:markdown-html <path>.md`.
+
+## Bypass
+
+`MARKDOWN_HTML_NO_CONFIG=1` skips saved config and returns DEFAULTS only. Useful for headless CI, ephemeral test containers, and evaluator loops. Never set it silently for an interactive user.

--- a/markdown-html/commands/cs-grill-markdown-html.md
+++ b/markdown-html/commands/cs-grill-markdown-html.md
@@ -1,0 +1,88 @@
+---
+description: Matt-Pocock-style forcing-question grill for markdown-html conversions. Walks 5 cited-canon questions (purpose, line-count threshold, design-system onboarding, output path, doctype confidence) one at a time with a recommended answer. Run before /cs:markdown-html when you want clarity about what the HTML is for, not just a route to the closest sub-skill.
+argument-hint: "<path to markdown file>"
+---
+
+# /cs:grill-markdown-html — Pre-conversion grill
+
+Walk the user through 5 forcing questions before routing to the converter. **One question per turn**, with a recommended answer and a canon citation. The user must answer Q1 before Q2 is asked. Never bundle.
+
+**$ARGUMENTS**
+
+## The 5 questions (Matt Pocock grill-with-docs pattern)
+
+### Q1/5 — Purpose
+
+> **What decision does this HTML drive — is the reader skimming, deciding, or presenting?**
+>
+> Recommended: name it first; density follows from purpose.
+>
+> Canon: Shihipar (Claude Code HTML output essay) — "match output format to consumption context"; Tufte, *Visual Display of Quantitative Information*, ch. 1.
+
+If the user shrugs, ask once: "Skimming → minimal layout. Deciding → sticky TOC + search. Presenting → slide deck."
+
+### Q2/5 — Line count threshold
+
+> **Is the input markdown ≥ 100 lines?**
+>
+> Recommended: yes — below that, keep it as markdown. Run `wc -l <file>.md` to confirm.
+>
+> Canon: Shihipar — markdown still wins under 100 lines.
+
+If under 100 lines, refuse the conversion. Do NOT proceed.
+
+### Q3/5 — Design-system onboarded?
+
+> **Has the design-system been onboarded?**
+>
+> Recommended: yes, globally. Run `python3 markdown-html/skills/design-system/scripts/onboard.py` (or `--defaults` for zero-touch) if not.
+>
+> Canon: research-ops onboarding pattern (`research-ops/CLAUDE.md` §8); WCAG 2.2 §1.4.3.
+
+Check via:
+
+```bash
+python3 markdown-html/skills/design-system/scripts/config_loader.py --status
+```
+
+If `setup_completed: false`, surface onboarding. Do NOT proceed without it.
+
+### Q4/5 — Output path
+
+> **Where does the output save, and will it overwrite anything?**
+>
+> Recommended: the configured `default_output_dir` with `--on-collision suffix` (the default, which generates `-2`, `-3`, … instead of overwriting).
+>
+> Canon: Matt Pocock `handoff` skill — never silently overwrite a working artifact.
+
+Resolve via:
+
+```bash
+python3 markdown-html/skills/markdown-html-orchestrator/scripts/output_path_resolver.py \
+    --input "$ARGUMENTS" --doctype <verdict>
+```
+
+### Q5/5 — Doctype confidence
+
+> **Document type confidence — silent-route, or one clarifying question?**
+>
+> Recommended: silent-route only when `silent_route_allowed: true` in the classifier output. Otherwise, ask one clarifying question and recommend the winner.
+>
+> Canon: research-ops two-signal threshold (`research-ops/skills/research-ops-skills/SKILL.md` §"Routing logic").
+
+Classify via:
+
+```bash
+python3 markdown-html/skills/markdown-html-orchestrator/scripts/doctype_classifier.py \
+    --input "$ARGUMENTS" --output human
+```
+
+## Discipline
+
+- **One question per turn.** Don't bundle Q1+Q2 in the same message. Wait for the answer.
+- **Always recommend an answer.** Never ask an open question.
+- **Always cite the canon.** The recommendation must reference the source.
+- **Refuse, don't override.** If Q2 or Q3 fails, the conversion does not proceed. The grill protects against silent-failure.
+- **Walk depth-first.** Finish all 5 questions for THIS conversion before starting a different one.
+
+After Q5, hand off to `/cs:markdown-html <path>` to actually run the conversion with the confirmed answers in hand.

--- a/markdown-html/commands/cs-markdown-html.md
+++ b/markdown-html/commands/cs-markdown-html.md
@@ -1,0 +1,58 @@
+---
+description: Top-level markdown-to-HTML router. Classifies the input markdown (document / review / slides), checks the design-system onboarding gate + 100-line threshold, then forks context to the right converter sub-skill via the markdown-html-orchestrator skill. Returns a ≤100-word digest with input lines, output path, design style, top features used, and one forcing question.
+argument-hint: "<path to markdown file>"
+---
+
+# /cs:markdown-html — Markdown-to-HTML router
+
+Route this conversion through the `markdown-html-orchestrator` skill:
+
+**$ARGUMENTS**
+
+## Pre-flight gates (refuse and surface, never override)
+
+1. **Input < 100 lines.** Markdown still wins below the threshold (Shihipar). Refuse with the line count + recommendation to keep as markdown.
+2. **Design-system not onboarded.** Surface `python3 markdown-html/skills/design-system/scripts/onboard.py` and re-prompt after.
+3. **Output directory unwritable.** Refuse; let the user fix the path or re-onboard.
+
+## Routing (deterministic, two-signal threshold)
+
+| Signal class | Filename hints | Content signals | Sub-skill |
+|---|---|---|---|
+| DOCUMENT | `report.md`, `spec.md`, `rfc-*.md`, `*-doc.md`, `*-analysis.md`, `*-explainer.md` | `## Table of Contents`, `^# `, `^## `, table rows, GFM callouts | `md-document` |
+| REVIEW | `review.md`, `*-pr-*.md`, `*.diff.md`, `code-review*.md` | ` ```diff `, `^[-+]{3} `, `^@@`, `> [!BLOCKER]/[!MAJOR]/[!MINOR]/[!NIT]`, `LGTM`/`nit:`/`blocker:` | `md-review` |
+| SLIDES | `deck.md`, `slides.md`, `*-talk.md`, `presentation*.md` | `^---$` ≥ 3, `<!-- notes:`, H1 cadence ≥ 5 with median gap ≤ 12 lines | `md-slides` |
+
+Pipeline:
+
+```bash
+python3 markdown-html/skills/markdown-html-orchestrator/scripts/doctype_classifier.py \
+    --input "$ARGUMENTS" --output json \
+  | python3 markdown-html/skills/markdown-html-orchestrator/scripts/route_explainer.py
+
+python3 markdown-html/skills/markdown-html-orchestrator/scripts/output_path_resolver.py \
+    --input "$ARGUMENTS" --doctype <verdict>
+```
+
+1. Silent-route only when winner ≥ 3 AND (runner-up = 0 OR winner ≥ 2× runner-up).
+2. Single signal or tie → one clarifying question with a recommended answer.
+3. No signals → ask which lane, recommend `md-document` as the safe default.
+
+## Output (≤ 100-word digest)
+
+- Input lines + doctype
+- Output path (resolved by `output_path_resolver.py`)
+- Design style + brand primary applied (from `config_loader.py`)
+- Top 3 features used (sticky TOC, scrollspy, code-copy, severity badges, presenter mode, etc.)
+- One forcing question for the user (cite Shihipar / WCAG / Lupton / Tufte)
+
+## Hard rules
+
+- Never silently chain two converters. Pick one, finish, ask before chaining.
+- Never override a `REFUSE` from `route_explainer.py`.
+- Never invent brand colors when the user hasn't onboarded. Surface onboarding.
+- Output is single-file HTML. External CDN is limited to Google Fonts + Prism.js.
+
+## Foundation status (v2.10.0)
+
+The orchestrator + `design-system` are live. Converter sub-skills (`md-document`, `md-review`, `md-slides`) land in v2.10.1 follow-up PRs. Until then, this command runs the classifier + design-system gate and returns the routing brief; Claude does the rendering inline with the design-system tokens.

--- a/markdown-html/skills/design-system/SKILL.md
+++ b/markdown-html/skills/design-system/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: design-system
+description: Captures the user's brand identity once via a 10-question onboarding wizard (primary/accent HEX + heading + body Google Fonts + design style editorial/technical/minimal/playful + default output directory + syntax theme + TOC behavior + optional logo/company), validates body-text and link contrast against WCAG 2.2 AA, derives 12 CSS custom properties in HSL space, and stores the result for every markdown-html converter to consume. Use before any markdown-html conversion. Triggers on first-run onboarding ("set up the brand", "configure markdown-html", "run onboarding"), on explicit reset ("reset the design system", "re-onboard"), and is checked by every converter via config_loader.py before rendering. Refuses to save if body-text contrast fails AA 4.5:1 or the output dir isn't writable. Precedence: project (./.markdown-html/) > global (~/.config/markdown-html/) > built-in defaults; MARKDOWN_HTML_NO_CONFIG=1 bypasses.
+version: 2.10.0
+author: Alireza Rezvani
+license: MIT
+tags: [design-system, brand-palette, wcag, onboarding, customization, markdown-html, css-variables, typography]
+compatible_tools: [claude-code, codex-cli, cursor, antigravity, opencode, gemini-cli]
+---
+
+# Design System — Onboarding + Shared Brand Tokens
+
+The design-system skill is the **shared brand owner** for the markdown-html plugin. Run its onboarding once. Every converter (`md-document`, `md-review`, `md-slides`) reads the resulting config via `config_loader.py` and applies the same 12 CSS custom properties to its output. Without this, conversions render with placeholder defaults — technically functional but unbranded.
+
+This skill ships exactly three Python tools:
+
+1. **`onboard.py`** — interactive (or `--defaults` / `--set` / `--show` / `--reset`) wizard.
+2. **`config_loader.py`** — importable customization loader with project > global > defaults precedence and `MARKDOWN_HTML_NO_CONFIG=1` bypass.
+3. **`brand_palette_validator.py`** — WCAG-AA contrast checker + HSL palette deriver.
+
+All three are stdlib-only and contain no LLM calls (deterministic per Path-B discipline).
+
+## When to invoke
+
+| Symptom | Action |
+|---|---|
+| User says "convert this markdown to HTML" for the first time in this workspace | Run `python3 markdown-html/skills/design-system/scripts/onboard.py` |
+| `~/.config/markdown-html/design-system.json` doesn't exist OR `setup_completed_at` is null | Refuse conversion, surface onboarding |
+| User wants per-repo brand override | `python3 .../onboard.py --scope project` |
+| User wants to change a single field non-interactively | `python3 .../onboard.py --set brand.primary=#FF6B35` |
+| User wants to reset and re-onboard | `python3 .../onboard.py --reset` then re-run |
+| User wants zero-touch defaults (CI, ephemeral session) | `python3 .../onboard.py --defaults` |
+| Headless / containerized run that should ignore saved config | `MARKDOWN_HTML_NO_CONFIG=1 ...` |
+
+## Onboarding question set (10 questions)
+
+| # | Key | Choices / Validator | Default |
+|---|---|---|---|
+| 1 | `default_output_dir` | path; `os.access(parent, os.W_OK)` | `./markdown-html-out/` |
+| 2 | `brand.primary` | HEX `^#?[0-9a-fA-F]{6}$` | `#0A1628` |
+| 3 | `brand.accent` | HEX or blank (auto-derive) | derive from primary |
+| 4 | `typography.heading_font` | Google Font name (12 safe defaults) | `Inter` |
+| 5 | `typography.body_font` | Google Font name | `Inter` |
+| 6 | `design_style` | `editorial / technical / minimal / playful` | `technical` |
+| 7 | `code_theme` | `light / dark / auto` | `auto` |
+| 8 | `toc.behavior` | `sticky-sidebar / collapsible-top / inline / none` | `sticky-sidebar` |
+| 9 | `company_name` | string (may be empty) | `""` |
+| 10 | `logo_url` | URL or empty (base64-embedded at render) | `""` |
+
+## Hard rules
+
+1. **WCAG AA body-text contrast must pass.** `brand_palette_validator.validate()` runs after every change. Body text on bg must reach 4.5:1; link on bg must reach 4.5:1. If either fails, `onboard.py` refuses to save (exit code 4) and tells the user to pick a darker primary, blank `brand.bg`/`brand.text` to let derivation pick a safe pair, or override `brand.text` directly. Canon: WCAG 2.2 §1.4.3.
+2. **Output directory must be writable.** `onboard.py` walks up the path to find an existing ancestor and checks `os.W_OK`. Empty or unwritable path → exit code 3. The orchestrator's `output_path_resolver.py` honors the same rule per-conversion.
+3. **Customization must change behavior, not sit as decoration.** Every consumer (md-document, md-review, md-slides) must read the config and render differently when the user changes `design_style`, `brand.primary`, `code_theme`, or `toc.behavior`. Decorative-only fields fail the design discipline.
+4. **Precedence is fixed.** Project > global > defaults. The deep-merge preserves nested keys (e.g. you can override `brand.primary` in a project config without losing `typography.heading_font` from global).
+5. **Bypass env exists for a reason.** `MARKDOWN_HTML_NO_CONFIG=1` is for headless CI, ephemeral test containers, and the autoresearch-style evaluator loops. Never set it silently for an interactive user.
+
+## Derived 12-token palette
+
+Once the user's brand is captured, `brand_palette_validator.derive_palette()` produces 12 CSS custom properties stored under `derived_palette` in the same config file. Every converter inlines these into its `<style>` block.
+
+| Token | Purpose | Derivation |
+|---|---|---|
+| `--md-bg` | Document background | Primary if dark, near-neutral if vibrant |
+| `--md-surface` | Card / callout / blockquote background | Bg ± 4-6% luminance |
+| `--md-border` | Hairline dividers, table borders | Bg ± 8-12% luminance |
+| `--md-text` | Body text | Off-white on dark bg, near-black on light bg |
+| `--md-text-muted` | Captions, metadata, footers | `rgba(text, 0.68)` |
+| `--md-accent` | Primary CTA, callout headers, link emphasis | Primary if vibrant, hue-shifted lighter if dark |
+| `--md-accent-soft` | Accent backgrounds, hover states | `rgba(accent, 0.14)` |
+| `--md-code-bg` | Inline code, fenced block bg | Bg ± 4-5% luminance |
+| `--md-link` | Hyperlinks | Iteratively walked to reach 4.5:1 contrast on bg |
+| `--md-link-hover` | Hover state | Link ± 6-8% luminance |
+| `--md-success` | OK / approved / passed | Green anchored, luminance-matched |
+| `--md-warn` | Caution / nit / TODO | Amber anchored, luminance-matched |
+
+## Forcing-question library (Matt Pocock grill-with-docs pattern)
+
+One question per turn, recommended answer, canon citation.
+
+1. **What's your brand primary color?** Recommended: a HEX you already use in your product or docs — not a stock blue. Canon: Aarron Walter, *Designing for Emotion* (color carries brand affect).
+2. **Should accent be derived or set?** Recommended: derive on first run (hue-shift + lighten produces a coherent companion); set explicitly only if your brand kit specifies one. Canon: Adobe Spectrum, *Color Foundations*.
+3. **Editorial, technical, minimal, or playful?** Recommended: `technical` for engineering specs/reports, `editorial` for long-read narratives, `minimal` for sparse reference docs, `playful` for marketing/landing content. Canon: Ellen Lupton, *Thinking with Type* (style serves the rhetorical purpose).
+4. **Sticky-sidebar TOC, or inline?** Recommended: `sticky-sidebar` for documents over 800 words, `inline` for short reads. Canon: Nielsen-Norman, *Table of Contents Best Practices* (2023).
+5. **Save to global or per-project?** Recommended: global by default (consistent across your work); use `--scope project` only when this repo has a different brand. Canon: research-ops onboarding pattern, `research-ops/CLAUDE.md` §8.
+
+## Customization in use (worked example)
+
+```bash
+# First-run onboarding (interactive, walks all 10 questions)
+python3 markdown-html/skills/design-system/scripts/onboard.py
+
+# Zero-touch defaults for CI / first-test
+python3 .../onboard.py --defaults
+
+# Change just the primary color and design style
+python3 .../onboard.py --set brand.primary=#FF6B35 --set design_style=editorial
+
+# Per-repo override
+python3 .../onboard.py --scope project --set design_style=minimal
+
+# Reset and re-onboard
+python3 .../onboard.py --reset
+python3 .../onboard.py
+
+# Inspect the effective config (project > global > defaults)
+python3 .../config_loader.py --show
+python3 .../config_loader.py --status
+
+# Bypass saved config (returns DEFAULTS only)
+MARKDOWN_HTML_NO_CONFIG=1 python3 .../config_loader.py --show
+
+# Spot-check WCAG contrast before committing to a brand
+python3 .../brand_palette_validator.py --primary "#FF6B35" --accent "#00D4AA"
+```
+
+## Assumptions
+
+1. User has at least one brand HEX they want consistent across their HTML conversions.
+2. User accepts a 1-2 minute one-time setup.
+3. User is OK with Google Fonts as the typography source (CDN, no local font hosting).
+4. WCAG 2.2 AA is the accessibility floor (4.5:1 body, 3:1 large/UI). AAA (7:1) is out of scope.
+
+## Non-goals
+
+- Not a full design-token system (Style Dictionary, Theo). Twelve tokens, not a hundred.
+- Not a custom-font hosting solution. Google Fonts only.
+- Not a dark/light mode switcher in the converters. `code_theme: auto` handles the prefers-color-scheme case for syntax highlighting; layout palette is single-mode per onboarding.
+- Not an accessibility audit suite (use axe-core / pa11y for that). We enforce contrast only.
+- Does not transform existing CSS — the derived palette is injected into freshly generated HTML.
+
+## Distinct from
+
+- **`marketing/landing/skills/landing/scripts/brand_palette_validator.py`** — that script's `derive_palette()` produces 8 tokens shaped for hero-page rendering (`--navy`, `--teal`, `--card-bg`, `--card-border`). This script produces 12 tokens shaped for document rendering (sticky surface, hairline border, code bg, link, link-hover, success, warn). Same WCAG + HSL math, different token taxonomy.
+- **`research-ops/skills/clinical-research/scripts/onboard.py`** — same pattern (interactive + `--defaults`/`--set`/`--show`/`--reset`/`--scope`), different question set (clinical alpha/power/dropout vs. brand palette/typography/layout).
+
+## Output artifact
+
+`~/.config/markdown-html/design-system.json` (global) or `./.markdown-html/design-system.json` (project). JSON schema lives at `assets/design_system_schema.json`.
+
+## Anti-patterns (do not)
+
+- ❌ Skip onboarding and run a converter with placeholder defaults — output looks unbranded.
+- ❌ Pick a vibrant brand primary as `brand.bg` directly (low text contrast). Use it as accent instead.
+- ❌ Set `MARKDOWN_HTML_NO_CONFIG=1` silently for an interactive user — they'll wonder why their tokens disappeared.
+- ❌ Encode brand semantics in `derived_palette` outside the 12-token taxonomy. Add a new token only with a deliberate name + purpose + derivation rule.
+
+## References
+
+- WCAG 2.2 — §1.4.3 (contrast), §1.4.4 (resize), §1.4.11 (non-text contrast)
+- Aarron Walter — *Designing for Emotion* (A Book Apart)
+- Ellen Lupton — *Thinking with Type*
+- Adobe Spectrum — *Color Foundations*
+- Nielsen-Norman — *Table of Contents Best Practices* (2023)
+- research-ops onboarding pattern: `research-ops/CLAUDE.md` §8
+- Brand palette math source: `marketing/landing/skills/landing/scripts/brand_palette_validator.py`

--- a/markdown-html/skills/design-system/assets/design_system_schema.json
+++ b/markdown-html/skills/design-system/assets/design_system_schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alirezarezvani/claude-skills/blob/main/markdown-html/skills/design-system/assets/design_system_schema.json",
+  "title": "markdown-html design-system customization config",
+  "description": "JSON schema for the design-system config written by onboard.py and consumed by every markdown-html converter via config_loader.py. Lives at ~/.config/markdown-html/design-system.json (global) or ./.markdown-html/design-system.json (project).",
+  "type": "object",
+  "required": ["version", "skill", "default_output_dir", "brand", "typography", "design_style", "code_theme", "toc"],
+  "properties": {
+    "version": {"type": "integer", "const": 1, "description": "Schema version. Bump on breaking changes to the layout."},
+    "skill": {"type": "string", "const": "design-system"},
+    "default_output_dir": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Where converters save generated HTML by default. Must be a writable path. The orchestrator's output_path_resolver.py also accepts a --out override per conversion."
+    },
+    "brand": {
+      "type": "object",
+      "required": ["primary"],
+      "properties": {
+        "primary": {"type": "string", "pattern": "^#?[0-9a-fA-F]{6}$", "description": "Primary brand color, HEX."},
+        "accent": {"type": ["string", "null"], "pattern": "^#?[0-9a-fA-F]{6}$|^$", "description": "Optional accent color. If null/empty, brand_palette_validator derives it from the primary via hue-shift + lighten."},
+        "bg": {"type": ["string", "null"], "description": "Optional background override. If null, derived from primary."},
+        "text": {"type": ["string", "null"], "description": "Optional body text override. If null, derived (off-white on dark bg, near-black on light bg)."}
+      }
+    },
+    "typography": {
+      "type": "object",
+      "required": ["heading_font", "body_font"],
+      "properties": {
+        "heading_font": {"type": "string", "description": "Google Font family for headings. e.g., Inter, Source Serif 4, Playfair Display."},
+        "body_font": {"type": "string", "description": "Google Font family for body text."},
+        "scale_ratio": {"type": "number", "minimum": 1.0, "maximum": 2.0, "description": "Modular type-scale ratio. 1.25 = major third (default), 1.333 = perfect fourth, 1.5 = perfect fifth."}
+      }
+    },
+    "design_style": {
+      "type": "string",
+      "enum": ["editorial", "technical", "minimal", "playful"],
+      "description": "Layout density preset consumed by every converter. editorial = magazine-like with wide margins and pull-quotes; technical = docs-like with sticky TOC and code emphasis; minimal = sparse with maximum whitespace; playful = product-marketing with color blocks and varied scale."
+    },
+    "code_theme": {
+      "type": "string",
+      "enum": ["light", "dark", "auto"],
+      "description": "Prism.js theme selection. auto = follows prefers-color-scheme."
+    },
+    "toc": {
+      "type": "object",
+      "required": ["behavior"],
+      "properties": {
+        "behavior": {"type": "string", "enum": ["sticky-sidebar", "collapsible-top", "inline", "none"]},
+        "max_depth": {"type": "integer", "minimum": 1, "maximum": 6, "description": "Deepest heading level included in the TOC."}
+      }
+    },
+    "company_name": {"type": "string", "description": "Optional, shown in footer of every generated HTML."},
+    "logo_url": {"type": "string", "description": "Optional. Base64-embedded at render time by default; pass --logo-mode link to inline the URL instead."},
+    "derived_palette": {
+      "type": "object",
+      "description": "12 CSS custom properties derived from the brand input by brand_palette_validator.derive_palette(). Stored here so every converter has identical tokens without re-deriving. Keys are CSS variable names; values are HEX or rgba() strings.",
+      "properties": {
+        "--md-bg": {"type": "string"},
+        "--md-surface": {"type": "string"},
+        "--md-border": {"type": "string"},
+        "--md-text": {"type": "string"},
+        "--md-text-muted": {"type": "string"},
+        "--md-accent": {"type": "string"},
+        "--md-accent-soft": {"type": "string"},
+        "--md-code-bg": {"type": "string"},
+        "--md-link": {"type": "string"},
+        "--md-link-hover": {"type": "string"},
+        "--md-success": {"type": "string"},
+        "--md-warn": {"type": "string"}
+      }
+    },
+    "setup_completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 timestamp written by onboard.py on successful completion. The orchestrator refuses to convert if this is null."
+    }
+  }
+}

--- a/markdown-html/skills/design-system/references/design_token_canon.md
+++ b/markdown-html/skills/design-system/references/design_token_canon.md
@@ -1,0 +1,49 @@
+# Design Token Canon
+
+**Why this exists:** This skill ships 12 CSS custom properties — small by design-system standards. This document explains why 12 is enough, the taxonomy the tokens follow, and the canon they derive from.
+
+## The 12-token taxonomy
+
+| Layer | Tokens | Purpose |
+|---|---|---|
+| **Surface** | `--md-bg`, `--md-surface`, `--md-border`, `--md-code-bg` | Vertical layering: page bg → cards/callouts → hairlines → fenced code |
+| **Text** | `--md-text`, `--md-text-muted` | Body + secondary (captions, metadata) |
+| **Accent** | `--md-accent`, `--md-accent-soft` | Brand emphasis (CTA, callout headers); soft for hover backgrounds |
+| **Link** | `--md-link`, `--md-link-hover` | Hyperlink + hover state; iteratively contrast-walked |
+| **Semantic** | `--md-success`, `--md-warn` | Inline status, callouts, review severity |
+
+Twelve covers every visual decision a long-form document needs. More tokens (e.g. Material Design's hundreds) optimize for design systems that span many UIs; markdown-html spans one artifact type (a generated HTML file) so we don't need the extra.
+
+## Sources
+
+### 1. Salesforce Lightning Design System — *Tokens* (lightningdesignsystem.com)
+First widely-adopted token system at scale. Established the layered taxonomy: surface → text → border → accent → semantic. Markdown-html's 12 tokens follow the same layering, scoped down to document-rendering needs.
+
+### 2. Adobe Spectrum — *Color Foundations* (spectrum.adobe.com)
+Documents the four roles a brand color plays: bg, accent, text, semantic. Validates the decision to derive accent from primary rather than treat them as independent (Spectrum: "accent should be a tinted, brightness-adjusted variant of the brand color").
+
+### 3. Material Design 3 — *Color Roles* (m3.material.io)
+Token taxonomy of `primary`/`onPrimary`/`primaryContainer`/`onPrimaryContainer` etc. We deliberately simplify: a long-form document doesn't need surface containers within accent containers. The 12-token system is the Material taxonomy collapsed to what document rendering actually requires.
+
+### 4. Sara Soueidan — *Color Tokens for Accessible Color Systems* (sarasoueidan.com, 2022)
+Argues for contrast-walked link colors: a link in brand accent often fails the 4.5:1 floor against bg; the system must lighten or darken until it passes. Our `_ensure_link_contrast()` is the direct implementation.
+
+### 5. Style Dictionary (amzn.github.io/style-dictionary)
+The industry-standard token transformation tool — takes JSON tokens and emits CSS / Swift / Kotlin / Flutter. We deliberately ship JSON tokens compatible with Style Dictionary in case a user wants to extend; we don't depend on it.
+
+### 6. CSS Custom Properties (MDN)
+The native browser primitive for runtime-themable styles. Inlining `:root { --md-bg: #...; }` into the generated `<style>` block means the user can override any token by adding their own `:root` override in a custom-CSS section of the document (escape hatch).
+
+### 7. Material Design 2 — *Type Scale* and *Color System* (material.io archive)
+Original 8-point grid + modular type scale + tonal palette. We use a smaller subset (just modular scale via `typography.scale_ratio`, default 1.25 = major third) and 12 tokens; same philosophy.
+
+## Why not 8? Why not 50?
+
+- **8 tokens** (the original landing-skill palette) — covers a landing page (hero bg, accent CTA, card bg, card border, off-white text, muted text, glow). Documents need link, link-hover, code-bg, success, and warn that landing doesn't.
+- **50 tokens** (Material Design 3 / IBM Carbon) — covers a multi-surface UI with elevated containers, interactive states, focus rings, disabled states. A document is a single surface with text — most of those tokens never render.
+
+Twelve is the smallest number that covers every visual decision a long-form document, code review, or slide deck must make, without inventing decisions the document doesn't have.
+
+## Applied to markdown-html
+
+Every converter inlines the user's `derived_palette` into a `:root { }` block at the top of `<style>`. Every other CSS rule references the variables — no hard-coded colors anywhere. This makes the converters honestly customizable: change `brand.primary` and re-onboard, all 12 tokens re-derive, and the document re-renders with a different brand without any code change.

--- a/markdown-html/skills/design-system/references/typography_pairing.md
+++ b/markdown-html/skills/design-system/references/typography_pairing.md
@@ -1,0 +1,76 @@
+# Typography Pairing
+
+**Why this exists:** The onboarding wizard offers 12 Google Fonts and asks the user to pick a heading + body pair. Most users don't have strong opinions on type. This document codifies the pairs that work without further thought, so the wizard can recommend confidently and the converters can render coherently.
+
+## Safe pairs
+
+| Pair | Use for | Reason |
+|---|---|---|
+| `Inter` + `Inter` | Technical docs, dashboards | Single family across heading/body — clean, neutral, OpenType-rich |
+| `Inter` + `Source Sans 3` | Long-form reports | Sans-on-sans pairing; Source Sans is more readable at body size |
+| `Source Serif 4` + `Source Sans 3` | Editorial / narrative | Adobe's Source family — designed as a coherent system |
+| `Playfair Display` + `Lora` | Magazine-style | Serif heading with personality; serif body that pairs |
+| `Merriweather` + `Open Sans` | Long-form reading | Editorial serif + neutral sans body; oldest-and-safest pair |
+| `IBM Plex Sans` + `IBM Plex Sans` | Technical + brand | Plex is designed for documentation; coherent across weights |
+| `JetBrains Mono` + (Inter or Source Sans 3) | Engineering notebooks | Mono headings signal a coding/terminal context |
+
+## Sources
+
+### 1. Ellen Lupton — *Thinking with Type* (Princeton Architectural Press, 2010)
+Foundational. The "stress, weight, and contrast" framework for pairing: the heading and body should share at least one of {stress angle, x-height, terminal style} and contrast in at least one of {weight, scale}. Every recommended pair above satisfies this.
+
+### 2. Tim Brown — *Combining Typefaces* (Five Simple Steps, 2013)
+The "concord / contrast / conflict" framework. Concord (same family) is always safe — hence the Inter+Inter and IBM Plex Sans+IBM Plex Sans pairs. Contrast is rewarding when done with intent (Playfair + Lora). Conflict is what users should avoid; the wizard's curated list rules out conflict pairs.
+
+### 3. Erik Spiekermann — *Stop Stealing Sheep & Find Out How Type Works* (Adobe Press, 2013, 3rd ed.)
+Argues that body type carries 95% of the visual weight in a document. The wizard prioritizes body font choice over heading font choice in the recommendation framing.
+
+### 4. Google Fonts — *Pairings* and *Featured Pairs* (fonts.google.com)
+The 12 fonts in `SAFE_FONTS` are pulled from Google Fonts' own curated catalog, biased toward families with multiple weights and broad language coverage. All available under the SIL Open Font License — no licensing concerns.
+
+### 5. IBM Design Language — *Plex Family Documentation* (ibm.com/design/language/typography/type-basics)
+Documents the "designed as a system" pattern: Plex Sans, Serif, Mono share metrics and x-height, so any combination renders coherently. We surface Plex Sans for users who want IBM-style technical documents.
+
+### 6. Adobe Fonts — *Source Sans, Source Serif, Source Code* (fonts.adobe.com/foundries/adobe-originals)
+Same "designed as a system" idea: Source family was created by Adobe to be a coherent triple. We surface Source Sans 3 and Source Serif 4 (the current versions, with extended Cyrillic and Vietnamese coverage).
+
+### 7. Marcin Wichary — *The Hardest Working Font in Manhattan* (figma.com/blog, 2023)
+A case study on choosing Inter for the Figma marketing site. Reinforces Inter as a reasonable default for technical-yet-broad audiences.
+
+## What about display fonts, script fonts, decorative fonts?
+
+Excluded from the wizard's options. Decorative fonts work for the first 200 words and exhaust the reader thereafter — they're a marketing-page choice, not a document choice. If the user wants a decorative heading, they can set `typography.heading_font` to any Google Font name manually after onboarding (the field accepts any string).
+
+## What about variable fonts?
+
+Inter, Roboto, Source Sans 3, Source Serif 4, IBM Plex Sans, and JetBrains Mono are all available as variable fonts on Google Fonts. The converters use the `wght@400;600` slice by default — sufficient for body + bold heading — to keep CDN payload small. Users who want a wider weight range can override the Google Fonts URL directly in the generated HTML.
+
+## Type scale
+
+`typography.scale_ratio` (default 1.25 = major third) drives a modular scale: body = 1rem, h6 = 1rem × 1.25, h5 = 1rem × 1.25², etc. Defaults:
+
+| Ratio | Name | Effect |
+|---|---|---|
+| 1.125 | Major second | Tight; good for dense reference docs |
+| 1.2 | Minor third | Standard for technical writing |
+| **1.25** | **Major third** | Default; balanced for long-form reading |
+| 1.333 | Perfect fourth | Editorial; pronounced hierarchy |
+| 1.5 | Perfect fifth | Magazine-style with bold headings |
+
+Each converter applies the scale based on this single ratio — no per-level overrides.
+
+## Applied to markdown-html
+
+The converters emit a `<link>` to Google Fonts at document head and apply the typography choice via CSS:
+
+```css
+:root {
+  --md-font-heading: 'Source Serif 4', Georgia, serif;
+  --md-font-body: 'Source Sans 3', system-ui, sans-serif;
+  --md-scale: 1.25;
+}
+body { font-family: var(--md-font-body); }
+h1, h2, h3, h4, h5, h6 { font-family: var(--md-font-heading); }
+```
+
+The system fallback in each `font-family` declaration means the document still reads well if Google Fonts is blocked.

--- a/markdown-html/skills/design-system/references/wcag_accessibility.md
+++ b/markdown-html/skills/design-system/references/wcag_accessibility.md
@@ -1,0 +1,57 @@
+# WCAG Accessibility Floor
+
+**Why this exists:** Every converter renders text on backgrounds, links on backgrounds, and accent UI on backgrounds. WCAG 2.2 sets minimum contrast ratios that, if violated, make the document unreadable for users with low vision. This skill enforces those ratios as hard refusals during onboarding — not as warnings — because no user expects an onboarding wizard to ship them an inaccessible default.
+
+## The floor
+
+WCAG 2.2 AA Level (Section 1.4.3):
+
+| Foreground / Background | Minimum contrast |
+|---|---|
+| Body text (< 18pt regular or < 14pt bold) | **4.5 : 1** |
+| Large text (≥ 18pt regular or ≥ 14pt bold) | 3 : 1 |
+| Non-text UI (focus rings, button borders, icons) | 3 : 1 |
+| Links (treated as body text) | **4.5 : 1** |
+
+`brand_palette_validator.py` enforces all four during onboarding. Failures on body-text or link contrast → refuse (exit code 4). Failures on non-text UI → warn but proceed (the user might be using accent for a backdrop that doesn't carry semantic meaning).
+
+## Sources
+
+### 1. WCAG 2.2 — *Understanding Success Criterion 1.4.3: Contrast (Minimum)* (w3.org/WAI/WCAG22)
+The text and the formula. We implement `relative_luminance()` per the spec's sRGB-linearization rule and `contrast_ratio()` per `(L1 + 0.05) / (L2 + 0.05)`. No deviation.
+
+### 2. WCAG 2.2 — *Understanding Success Criterion 1.4.11: Non-text Contrast* (w3.org/WAI/WCAG22)
+Establishes the 3:1 floor for UI components. Used for `wcag-accent-on-bg` check.
+
+### 3. WCAG 2.2 — *Understanding Success Criterion 1.4.4: Resize Text* (w3.org/WAI/WCAG22)
+Mandates that text can be resized to 200% without loss of content. The converters use `rem` units for type scale (driven by `typography.scale_ratio`) so browser zoom respects user preference.
+
+### 4. WebAIM — *Contrast Checker* (webaim.org/resources/contrastchecker)
+The de-facto reference implementation. Cross-checked against our `contrast_ratio()` — identical results to 2 decimal places.
+
+### 5. Sara Soueidan — *Color Tokens for Accessible Color Systems* (sarasoueidan.com, 2022)
+Articulates the iterative-contrast-walk strategy: when a brand color fails on the link role, lighten or darken until it passes, then snap. The `_ensure_link_contrast()` helper is the direct implementation.
+
+### 6. Léonie Watson — *Accessibility is a Process* (talks across 2018-2024)
+Reinforces that contrast is the lowest-cost-highest-impact accessibility win. Most other a11y improvements take design effort; contrast can be enforced algorithmically.
+
+### 7. CSS `prefers-color-scheme` (MDN)
+The browser primitive for dark/light mode detection. `code_theme: "auto"` in the design-system config maps to a CSS media query, so syntax-highlighting follows OS preference automatically without forcing a re-onboard.
+
+## What this skill does NOT enforce
+
+- **WCAG 2.2 AAA (7:1)** — out of scope. AA is the realistic floor for design systems shipping to broad audiences; AAA is reserved for medical/legal/government content.
+- **Focus order, ARIA, keyboard nav** — out of scope here (the converters handle these in their own renderers). md-review enforces `aria-label` on severity badges, md-slides enforces keyboard nav per WCAG 2.1.1, md-document enforces `aria-current="location"` on TOC scrollspy.
+- **Reduced motion** — out of scope here. Converters emit `@media (prefers-reduced-motion: reduce) { * { animation: none; } }` independently.
+- **Screen-reader semantic correctness** — out of scope. Beyond ensuring `<h1>...<h6>` hierarchy is preserved and `<table>` has `<thead>`, deeper SR audit needs a tool like pa11y / axe-core.
+
+## Why hard refusal, not warning
+
+A warning that ships an inaccessible default is the worst outcome of an onboarding wizard. The user trusted the wizard to set them up right. WCAG AA on body text is the one thing we can verify deterministically — so we do.
+
+If the user genuinely wants to override (rare: a brand-mandated low-contrast scheme for a graphic design portfolio, say), they can:
+1. Set `MARKDOWN_HTML_NO_CONFIG=1` and run with built-in defaults
+2. Manually edit `~/.config/markdown-html/design-system.json` (the saved file)
+3. Add a `<style>` override block in the converted HTML directly
+
+These are all explicit, deliberate acts. The wizard's job is to ship an accessible default; the user can break that contract knowingly.

--- a/markdown-html/skills/design-system/scripts/brand_palette_validator.py
+++ b/markdown-html/skills/design-system/scripts/brand_palette_validator.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""brand_palette_validator.py - Validate brand HEX colors + derive 12-token palette.
+
+Stdlib-only. Validates the brand primary + optional accent/bg/text the user supplies
+during onboarding, then derives the full 12-CSS-custom-property palette consumed by
+every markdown-html converter (md-document, md-review, md-slides).
+
+Pipeline:
+  1. Parse + verify each HEX is well-formed
+  2. WCAG 2.2 contrast checks (text-on-bg, accent-on-bg, link-on-bg)
+  3. Derive missing tokens algorithmically (lighten/darken in HSL, hue-shift for accent)
+  4. Emit the 12-token palette as a JSON dict ready to inject into onboard.py config
+
+Forked from marketing/landing/skills/landing/scripts/brand_palette_validator.py
+(WCAG math + HSL color manipulation + derive_palette shape) and adapted: 12 tokens
+instead of 8, document-reading focus (longer reading sessions → tighter contrast
+floors), no "card" semantics, dedicated --md-link / --md-link-hover / --md-success
+/ --md-warn / --md-code-bg tokens for document/review/slides use cases.
+
+NO LLM CALLS. Pure color-math + WCAG formula.
+
+Usage:
+    python brand_palette_validator.py --primary "#0A1628" --accent "#00D4AA" --output json
+    python brand_palette_validator.py --primary "#FF6B35" --output human
+    python brand_palette_validator.py --sample
+"""
+
+from __future__ import annotations
+
+import argparse
+import colorsys
+import json
+import re
+import sys
+from typing import Any
+
+HEX_RE = re.compile(r"^#?([0-9a-fA-F]{6})$")
+
+
+def parse_hex(hex_str: str) -> tuple[int, int, int]:
+    m = HEX_RE.match(hex_str.strip())
+    if not m:
+        raise ValueError(f"Invalid HEX '{hex_str}'. Expected #RRGGBB or RRGGBB (6 hex chars).")
+    h = m.group(1)
+    return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def rgb_to_hex(rgb: tuple[int, int, int]) -> str:
+    return "#{:02X}{:02X}{:02X}".format(*rgb)
+
+
+def relative_luminance(rgb: tuple[int, int, int]) -> float:
+    """Per WCAG 2.2 — sRGB-linearized luminance."""
+    def linearize(channel: int) -> float:
+        c = channel / 255.0
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+    r, g, b = rgb
+    return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+
+
+def contrast_ratio(rgb1: tuple[int, int, int], rgb2: tuple[int, int, int]) -> float:
+    l1 = relative_luminance(rgb1)
+    l2 = relative_luminance(rgb2)
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def lighten_hsl(rgb: tuple[int, int, int], pct: float) -> tuple[int, int, int]:
+    r, g, b = (c / 255.0 for c in rgb)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    l = min(1.0, max(0.0, l + pct))
+    r2, g2, b2 = colorsys.hls_to_rgb(h, l, s)
+    return (int(r2 * 255), int(g2 * 255), int(b2 * 255))
+
+
+def darken_hsl(rgb: tuple[int, int, int], pct: float) -> tuple[int, int, int]:
+    return lighten_hsl(rgb, -pct)
+
+
+def shift_hue(rgb: tuple[int, int, int], degrees: float) -> tuple[int, int, int]:
+    r, g, b = (c / 255.0 for c in rgb)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    h = (h + degrees / 360.0) % 1.0
+    r2, g2, b2 = colorsys.hls_to_rgb(h, l, s)
+    return (int(r2 * 255), int(g2 * 255), int(b2 * 255))
+
+
+def rgba_str(rgb: tuple[int, int, int], alpha: float) -> str:
+    return f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {alpha})"
+
+
+def is_dark(rgb: tuple[int, int, int]) -> bool:
+    return relative_luminance(rgb) < 0.18
+
+
+def _ensure_link_contrast(
+    link: tuple[int, int, int],
+    bg: tuple[int, int, int],
+    target: float = 4.5,
+) -> tuple[int, int, int]:
+    """Iteratively adjust link luminance toward the target contrast on bg.
+
+    Documents have long reading sessions and lots of links — the WCAG AA
+    4.5:1 floor matters. Walk the luminance up or down (depending on which
+    direction increases contrast) until we hit the target or saturate.
+    """
+    bg_lum = relative_luminance(bg)
+    # If bg is dark we lighten the link; if bg is light we darken it.
+    step = 0.04 if bg_lum < 0.5 else -0.04
+    result = link
+    for _ in range(20):
+        if contrast_ratio(result, bg) >= target:
+            return result
+        nxt = lighten_hsl(result, step)
+        if nxt == result:
+            break
+        result = nxt
+    return result
+
+
+def derive_palette(
+    primary: tuple[int, int, int],
+    accent: tuple[int, int, int] | None = None,
+    bg: tuple[int, int, int] | None = None,
+    text: tuple[int, int, int] | None = None,
+) -> dict[str, str]:
+    """Derive the 12-token --md-* palette from a partial input.
+
+    Interpretation rule: `primary` is the user's *brand-identity* color
+    (CTA / accent / link emphasis), not necessarily the background. Three
+    branches based on primary luminance:
+
+    1. **Dark primary** (luminance < 0.18, e.g. navy #0A1628): assume the
+       user wants a dark-themed document — bg = primary, text = off-white,
+       accent = a hue-shifted lighter derivative.
+    2. **Light/vibrant primary** (luminance ≥ 0.18, e.g. orange #FF6B35):
+       use a near-neutral document bg (#FAFAFA with a hint of primary hue
+       for warmth), text = near-black, accent = primary itself.
+    3. **Explicit overrides** (bg, text supplied by user) win unconditionally.
+
+    Link contrast on bg is then iteratively enforced to WCAG AA 4.5:1 by
+    walking link luminance toward the target. Documents have long reading
+    sessions and lots of links — the floor matters.
+    """
+    # Resolve bg first (it anchors every other contrast decision)
+    if bg is None:
+        if is_dark(primary):
+            bg = primary
+        else:
+            # Near-neutral light document bg with a faint warmth from primary's hue
+            r, g, b = (c / 255.0 for c in primary)
+            h, _, _ = colorsys.rgb_to_hls(r, g, b)
+            r2, g2, b2 = colorsys.hls_to_rgb(h, 0.97, 0.04)
+            bg = (int(r2 * 255), int(g2 * 255), int(b2 * 255))
+
+    if text is None:
+        text = (247, 247, 242) if is_dark(bg) else (16, 24, 32)
+
+    if accent is None:
+        if is_dark(primary):
+            accent = lighten_hsl(shift_hue(primary, 160), 0.45)
+        else:
+            accent = primary
+
+    surface = lighten_hsl(bg, 0.06 if is_dark(bg) else -0.03)
+    border = lighten_hsl(bg, 0.12 if is_dark(bg) else -0.08)
+    text_muted = rgba_str(text, 0.68)
+    accent_soft = rgba_str(accent, 0.14)
+    code_bg = lighten_hsl(bg, 0.04 if is_dark(bg) else -0.04)
+
+    link = _ensure_link_contrast(accent, bg, target=4.5)
+    link_hover = lighten_hsl(link, 0.08 if is_dark(bg) else -0.06)
+    # Success/warn derived from fixed hue anchors (green-ish / amber-ish), then
+    # luminance-matched to bg so they remain readable as inline labels.
+    green = (16, 168, 92)
+    amber = (200, 124, 16)
+    success = green if is_dark(bg) else darken_hsl(green, 0.08)
+    warn = amber if is_dark(bg) else darken_hsl(amber, 0.04)
+
+    return {
+        "--md-bg":          rgb_to_hex(bg),
+        "--md-surface":     rgb_to_hex(surface),
+        "--md-border":      rgb_to_hex(border),
+        "--md-text":        rgb_to_hex(text),
+        "--md-text-muted":  text_muted,
+        "--md-accent":      rgb_to_hex(accent),
+        "--md-accent-soft": accent_soft,
+        "--md-code-bg":     rgb_to_hex(code_bg),
+        "--md-link":        rgb_to_hex(link),
+        "--md-link-hover":  rgb_to_hex(link_hover),
+        "--md-success":     rgb_to_hex(success),
+        "--md-warn":        rgb_to_hex(warn),
+    }
+
+
+def validate(
+    primary: str,
+    accent: str | None = None,
+    bg: str | None = None,
+    text: str | None = None,
+) -> dict[str, Any]:
+    findings: list[dict[str, str]] = []
+
+    def add(rule: str, level: str, message: str) -> None:
+        findings.append({"rule": rule, "level": level, "message": message})
+
+    try:
+        primary_rgb = parse_hex(primary)
+        add("primary-hex", "PASS", f"Primary parsed: {primary} = RGB{primary_rgb}")
+    except ValueError as e:
+        add("primary-hex", "FAIL", str(e))
+        return finalize(findings, {})
+
+    accent_rgb: tuple[int, int, int] | None = None
+    if accent:
+        try:
+            accent_rgb = parse_hex(accent)
+            add("accent-hex", "PASS", f"Accent parsed: {accent} = RGB{accent_rgb}")
+        except ValueError as e:
+            add("accent-hex", "FAIL", str(e))
+            return finalize(findings, {})
+
+    bg_rgb: tuple[int, int, int] | None = None
+    if bg:
+        try:
+            bg_rgb = parse_hex(bg)
+            add("bg-hex", "PASS", f"Bg parsed: {bg} = RGB{bg_rgb}")
+        except ValueError as e:
+            add("bg-hex", "FAIL", str(e))
+            return finalize(findings, {})
+
+    text_rgb: tuple[int, int, int] | None = None
+    if text:
+        try:
+            text_rgb = parse_hex(text)
+            add("text-hex", "PASS", f"Text parsed: {text} = RGB{text_rgb}")
+        except ValueError as e:
+            add("text-hex", "FAIL", str(e))
+            return finalize(findings, {})
+
+    palette = derive_palette(primary_rgb, accent_rgb, bg_rgb, text_rgb)
+
+    bg_final = parse_hex(palette["--md-bg"])
+    text_final = parse_hex(palette["--md-text"])
+    accent_final = parse_hex(palette["--md-accent"])
+    link_final = parse_hex(palette["--md-link"])
+
+    text_on_bg = contrast_ratio(text_final, bg_final)
+    accent_on_bg = contrast_ratio(accent_final, bg_final)
+    link_on_bg = contrast_ratio(link_final, bg_final)
+
+    add(
+        "wcag-text-on-bg",
+        "PASS" if text_on_bg >= 4.5 else ("WARN" if text_on_bg >= 3.0 else "FAIL"),
+        f"Body text on bg contrast: {text_on_bg:.2f}:1 (need 4.5:1 for body, WCAG AA)",
+    )
+    add(
+        "wcag-accent-on-bg",
+        "PASS" if accent_on_bg >= 3.0 else "WARN",
+        f"Accent (UI/CTA) on bg contrast: {accent_on_bg:.2f}:1 (need 3:1 for non-text UI)",
+    )
+    add(
+        "wcag-link-on-bg",
+        "PASS" if link_on_bg >= 4.5 else ("WARN" if link_on_bg >= 3.0 else "FAIL"),
+        f"Link on bg contrast: {link_on_bg:.2f}:1 (need 4.5:1, links are body-text-equivalent)",
+    )
+
+    return finalize(findings, palette)
+
+
+def finalize(findings: list[dict[str, str]], palette: dict[str, str]) -> dict[str, Any]:
+    counts = {"PASS": 0, "WARN": 0, "FAIL": 0}
+    for f in findings:
+        counts[f["level"]] = counts.get(f["level"], 0) + 1
+    if counts["FAIL"] > 0:
+        verdict = "FAIL"
+    elif counts["WARN"] > 0:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+    return {"verdict": verdict, "counts": counts, "findings": findings, "derived_palette": palette}
+
+
+def render_human(result: dict[str, Any]) -> str:
+    out: list[str] = []
+    out.append(f"Brand palette validation verdict: {result['verdict']}")
+    c = result["counts"]
+    out.append(f"  PASS: {c['PASS']}  WARN: {c['WARN']}  FAIL: {c['FAIL']}")
+    out.append("")
+    out.append("Findings:")
+    for f in result["findings"]:
+        marker = {"PASS": "[ok]", "WARN": "[warn]", "FAIL": "[FAIL]"}[f["level"]]
+        out.append(f"  {marker} {f['rule']}: {f['message']}")
+    if result["derived_palette"]:
+        out.append("")
+        out.append("Derived 12-token palette (use in :root CSS):")
+        for k, v in result["derived_palette"].items():
+            out.append(f"  {k:<20s} {v}")
+    return "\n".join(out)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--primary", help="Primary HEX color (e.g., #0A1628)")
+    parser.add_argument("--accent", help="Accent HEX color (optional; derived if missing)")
+    parser.add_argument("--bg", help="Background HEX color (optional; derived if missing)")
+    parser.add_argument("--text", help="Text HEX color (optional; derived if missing)")
+    parser.add_argument("--sample", action="store_true", help="Validate built-in sample palette")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        result = validate("#0A1628", "#00D4AA")
+    elif args.primary:
+        result = validate(args.primary, args.accent, args.bg, args.text)
+    else:
+        parser.print_help()
+        return 0
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0 if result["verdict"] != "FAIL" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/markdown-html/skills/design-system/scripts/config_loader.py
+++ b/markdown-html/skills/design-system/scripts/config_loader.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""config_loader.py - Customization loader for the markdown-html design-system skill.
+
+Stdlib-only. Importable from every converter sub-skill (md-document, md-review,
+md-slides) via `sys.path.insert(0, .../design-system/scripts)` so each renderer
+picks up the user's onboarded brand tokens automatically.
+
+Precedence (highest wins):
+  1. Project config:  <cwd>/.markdown-html/design-system.json
+  2. Global config:   ~/.config/markdown-html/design-system.json
+  3. Built-in DEFAULTS
+
+Set MARKDOWN_HTML_NO_CONFIG=1 to ignore saved config (always returns DEFAULTS).
+
+The onboarding answers (written by onboard.py) live in these files and are read
+here so every converter renders with the user's tokens. Pattern lifted from
+research-ops/skills/clinical-research/scripts/config_loader.py and adapted for
+the markdown-html domain (brand palette + typography + layout + save location).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SKILL = "design-system"
+DOMAIN = "markdown-html"
+
+GLOBAL_CONFIG_DIR = Path.home() / ".config" / DOMAIN
+GLOBAL_CONFIG_PATH = GLOBAL_CONFIG_DIR / f"{SKILL}.json"
+PROJECT_CONFIG_DIRNAME = f".{DOMAIN}"
+
+DEFAULTS: dict[str, Any] = {
+    "version": 1,
+    "skill": SKILL,
+    "default_output_dir": "./markdown-html-out/",
+    "brand": {
+        "primary": "#0A1628",
+        "accent": "#00D4AA",
+        "bg": None,
+        "text": None,
+    },
+    "typography": {
+        "heading_font": "Inter",
+        "body_font": "Inter",
+        "scale_ratio": 1.25,
+    },
+    "design_style": "technical",
+    "code_theme": "auto",
+    "toc": {
+        "behavior": "sticky-sidebar",
+        "max_depth": 3,
+    },
+    "company_name": "",
+    "logo_url": "",
+    "derived_palette": {},
+    "setup_completed_at": None,
+}
+
+
+def project_config_path(cwd: Path | None = None) -> Path:
+    cwd = cwd or Path.cwd()
+    return cwd / PROJECT_CONFIG_DIRNAME / f"{SKILL}.json"
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def load_config(cwd: Path | None = None) -> dict[str, Any]:
+    """Effective config = DEFAULTS <- global <- project. Honors MARKDOWN_HTML_NO_CONFIG."""
+    config = dict(DEFAULTS)
+    if os.environ.get("MARKDOWN_HTML_NO_CONFIG") == "1":
+        return config
+    global_cfg = _read_json(GLOBAL_CONFIG_PATH)
+    if global_cfg:
+        config = _deep_merge(config, global_cfg)
+    project_cfg = _read_json(project_config_path(cwd))
+    if project_cfg:
+        config = _deep_merge(config, project_cfg)
+    return config
+
+
+def setup_completed() -> bool:
+    cfg = _read_json(GLOBAL_CONFIG_PATH) or _read_json(project_config_path())
+    return bool(cfg and cfg.get("setup_completed_at"))
+
+
+def write_config(config: dict[str, Any], scope: str = "global", cwd: Path | None = None) -> Path:
+    if scope == "project":
+        path = project_config_path(cwd)
+    else:
+        path = GLOBAL_CONFIG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2, sort_keys=True)
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=f"Inspect {DOMAIN}/{SKILL} customization config.")
+    p.add_argument("--show", action="store_true", help="Print the effective config")
+    p.add_argument("--status", action="store_true", help="Print setup status + paths")
+    p.add_argument("--sample", action="store_true", help="Print the built-in defaults")
+    args = p.parse_args(argv)
+
+    if args.sample:
+        print(json.dumps(DEFAULTS, indent=2, sort_keys=True))
+    elif args.status:
+        print(json.dumps({
+            "domain": DOMAIN,
+            "skill": SKILL,
+            "global_config_path": str(GLOBAL_CONFIG_PATH),
+            "global_config_exists": GLOBAL_CONFIG_PATH.exists(),
+            "project_config_path": str(project_config_path()),
+            "project_config_exists": project_config_path().exists(),
+            "setup_completed": setup_completed(),
+            "bypass_env_set": os.environ.get("MARKDOWN_HTML_NO_CONFIG") == "1",
+        }, indent=2))
+    else:
+        print(json.dumps(load_config(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/markdown-html/skills/design-system/scripts/onboard.py
+++ b/markdown-html/skills/design-system/scripts/onboard.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""onboard.py - First-run onboarding wizard for the markdown-html design-system.
+
+Stdlib-only. Walks the user through 10 questions ONCE, validates the brand colors
+against WCAG 2.2 AA, derives the 12 CSS custom properties, and writes the result
+to a customization config that every markdown-html converter (md-document,
+md-review, md-slides) reads via config_loader.py.
+
+Modes:
+  --show                   print the questions + current effective config
+  --defaults               write the built-in defaults without prompting
+  --set key=value ...      set specific answers non-interactively (repeatable)
+  --reset                  delete the saved config at the chosen scope
+  --scope {global,project} where to save (default: global = ~/.config/markdown-html)
+
+With no flags and an interactive terminal, walks the questions one at a time.
+Refuses to complete onboarding if:
+  - default_output_dir is empty or unwritable (Q1 hard rule)
+  - the chosen brand colors fail WCAG AA contrast for body text on bg
+
+Pattern lifted from research-ops/skills/clinical-research/scripts/onboard.py
+(QUESTIONS table, _apply, run_interactive, main shape) and adapted for the
+design-system surface (color validation via brand_palette_validator, palette
+derivation persisted into the config alongside the raw user inputs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import brand_palette_validator as bpv  # noqa: E402
+import config_loader as cfg  # noqa: E402
+
+DESIGN_STYLES = ["editorial", "technical", "minimal", "playful"]
+CODE_THEMES = ["light", "dark", "auto"]
+TOC_BEHAVIORS = ["sticky-sidebar", "collapsible-top", "inline", "none"]
+SAFE_FONTS = [
+    "Inter", "Roboto", "Open Sans", "Lato", "Source Sans 3", "IBM Plex Sans",
+    "Merriweather", "Source Serif 4", "Lora", "Playfair Display",
+    "JetBrains Mono", "Fira Code",
+]
+
+# (key, prompt, choices_or_None, caster, hint)
+QUESTIONS = [
+    ("default_output_dir",
+     "1. Where should generated HTML files go? (path; must be writable)",
+     None, str, "e.g., ./markdown-html-out/ or ~/Documents/claude-html/"),
+    ("brand.primary",
+     "2. Brand primary color (HEX)?",
+     None, str, "e.g., #0A1628 (dark navy) or #FF6B35 (orange)"),
+    ("brand.accent",
+     "3. Brand accent color (HEX, optional — leave blank to derive)?",
+     None, str, "e.g., #00D4AA (teal) or leave blank for auto-derive"),
+    ("typography.heading_font",
+     "4. Heading Google Font?",
+     SAFE_FONTS, str, "pick from the list or type your own"),
+    ("typography.body_font",
+     "5. Body Google Font?",
+     SAFE_FONTS, str, "Inter/Roboto/Lato pair well as body fonts"),
+    ("design_style",
+     "6. Design style?",
+     DESIGN_STYLES, str, "editorial = magazine-like; technical = docs-like; minimal = sparse; playful = product-marketing"),
+    ("code_theme",
+     "7. Syntax-highlighting theme?",
+     CODE_THEMES, str, "auto = follows prefers-color-scheme"),
+    ("toc.behavior",
+     "8. Table-of-contents behavior?",
+     TOC_BEHAVIORS, str, "sticky-sidebar = best for long docs; inline = best for slides"),
+    ("company_name",
+     "9. Company / project name (optional, shows in footer)?",
+     None, str, "leave blank to omit"),
+    ("logo_url",
+     "10. Logo URL (optional; base64-embedded at render time)?",
+     None, str, "leave blank to omit; URL or local path both work"),
+]
+
+
+def _apply(config: dict, key: str, value) -> None:
+    """Apply a dotted key path into the nested config dict."""
+    if "." in key:
+        parts = key.split(".")
+        d = config
+        for part in parts[:-1]:
+            d = d.setdefault(part, {})
+        d[parts[-1]] = value
+    else:
+        config[key] = value
+
+
+def _get(config: dict, key: str):
+    if "." in key:
+        parts = key.split(".")
+        d = config
+        for part in parts:
+            if not isinstance(d, dict):
+                return None
+            d = d.get(part)
+        return d
+    return config.get(key)
+
+
+def _derive_and_check_palette(config: dict) -> tuple[bool, str]:
+    """Run brand_palette_validator on the current colors and store the derived palette.
+
+    Returns (ok, message). If WCAG body-text contrast FAILs, ok=False.
+    """
+    primary = _get(config, "brand.primary") or bpv.rgb_to_hex((10, 22, 40))
+    accent = _get(config, "brand.accent") or None
+    bg = _get(config, "brand.bg") or None
+    text = _get(config, "brand.text") or None
+    result = bpv.validate(primary, accent, bg, text)
+    config["derived_palette"] = result["derived_palette"]
+    if result["verdict"] == "FAIL":
+        msgs = [f for f in result["findings"] if f["level"] == "FAIL"]
+        return False, "; ".join(m["message"] for m in msgs)
+    if result["verdict"] == "WARN":
+        msgs = [f for f in result["findings"] if f["level"] == "WARN"]
+        return True, "warnings: " + "; ".join(m["message"] for m in msgs)
+    return True, "WCAG AA contrast met"
+
+
+def _writable(path_str: str) -> bool:
+    if not path_str or not path_str.strip():
+        return False
+    p = Path(path_str).expanduser()
+    parent = p.parent if p.suffix else p
+    # If neither the path nor its parent exists, walk up until we find one
+    while not parent.exists():
+        if parent.parent == parent:
+            return False
+        parent = parent.parent
+    return os.access(parent, os.W_OK)
+
+
+def _print_questions() -> None:
+    print(f"Onboarding questions — markdown-html/{cfg.SKILL}:\n")
+    for key, prompt, choices, _c, hint in QUESTIONS:
+        line = f"  {prompt}"
+        if choices:
+            line += f"\n     choices: {', '.join(choices[:6])}{'...' if len(choices) > 6 else ''}"
+        if hint:
+            line += f"\n     hint: {hint}"
+        print(line)
+        print()
+
+
+def run_interactive(config: dict) -> dict:
+    print(f"Onboarding — markdown-html/{cfg.SKILL}. Press Enter to keep the current/default.\n")
+    for key, prompt, choices, caster, hint in QUESTIONS:
+        current = _get(config, key)
+        suffix = ""
+        if choices:
+            suffix = f" [{ '/'.join(choices[:4]) }{'...' if len(choices) > 4 else ''}]"
+        cur = f" (current: {current})" if current not in (None, "") else ""
+        if hint:
+            print(f"   hint: {hint}")
+        raw = input(f"{prompt}{suffix}{cur}: ").strip()
+        if not raw:
+            continue
+        try:
+            _apply(config, key, caster(raw))
+        except ValueError:
+            print(f"   ! invalid value for {key}, keeping current")
+        print()
+    return config
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Onboarding for the markdown-html design-system skill."
+    )
+    p.add_argument("--show", action="store_true", help="print questions + effective config")
+    p.add_argument("--defaults", action="store_true", help="write built-in defaults, no prompt")
+    p.add_argument("--set", action="append", default=[], metavar="key=value",
+                   help="set an answer non-interactively (repeatable; supports dotted keys like brand.primary=#FF6B35)")
+    p.add_argument("--reset", action="store_true", help="delete saved config at the scope")
+    p.add_argument("--scope", choices=["global", "project"], default="global")
+    args = p.parse_args(argv)
+
+    if args.show:
+        _print_questions()
+        print("Current effective config:")
+        import json
+        print(json.dumps(cfg.load_config(), indent=2, sort_keys=True))
+        return 0
+
+    if args.reset:
+        path = cfg.project_config_path() if args.scope == "project" else cfg.GLOBAL_CONFIG_PATH
+        if path.exists():
+            path.unlink()
+            print(f"removed {path}")
+        else:
+            print(f"no config at {path}")
+        return 0
+
+    config = cfg.load_config()
+
+    if args.set:
+        for item in args.set:
+            if "=" not in item:
+                print(f"error: --set expects key=value, got '{item}'", file=sys.stderr)
+                return 2
+            k, v = item.split("=", 1)
+            # numeric keys
+            if k == "typography.scale_ratio":
+                try:
+                    v = float(v)
+                except ValueError:
+                    pass
+            _apply(config, k, v)
+    elif not args.defaults:
+        if sys.stdin.isatty():
+            config = run_interactive(config)
+        else:
+            print("non-interactive shell: use --defaults or --set key=value. Showing questions:\n")
+            _print_questions()
+            return 0
+
+    # Hard rule 1: refuse if default_output_dir is empty or unwritable
+    out_dir = config.get("default_output_dir") or ""
+    if not _writable(out_dir):
+        print(
+            f"refusing to save: default_output_dir '{out_dir}' is empty or its parent "
+            f"is not writable. Pick a path you control (e.g., ./markdown-html-out/ or "
+            f"~/Documents/claude-html/) and re-run.",
+            file=sys.stderr,
+        )
+        return 3
+
+    # Hard rule 2: refuse if WCAG AA body-text contrast fails on the chosen colors
+    ok, msg = _derive_and_check_palette(config)
+    if not ok:
+        print(
+            f"refusing to save: WCAG AA contrast failed for the chosen colors — {msg}. "
+            f"Pick a darker primary (or a lighter text), or leave brand.bg/brand.text "
+            f"blank to let the validator derive a passing pair.",
+            file=sys.stderr,
+        )
+        return 4
+    if msg.startswith("warnings:"):
+        print(f"note: {msg} — proceeding (warnings, not failures).")
+
+    config["setup_completed_at"] = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    path = cfg.write_config(config, scope=args.scope)
+    print(f"saved markdown-html/{cfg.SKILL} customization -> {path}")
+    print(f"derived 12-token palette stored under derived_palette in the same file.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/markdown-html/skills/markdown-html-orchestrator/SKILL.md
+++ b/markdown-html/skills/markdown-html-orchestrator/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: markdown-html-orchestrator
+description: Use when a user wants to convert any markdown file in their Claude project into a single-file, lightly-interactive HTML — long-form documents (specs, plans, RFCs, reports, explainers), code reviews with diffs and severity-tagged annotations, or slide decks. Triggers on "convert this markdown to HTML", "make this an HTML file", "turn this into an interactive document", "render this report as HTML", "PR writeup as HTML", "slides from this markdown". Forks context to route to one of three converter sub-skills (md-document, md-review, md-slides) based on a deterministic doctype classifier, after the user has run the design-system onboarding once. Refuses if input is under 100 lines (per Shihipar — markdown still wins below the threshold) or design-system isn't onboarded. Distinct from Anthropic's official Playground plugin (which is interactive prompt-tuning controls with sliders/knobs/prompt-copy-back) and from marketing/landing/ (which is a landing-page generator).
+context: fork
+version: 2.10.0
+author: Alireza Rezvani
+license: MIT
+tags: [markdown, html, converter, orchestrator, documentation, code-review, slides, design-system]
+compatible_tools: [claude-code, codex-cli, cursor, antigravity, opencode, gemini-cli]
+---
+
+# Markdown → HTML — Domain Orchestrator
+
+Thariq Shihipar's argument (Claude Code HTML output essay, Medium 2026): **markdown collapses past 100 lines for agent-generated artifacts.** Long specs, code reviews, and architecture explainers lose density, hierarchy, and lightweight interaction the moment they exceed a screen of text. HTML restores all three — single-file, browser-native, shareable.
+
+This orchestrator forks context, classifies the input markdown deterministically, routes to the right converter sub-skill, and returns a digest with the output path. Heavy intake (full markdown bodies, diffs, slide decks) stays in the forked context.
+
+**Foundation status (v2.10.0):** orchestrator + `design-system` (onboarding + shared brand tokens) are live. Converter sub-skills (`md-document`, `md-review`, `md-slides`) land in v2.10.1 follow-up PRs. Until they land, this skill still runs the classifier and the design-system gate, and surfaces the routing recommendation — it just hands the rendering work back to Claude with the structured brief.
+
+## When to invoke
+
+| Symptom | Sub-skill |
+|---|---|
+| "Convert this RFC / spec / report / explainer to HTML" — long-form doc | `md-document` |
+| "Turn this PR writeup / code review into HTML" — markdown with diff blocks | `md-review` |
+| "Make a slide deck from this markdown" — `---` boundaries or H1 cadence | `md-slides` |
+
+## Pre-flight gates (hard refusals)
+
+1. **Below the 100-line threshold.** Markdown wins below 100 lines (Shihipar). The classifier prints `below_min_lines: true` and `route_explainer.py` refuses. Tell the user to keep their input as markdown.
+2. **Design-system not onboarded.** If `~/.config/markdown-html/design-system.json` doesn't exist (or its `setup_completed_at` is null), refuse. Point the user at `python3 markdown-html/skills/design-system/scripts/onboard.py` (or `--defaults` for a zero-touch run).
+3. **Unwritable save location.** `output_path_resolver.py` refuses if the configured `default_output_dir` (or `--out` override) isn't writable.
+
+## Routing logic (deterministic)
+
+Two-signal threshold pattern lifted from `research-ops/skills/research-ops-skills/SKILL.md`. Filename hint = 2 points; each content signal = 1 point. Silent-route allowed when winner ≥ 3 AND (runner-up = 0 OR winner ≥ 2× runner-up). Below threshold → one clarifying question with a recommended answer.
+
+### Signal table
+
+| Signal class | Filename hints | Content signals | Sub-skill |
+|---|---|---|---|
+| DOCUMENT | `report.md`, `*-doc.md`, `spec.md`, `rfc-*.md`, `*-analysis.md`, `*-explainer.md` | `## Table of Contents` (2), `^# `, `^## `, markdown table rows, `> [!NOTE]/[!TIP]/[!IMPORTANT]` callouts | `md-document` |
+| REVIEW | `review.md`, `*-pr-*.md`, `*.diff.md`, `code-review*.md` | ` ```diff ` (2), `^[-+]{3} ` (2), `^@@` (2), `> [!BLOCKER]/[!MAJOR]/[!MINOR]/[!NIT]` (2), `LGTM`/`nit:`/`blocker:` | `md-review` |
+| SLIDES | `deck.md`, `slides.md`, `*-talk.md`, `presentation*.md` | `^---$` ≥ 3 (2 + per-boundary), `<!-- notes:` (2), H1 count ≥ 5 with median gap ≤ 12 lines (2) | `md-slides` |
+
+The pipeline:
+
+```bash
+python3 skills/markdown-html-orchestrator/scripts/doctype_classifier.py \
+    --input <path>.md --output json \
+  | python3 skills/markdown-html-orchestrator/scripts/route_explainer.py
+```
+
+`route_explainer.py` checks the design-system status, applies the < 100-line refusal, and prints one of: `ROUTE_SILENTLY -> md-<type>`, `ASK_USER one question: ...`, or `REFUSE — fix the issues above`.
+
+## Workflow
+
+### Step 1 — Confirm onboarding
+
+If the user has never run onboarding, surface the one-time setup:
+
+```bash
+python3 markdown-html/skills/design-system/scripts/onboard.py
+```
+
+Ten questions, 1-2 minutes. Captures brand primary + accent + heading/body Google Fonts + design style (editorial/technical/minimal/playful) + default output dir + syntax theme + TOC behavior + optional logo/company. Stored at `~/.config/markdown-html/design-system.json`. Re-runnable with `--scope project` for per-repo overrides.
+
+### Step 2 — Classify the input
+
+Run `doctype_classifier.py` on the markdown. Inspect the verdict.
+
+### Step 3 — Route or ask
+
+Pipe the classification into `route_explainer.py`. If it says `ROUTE_SILENTLY`, forward the original markdown + the design-system config into the named sub-skill's renderer in the forked context. If it says `ASK_USER`, ask ONE question with the recommended answer.
+
+### Step 4 — Resolve the output path
+
+```bash
+python3 skills/markdown-html-orchestrator/scripts/output_path_resolver.py \
+    --input <path>.md --doctype <document|review|slides>
+```
+
+Collision handling defaults to `-2 / -3 / ...` suffix; `--on-collision timestamp` for stamped names.
+
+### Step 5 — Hand off to the sub-skill (when shipped)
+
+In v2.10.1+, the converter sub-skill's renderer takes the input markdown, the design-system config, and the resolved output path, and writes a single self-contained HTML file. The orchestrator returns a ≤ 100-word digest: input lines, output path, design style applied, top 3 features used (TOC, search, code-copy, etc.), and one forcing question for the user.
+
+Until v2.10.1, the orchestrator's job stops at step 4 — it returns the classification + routing brief and lets Claude do the rendering inline with the design-system tokens.
+
+## Forcing-question library (Matt Pocock grill-with-docs pattern)
+
+Walk these one at a time, with a recommended answer per question, citing the canon. Lift this list into `/cs:grill-markdown-html` for plan-stage interrogation.
+
+1. **What decision does this HTML drive — is the reader skimming, deciding, or presenting?**
+   Recommended: name it first; density follows from purpose. Canon: Shihipar — "match output format to consumption context"; Tufte — *Visual Display of Quantitative Information*, ch. 1.
+2. **Is the input markdown ≥ 100 lines?**
+   Recommended: yes — below that, keep it as markdown. Canon: Shihipar — markdown still wins under 100 lines.
+3. **Is the design-system onboarded?**
+   Recommended: yes, globally (`~/.config/markdown-html/design-system.json`). Canon: research-ops onboarding pattern (`research-ops/CLAUDE.md` §8); WCAG 2.2 §1.4.3 (text contrast 4.5:1).
+4. **Where does the output save, and will it overwrite anything?**
+   Recommended: the configured `default_output_dir` with `--on-collision suffix`. Canon: Matt Pocock `handoff` skill — never silently overwrite a working artifact.
+5. **Document type confidence — silent-route or one question?**
+   Recommended: silent-route only when the classifier's verdict is one of `document/review/slides` AND `silent_route_allowed: true`. Otherwise ask. Canon: research-ops two-signal threshold (`research-ops/skills/research-ops-skills/SKILL.md` §"Routing logic").
+
+Never run a sub-skill before the lane is locked.
+
+## Assumptions
+
+1. User has a markdown file ≥ 100 lines they want to convert.
+2. User has run onboarding once (`~/.config/markdown-html/design-system.json` exists with `setup_completed_at` populated).
+3. Single-file HTML output is acceptable (no multi-file site, no embedded server, no build step).
+4. Externals limited to Google Fonts CSS + Prism.js CDN (jsdelivr / cdnjs).
+
+## Non-goals
+
+- Not a landing-page generator (use `marketing/landing/`).
+- Not an interactive prompt-tuning playground (use Anthropic's official `playground` plugin).
+- Not a static-site generator (no multi-file output, no site index).
+- Not a PDF generator (slides use `@media print`; user prints from browser).
+- Not a watch / live-reload pipeline (conversion is one-shot).
+
+## Distinct from
+
+- **Anthropic Playground plugin** (`/playground`) — builds interactive controls (sliders, knobs, drag-drop) for prompt tuning, with a copy-prompt-back loop. This plugin converts existing markdown documents to HTML. Different tools for different jobs.
+- **`marketing/landing/`** — generates landing pages from scratch (Phase-0 intake → 3 sections → branded TSX/HTML). This plugin converts an existing markdown file you already have.
+- **`engineering/handoff/` + `productivity/handoff/`** — preserve session continuity between Claude conversations. Different artifact type (handoff brief vs. document conversion).
+
+## Output artifacts
+
+| Sub-skill | Artifact | Status |
+|---|---|---|
+| `md-document` | `doc-<slug>.html` (single file, sticky TOC, collapsibles, search, code-copy, scrollspy) | v2.10.1 |
+| `md-review` | `review-<slug>.html` (2-col diff + severity margin notes + jump-nav) | v2.10.1 |
+| `md-slides` | `deck-<slug>.html` (arrow-key nav + presenter mode + print-to-PDF) | v2.10.1 |
+
+## Anti-patterns (do not)
+
+- ❌ Convert markdown < 100 lines — markdown still wins. Refuse and tell the user.
+- ❌ Run the orchestrator before the design-system is onboarded. The output looks broken without tokens.
+- ❌ Silently chain two sub-skills (e.g., "convert doc AND make slides from it"). Pick one, finish, ask before chaining.
+- ❌ Use external JS frameworks (React/Vue/Svelte). Vanilla JS + IntersectionObserver only. Prism.js CDN is the single exception.
+- ❌ Multi-file output (extracted CSS, asset directories). Single file or nothing — that's the whole point.
+- ❌ Overwrite an existing output file by default. The path resolver suffixes `-2`, `-3`, …; `--on-collision overwrite` is opt-in only.
+
+## References
+
+- Spec: Thariq Shihipar — "Claude Code HTML output" (Medium, 2026)
+- Forking pattern: `research-ops/skills/research-ops-skills/SKILL.md` (`context: fork`, two-signal routing)
+- Customization pattern: `research-ops/skills/clinical-research/scripts/` (`onboard.py`, `config_loader.py`)
+- Brand palette math: `marketing/landing/skills/landing/scripts/brand_palette_validator.py` (WCAG + HSL derive)
+- Information-density canon: Tufte; Shihipar's `thariqs.github.io/html-effectiveness/` gallery; Wattenberger interactive essays; Maggie Appleton digital gardens

--- a/markdown-html/skills/markdown-html-orchestrator/references/information_density_canon.md
+++ b/markdown-html/skills/markdown-html-orchestrator/references/information_density_canon.md
@@ -1,0 +1,46 @@
+# Information Density Canon
+
+**Why this exists:** Thariq Shihipar's central claim is empirical: markdown collapses past ~100 lines because it lacks the visual machinery to manage density. This document anchors that claim in a longer tradition — from Edward Tufte's *Visual Display* to Maggie Appleton's digital gardens — so the orchestrator can defend the 100-line threshold against pushback ("why not 50?", "why not 200?") with cited evidence rather than vibes.
+
+## Core claim
+
+A reader skimming linear markdown loses orientation after roughly 5-7 screens. HTML restores orientation through:
+1. **Hierarchy made visible** — typography scale, color, weight, indent, surface
+2. **Lateral navigation** — TOC, scrollspy, anchored sections
+3. **Lateral structure** — tables, grids, side-by-side comparisons
+4. **Lateral interaction** — collapsibles, search, code-copy, hover state
+
+Markdown collapses each of these into the same channel: indented text. HTML opens each into its own channel.
+
+## Sources
+
+### 1. Thariq Shihipar — "Claude Code HTML output" (Medium, 2026)
+The spec for this plugin. Key claims used here:
+- Threshold ≈ 100 lines: "I stopped reading markdown files past 100 lines. My threshold was about the same. Yours probably is too."
+- Three forces converged: agent outputs got longer, editing relationship changed (LLM edits, not human), information became spatial.
+- Five advantages: density, clarity, shareability, two-way interaction, context ingestion.
+- Examples gallery: `thariqs.github.io/html-effectiveness/` (20 self-contained HTML files across 9 categories).
+
+### 2. Edward Tufte — *The Visual Display of Quantitative Information* (Graphics Press, 1983/2001)
+Foundational text on data-ink ratio and small multiples. Specifically:
+- Ch. 1, "Graphical Excellence" — graphics should reveal the data; markdown's linear structure conceals comparison.
+- Ch. 4, "Data-Ink and Graphical Redesign" — every visual element should earn its place. HTML's collapsibles and tabs are data-ink positive (they reveal more per pixel than the same content laid out linearly).
+
+### 3. Bret Victor — "Up and Down the Ladder of Abstraction" (2011, worrydream.com)
+Argues that interactive controls let a reader move fluidly between concrete examples and abstract rules. The "lightweight interactivity" tier of this plugin (search, collapsibles, hover tooltips) is the documents-equivalent: it lets a reader move between TOC abstraction and section detail without losing place.
+
+### 4. Maggie Appleton — *A Brief History & Ethos of the Digital Garden* (2020, maggieappleton.com)
+Establishes the "garden" pattern: persistent, interlinked, editable knowledge artifacts rendered as HTML. Reinforces single-file HTML as the right artifact shape for long-form thinking (vs. blog posts as linear sequences). Many of her gardens use the exact patterns this plugin generates: sticky TOC, collapsibles, callouts.
+
+### 5. Amelia Wattenberger — "Why React isn't great for actually building websites" + interactive essay archive (wattenberger.com)
+Demonstrates lightweight interactivity in essays without frameworks — IntersectionObserver, vanilla scroll handling, inline SVG. The exact technical patterns md-document will use.
+
+### 6. Bartosz Ciechanowski — *Internal Combustion Engine* and other essays (ciechanow.ski)
+The high-water mark of single-page interactive explainers. Each essay is a single HTML file with inline SVG animation and controls. Validates the single-file-HTML-as-artifact thesis at the upper bound.
+
+### 7. GitHub READMEs-as-landing-pages (2021-present)
+Empirically, READMEs that exceed ~200 lines either (a) get split into a `docs/` folder or (b) get an HTML-rendered version (e.g., GitBook, Docusaurus, mdBook). The market has already voted on the 100-200-line threshold.
+
+## Practical takeaway for the orchestrator
+
+When `doctype_classifier.below_min_lines` is true, refuse the conversion and quote Shihipar. The threshold is empirically defended and stylistically consistent with the wider canon of information-design discipline.

--- a/markdown-html/skills/markdown-html-orchestrator/references/orchestrator_routing_patterns.md
+++ b/markdown-html/skills/markdown-html-orchestrator/references/orchestrator_routing_patterns.md
@@ -1,0 +1,56 @@
+# Orchestrator Routing Patterns
+
+**Why this exists:** The two-signal routing discipline (silent-route only above a confidence threshold; otherwise ask one question with a recommended answer) is not original to this plugin. It's been established in the research-ops, commercial, and business-operations domains. This document records the canon so the orchestrator never silently chains or guesses below threshold.
+
+## The pattern
+
+Three discrete behaviors based on the classifier's score:
+
+1. **Silent route** — winner ≥ 3 points AND (runner-up = 0 OR winner ≥ 2× runner-up). Hand off to the sub-skill without asking.
+2. **Clarify** — winner ≥ 2 points but ratio against runner-up is too close. Ask ONE question, recommend the winner, take the user's confirmation or override.
+3. **Ambiguous** — no signals matched. Ask which lane, default to md-document if the user shrugs.
+
+Filename hint counts double (2 points each) because filename is high-signal user intent — a file named `pr-review.md` is almost certainly a code review.
+
+## Sources
+
+### 1. research-ops/skills/research-ops-skills/SKILL.md §"Routing logic (deterministic)"
+The two-signal threshold pattern formalized: "Same two-signal threshold pattern as `commercial-skills`. Single-signal → clarifying question. Mixed signals → highest-confidence first, chain second in a follow-up turn. Never silently chain."
+
+### 2. commercial/skills/commercial-skills/SKILL.md
+First domain to ship the explicit "never silently chain" rule, with named signal classes (PRICING / DEAL / PARTNERSHIPS / RFP / FORECAST). The discipline is independent of subject matter — same shape for research, for commercial deals, for markdown docs.
+
+### 3. business-operations/skills/business-operations-skills/SKILL.md
+The "explore the workspace first" pattern: filenames like `vendor-list.csv` or `sla-tracker.xlsx` resolve the lane without asking. Filename hint = 2 points is calibrated here.
+
+### 4. Matt Pocock — *grill-with-docs* (engineering/grill-with-docs/SKILL.md, MIT)
+Five rules formalized:
+1. One question per turn — never bundle.
+2. Always recommend an answer with citation-backed rationale.
+3. Explore before asking.
+4. Walk the decision tree depth-first.
+5. Track dependencies (don't ask Q3 before Q1's answer determines whether Q3 applies).
+
+### 5. Anthropic — `context: fork` (SKILL.md frontmatter)
+The mechanism that makes orchestrator routing efficient: forked sub-skills run in isolated context, so the parent thread doesn't bloat with the full markdown body, the diff hunks, or the slide bodies. Documented in research-ops, commercial, and business-operations orchestrators.
+
+### 6. The "never silently chain" hard rule
+Originates from research-ops Sprint 1 design (`documentation/implementation/research-ops-expansion-plan.md`). The rule prevents the worst orchestrator failure mode: routing to two sub-skills in sequence without explicit user acknowledgment of the chain. Markdown-html applies it: "convert this markdown to HTML and also make slides from it" is two operations, asked explicitly.
+
+### 7. NN/g — *Defaults Are the Best Friend of UX* (Jakob Nielsen, 2007)
+Recommended answers in clarifying questions reduce decision fatigue. The orchestrator never asks an open question — every clarification ships with "Recommended: <answer>, because <rationale>" so the user can just say "yes."
+
+## Applied to markdown-html
+
+The classifier produces a `total_scores` dict. The orchestrator's decision tree:
+
+```
+if below_min_lines:                          → REFUSE (Shihipar 100-line rule)
+elif not setup_completed_at:                 → REFUSE (point at onboarding)
+elif winner_score == 0:                      → ASK_USER (lane + recommend md-document)
+elif silent_route_allowed:                   → ROUTE_SILENTLY to md-<winner>
+elif winner_score >= 2:                      → ASK_USER (recommend md-<winner>)
+else:                                        → ASK_USER (treat as md-document by default)
+```
+
+Never two routes in one turn. Never "I'll just do both."

--- a/markdown-html/skills/markdown-html-orchestrator/references/single_file_html_discipline.md
+++ b/markdown-html/skills/markdown-html-orchestrator/references/single_file_html_discipline.md
@@ -1,0 +1,85 @@
+# Single-File HTML Discipline
+
+**Why this exists:** Multi-file HTML output (separate CSS, JS, images, asset folders) breaks the central value proposition: shareability. The recipient can't drop the file into Slack, attach it to an email, or upload it to a static host with one drag. This document codifies the single-file constraint and names the few permitted exceptions.
+
+## The constraint
+
+Every converter (md-document, md-review, md-slides) MUST produce one `.html` file containing all CSS and all JavaScript inline. The only externals permitted are:
+
+1. **Google Fonts CSS** — pulled from `fonts.googleapis.com` via `<link rel="stylesheet">`. Falls back to system stack if blocked.
+2. **Prism.js** — pulled from `cdn.jsdelivr.net` or `cdnjs.cloudflare.com` for syntax highlighting. Falls back to plain `<pre>` if blocked.
+
+No other CDN. No build step. No bundler. No framework runtime.
+
+## Why
+
+### Shareability
+A single .html file uploads to S3, Vercel, Netlify, or any static host in one operation. It also opens in a recipient's browser without a server, which means it works in:
+- Slack DM previews
+- Email attachments (Gmail / Outlook web)
+- Local `file://` URLs
+- GitHub `raw.githubusercontent.com` links
+- USB sticks given to a non-technical reviewer
+
+Multi-file output breaks every one of those flows. The marketing/landing/ skill made the same choice for the same reason.
+
+### Portability
+Single-file HTML survives copying, archiving, and email-attachment workflows. It's the closest thing to PDF that the web has, with the advantage of being editable and searchable.
+
+### No build-step regret
+The moment you require a build step, you require: a Node version, a package.json, a node_modules folder, a transpiler, a watcher, a runtime, and a deployment story. None of that survives "send this to a teammate."
+
+## Permitted CDN externals — discipline
+
+```html
+<!-- Google Fonts (CSS only — woff files lazy-loaded by browser) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+<link rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+
+<!-- Prism.js core + theme + autoloader (gracefully degrades without it) -->
+<link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+<script defer
+        src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
+<script defer
+        src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+```
+
+Both fall back gracefully: if the CDN is blocked, fonts default to the system stack and code blocks render as plain `<pre>`. The page is still readable, still searchable, still copy-pasteable.
+
+## Anti-patterns
+
+- ❌ External CSS file (`<link rel="stylesheet" href="./style.css">`) — recipient gets a broken page.
+- ❌ External JS file (`<script src="./app.js">`) — same problem.
+- ❌ External image references for hero/logo (`<img src="./logo.png">`) — base64-embed instead.
+- ❌ React/Vue/Svelte/Alpine runtime — vanilla JS only.
+- ❌ Tailwind via CDN (`cdn.tailwindcss.com`) — 200 KB of unused CSS; just inline what you use.
+- ❌ Web Components requiring a custom-element registry from CDN — same problem.
+
+## Sources
+
+### 1. Thariq Shihipar — "Claude Code HTML output" (Medium, 2026)
+"Every playground is a single HTML file with all CSS and JavaScript inlined. No external dependencies. No build step. Open it in any browser." (Playground plugin section — same discipline applies to converted documents.)
+
+### 2. marketing/landing/skills/landing/SKILL.md §"Single-File HTML Discipline"
+Established the rule for this repo. Marketing landing pages were the first artifact type to require single-file output; this plugin inherits the discipline directly.
+
+### 3. Tom MacWright — "Big" (github.com/tmcw/big, MIT)
+A presentation tool that compiles to a single HTML file. Demonstrates the upper bound of what's possible with the constraint (full slide deck, presenter mode, navigation, in one file).
+
+### 4. Mozilla MDN — *Performance: Reducing HTTP Requests*
+Single-file output minimizes round trips. Even on fast networks, a single 200 KB HTML file beats one HTML + three CSS + five JS + four image requests.
+
+### 5. The Web We Lost — Anil Dash (2012, dashes.com)
+Argues for portable, host-anywhere web artifacts as a counter to platform lock-in. Single-file HTML is the most portable web artifact possible — no platform, no JS framework, no server.
+
+### 6. Prism.js documentation (prismjs.com)
+Lightweight syntax highlighter (~2 KB core + per-language plugins on demand) designed for CDN delivery. The right tradeoff for "single-file with one allowed external."
+
+### 7. Google Fonts API documentation (developers.google.com/fonts/docs/css2)
+The `display=swap` parameter ensures system-font fallback while web fonts load, preventing FOUT/FOIT on slow connections. Required parameter for every Google Fonts link the converters emit.
+
+## Applied to markdown-html
+
+`md-document/scripts/html_renderer.py`, `md-review/scripts/review_html_renderer.py`, and `md-slides/scripts/deck_html_renderer.py` all emit single-file output with exactly the two permitted externals. Anything else is a regression.

--- a/markdown-html/skills/markdown-html-orchestrator/scripts/doctype_classifier.py
+++ b/markdown-html/skills/markdown-html-orchestrator/scripts/doctype_classifier.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""doctype_classifier.py - Deterministic document-type classifier for markdown-html.
+
+Stdlib-only. Reads a markdown file (or stdin), scans for filename + content signals,
+and returns a routing recommendation: document / review / slides / ambiguous.
+
+Routing discipline mirrors research-ops/skills/research-ops-skills/SKILL.md:
+  - Two-signal threshold: silent-route when score >= 3 OR (winner >= 2 AND
+    winner >= 2x runner-up). Below threshold => ambiguous, ask the user.
+  - Filename hint = 2 points; each content signal = 1 point.
+  - Never silently chain. The orchestrator (Claude) decides; this script
+    just produces a structured recommendation it can act on.
+
+Hard rule from the article: documents below MIN_LINES are NOT candidates for
+HTML conversion — markdown still wins. The classifier surfaces a line_count
+field and a below_min_lines boolean so the orchestrator can refuse before
+routing.
+
+NO LLM CALLS. Pure regex + counting.
+
+Usage:
+    python doctype_classifier.py --input report.md --output json
+    python doctype_classifier.py --input - --output human  # stdin
+    python doctype_classifier.py --sample
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+MIN_LINES = 100  # Shihipar's threshold — markdown wins below this
+
+FILENAME_HINTS: dict[str, list[str]] = {
+    "document": [
+        r"\breport\b", r"-doc\b", r"\bspec\b", r"^rfc-", r"-analysis\b",
+        r"\bexplainer\b", r"\bguide\b", r"\bplan\b",
+    ],
+    "review": [
+        r"\breview\b", r"-pr-", r"\.diff(?:\.md)?$", r"code-review",
+        r"\bpr-writeup\b",
+    ],
+    "slides": [
+        r"\bdeck\b", r"\bslides\b", r"-talk\b", r"\bpresentation\b",
+        r"\bkeynote\b",
+    ],
+}
+
+CONTENT_SIGNALS: dict[str, list[tuple[str, str, int]]] = {
+    "document": [
+        # (regex, description, weight)
+        (r"^## Table of Contents", "TOC heading", 2),
+        (r"^# .{3,}$", "H1 with title", 1),
+        (r"^## .{3,}$", "H2 with title", 1),
+        (r"^\| .+\| .+\|$", "markdown table row", 1),
+        (r"^> \[!NOTE\]|^> \[!TIP\]|^> \[!IMPORTANT\]", "GFM callout", 1),
+    ],
+    "review": [
+        (r"^```diff\b", "diff fence", 2),
+        (r"^[-+]{3} ", "unified-diff file header", 2),
+        (r"^@@ .* @@", "unified-diff hunk header", 2),
+        (r"^> \[!BLOCKER\]|^> \[!MAJOR\]|^> \[!MINOR\]|^> \[!NIT\]", "severity callout", 2),
+        (r"\bLGTM\b|\bnit:|\bblocker:|\bmajor:", "review-vocab inline", 1),
+    ],
+    "slides": [
+        (r"^---\s*$", "HR slide boundary", 1),
+        (r"<!--\s*notes:", "presenter notes", 2),
+        (r"^# .{3,}$", "H1 (slide title candidate)", 1),
+    ],
+}
+
+
+def _score_filename(path: Path) -> dict[str, int]:
+    name = path.name.lower()
+    out: dict[str, int] = {"document": 0, "review": 0, "slides": 0}
+    for cls, patterns in FILENAME_HINTS.items():
+        for p in patterns:
+            if re.search(p, name):
+                out[cls] += 2
+                break
+    return out
+
+
+def _score_content(text: str) -> tuple[dict[str, int], dict[str, list[str]]]:
+    scores: dict[str, int] = {"document": 0, "review": 0, "slides": 0}
+    evidence: dict[str, list[str]] = {"document": [], "review": [], "slides": []}
+
+    lines = text.splitlines()
+    for cls, sigs in CONTENT_SIGNALS.items():
+        for pattern, label, weight in sigs:
+            compiled = re.compile(pattern, re.MULTILINE)
+            matches = compiled.findall(text)
+            if matches:
+                hit_count = len(matches)
+                scores[cls] += weight * min(hit_count, 5)  # cap each signal at 5 hits to avoid runaway
+                evidence[cls].append(f"{label} x{hit_count}")
+
+    # slides special-case: HR slide boundary count >= 3 is a stronger signal
+    hr_count = len(re.findall(r"^---\s*$", text, re.MULTILINE))
+    if hr_count >= 3:
+        scores["slides"] += 2
+        evidence["slides"].append(f"hr boundaries >= 3 (count={hr_count})")
+
+    # slides special-case: many H1s with mostly-empty bodies between
+    h1_indices = [i for i, ln in enumerate(lines) if re.match(r"^# .{3,}$", ln)]
+    if len(h1_indices) >= 5:
+        gaps = [h1_indices[i + 1] - h1_indices[i] for i in range(len(h1_indices) - 1)]
+        if gaps and sum(g <= 12 for g in gaps) / len(gaps) >= 0.6:
+            scores["slides"] += 2
+            evidence["slides"].append(
+                f"H1 cadence: {len(h1_indices)} H1s, median gap ~{sorted(gaps)[len(gaps)//2]} lines"
+            )
+
+    return scores, evidence
+
+
+def classify(input_path: Path | None, text: str | None) -> dict[str, Any]:
+    if text is None:
+        if input_path is None:
+            raise ValueError("Need either input_path or text")
+        text = input_path.read_text(encoding="utf-8")
+
+    fn_scores = _score_filename(input_path) if input_path else {"document": 0, "review": 0, "slides": 0}
+    content_scores, evidence = _score_content(text)
+    total = {k: fn_scores[k] + content_scores[k] for k in fn_scores}
+
+    line_count = len(text.splitlines())
+    below_min = line_count < MIN_LINES
+
+    # Ranking
+    ranked = sorted(total.items(), key=lambda kv: kv[1], reverse=True)
+    winner_cls, winner_score = ranked[0]
+    runner_cls, runner_score = ranked[1]
+
+    silent_route = (
+        winner_score >= 3
+        and (runner_score == 0 or winner_score >= 2 * runner_score)
+    )
+
+    if winner_score == 0:
+        verdict = "ambiguous"
+        recommendation = "Ask the user which document type — no signals matched."
+    elif silent_route:
+        verdict = winner_cls
+        recommendation = f"Route to md-{winner_cls} (score {winner_score} vs runner-up {runner_score})."
+    elif winner_score >= 2:
+        verdict = "needs-clarification"
+        recommendation = (
+            f"Top candidate is md-{winner_cls} (score {winner_score}) "
+            f"but md-{runner_cls} also scored {runner_score} — ask user to confirm."
+        )
+    else:
+        verdict = "ambiguous"
+        recommendation = (
+            f"Weak signal ({winner_cls}={winner_score}). "
+            f"Ask user, or treat as md-document by default."
+        )
+
+    return {
+        "verdict": verdict,
+        "winner": winner_cls,
+        "winner_score": winner_score,
+        "runner_up": runner_cls,
+        "runner_up_score": runner_score,
+        "filename_scores": fn_scores,
+        "content_scores": content_scores,
+        "total_scores": total,
+        "evidence": evidence,
+        "line_count": line_count,
+        "below_min_lines": below_min,
+        "min_lines_threshold": MIN_LINES,
+        "recommendation": recommendation,
+        "silent_route_allowed": silent_route,
+    }
+
+
+def render_human(result: dict[str, Any]) -> str:
+    lines = []
+    lines.append(f"Doctype classification: {result['verdict']}")
+    lines.append(f"  recommendation: {result['recommendation']}")
+    lines.append(f"  line count: {result['line_count']} (threshold {result['min_lines_threshold']})")
+    if result["below_min_lines"]:
+        lines.append(
+            f"  ! below threshold — markdown still wins under "
+            f"{result['min_lines_threshold']} lines (Shihipar). Recommend keeping as markdown."
+        )
+    lines.append("")
+    lines.append("Scores:")
+    for cls in ["document", "review", "slides"]:
+        fn = result["filename_scores"][cls]
+        ct = result["content_scores"][cls]
+        total = result["total_scores"][cls]
+        lines.append(f"  md-{cls:<10s} total={total:<3d} (filename={fn}, content={ct})")
+    lines.append("")
+    lines.append("Evidence:")
+    for cls, sigs in result["evidence"].items():
+        if sigs:
+            lines.append(f"  md-{cls}: {', '.join(sigs)}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--input", help="Path to markdown file, or '-' for stdin")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    parser.add_argument("--sample", action="store_true",
+                        help="Classify a built-in sample (a Shihipar-style 200-line spec)")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        sample_text = SAMPLE_MARKDOWN
+        result = classify(None, sample_text)
+    elif args.input:
+        if args.input == "-":
+            text = sys.stdin.read()
+            result = classify(None, text)
+        else:
+            path = Path(args.input)
+            if not path.exists():
+                print(f"error: input not found: {path}", file=sys.stderr)
+                return 2
+            result = classify(path, None)
+    else:
+        parser.print_help()
+        return 0
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_human(result))
+    return 0
+
+
+SAMPLE_MARKDOWN = """# Implementation Plan: Payment Gateway Integration
+
+## Table of Contents
+
+- Goals
+- Architecture
+- Risks
+
+## Goals
+
+We will integrate Stripe Connect with the existing checkout flow.
+
+| Phase | Timeline | Owner |
+|---|---|---|
+| Design | Week 1 | jane |
+| Build | Week 2-3 | dev team |
+| Ship | Week 4 | jane |
+
+## Architecture
+
+The integration will use webhooks for async events.
+
+> [!NOTE]
+> All webhook handlers must be idempotent.
+
+## Risks
+
+1. Webhook delivery delays
+2. Tax calculation edge cases
+3. Refund cascading
+""" + "\n" * 120  # pad to > MIN_LINES
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/markdown-html/skills/markdown-html-orchestrator/scripts/output_path_resolver.py
+++ b/markdown-html/skills/markdown-html-orchestrator/scripts/output_path_resolver.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""output_path_resolver.py - Resolve the final output path for a conversion.
+
+Stdlib-only. Given:
+  - the input markdown filename
+  - an optional --out user override
+  - the design-system config's default_output_dir
+  - a --doctype hint (document/review/slides) for naming convention
+
+Returns the final absolute path the converter should write to. Handles
+collisions by suffixing -2, -3, ... or by inserting an ISO-8601 stamp,
+depending on --on-collision mode. Refuses if the chosen parent isn't
+writable (matches onboard.py's hard rule).
+
+Pattern (kebab slug + collision detection + timestamp fallback) lifted from
+marketing/landing/skills/landing/scripts/kebab_slug_generator.py and
+adapted: doctype prefix in the filename, --out override, design-system
+default_output_dir as the fallback root.
+
+NO LLM CALLS. Pure path math.
+
+Usage:
+    python output_path_resolver.py --input report.md
+    python output_path_resolver.py --input report.md --out ./docs/ --doctype document
+    python output_path_resolver.py --input PR-123.md --doctype review --on-collision timestamp
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Bridge to the design-system config
+_DESIGN_SYSTEM_SCRIPTS = (
+    Path(__file__).resolve().parent.parent.parent / "design-system" / "scripts"
+)
+sys.path.insert(0, str(_DESIGN_SYSTEM_SCRIPTS))
+try:
+    import config_loader as cfg
+except ImportError:
+    cfg = None
+
+DOCTYPE_PREFIXES = {
+    "document": "doc",
+    "review": "review",
+    "slides": "deck",
+}
+
+
+def kebab_slug(name: str) -> str:
+    """Convert a filename or title to a clean kebab-case slug.
+
+    'My Report v2!.md' -> 'my-report-v2'
+    '  Spaces   And   Stuff  ' -> 'spaces-and-stuff'
+    """
+    base = name.rsplit(".", 1)[0] if "." in name else name
+    # Strip non-alphanumerics, collapse to hyphen
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", base).strip("-").lower()
+    return slug or "untitled"
+
+
+def _writable(path: Path) -> bool:
+    p = path.expanduser()
+    parent = p.parent if p.suffix else p
+    while not parent.exists():
+        if parent.parent == parent:
+            return False
+        parent = parent.parent
+    return os.access(parent, os.W_OK)
+
+
+def _resolve_base_dir(out_override: str | None) -> Path:
+    if out_override:
+        return Path(out_override).expanduser()
+    if cfg is not None and not os.environ.get("MARKDOWN_HTML_NO_CONFIG") == "1":
+        config = cfg.load_config()
+        default_dir = config.get("default_output_dir") or "./markdown-html-out/"
+    else:
+        default_dir = "./markdown-html-out/"
+    return Path(default_dir).expanduser()
+
+
+def resolve(
+    input_path: str,
+    out_override: str | None = None,
+    doctype: str | None = None,
+    on_collision: str = "suffix",
+) -> dict[str, Any]:
+    """Resolve the final output path. Returns a structured dict with the path
+    and any collision-handling that happened.
+    """
+    in_p = Path(input_path)
+    slug = kebab_slug(in_p.name)
+    prefix = DOCTYPE_PREFIXES.get(doctype or "", "")
+    filename_base = f"{prefix}-{slug}" if prefix else slug
+
+    base_dir = _resolve_base_dir(out_override)
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    target = base_dir / f"{filename_base}.html"
+
+    collision_info: dict[str, Any] = {"existed": False, "strategy": None}
+    if target.exists():
+        collision_info["existed"] = True
+        if on_collision == "timestamp":
+            stamp = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+            target = base_dir / f"{filename_base}-{stamp}.html"
+            collision_info["strategy"] = "timestamp"
+        elif on_collision == "overwrite":
+            collision_info["strategy"] = "overwrite"
+            # target unchanged
+        else:  # suffix
+            for n in range(2, 1000):
+                candidate = base_dir / f"{filename_base}-{n}.html"
+                if not candidate.exists():
+                    target = candidate
+                    collision_info["strategy"] = f"suffix-{n}"
+                    break
+            else:
+                stamp = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+                target = base_dir / f"{filename_base}-{stamp}.html"
+                collision_info["strategy"] = "timestamp-after-suffix-exhausted"
+
+    return {
+        "input": str(in_p),
+        "slug": slug,
+        "doctype": doctype,
+        "prefix": prefix,
+        "base_dir": str(base_dir),
+        "output_path": str(target),
+        "writable": _writable(target),
+        "collision": collision_info,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--input", help="Input markdown filename or path")
+    parser.add_argument("--out", help="Override the output directory (else uses config default)")
+    parser.add_argument("--doctype", choices=["document", "review", "slides"],
+                        help="Doc type — controls filename prefix (doc-, review-, deck-)")
+    parser.add_argument("--on-collision", choices=["suffix", "timestamp", "overwrite"],
+                        default="suffix")
+    parser.add_argument("--output", choices=["human", "json"], default="human",
+                        dest="output_format")
+    parser.add_argument("--sample", action="store_true",
+                        help="Show a resolved-path example without touching disk semantics")
+    args = parser.parse_args(argv)
+
+    if args.sample:
+        result = resolve("example-report.md", None, "document", "suffix")
+    elif args.input:
+        result = resolve(args.input, args.out, args.doctype, args.on_collision)
+    else:
+        parser.print_help()
+        return 0
+
+    if not result["writable"]:
+        print(
+            f"refusing: target parent '{result['base_dir']}' is not writable. "
+            f"Re-run onboarding or pass --out to a writable dir.",
+            file=sys.stderr,
+        )
+        return 3
+
+    if args.output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"output -> {result['output_path']}")
+        if result["collision"]["existed"]:
+            print(f"  (collision handled: {result['collision']['strategy']})")
+        print(f"  base_dir: {result['base_dir']}")
+        print(f"  slug: {result['slug']}, prefix: {result['prefix']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/markdown-html/skills/markdown-html-orchestrator/scripts/route_explainer.py
+++ b/markdown-html/skills/markdown-html-orchestrator/scripts/route_explainer.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""route_explainer.py - Print the routing decision in a form the LLM can act on.
+
+Stdlib-only. Takes the JSON output of doctype_classifier.py (or runs the
+classifier itself), and prints a short routing brief: which sub-skill to
+invoke, what evidence supports the decision, and what to ask the user if
+the verdict is ambiguous.
+
+This is the "never silently chain" enforcer — it prints the recommendation
+in a structured form that makes it obvious whether the orchestrator should
+route silently, ask one clarifying question, or refuse outright (because
+the input is below the 100-line threshold or design-system isn't onboarded).
+
+NO LLM CALLS. Pure formatting + decision-tree branching.
+
+Usage:
+    python doctype_classifier.py --input X.md --output json | python route_explainer.py
+    python route_explainer.py --classification-file classification.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Bridge to the design-system config so we can refuse if not onboarded
+_DESIGN_SYSTEM_SCRIPTS = (
+    Path(__file__).resolve().parent.parent.parent / "design-system" / "scripts"
+)
+sys.path.insert(0, str(_DESIGN_SYSTEM_SCRIPTS))
+try:
+    import config_loader as cfg
+except ImportError:
+    cfg = None
+
+
+def _design_system_status() -> dict[str, Any]:
+    if cfg is None:
+        return {"onboarded": False, "reason": "config_loader not importable"}
+    if os.environ.get("MARKDOWN_HTML_NO_CONFIG") == "1":
+        return {"onboarded": True, "reason": "bypass env set", "bypass": True}
+    if cfg.setup_completed():
+        c = cfg.load_config()
+        return {
+            "onboarded": True,
+            "default_output_dir": c.get("default_output_dir"),
+            "design_style": c.get("design_style"),
+            "brand_primary": (c.get("brand") or {}).get("primary"),
+            "completed_at": c.get("setup_completed_at"),
+        }
+    return {"onboarded": False, "reason": "no setup_completed_at in config"}
+
+
+def explain(classification: dict[str, Any]) -> dict[str, Any]:
+    verdict = classification["verdict"]
+    line_count = classification["line_count"]
+    below_min = classification["below_min_lines"]
+    ds = _design_system_status()
+
+    refusals: list[str] = []
+
+    if below_min:
+        refusals.append(
+            f"Input is {line_count} lines (< {classification['min_lines_threshold']}). "
+            f"Per Shihipar's threshold, markdown wins below 100 lines. "
+            f"Recommend keeping this as markdown and re-running only on longer documents."
+        )
+    if not ds.get("onboarded"):
+        refusals.append(
+            "Design-system has not been onboarded. Run "
+            "`python3 markdown-html/skills/design-system/scripts/onboard.py` "
+            "(or `--defaults`) before conversion, so the converters have brand tokens to apply."
+        )
+
+    next_action = ""
+    sub_skill = None
+
+    if refusals:
+        next_action = "REFUSE — fix the issues above before routing."
+    elif verdict in ("document", "review", "slides"):
+        sub_skill = f"md-{verdict}"
+        next_action = (
+            f"ROUTE_SILENTLY -> {sub_skill}. "
+            f"Evidence: {classification['winner']} won with score "
+            f"{classification['winner_score']} (runner-up {classification['runner_up']}="
+            f"{classification['runner_up_score']})."
+        )
+    elif verdict == "needs-clarification":
+        winner = classification["winner"]
+        runner = classification["runner_up"]
+        next_action = (
+            f"ASK_USER one question: 'I see signals for both md-{winner} (score "
+            f"{classification['winner_score']}) and md-{runner} (score "
+            f"{classification['runner_up_score']}). Recommended: md-{winner}. "
+            f"Confirm or override?'"
+        )
+    else:  # ambiguous
+        next_action = (
+            "ASK_USER one question: 'Which document type is this — long-form "
+            "document, code review with diff, or slide deck? "
+            "Recommended: md-document (safe default).'"
+        )
+
+    return {
+        "decision": "REFUSE" if refusals else next_action.split(" ", 1)[0],
+        "sub_skill": sub_skill,
+        "next_action": next_action,
+        "refusals": refusals,
+        "classification_verdict": verdict,
+        "line_count": line_count,
+        "design_system": ds,
+    }
+
+
+def render_human(explanation: dict[str, Any]) -> str:
+    out = []
+    out.append(f"Routing decision: {explanation['decision']}")
+    if explanation["sub_skill"]:
+        out.append(f"  sub-skill: {explanation['sub_skill']}")
+    out.append(f"  next action: {explanation['next_action']}")
+    if explanation["refusals"]:
+        out.append("")
+        out.append("Refusals:")
+        for r in explanation["refusals"]:
+            out.append(f"  - {r}")
+    out.append("")
+    out.append("Design-system:")
+    ds = explanation["design_system"]
+    out.append(f"  onboarded: {ds.get('onboarded')}")
+    if ds.get("onboarded"):
+        out.append(f"  default_output_dir: {ds.get('default_output_dir')}")
+        out.append(f"  design_style: {ds.get('design_style')}")
+        out.append(f"  brand_primary: {ds.get('brand_primary')}")
+    else:
+        out.append(f"  reason: {ds.get('reason')}")
+    return "\n".join(out)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--classification-file",
+                        help="Path to a doctype_classifier JSON output. Default: read stdin.")
+    parser.add_argument("--output", choices=["human", "json"], default="human")
+    args = parser.parse_args(argv)
+
+    if args.classification_file:
+        with open(args.classification_file, encoding="utf-8") as f:
+            classification = json.load(f)
+    else:
+        if sys.stdin.isatty():
+            parser.print_help()
+            return 0
+        classification = json.load(sys.stdin)
+
+    explanation = explain(classification)
+    if args.output == "json":
+        print(json.dumps(explanation, indent=2))
+    else:
+        print(render_human(explanation))
+    return 0 if explanation["decision"] != "REFUSE" else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/sync-codex-skills.py
+++ b/scripts/sync-codex-skills.py
@@ -80,6 +80,10 @@ SKILL_DOMAINS = {
         "category": "research-ops",
         "description": "Enterprise Research Operations skills (v2.9.0): clinical study design, R&D program finance, market research methodology, product/user research"
     },
+    "markdown-html": {
+        "category": "documentation",
+        "description": "Markdown-to-HTML converter (v2.10.0 foundation): orchestrator (context: fork, deterministic doctype classifier, refuses < 100 lines per Shihipar) + design-system (one-time onboarding wizard with WCAG-AA-validated 12-token palette, project > global > defaults precedence). Converter sub-skills (md-document, md-review, md-slides) land in v2.10.1."
+    },
     "compliance-os": {
         "category": "compliance",
         "description": "Compliance-OS skills: ISO 13485 / ISO 27001 / SOC 2 / GDPR / FDA QSR / EU AI Act audit-prep + compliance-readiness orchestrator"


### PR DESCRIPTION
## Summary

Foundation PR for the new `markdown-html/` top-level domain. Operationalizes **Thariq Shihipar's *Claude Code HTML output* essay** (Medium, 2026): markdown collapses past ~100 lines for agent-generated artifacts; HTML restores density, clarity, shareability, and lightweight interaction.

Ships **2 of 5 planned skills** (converter sub-skills land in v2.10.1 follow-up PRs):

- **`markdown-html-orchestrator`** (`context: fork`) — deterministic doctype classifier scoring filename hints (×2) + content signals (×1) across DOCUMENT / REVIEW / SLIDES. Silent-routes when winner ≥ 3 AND (runner-up = 0 OR winner ≥ 2× runner-up); below threshold asks **one** clarifying question with a recommended answer. **Three pre-flight refusals:** input < 100 lines (Shihipar threshold), design-system not onboarded, output dir unwritable. 3 stdlib tools: `doctype_classifier.py`, `route_explainer.py` (never-silently-chain enforcer + onboarding gate), `output_path_resolver.py` (kebab slug + collision suffix).

- **`design-system`** — one-time onboarding wizard (10 questions). WCAG-2.2-AA-validated **12-token CSS custom-property palette** derived in HSL space; primary's luminance branch decides whether bg = primary (dark-mode docs) or bg = near-neutral with primary as accent (vibrant-primary docs). Link contrast iteratively walked to 4.5:1. 3 stdlib tools: `onboard.py` (interactive + `--defaults/--set/--show/--reset/--scope`), `config_loader.py` (project > global > defaults, deep merge, `MARKDOWN_HTML_NO_CONFIG=1` bypass), `brand_palette_validator.py`. Refuses to save on body-text/link contrast failure or unwritable output dir.

Plus `cs-markdown-html-orchestrator` agent, 3 slash commands (`/cs:markdown-html` router, `/cs:grill-markdown-html` Matt-Pocock 5-question grill, `/cs:design-system` onboarding surface), 6 reference docs citing 5-7 sources each (Tufte, Shihipar, Bret Victor, Maggie Appleton, Bartosz Ciechanowski, Amelia Wattenberger; WCAG 2.2, Ellen Lupton, Adobe Spectrum, Sara Soueidan, Material Design 3), 1 JSON schema asset.

**Distinct from** Anthropic's official Playground plugin (interactive prompt-tuning controls with sliders/knobs/prompt-copy-back) and from `marketing/landing/` (landing-page generator from scratch).

### What ships in v2.10.1 (follow-up PRs)

- `md-document` — sticky TOC + collapsibles + search + code-copy + scrollspy
- `md-review` — 2-col diff + severity-tagged margin annotations + jump-nav
- `md-slides` — arrow-key nav + presenter mode + print-to-PDF

All three will import `design-system/scripts/config_loader.py` for shared brand tokens.

### Repo-level updates

- `scripts/sync-codex-skills.py` SKILL_DOMAINS adds `markdown-html → documentation` category
- `.claude-plugin/marketplace.json` adds `markdown-html-skills` plugin entry (**63 → 64 plugins**, **16 → 17 domains**)
- Root `CLAUDE.md` adds nav-map row, structure-tree entry, v2.10.0 release-notes block

## Test plan

- [x] `python3 scripts/check_plugin_json.py markdown-html/.claude-plugin/plugin.json` → **OK**
- [x] `python3 scripts/sync-codex-skills.py --dry-run --verbose` → 2 new symlinks, total **338 → 340 skills**, new `documentation: 2 skills` category
- [x] `skill_description_validator.py` → **PASS** on both new SKILL.md files
- [x] `skill_review_checklist_runner.py` → 5/6 PASS on both (under-100-lines is the advisory rule that warns; same as `research-ops-skills` orchestrator)
- [x] All 6 Python tools smoke-tested with `--help` and `--sample`
- [x] **End-to-end onboarding round-trip**: `--reset` → `--defaults` → `config_loader.py --status` confirms `setup_completed: true` + 12 derived palette tokens
- [x] **WCAG hard-refusal**: `--set brand.bg=#FFFFFF --set brand.text=#F0F0F0` correctly exits 4 with "refusing to save: WCAG AA contrast failed"
- [x] **Classifier on the repo's own CLAUDE.md** (438 lines) correctly returns `needs-clarification` (DOCUMENT=15 vs SLIDES=14 — many `---` HRs); `route_explainer.py` says `ASK_USER one question: ... Recommended: md-document`. Confirms the "never silently chain" discipline.
- [x] **Output path resolver**: `markdown-html-out/doc-claude.html` (kebab slug + `doc-` prefix from `--doctype document`)
- [x] **`MARKDOWN_HTML_NO_CONFIG=1`** bypass returns DEFAULTS only — verified
- [x] `python3 markdown-html/skills/design-system/scripts/brand_palette_validator.py --primary "#0A1628" --accent "#00D4AA"` → all 3 WCAG checks PASS (text on bg 16.87:1, accent on bg 4.90:1, link on bg 4.90:1)
- [x] Same validator with vibrant primary `#FF6B35` → WARN on accent-on-bg (2.65:1; the warn is honest — pure orange on white is borderline as a UI surface), link iteratively walked to `#CB3600` for 4.82:1 ✓

## Plan reference

Full design plan: `/root/.claude/plans/the-goal-is-to-jiggly-ripple.md` (the planning file from the session).

https://claude.ai/code/session_01BK2KoQot1U7J5oSosrCQdc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BK2KoQot1U7J5oSosrCQdc)_