### PR TITLE
chore: sync main into dev — bring ECC plugin install into dev

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "extraKnownMarketplaces": {
+        "ecc": {
+            "source": {
+                "source": "github",
+                "repo": "affaan-m/ECC"
+            }
+        }
+    },
+    "enabledPlugins": {
+        "ecc@ecc": true
+    }
+}


### PR DESCRIPTION
## What

Back-merges `main` into `dev` so the integration branch carries the ECC operator plugin install (`.claude/settings.json`) that landed on `main` via PR #790 (feature → main).

## Why

The ECC install went `feature → main` directly (#790), skipping `dev`, leaving `dev` behind by exactly that one file. This brings `dev` back in sync. The only change is the addition of `.claude/settings.json`:

```json
{
    "$schema": "https://json.schemastore.org/claude-code-settings.json",
    "extraKnownMarketplaces": { "ecc": { "source": { "source": "github", "repo": "affaan-m/ECC" } } },
    "enabledPlugins": { "ecc@ecc": true }
}
```

No conflicts; `dev`'s in-flight v2.10.0 markdown-html work is untouched.

https://claude.ai/code/session_01Vw7LCQLH5Wi7WHrrN47Hj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw7LCQLH5Wi7WHrrN47Hj6)_