### PR TITLE
chore(plugins): install ECC operator plugin via project marketplace reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "extraKnownMarketplaces": {
+        "ecc": {
+            "source": {
+                "source": "github",
+                "repo": "affaan-m/ECC"
+            }
+        }
+    },
+    "enabledPlugins": {
+        "ecc@ecc": true
+    }
+}


### PR DESCRIPTION
Register the ECC marketplace (affaan-m/ECC) and enable the ecc@ecc plugin
in committed .claude/settings.json so the 63 agents / 249 skills / 79
commands / hooks load at runtime for anyone who opens this repo (one-time
trust prompt). Uses ECC's recommended plugin path; files are not vendored,
so there is no collision with the existing skills library.

https://claude.ai/code/session_01Vw7LCQLH5Wi7WHrrN47Hj6