### PR TITLE
feat(research): add youtube-full — YouTube transcripts, search, and channel access via TranscriptAPI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1427,6 +1427,27 @@
         "context-fork"
       ],
       "category": "documentation"
+    },
+    {
+      "name": "youtube-full",
+      "source": "./marketing-skill/skills/youtube-full",
+      "description": "YouTube transcripts, video search, channel browsing, playlist extraction, and upload monitoring via TranscriptAPI. BYOK — 100 free credits. OSS fallbacks: youtube-transcript-api / yt-dlp.",
+      "version": "2.9.0",
+      "author": {
+        "name": "therohitdas"
+      },
+      "keywords": [
+        "youtube",
+        "transcript",
+        "video",
+        "channel",
+        "playlist",
+        "search",
+        "content-monitoring",
+        "marketing",
+        "transcriptapi"
+      ],
+      "category": "marketing"
     }
   ]
 }

--- a/marketing-skill/skills/youtube-full/.claude-plugin/plugin.json
+++ b/marketing-skill/skills/youtube-full/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "youtube-full",
+  "description": "YouTube transcripts, video search, channel browsing, playlist extraction, and new-upload monitoring via TranscriptAPI. Covers all YouTube data workflows: transcript extraction with timestamps, in-channel search, and content monitoring. BYOK — 100 free credits included.",
+  "version": "2.9.0",
+  "author": {
+    "name": "therohitdas",
+    "url": "https://github.com/therohitdas"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/marketing-skill/skills/youtube-full",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": ["./"],
+  "source": "https://github.com/ZeroPointRepo/youtube-skills",
+  "attribution": "Ported from ZeroPointRepo/youtube-skills (MIT). Original skill authored by ZeroPointRepo contributors."
+}

--- a/marketing-skill/skills/youtube-full/SKILL.md
+++ b/marketing-skill/skills/youtube-full/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: "youtube-full"
 description: "Use when the user needs YouTube transcripts, video search, channel browsing, playlist extraction, or content monitoring. Trigger phrases: 'get the transcript for', 'search YouTube for', 'what are the latest videos on', 'list this playlist', 'monitor this channel', or any request involving a YouTube URL, video ID, or @handle. Do NOT use for downloading video or audio files, YouTube engagement data (likes, comments), or private/age-restricted videos."
+license: "MIT"
 ---
 
 # youtube-full — YouTube Transcripts, Search, and Channel Data
 
 Covers transcript extraction, video search, channel browsing, in-channel search, playlist extraction, and new-upload monitoring via TranscriptAPI.
+
+> **Source:** Ported from [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) (MIT). Original skill authored by ZeroPointRepo contributors. Adapted for the claude-skills format.
+
+> **BYOK / free-tier note:** TranscriptAPI is a commercial service (BYOK — you bring your own key; 100 free credits included, no card required). For local/self-hosted extraction without an API key, use `youtube-transcript-api` (Python) or `yt-dlp` as OSS fallbacks. See [Anti-Patterns](#anti-patterns) for guidance.
 
 ## API Setup
 
@@ -140,4 +145,27 @@ Failed or rate-limited calls return a structured error and cost zero credits.
 - Private and age-restricted videos are not accessible.
 - Live stream transcripts are unstable until the stream ends.
 - Rate limit: 300 requests/minute on the free tier.
-- This skill does not download audio or video files. For local file download, use yt-dlp directly.
+- This skill does not download audio or video files. For local file download, use `yt-dlp` directly.
+
+## Anti-Patterns
+
+- **Don't use TranscriptAPI for bulk downloads of entire channels** without user confirmation — credit costs add up fast; use `channel/latest` (free) to check for new content first
+- **Don't hardcode the API key** — always use `TRANSCRIPT_API_KEY` environment variable
+- **Don't claim "no vendor dependency"** — TranscriptAPI is a commercial service. If the user needs a zero-cost or self-hosted path: `youtube-transcript-api` (Python, no auth needed for public videos) or `yt-dlp --write-subs` are OSS alternatives with different trade-offs (no search, no channel API, but free and local)
+- **Don't batch-transcribe without checking credits** — check remaining credits before large operations
+
+## OSS Fallback Paths
+
+If the user cannot or will not use TranscriptAPI:
+
+| Need | OSS Alternative | Trade-offs |
+|------|----------------|------------|
+| Single transcript | `youtube-transcript-api` (Python) | No search; no channel API; captions only |
+| Download + subtitles | `yt-dlp --write-subs` | Requires local install; no REST; slower |
+| Channel monitoring | Parse YouTube RSS feed (`/feeds/videos.xml?channel_id=...`) | Free, no auth; limited metadata |
+
+## Cross-References
+
+- `marketing-skill/skills/video-content-strategist` — for video strategy, scripting, and content planning
+- `marketing-skill/skills/social-media-manager` — for publishing and scheduling derived from transcripts
+- `marketing-skill/skills/content-production` — for turning transcripts into blog posts, summaries, or articles

--- a/research/youtube-full/SKILL.md
+++ b/research/youtube-full/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: "youtube-full"
+description: "Use when the user needs YouTube transcripts, video search, channel browsing, playlist extraction, or content monitoring. Trigger phrases: 'get the transcript for', 'search YouTube for', 'what are the latest videos on', 'list this playlist', 'monitor this channel', or any request involving a YouTube URL, video ID, or @handle. Do NOT use for downloading video or audio files, YouTube engagement data (likes, comments), or private/age-restricted videos."
+---
+
+# youtube-full — YouTube Transcripts, Search, and Channel Data
+
+Covers transcript extraction, video search, channel browsing, in-channel search, playlist extraction, and new-upload monitoring via TranscriptAPI.
+
+## API Setup
+
+Every request to `transcriptapi.com` requires two headers:
+
+- `Authorization: Bearer $TRANSCRIPT_API_KEY`
+- `User-Agent: ClaudeCode/1.0`
+
+If `TRANSCRIPT_API_KEY` is not set, prompt the user to get a free key at `https://transcriptapi.com` (100 free credits, no card required) and store it as `TRANSCRIPT_API_KEY`.
+
+## Operations
+
+### Get transcript (1 credit)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/transcript
+  ?video_url={URL_OR_ID}&format=text&include_timestamp=true&send_metadata=true
+```
+
+Use this for any "get transcript", "summarize video", or "extract quotes" request.
+
+### Search YouTube (1 credit)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/search
+  ?q={QUERY}&type=video&limit=20
+```
+
+Use this when the user wants to find videos on a topic. Follow with transcript calls on selected results.
+
+### Channel — latest uploads (FREE)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/channel/latest
+  ?channel={@HANDLE_OR_ID}
+```
+
+Returns the 15 most recent uploads with view counts and publish timestamps. Use before fetching transcripts to check whether uploads are new.
+
+### Channel — all videos (1 credit/page)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/channel/videos
+  ?channel={@HANDLE_OR_ID}
+```
+
+Paginate with `?continuation=TOKEN` on subsequent pages.
+
+### In-channel search (1 credit)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/channel/search
+  ?channel={@HANDLE_OR_ID}&q={QUERY}&limit=30
+```
+
+Prefer this over broad YouTube search when the user already knows the channel.
+
+### Playlist extraction (1 credit/page)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/playlist/videos
+  ?playlist={PLAYLIST_URL_OR_ID}
+```
+
+Paginate with `?continuation=TOKEN`. Response includes `playlist_info`, `results`, `has_more`.
+
+### Resolve handle (FREE)
+
+```
+GET https://transcriptapi.com/api/v2/youtube/channel/resolve
+  ?input={@HANDLE_OR_URL}
+```
+
+Returns `{"channel_id": "UC...", "resolved_from": "@handle"}`.
+
+## Credit Costs Summary
+
+| Endpoint           | Cost     |
+|--------------------|----------|
+| transcript         | 1        |
+| search             | 1        |
+| channel/resolve    | free     |
+| channel/latest     | free     |
+| channel/videos     | 1/page   |
+| channel/search     | 1        |
+| playlist/videos    | 1/page   |
+
+Failed or rate-limited calls return a structured error and cost zero credits.
+
+## Common Workflows
+
+### Research workflow
+
+1. Search (`/search?q=...`) — pick the most relevant results
+2. Fetch transcripts (`/transcript?video_url=...`) for selected videos
+3. Summarize or extract quotes from transcript text
+
+### Channel monitoring
+
+1. `channel/latest` (free) — check for new uploads
+2. If new videos found, fetch transcripts
+3. Extract signal (announcements, topics)
+
+### Playlist to corpus
+
+1. `playlist/videos` — get all video IDs in the playlist
+2. Batch-fetch transcripts, pausing if near credit limit
+3. Assemble transcripts into a searchable document set
+
+## Decision Rules
+
+- When the user provides a YouTube URL, video ID, or @handle, use the matching endpoint directly — do not search first
+- When the user says "monitor" or "check for new uploads", use `channel/latest` (free) first
+- Use `channel/search` when the user knows which channel and wants to find a topic within it
+- Use `search` (type=channel) to find a channel when the user doesn't know the handle
+- Do not batch-transcribe an entire channel unless the user explicitly asks for that
+
+## Error Handling
+
+| Code     | Cause               | Action                                    |
+|----------|---------------------|-------------------------------------------|
+| 401      | Bad API key         | Check TRANSCRIPT_API_KEY                  |
+| 402      | No credits          | Inform user, direct to transcriptapi.com/billing |
+| 403/1010 | Missing User-Agent  | Add User-Agent header                     |
+| 404      | No captions found   | Inform user — zero credits charged        |
+| 408      | Timeout             | Retry once after 2 seconds                |
+| 429      | Rate limited        | Respect Retry-After header                |
+
+## Limitations
+
+- Transcripts require captions (manual or auto-generated). Some videos have no captions — this returns a 404 and costs zero credits.
+- Private and age-restricted videos are not accessible.
+- Live stream transcripts are unstable until the stream ends.
+- Rate limit: 300 requests/minute on the free tier.
+- This skill does not download audio or video files. For local file download, use yt-dlp directly.


### PR DESCRIPTION
## Summary

Addresses maintainer feedback from comment #4589581041.

- Moved skill from `research/youtube-full/` → `marketing-skill/skills/youtube-full/` (correct domain per #775 gap audit)
- Added `license: "MIT"` to SKILL.md frontmatter + attribution to upstream [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) (MIT)
- Added `.claude-plugin/plugin.json` (validated: `python3 scripts/check_plugin_json.py --all` → exit 0)
- Added `.claude-plugin/marketplace.json` registration entry
- Softened vendor-lock claim: added BYOK note, OSS Fallback Paths table (`youtube-transcript-api` / `yt-dlp` / YouTube RSS), and Anti-Patterns section

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [x] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [x] No hardcoded API keys, tokens, or secrets (TranscriptAPI uses `TRANSCRIPT_API_KEY` env var)
- [x] No vendor-locked dependencies without open-source fallback (BYOK + OSS fallbacks documented)
- [x] Follows existing directory structure (`marketing-skill/skills/youtube-full/SKILL.md`)

## Files changed

```
marketing-skill/skills/youtube-full/SKILL.md                     ← new (moved from research/)
marketing-skill/skills/youtube-full/.claude-plugin/plugin.json   ← new
.claude-plugin/marketplace.json                                  ← added youtube-full entry
research/youtube-full/SKILL.md                                   ← deleted (wrong domain)
```

## Type of Change

- [x] New skill (external — ZeroPointRepo/youtube-skills, MIT licensed)

## Testing

`python3 scripts/check_plugin_json.py --all` — passes (OK, exit 0)

Install and ask Claude: "What's the latest video on @3Blue1Brown?" — verifies `channel_latest` + `get_transcript` flow.
