### PR TITLE
feat(marketing): add local-seo-manager skill for local service businesses

### DIFF
--- a/marketing-skill/skills/local-seo-manager/SKILL.md
+++ b/marketing-skill/skills/local-seo-manager/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: "local-seo-manager"
+description: "Local SEO for service-area businesses — appliance repair, HVAC, plumbing, cleaning, and any business that serves customers at their location. Use when the user wants to: audit Google Business Profile, generate neighborhood service area pages, check NAP consistency across directories, create LocalBusiness schema, or write review responses. Triggers: 'local SEO', 'Google Business Profile', 'GBP', 'service area page', 'NAP consistency', 'local citations', 'LocalBusiness schema', 'review responses', 'Google Maps ranking'. NOT for national SEO (use seo-audit). NOT for general schema (use schema-markup). NOT for AI search visibility (use ai-seo)."
+license: MIT
+metadata:
+  version: 1.0.0
+  author: Stan Varashilov (Steffonet)
+  category: marketing
+  updated: 2026-06-03
+---
+
+# Local SEO Manager
+
+You are a local SEO specialist for service-area businesses. Your focus is the tactics that move the needle for businesses that serve customers in a geographic area — appliance repair, HVAC, plumbing, cleaning, electrical, and similar trades.
+
+Local SEO is a different game from national SEO. The Google Map Pack, Google Business Profile signals, and hyperlocal content all matter more here than domain authority or backlink count.
+
+## Before Starting
+
+**Check for business context first:**
+If `local-seo-context.md` exists in the project, read it. It contains the business name, service areas, primary services, NAP data, and competitor information.
+
+If no context file exists, gather:
+
+1. **Business basics** — Name, address (or service-area-only?), phone, website URL
+2. **Services** — Primary + secondary services (e.g., appliance repair: washer, dryer, refrigerator, dishwasher, oven)
+3. **Service areas** — Which cities, neighborhoods, zip codes do you cover?
+4. **Current presence** — GBP claimed? Any existing service area pages? Any directory listings?
+5. **Competitors** — Who ranks in the Map Pack for your top service keywords?
+
+---
+
+## The 4 Modes
+
+### Mode 1: GBP Audit
+Audit and optimize the Google Business Profile to rank higher in the Map Pack.
+
+### Mode 2: Service Area Content
+Generate neighborhood-specific service area pages (1,000+ words) that rank for "[service] in [neighborhood]" queries.
+
+### Mode 3: NAP Consistency Check
+Surface and fix Name / Address / Phone inconsistencies across major directories. Run `scripts/nap_checker.py` to scan.
+
+### Mode 4: Schema & Technical
+Generate LocalBusiness schema, review response templates, and technical fixes.
+
+---
+
+## Mode 1: GBP Audit
+
+Google Business Profile is the single highest-leverage local SEO asset. It drives Map Pack rankings.
+
+### GBP Ranking Factors (in order of impact)
+
+1. **Relevance** — Does the category and description match the search query?
+2. **Proximity** — How close is the business to the searcher?
+3. **Prominence** — Reviews count, rating, response rate, posting frequency, backlinks
+
+You control relevance and prominence. Proximity is fixed.
+
+### GBP Audit Checklist
+
+**Categories:**
+- [ ] Primary category is the most specific match (e.g., "Appliance Repair Service" not just "Repair Service")
+- [ ] Secondary categories added for all major service lines
+- [ ] No competitor categories added that don't apply
+
+**Business Info:**
+- [ ] Business name matches legal name (no keyword stuffing — Google penalizes this)
+- [ ] Address is exact match to website, Yelp, BBB, and other directories
+- [ ] Phone number is local area code (not 1-800) and matches all directories
+- [ ] Website URL correct and using UTM tracking (`?utm_source=gmb`)
+- [ ] Hours of operation accurate + holiday hours added
+
+**Services:**
+- [ ] All services listed in the Services section
+- [ ] Each service has a description (150-300 words)
+- [ ] Prices added where applicable (even ranges help)
+
+**Description (750 char max):**
+- [ ] Primary keyword in first sentence
+- [ ] Mentions 3-5 main services by name
+- [ ] Mentions city/metro area
+- [ ] No URLs, no promotional language ("best," "#1," "guaranteed")
+- [ ] Does NOT duplicate the website meta description verbatim
+
+**Photos:**
+- [ ] Logo uploaded (400x400px min)
+- [ ] Cover photo uploaded (1024x576px min)
+- [ ] At least 10 interior/exterior/team/work photos
+- [ ] Photos geotagged before upload (use GeoImgr.com)
+- [ ] New photos added monthly
+
+**Posts (Google Posts):**
+- [ ] At least 1 post per week (offers, updates, events, or what's new)
+- [ ] Each post includes a CTA (call, book, learn more)
+- [ ] Seasonal/promotional posts scheduled in advance
+
+**Q&A Section:**
+- [ ] Seed 5-10 common customer questions + your answers
+- [ ] Monitor for unanswered questions (check weekly)
+
+**Reviews:**
+- [ ] Average rating ≥ 4.5 stars
+- [ ] Minimum 50 reviews (100+ for competitive markets)
+- [ ] Response rate 100% (respond to every review — positive and negative)
+- [ ] Response time < 48 hours
+
+### Review Response Templates
+
+See [references/review-response-templates.md](references/review-response-templates.md) for full templates by scenario.
+
+**Positive review response framework:**
+> Thank [customer name if available]. [Acknowledge the specific service they mentioned]. [Add one sentence about your commitment/value]. [Invite them back or refer]. — [Your name], [Business name]
+
+**Negative review response framework (never argue):**
+> [Acknowledge their experience without admitting fault]. [Apologize for falling short of expectations]. [Offer to resolve offline: phone/email]. [Sign with name and contact].
+
+---
+
+## Mode 2: Service Area Pages
+
+Service area pages rank for "[service] in [neighborhood]" searches — the highest-intent local queries.
+
+### What Makes a Good Service Area Page
+
+**Bad (thin, gets filtered out by Google):**
+> "We provide appliance repair in Richmond District. Call us today!"
+
+**Good (ranks and converts):**
+- 1,000-1,500 words
+- Mentions the neighborhood naturally 8-12 times (not stuffed)
+- Includes local landmarks, cross-streets, zip code
+- Lists specific services available in that area
+- Includes a FAQ section (4-6 questions)
+- Has LocalBusiness + Service schema
+- Has a unique intro specific to that neighborhood (not copy-paste)
+
+### Service Area Page Template
+
+Generate pages using `scripts/service_area_generator.py`, then customize:
+
+```
+[Title]: [Appliance Repair] in [Neighborhood Name], [City] | [Business Name]
+[Meta]: [Business Name] provides [service] in [Neighborhood]. [Unique selling point]. Call [phone] or book online.
+
+H1: [Appliance Repair] in [Neighborhood Name]
+
+[Opening paragraph — 150 words]
+Mention: neighborhood name, services offered, years in business, why locals choose you.
+DO NOT use: "we are proud to offer", "look no further", "your one-stop shop"
+
+H2: [Appliance Brands We Service in [Neighborhood]]
+List: Samsung, LG, Whirlpool, GE, Bosch, Maytag, KitchenAid, Frigidaire, Electrolux
+One sentence each on why brand expertise matters.
+
+H2: [Our [Neighborhood] Service Area]
+Describe the boundaries: "We serve [Neighborhood] including [streets/landmarks]."
+Mention adjacent neighborhoods if relevant for internal linking.
+
+H2: Common [Appliance] Problems in [Neighborhood] Homes
+3-5 specific repair scenarios with brief descriptions.
+This section adds genuine local relevance.
+
+H2: Why [Business Name] for [Neighborhood] Residents
+3-4 unique selling points specific to local customers.
+Avoid generic claims — be specific.
+
+H2: Frequently Asked Questions
+4-6 Q&A pairs targeting "[service] in [neighborhood]" and related queries.
+Format for FAQPage schema.
+
+H2: Book [Appliance Repair] in [Neighborhood]
+CTA section with phone, booking link, hours.
+Repeat the local address/service area for reinforcement.
+```
+
+### Neighborhood Page Uniqueness Checklist
+
+Before publishing, verify:
+- [ ] Intro paragraph is unique (not duplicated from another page)
+- [ ] At least 3 neighborhood-specific details (landmarks, cross streets, zip)
+- [ ] Internal links to 2-3 related service pages
+- [ ] Internal link TO this page from at least the main service page
+
+---
+
+## Mode 3: NAP Consistency
+
+NAP = Name, Address, Phone. Inconsistencies across the web confuse Google and suppress rankings.
+
+**Run the NAP checker:**
+```bash
+python3 scripts/nap_checker.py
+```
+
+The script checks known directory listings and outputs a consistency report with mismatch count and fix priority.
+
+### Priority Directories (fix in this order)
+
+| Tier | Directory | Why It Matters |
+|---|---|---|
+| 1 | Google Business Profile | Highest weight local signal |
+| 1 | Apple Maps | iOS users — major traffic source |
+| 1 | Bing Places | 25% of desktop search |
+| 2 | Yelp | High DA, frequent appearing in Map Pack vicinity |
+| 2 | BBB | Trust signal for home services |
+| 2 | Angi (formerly Angie's List) | High-intent home service searches |
+| 2 | HomeAdvisor | Same audience as Angi |
+| 3 | Facebook | Social signals + local discovery |
+| 3 | Yellow Pages | Legacy DA, slow to affect but matters |
+| 3 | Nextdoor | Hyperlocal; high conversion for home services |
+| 3 | Thumbtack | Leads + citation |
+
+### Common NAP Errors to Fix
+
+- Phone format inconsistency: (415) 555-0100 vs 415-555-0100 vs 4155550100
+- Business name variations: "Stan's Appliance Repair" vs "Stan's Appliance Repair LLC" vs "Smart Solution Appliances"
+- Address abbreviations: "St." vs "Street", "Ave" vs "Avenue"
+- Suite number missing on some listings
+- Old phone number still live on legacy directories
+
+---
+
+## Mode 4: Schema & Technical
+
+### LocalBusiness Schema
+
+Generate with `scripts/schema_generator.py`. The script produces JSON-LD ready to paste into WordPress (via Rank Math custom schema or a `<head>` code snippet).
+
+**Priority schema types for local service businesses:**
+
+| Type | Use For | Impact |
+|---|---|---|
+| `LocalBusiness` | All location pages | High — establishes entity in Google's knowledge graph |
+| `HomeAndConstructionBusiness` | Appliance repair, HVAC, plumbing, electrical | High — specific category signal |
+| `Service` | Individual service pages | Medium — helps service-specific queries |
+| `FAQPage` | Pages with FAQ sections | High — rich results + AI citation |
+| `Review` / `AggregateRating` | Pages showing review stars | High — CTR lift from star snippets |
+
+See [references/local-schema-types.md](references/local-schema-types.md) for full schema examples.
+
+### Technical Local SEO Checklist
+
+- [ ] `LocalBusiness` schema on homepage and all location/service area pages
+- [ ] NAP in text on every page (footer at minimum) — exact match to GBP
+- [ ] `rel="canonical"` on all service area pages (avoid duplicate content)
+- [ ] Mobile-friendly (Core Web Vitals — LCP < 2.5s, CLS < 0.1)
+- [ ] HTTPS everywhere (no mixed content)
+- [ ] Local phone number in click-to-call format: `<a href="tel:+14155550100">`
+- [ ] Embedded Google Map on contact/location page
+- [ ] Hreflang not needed (single-language local business)
+- [ ] XML sitemap submitted to Google Search Console and Bing Webmaster
+
+---
+
+## Proactive Triggers
+
+Flag these without being asked:
+
+- **Multiple business name variations found** — NAP inconsistency will suppress rankings. Flag and prioritize fix.
+- **GBP response rate < 100%** — Unresponded reviews signal low engagement to Google. Every review needs a response.
+- **Service area pages < 500 words** — Google filters thin local pages. Flag for expansion.
+- **No LocalBusiness schema** — Schema absence means Google must infer your entity. Easy fix with big impact.
+- **GBP photos not updated in 30 days** — Photo freshness signals active business to Google.
+- **Review count < 50** — Under 50 reviews makes you non-competitive in most SF Bay Area markets.
+
+---
+
+## Output Artifacts
+
+| When you ask for... | You get... |
+|---|---|
+| GBP audit | Checklist with pass/fail per item + prioritized fix list |
+| Service area page | Full 1,000-1,500 word page draft with H-tags, FAQ, and meta description |
+| NAP report | Directory-by-directory mismatch table with fix instructions |
+| LocalBusiness schema | JSON-LD block ready to paste + Rank Math implementation note |
+| Review responses | 3-5 response drafts for provided reviews (positive + negative) |
+| Full local SEO audit | All of the above in one structured report |
+
+---
+
+## Scripts
+
+- `scripts/nap_checker.py` — NAP consistency scanner with directory report
+- `scripts/service_area_generator.py` — Service area page content generator
+- `scripts/schema_generator.py` — LocalBusiness / HomeAndConstructionBusiness JSON-LD generator
+
+---
+
+## References
+
+- [Local SEO Checklist](references/local-seo-checklist.md) — Full 80-point checklist covering GBP, citations, on-page, technical
+- [Local Schema Types](references/local-schema-types.md) — Schema.org types for local service businesses with examples
+
+---
+
+## Related Skills
+
+- **seo-audit** — General technical SEO. Use alongside this skill for full-site coverage.
+- **ai-seo** — AI search visibility. Local businesses appear in "near me" AI Overviews — optimize both.
+- **schema-markup** — Detailed schema implementation. Use when schema needs go beyond LocalBusiness.
+- **content-production** — Use to write the underlying service area page content at scale.
+- **gbp-content-creator** — GBP post generation, photo captions, Q&A seeds. Companion to this skill.

--- a/marketing-skill/skills/local-seo-manager/references/local-schema-types.md
+++ b/marketing-skill/skills/local-seo-manager/references/local-schema-types.md
@@ -1,0 +1,253 @@
+# Local Business Schema Types — Reference Guide
+
+Complete schema.org reference for local service businesses. All examples are JSON-LD format.
+
+---
+
+## 1. LocalBusiness + HomeAndConstructionBusiness
+
+Use on: homepage, contact page, all location/service pages.
+This is the most important schema for local businesses — it establishes your entity in Google's knowledge graph.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": ["LocalBusiness", "HomeAndConstructionBusiness"],
+  "name": "Smart Solution Appliances",
+  "url": "https://smartsolutionappliances.com",
+  "telephone": "(415) 555-0100",
+  "priceRange": "$$",
+  "image": "https://smartsolutionappliances.com/logo.png",
+  "description": "Professional appliance repair in San Francisco. Same-day service for washers, dryers, refrigerators, dishwashers, and ovens.",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Market Street",
+    "addressLocality": "San Francisco",
+    "addressRegion": "CA",
+    "postalCode": "94102",
+    "addressCountry": "US"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "37.7749",
+    "longitude": "-122.4194"
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Monday",
+      "opens": "08:00",
+      "closes": "18:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["https://schema.org/Tuesday", "https://schema.org/Wednesday", "https://schema.org/Thursday", "https://schema.org/Friday"],
+      "opens": "08:00",
+      "closes": "18:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "https://schema.org/Saturday",
+      "opens": "09:00",
+      "closes": "15:00"
+    }
+  ],
+  "areaServed": [
+    {"@type": "Place", "name": "San Francisco"},
+    {"@type": "Place", "name": "Richmond District"},
+    {"@type": "Place", "name": "Mission District"}
+  ],
+  "sameAs": [
+    "https://www.yelp.com/biz/smart-solution-appliances-san-francisco",
+    "https://www.facebook.com/smartsolutionappliances"
+  ],
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.8",
+    "bestRating": "5",
+    "worstRating": "1",
+    "ratingCount": "124"
+  }
+}
+```
+
+**Notes:**
+- `HomeAndConstructionBusiness` is the most specific type for appliance repair, HVAC, plumbing. Use it alongside `LocalBusiness`.
+- `areaServed` should list all neighborhoods/cities you serve — helps with broader service-area queries.
+- `aggregateRating` pulls star snippet if you have enough reviews. Do NOT fabricate — Google cross-checks with GBP.
+- Run `scripts/schema_generator.py --type local-business` to generate for your business.
+
+---
+
+## 2. Service (per service page)
+
+Use on: individual service pages (washer-repair, dryer-repair, etc.) and service area pages.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "serviceType": "Appliance Repair",
+  "provider": {
+    "@type": "LocalBusiness",
+    "name": "Smart Solution Appliances",
+    "telephone": "(415) 555-0100",
+    "url": "https://smartsolutionappliances.com"
+  },
+  "areaServed": {
+    "@type": "Place",
+    "name": "Richmond District, San Francisco"
+  },
+  "description": "Professional appliance repair in the Richmond District. Same-day service for washers, dryers, refrigerators, dishwashers, and ovens. All major brands serviced."
+}
+```
+
+---
+
+## 3. FAQPage
+
+Use on: any page with a FAQ section. High impact — Google shows FAQ rich results (expandable Q&A in search).
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How quickly can you reach the Richmond District for appliance repair?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We offer same-day service in the Richmond District. Call before noon for a same-afternoon appointment."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you offer a warranty on appliance repairs?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. All repairs come with a 90-day parts and labor warranty."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What appliance brands do you service?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We service all major brands including Samsung, LG, Whirlpool, GE, Bosch, Maytag, KitchenAid, Frigidaire, and Electrolux."
+      }
+    }
+  ]
+}
+```
+
+**Notes:**
+- Max 5 Q&A pairs for FAQ rich results (Google truncates beyond 5 in the SERP).
+- Each answer should be 30-250 words. Too short = not useful. Too long = not shown.
+- Validate at: search.google.com/test/rich-results
+
+---
+
+## 4. HowTo (for how-to content)
+
+Use on: blog posts or guides like "How to Know if Your Washing Machine Needs Repair."
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Tell if Your Washing Machine Needs Professional Repair",
+  "description": "Five signs your washer needs a repair technician, not a DIY fix.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Check for error codes",
+      "text": "Modern washers display error codes on the control panel. Look up your model's error code in the manual — E1, E2, F codes usually indicate internal component failure requiring a technician."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Listen for unusual sounds",
+      "text": "Loud grinding, banging, or squealing during the spin cycle often indicates a worn drum bearing or motor coupling — both require professional repair."
+    }
+  ]
+}
+```
+
+---
+
+## 5. Review (individual review)
+
+Use when displaying individual testimonials on your site.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Review",
+  "reviewRating": {
+    "@type": "Rating",
+    "ratingValue": "5",
+    "bestRating": "5"
+  },
+  "name": "Excellent washer repair — same day service",
+  "reviewBody": "Called in the morning, technician arrived by 2pm. Fixed our Samsung washer quickly and explained what was wrong. Very professional.",
+  "author": {
+    "@type": "Person",
+    "name": "M. Chen"
+  },
+  "itemReviewed": {
+    "@type": "LocalBusiness",
+    "name": "Smart Solution Appliances"
+  }
+}
+```
+
+---
+
+## Implementation in WordPress
+
+### Option A: Rank Math (recommended)
+1. Go to Rank Math → Schema → Schema Generator
+2. Select "Local Business"
+3. Fill in the fields — Rank Math generates the JSON-LD automatically
+4. For service area pages: use "Custom Schema" and paste the output from `schema_generator.py`
+
+### Option B: Header code snippet (any theme)
+Add to `functions.php` or use a header/footer code plugin:
+
+```php
+function add_local_business_schema() {
+    if ( is_front_page() || is_page( 'contact' ) ) {
+        echo '<script type="application/ld+json">';
+        echo '{ ... your schema JSON ... }';
+        echo '</script>';
+    }
+}
+add_action( 'wp_head', 'add_local_business_schema' );
+```
+
+### Option C: WordPress plugin
+- **Schema & Structured Data for WP** (free, 100k+ installs)
+- **WP Schema Pro** (paid, more control)
+- **Yoast SEO** (has basic Local Business if Local SEO addon purchased)
+
+---
+
+## Validation
+
+Always validate before deploying:
+- **Schema.org validator:** https://validator.schema.org/
+- **Google Rich Results Test:** https://search.google.com/test/rich-results
+- **Google Search Console → Enhancements** — monitor for schema errors post-deployment
+
+---
+
+## Common Errors to Avoid
+
+| Error | Problem | Fix |
+|---|---|---|
+| Missing `telephone` | GBP match fails | Always include exact phone from GBP |
+| `aggregateRating` doesn't match GBP | Google flags as misleading | Keep in sync or omit |
+| Duplicate `LocalBusiness` schemas | Conflicting entity signals | One per page, in `<head>` |
+| Using `Organization` instead of `LocalBusiness` | Weaker local signal | Use `LocalBusiness` + specific subtype |
+| FAQPage with 10+ questions | Too many for rich results display | Limit to 5 most important |
+| `openingHoursSpecification` wrong format | Breaks rich results | Use ISO 8601 time format (HH:MM) |

--- a/marketing-skill/skills/local-seo-manager/references/local-seo-checklist.md
+++ b/marketing-skill/skills/local-seo-manager/references/local-seo-checklist.md
@@ -1,0 +1,141 @@
+# Local SEO Checklist — 80 Points
+
+Complete reference checklist for service-area businesses. Use alongside the `local-seo-manager` skill for full audits.
+
+---
+
+## 1. Google Business Profile (GBP) — 25 Points
+
+### Category & Identity
+- [ ] Primary category is the most specific available (e.g., "Appliance Repair Service")
+- [ ] 3-5 secondary categories added for all major service lines
+- [ ] Business name matches legal name exactly — no keyword stuffing
+- [ ] Short name (if applicable) is clean and brand-aligned
+
+### Contact & Location
+- [ ] Address matches all directory listings character-for-character
+- [ ] Phone is a local area-code number (not 1-800)
+- [ ] Website URL is correct + uses UTM tracking (`?utm_source=gmb&utm_medium=organic`)
+- [ ] Service area defined correctly (for SABs: no physical address shown)
+- [ ] Hours are accurate — including holiday hours
+
+### Content
+- [ ] Description uses primary keyword in first sentence (750 char max)
+- [ ] Description mentions 3-5 services by name
+- [ ] Description mentions city/metro area
+- [ ] Description has NO promotional language ("best," "#1," "guaranteed")
+- [ ] All services listed in Services section with descriptions
+- [ ] Products added (if applicable)
+- [ ] At least one Q&A seeded and answered by the business
+
+### Photos
+- [ ] Logo uploaded (400×400px min)
+- [ ] Cover photo uploaded (1024×576px min)
+- [ ] 10+ interior/exterior/team/work photos
+- [ ] Photos geotagged (use GeoImgr.com before upload)
+- [ ] New photo added at least monthly
+
+### Posts & Activity
+- [ ] At least 1 Google Post per week
+- [ ] Posts include a call-to-action button
+- [ ] Response rate on reviews = 100%
+- [ ] Average rating ≥ 4.5 stars
+
+---
+
+## 2. NAP Consistency — 10 Points
+
+- [ ] Name identical across Google, Yelp, BBB, Apple Maps, Bing
+- [ ] Phone format consistent (prefer: (XXX) XXX-XXXX)
+- [ ] Address abbreviations consistent (St. or Street — pick one, use everywhere)
+- [ ] Website URL consistent (with or without trailing slash, www vs non-www)
+- [ ] Listed on all Tier 1 directories: Google, Apple Maps, Bing Places
+- [ ] Listed on all Tier 2 directories: Yelp, BBB, Angi, HomeAdvisor
+- [ ] Listed on relevant Tier 3: Facebook, Yellow Pages, Nextdoor, Thumbtack
+- [ ] Old/duplicate listings claimed and removed or merged
+- [ ] No listings with outdated phone numbers (old numbers still live)
+- [ ] Run `scripts/nap_checker.py` — zero mismatches in Tier 1 directories
+
+---
+
+## 3. On-Page Local SEO — 20 Points
+
+### Homepage
+- [ ] Title tag: `[Primary Service] in [City] | [Business Name]`
+- [ ] Meta description: Includes service + city + phone or CTA
+- [ ] H1 includes primary keyword + city
+- [ ] NAP in footer (text format, matches GBP exactly)
+- [ ] Google Maps embed on contact/location page
+- [ ] LocalBusiness schema in `<head>` (run `scripts/schema_generator.py`)
+- [ ] Phone number as `<a href="tel:+1XXXXXXXXXX">` (click-to-call)
+
+### Service Area Pages
+- [ ] One dedicated page per major service area (city/neighborhood)
+- [ ] Each page ≥ 1,000 words (use `scripts/service_area_generator.py` for briefs)
+- [ ] Each page has a unique opening paragraph (not duplicated)
+- [ ] Each page has 2+ neighborhood-specific references
+- [ ] Each page has a FAQ section (5 Q&A pairs minimum)
+- [ ] FAQPage schema on each service area page
+- [ ] Service area pages linked from main navigation or sitemap
+
+### Internal Linking
+- [ ] Main service page links to all service area pages
+- [ ] Service area pages cross-link to adjacent neighborhoods
+- [ ] All service area pages in XML sitemap
+
+---
+
+## 4. Review Strategy — 10 Points
+
+- [ ] Review request process in place (ask after every completed job)
+- [ ] QR code or short link for easy review submission
+- [ ] 50+ reviews on Google (100+ in competitive markets)
+- [ ] Respond to 100% of reviews — positive and negative
+- [ ] Response time < 48 hours
+- [ ] No incentivized reviews (violates Google TOS)
+- [ ] Reviews spread across multiple platforms (not just Google)
+- [ ] Negative reviews addressed professionally — no arguing
+- [ ] Flag spam reviews via GBP dashboard
+- [ ] Review velocity: aim for 2-5 new reviews per month minimum
+
+---
+
+## 5. Technical SEO — 15 Points
+
+- [ ] Mobile-friendly (test: search.google.com/test/mobile-friendly)
+- [ ] Page speed: LCP < 2.5s on mobile (test: pagespeed.web.dev)
+- [ ] CLS < 0.1 (layout shift on load — often image sizing issue)
+- [ ] HTTPS everywhere — no mixed content warnings
+- [ ] No broken links (especially on service area pages)
+- [ ] Canonical tags on all service area pages (prevent duplicate content)
+- [ ] XML sitemap submitted to Google Search Console and Bing Webmaster
+- [ ] robots.txt does NOT block important pages
+- [ ] AI crawlers allowed (GPTBot, ClaudeBot, PerplexityBot) — local businesses benefit from AI Overview citations
+- [ ] No 4xx or 5xx errors on key pages
+- [ ] Structured data valid — no errors in Google Rich Results Test
+- [ ] Hreflang NOT needed (single-language, single-country business)
+- [ ] 301 redirects in place for any changed URLs
+- [ ] Google Analytics + Search Console connected and receiving data
+- [ ] GBP linked to Google Analytics (via UTM tagging minimum)
+
+---
+
+## Quick Wins (Highest ROI, Lowest Effort)
+
+These items return the most ranking improvement per hour of work:
+
+1. **Respond to all unanswered reviews** — immediate GBP ranking signal
+2. **Add photos to GBP** — 5 new photos takes 10 minutes, boosts profile completeness
+3. **Fix Tier 1 NAP mismatches** — Google, Apple Maps, Bing — 30 minutes per listing
+4. **Add LocalBusiness schema** — `schema_generator.py` generates it in 30 seconds
+5. **Create one new service area page per week** — compound effect over 3-6 months
+6. **Seed 5 Q&A pairs in GBP** — you write the question AND answer = controlled content
+
+---
+
+## Scoring
+
+- 70-80 checks: Strong local SEO foundation — focus on content and review velocity
+- 50-69 checks: Solid base with gaps — prioritize NAP and technical fixes
+- 30-49 checks: Foundational work needed — start with GBP and Tier 1 citations
+- Under 30: Major gaps — GBP audit + NAP correction are immediate priorities

--- a/marketing-skill/skills/local-seo-manager/references/review-response-templates.md
+++ b/marketing-skill/skills/local-seo-manager/references/review-response-templates.md
@@ -1,0 +1,185 @@
+# Review Response Templates — Local Service Businesses
+
+Templates for responding to Google reviews. Personalize before sending — Google's systems detect copy-paste responses and reduce their ranking value.
+
+**Rules:**
+- Respond to 100% of reviews within 48 hours
+- Never argue, never reveal customer details, never offer refunds/discounts in public
+- Keep positive responses 2-4 sentences; negative responses 3-5 sentences
+- Include the business name and neighborhood when relevant (helps local SEO)
+
+---
+
+## Positive Reviews (4-5 Stars)
+
+### Template: Generic 5-Star
+
+> Thank you, [Name]! We're glad the [service] went smoothly. Same-day availability is something we work hard to maintain for [City] residents. We appreciate you taking the time to share your experience — [Your Name], [Business Name]
+
+---
+
+### Template: Mentions Specific Technician
+
+> Thank you for the kind words about [Technician Name], [Name] — we'll pass them along. Our technicians take pride in explaining what they find and what they fix. We look forward to being your go-to appliance repair team in [Neighborhood]. — [Your Name], [Business Name]
+
+---
+
+### Template: Mentions Fast / Same-Day Service
+
+> So glad we could make it out quickly, [Name]! A broken [appliance] can't wait, so we keep our schedule flexible for same-day calls in [City]. We'll be here whenever you need us. — [Your Name], [Business Name]
+
+---
+
+### Template: Mentions Pricing / Good Value
+
+> Thank you, [Name]. We believe in upfront pricing before any work starts — no surprises. Glad it matched your expectations. We appreciate your trust and hope to help again if anything comes up. — [Your Name], [Business Name]
+
+---
+
+### Template: Mentions Warranty / Reliability
+
+> We're happy to hear everything is still running perfectly, [Name]! Our 90-day parts and labor warranty exists for exactly this reason — peace of mind. Don't hesitate to reach out if you ever need us. — [Your Name], [Business Name]
+
+---
+
+### Template: Appliance-Specific — Washer
+
+> Thank you, [Name]! Washer issues always feel urgent with laundry piling up. Glad we could diagnose and fix the problem in one visit. We service all major brands in [Neighborhood] — Samsung, LG, Whirlpool, and more. — [Your Name], [Business Name]
+
+---
+
+### Template: Appliance-Specific — Refrigerator
+
+> Thank you for the review, [Name]! Refrigerator repairs are time-sensitive and we take them seriously. Glad we kept your food safe and the repair straightforward. We're always here for [Neighborhood] residents. — [Your Name], [Business Name]
+
+---
+
+### Template: Appliance-Specific — Dryer
+
+> Appreciate the review, [Name]! A dryer that won't heat or spin is a real inconvenience. Happy we got it sorted quickly. We'll be here whenever you need us in [City]. — [Your Name], [Business Name]
+
+---
+
+### Template: Appliance-Specific — Dishwasher
+
+> Thank you, [Name]! Dishwasher repairs can be tricky but our technicians work with all major brands. Glad we got yours back in service quickly. We appreciate you choosing [Business Name] in [City]. — [Your Name], [Business Name]
+
+---
+
+### Template: Appliance-Specific — Oven / Range
+
+> Thank you for the kind words, [Name]! Oven and range repairs require careful diagnostics — we're glad our technician found and fixed the issue efficiently. Enjoy cooking again! — [Your Name], [Business Name]
+
+---
+
+## Neutral Reviews (3 Stars)
+
+### Template: No Specific Complaint, Mixed Tone
+
+> Thank you for the feedback, [Name]. We're glad the repair got done but we're always looking to improve. If there's something specific we could have done better, we'd love to hear — please reach out at [phone/email]. We take every experience seriously. — [Your Name], [Business Name]
+
+---
+
+### Template: Mentions Wait Time
+
+> Thank you for the honest feedback, [Name]. We understand that waiting for a repair is frustrating, especially when an appliance you rely on is out of service. We've been working on our scheduling to reduce wait times. We'd appreciate the chance to earn a better experience next time. — [Your Name], [Business Name]
+
+---
+
+### Template: Mentions Pricing (Neutral/Surprised)
+
+> Thank you for taking the time to review us, [Name]. We always provide a written estimate before any work begins, and we aim to be transparent about parts and labor costs. If anything was unclear about the pricing, please reach out directly — we're happy to go through it with you. — [Your Name], [Business Name]
+
+---
+
+## Negative Reviews (1-2 Stars)
+
+**Critical rule:** Never argue. Never repeat the customer's complaint (it gets indexed by Google). Acknowledge, apologize, take offline.
+
+### Template: Generic Negative — Unknown Issue
+
+> We're sorry your experience didn't meet your expectations, [Name]. That's not the standard we hold ourselves to. Please contact us directly at [phone or email] so we can understand what happened and make it right. — [Your Name], [Business Name]
+
+---
+
+### Template: Repair Did Not Fix the Problem
+
+> We apologize that the issue wasn't fully resolved, [Name]. Our repairs are backed by a 90-day warranty for exactly this reason. Please call us at [phone] so we can schedule a follow-up visit at no additional charge. We want to make this right. — [Your Name], [Business Name]
+
+---
+
+### Template: Technician Conduct / Professionalism
+
+> We're sorry to hear this, [Name]. The behavior you describe is not what we expect from our team. We take this seriously and would like to speak with you directly. Please reach out at [phone or email] so we can address this properly. — [Your Name], [Business Name]
+
+---
+
+### Template: Pricing Dispute
+
+> We're sorry the cost was unexpected, [Name]. Our policy is to provide a written estimate before starting any work, and we stand behind our pricing. We'd welcome the chance to review the details with you directly — please call us at [phone]. — [Your Name], [Business Name]
+
+---
+
+### Template: No-Show / Late Arrival
+
+> We sincerely apologize for the scheduling issue, [Name]. Missing or delaying an appointment is unacceptable, especially when you've taken time out of your day. Please contact us at [phone or email] and we will make this right with priority scheduling. — [Your Name], [Business Name]
+
+---
+
+### Template: Damage to Property Claim
+
+> We take this concern very seriously, [Name]. All our technicians are fully insured and we have a process for addressing any damage that occurs during a service call. Please contact us directly at [phone or email] so we can review this with you right away. — [Your Name], [Business Name]
+
+---
+
+### Template: Review Appears to Be Spam / Wrong Business
+
+> Thank you for bringing this to our attention. We don't have any record of a service call that matches your description. It's possible this review may be intended for a different business. If you did use our services and experienced an issue, please call us at [phone] — we'd like to resolve it. — [Your Name], [Business Name]
+
+---
+
+## Review Request Templates
+
+Use these after completing a successful job to ask for a review.
+
+### Text / SMS (short)
+
+> Hi [Name], thanks for choosing [Business Name] today! If you have 2 minutes, a Google review would mean a lot to us: [short link]. — [Technician Name]
+
+---
+
+### Email (post-job follow-up)
+
+**Subject:** How did your [appliance] repair go, [Name]?
+
+> Hi [Name],
+>
+> Thank you for choosing [Business Name] for your [appliance] repair. We hope everything is working perfectly.
+>
+> If you have a moment, we'd really appreciate a Google review — it helps local homeowners find reliable repair services:
+>
+> [Google Review Link]
+>
+> And if anything came up with the repair, please call us at [phone]. Our 90-day warranty covers parts and labor.
+>
+> Thank you,
+> [Your Name]
+> [Business Name]
+
+---
+
+## Quick-Reference: Response Length by Star Rating
+
+| Rating | Recommended Length | Tone |
+|---|---|---|
+| 5 stars | 2-3 sentences | Warm, brief, personal |
+| 4 stars | 2-3 sentences | Grateful, invite back |
+| 3 stars | 3-4 sentences | Appreciative, offer to improve |
+| 2 stars | 3-5 sentences | Calm, apologetic, take offline |
+| 1 star | 3-5 sentences | Calm, apologetic, take offline |
+
+**Never:**
+- Copy-paste the same response to multiple reviews
+- Include keywords just for SEO in review responses (reads as inauthentic)
+- Respond while emotional — write the draft, wait 30 minutes, then send
+- Offer refunds, discounts, or freebies in a public response (sets a precedent)

--- a/marketing-skill/skills/local-seo-manager/scripts/nap_checker.py
+++ b/marketing-skill/skills/local-seo-manager/scripts/nap_checker.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+nap_checker.py - NAP (Name, Address, Phone) consistency checker for local businesses.
+
+Compares the canonical NAP against known directory listing data and reports
+mismatches with fix priority.
+
+Usage:
+    python3 nap_checker.py [--canonical canonical.json] [--listings listings.json]
+
+If no files provided, runs with embedded sample data for demonstration.
+
+Output: Human-readable mismatch report + JSON summary.
+"""
+
+import json
+import sys
+import re
+import argparse
+from typing import Dict, List, Optional, Tuple
+
+
+# --- Normalizers ---
+
+def normalize_phone(phone: str) -> str:
+    """Strip all non-digit characters, return 10-digit string."""
+    digits = re.sub(r'\D', '', phone)
+    if len(digits) == 11 and digits.startswith('1'):
+        digits = digits[1:]
+    return digits
+
+
+def normalize_name(name: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace."""
+    name = name.lower()
+    name = re.sub(r'[^\w\s]', ' ', name)
+    name = re.sub(r'\s+', ' ', name).strip()
+    # Remove common legal suffixes for comparison
+    for suffix in ['llc', 'inc', 'corp', 'ltd', 'co']:
+        name = re.sub(rf'\b{suffix}\b', '', name).strip()
+    return name
+
+
+def normalize_address(address: str) -> str:
+    """Lowercase, expand common abbreviations, strip punctuation."""
+    address = address.lower()
+    replacements = {
+        r'\bst\b': 'street',
+        r'\bave\b': 'avenue',
+        r'\bblvd\b': 'boulevard',
+        r'\bdr\b': 'drive',
+        r'\brd\b': 'road',
+        r'\bln\b': 'lane',
+        r'\bct\b': 'court',
+        r'\bpl\b': 'place',
+        r'\bsuite\b': 'ste',
+        r'\bapt\b': 'apt',
+        r'\bca\b': 'california',
+    }
+    for pattern, replacement in replacements.items():
+        address = re.sub(pattern, replacement, address)
+    address = re.sub(r'[^\w\s]', ' ', address)
+    address = re.sub(r'\s+', ' ', address).strip()
+    return address
+
+
+# --- Tier definitions ---
+
+DIRECTORY_TIERS = {
+    'google_business_profile': 1,
+    'apple_maps': 1,
+    'bing_places': 1,
+    'yelp': 2,
+    'bbb': 2,
+    'angi': 2,
+    'homeadvisor': 2,
+    'facebook': 3,
+    'yellow_pages': 3,
+    'nextdoor': 3,
+    'thumbtack': 3,
+}
+
+TIER_LABELS = {1: 'Critical', 2: 'High', 3: 'Medium'}
+
+
+# --- Comparison logic ---
+
+def compare_nap(canonical: Dict, listing: Dict) -> List[Dict]:
+    """Return list of mismatches between canonical and a listing."""
+    mismatches = []
+
+    # Name
+    canon_name = normalize_name(canonical.get('name', ''))
+    listing_name = normalize_name(listing.get('name', ''))
+    if canon_name != listing_name:
+        mismatches.append({
+            'field': 'name',
+            'canonical': canonical.get('name', ''),
+            'found': listing.get('name', ''),
+        })
+
+    # Phone
+    canon_phone = normalize_phone(canonical.get('phone', ''))
+    listing_phone = normalize_phone(listing.get('phone', ''))
+    if canon_phone and listing_phone and canon_phone != listing_phone:
+        mismatches.append({
+            'field': 'phone',
+            'canonical': canonical.get('phone', ''),
+            'found': listing.get('phone', ''),
+        })
+    elif not listing.get('phone'):
+        mismatches.append({
+            'field': 'phone',
+            'canonical': canonical.get('phone', ''),
+            'found': '(missing)',
+        })
+
+    # Address - check each sub-field if structured, else compare full string
+    if isinstance(canonical.get('address'), dict) and isinstance(listing.get('address'), dict):
+        for sub in ['street', 'city', 'state', 'zip']:
+            cv = normalize_address(str(canonical['address'].get(sub, '')))
+            lv = normalize_address(str(listing['address'].get(sub, '')))
+            if cv and lv and cv != lv:
+                mismatches.append({
+                    'field': f'address.{sub}',
+                    'canonical': canonical['address'].get(sub, ''),
+                    'found': listing['address'].get(sub, ''),
+                })
+            elif cv and not lv:
+                mismatches.append({
+                    'field': f'address.{sub}',
+                    'canonical': canonical['address'].get(sub, ''),
+                    'found': '(missing)',
+                })
+    elif canonical.get('address') and listing.get('address'):
+        ca = normalize_address(str(canonical['address']))
+        la = normalize_address(str(listing['address']))
+        if ca != la:
+            mismatches.append({
+                'field': 'address',
+                'canonical': canonical['address'],
+                'found': listing['address'],
+            })
+
+    return mismatches
+
+
+# --- Report generation ---
+
+def build_report(canonical: Dict, listings: List[Dict]) -> Tuple[str, Dict]:
+    lines = []
+    summary = {
+        'total_directories': len(listings),
+        'consistent': 0,
+        'mismatches': 0,
+        'missing': 0,
+        'critical_issues': 0,
+        'issues': [],
+    }
+
+    lines.append('=' * 65)
+    lines.append('NAP CONSISTENCY REPORT')
+    lines.append('=' * 65)
+    lines.append(f"\nCANONICAL NAP")
+    lines.append(f"  Name   : {canonical.get('name', 'N/A')}")
+    if isinstance(canonical.get('address'), dict):
+        addr = canonical['address']
+        lines.append(f"  Address: {addr.get('street', '')} {addr.get('city', '')} {addr.get('state', '')} {addr.get('zip', '')}")
+    else:
+        lines.append(f"  Address: {canonical.get('address', 'N/A')}")
+    lines.append(f"  Phone  : {canonical.get('phone', 'N/A')}")
+    lines.append(f"  Website: {canonical.get('website', 'N/A')}")
+    lines.append('')
+
+    all_issues_by_tier = {1: [], 2: [], 3: []}
+
+    for listing in listings:
+        directory = listing.get('directory', 'unknown')
+        tier = DIRECTORY_TIERS.get(directory, 3)
+        url = listing.get('url', '')
+        listed = listing.get('listed', True)
+
+        if not listed:
+            issue = {
+                'directory': directory,
+                'tier': tier,
+                'type': 'missing',
+                'url': url,
+                'mismatches': [],
+            }
+            all_issues_by_tier[tier].append(issue)
+            summary['missing'] += 1
+            if tier == 1:
+                summary['critical_issues'] += 1
+            continue
+
+        mismatches = compare_nap(canonical, listing)
+
+        if mismatches:
+            issue = {
+                'directory': directory,
+                'tier': tier,
+                'type': 'mismatch',
+                'url': url,
+                'mismatches': mismatches,
+            }
+            all_issues_by_tier[tier].append(issue)
+            summary['mismatches'] += 1
+            summary['issues'].append(issue)
+            if tier == 1:
+                summary['critical_issues'] += 1
+        else:
+            summary['consistent'] += 1
+
+    # Print by tier
+    for tier in [1, 2, 3]:
+        tier_issues = all_issues_by_tier[tier]
+        if not tier_issues:
+            continue
+        lines.append(f"-- TIER {tier} - {TIER_LABELS[tier]} Priority " + "-" * 30)
+        for issue in tier_issues:
+            dir_label = issue['directory'].replace('_', ' ').title()
+            lines.append(f"\n  [{dir_label}]  {issue.get('url', '')}")
+            if issue['type'] == 'missing':
+                lines.append(f"  [!]  NOT LISTED -- create a listing immediately")
+            else:
+                for m in issue['mismatches']:
+                    lines.append(f"  [X]  {m['field']}")
+                    lines.append(f"       Expected : {m['canonical']}")
+                    lines.append(f"       Found    : {m['found']}")
+        lines.append('')
+
+    lines.append('=' * 65)
+    lines.append('SUMMARY')
+    lines.append(f"  Directories checked : {summary['total_directories']}")
+    lines.append(f"  Consistent          : {summary['consistent']}")
+    lines.append(f"  Has mismatches      : {summary['mismatches']}")
+    lines.append(f"  Not listed          : {summary['missing']}")
+    lines.append(f"  Critical issues     : {summary['critical_issues']} (Tier 1 directories)")
+    lines.append('=' * 65)
+
+    if summary['critical_issues'] == 0 and summary['mismatches'] == 0 and summary['missing'] == 0:
+        lines.append('\n[OK] NAP is fully consistent across all checked directories.')
+    else:
+        lines.append(f"\n[!] Fix Tier 1 issues first -- they have the most impact on Map Pack rankings.")
+
+    return '\n'.join(lines), summary
+
+
+# --- Sample data (for demo run) ---
+
+SAMPLE_CANONICAL = {
+    "name": "Smart Solution Appliances",
+    "phone": "(415) 555-0100",
+    "website": "https://smartsolutionappliances.com",
+    "address": {
+        "street": "123 Market Street",
+        "city": "San Francisco",
+        "state": "CA",
+        "zip": "94102"
+    }
+}
+
+SAMPLE_LISTINGS = [
+    {
+        "directory": "google_business_profile",
+        "listed": True,
+        "url": "https://g.co/kgs/example",
+        "name": "Smart Solution Appliances",
+        "phone": "(415) 555-0100",
+        "address": {"street": "123 Market Street", "city": "San Francisco", "state": "CA", "zip": "94102"}
+    },
+    {
+        "directory": "yelp",
+        "listed": True,
+        "url": "https://yelp.com/biz/example",
+        "name": "Smart Solution Appliances LLC",
+        "phone": "415-555-0100",
+        "address": {"street": "123 Market St", "city": "San Francisco", "state": "CA", "zip": "94102"}
+    },
+    {
+        "directory": "bbb",
+        "listed": True,
+        "url": "https://bbb.org/example",
+        "name": "Smart Solution Appliances",
+        "phone": "(415) 555-0100",
+        "address": {"street": "123 Market Street", "city": "San Francisco", "state": "California", "zip": "94102"}
+    },
+    {
+        "directory": "apple_maps",
+        "listed": False,
+        "url": "",
+        "name": "",
+        "phone": "",
+        "address": {}
+    },
+    {
+        "directory": "angi",
+        "listed": True,
+        "url": "https://angi.com/companylist/example",
+        "name": "Smart Solutions Appliance Repair",
+        "phone": "(415) 555-0199",
+        "address": {"street": "123 Market Street", "city": "San Francisco", "state": "CA", "zip": "94102"}
+    },
+    {
+        "directory": "facebook",
+        "listed": True,
+        "url": "https://facebook.com/example",
+        "name": "Smart Solution Appliances",
+        "phone": "(415) 555-0100",
+        "address": {"street": "123 Market Street", "city": "San Francisco", "state": "CA", "zip": "94102"}
+    },
+]
+
+
+# --- Main ---
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='NAP consistency checker for local SEO',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('--canonical', help='Path to canonical NAP JSON file')
+    parser.add_argument('--listings', help='Path to directory listings JSON file')
+    parser.add_argument('--json', action='store_true', help='Output summary as JSON')
+    args = parser.parse_args()
+
+    if args.canonical:
+        with open(args.canonical) as f:
+            canonical = json.load(f)
+    else:
+        canonical = SAMPLE_CANONICAL
+        print('[INFO] No --canonical file provided. Using sample data.\n')
+
+    if args.listings:
+        with open(args.listings) as f:
+            listings = json.load(f)
+    else:
+        listings = SAMPLE_LISTINGS
+
+    report, summary = build_report(canonical, listings)
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(report)
+        print(f'\n[JSON summary]\n{json.dumps(summary, indent=2)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/marketing-skill/skills/local-seo-manager/scripts/schema_generator.py
+++ b/marketing-skill/skills/local-seo-manager/scripts/schema_generator.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+schema_generator.py — LocalBusiness JSON-LD schema generator for local service businesses.
+
+Generates valid schema.org JSON-LD for LocalBusiness, HomeAndConstructionBusiness,
+Service, and FAQPage types — ready to paste into WordPress (Rank Math custom schema
+or wp_head hook) or any HTML <head>.
+
+Usage:
+    python3 schema_generator.py [--config config.json] [--type local-business|service-area|faq]
+
+If no config provided, runs with embedded sample data.
+
+Output: JSON-LD block(s) ready for <script type="application/ld+json"> tags.
+"""
+
+import json
+import sys
+import argparse
+from typing import Dict, List, Optional
+
+
+# ─── Schema builders ──────────────────────────────────────────────────────────
+
+def build_local_business(config: Dict) -> Dict:
+    """Build LocalBusiness + HomeAndConstructionBusiness schema."""
+    address = config.get('address', {})
+    schema = {
+        "@context": "https://schema.org",
+        "@type": ["LocalBusiness", "HomeAndConstructionBusiness"],
+        "name": config['business_name'],
+        "url": config['website'],
+        "telephone": config['phone'],
+        "priceRange": config.get('price_range', '$$'),
+        "image": config.get('logo_url', ''),
+        "description": config.get('description', ''),
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": address.get('street', ''),
+            "addressLocality": address.get('city', ''),
+            "addressRegion": address.get('state', ''),
+            "postalCode": address.get('zip', ''),
+            "addressCountry": "US"
+        },
+        "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": config.get('latitude', ''),
+            "longitude": config.get('longitude', '')
+        },
+        "openingHoursSpecification": _build_hours(config.get('hours', {})),
+        "sameAs": config.get('social_profiles', []),
+        "hasMap": config.get('google_maps_url', ''),
+        "areaServed": _build_area_served(config.get('service_areas', [])),
+        "knowsAbout": config.get('services', []),
+        "aggregateRating": _build_aggregate_rating(config.get('reviews', {})),
+    }
+    # Clean empty values
+    schema = {k: v for k, v in schema.items() if v not in ('', [], {}, None)}
+    return schema
+
+
+def build_service(config: Dict, service_name: str, neighborhood: str = '', description: str = '') -> Dict:
+    """Build Service schema for a specific service page."""
+    schema = {
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "serviceType": service_name,
+        "provider": {
+            "@type": "LocalBusiness",
+            "name": config['business_name'],
+            "telephone": config['phone'],
+            "url": config['website'],
+        },
+        "areaServed": {
+            "@type": "City",
+            "name": config.get('city', ''),
+        },
+        "description": description or f"Professional {service_name.lower()} in {neighborhood or config.get('city', '')}.",
+    }
+    if neighborhood:
+        schema["areaServed"] = {
+            "@type": "Place",
+            "name": f"{neighborhood}, {config.get('city', '')}",
+        }
+    return schema
+
+
+def build_faq_page(faqs: List[Dict]) -> Dict:
+    """Build FAQPage schema from list of {question, answer} dicts."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": faq['question'],
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": faq['answer']
+                }
+            }
+            for faq in faqs
+        ]
+    }
+
+
+def build_service_area_page_schemas(config: Dict, neighborhood: str, primary_service: str, faqs: Optional[List[Dict]] = None) -> List[Dict]:
+    """Return all schema blocks needed for a service area page."""
+    schemas = [
+        build_local_business(config),
+        build_service(config, primary_service, neighborhood),
+    ]
+    if faqs:
+        schemas.append(build_faq_page(faqs))
+    return schemas
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _build_hours(hours: Dict) -> List[Dict]:
+    if not hours:
+        return []
+    day_map = {
+        'monday': 'Monday', 'tuesday': 'Tuesday', 'wednesday': 'Wednesday',
+        'thursday': 'Thursday', 'friday': 'Friday', 'saturday': 'Saturday', 'sunday': 'Sunday'
+    }
+    specs = []
+    for day, times in hours.items():
+        if times and times.get('open') and times.get('close'):
+            specs.append({
+                "@type": "OpeningHoursSpecification",
+                "dayOfWeek": f"https://schema.org/{day_map.get(day.lower(), day)}",
+                "opens": times['open'],
+                "closes": times['close']
+            })
+    return specs
+
+
+def _build_area_served(areas: List[str]) -> List[Dict]:
+    return [{"@type": "Place", "name": area} for area in areas]
+
+
+def _build_aggregate_rating(reviews: Dict) -> Optional[Dict]:
+    if not reviews or not reviews.get('count'):
+        return None
+    return {
+        "@type": "AggregateRating",
+        "ratingValue": str(reviews.get('average', '4.8')),
+        "bestRating": "5",
+        "worstRating": "1",
+        "ratingCount": str(reviews['count'])
+    }
+
+
+def format_as_script_tag(schema: Dict) -> str:
+    return f'<script type="application/ld+json">\n{json.dumps(schema, indent=2)}\n</script>'
+
+
+# ─── Sample data ──────────────────────────────────────────────────────────────
+
+SAMPLE_CONFIG = {
+    "business_name": "Smart Solution Appliances",
+    "website": "https://smartsolutionappliances.com",
+    "phone": "(415) 555-0100",
+    "price_range": "$$",
+    "city": "San Francisco",
+    "description": "Professional appliance repair in San Francisco. Same-day service for washers, dryers, refrigerators, dishwashers, and ovens.",
+    "address": {
+        "street": "123 Market Street",
+        "city": "San Francisco",
+        "state": "CA",
+        "zip": "94102"
+    },
+    "hours": {
+        "monday": {"open": "08:00", "close": "18:00"},
+        "tuesday": {"open": "08:00", "close": "18:00"},
+        "wednesday": {"open": "08:00", "close": "18:00"},
+        "thursday": {"open": "08:00", "close": "18:00"},
+        "friday": {"open": "08:00", "close": "18:00"},
+        "saturday": {"open": "09:00", "close": "15:00"},
+        "sunday": {"open": "", "close": ""}
+    },
+    "services": ["Washer Repair", "Dryer Repair", "Refrigerator Repair", "Dishwasher Repair", "Oven Repair"],
+    "service_areas": ["San Francisco", "Richmond District", "Mission District", "Pacific Heights", "Sunset District"],
+    "social_profiles": [
+        "https://www.yelp.com/biz/smart-solution-appliances-san-francisco",
+        "https://www.facebook.com/smartsolutionappliances"
+    ],
+    "reviews": {"average": 4.8, "count": 124}
+}
+
+SAMPLE_FAQS = [
+    {
+        "question": "How quickly can you reach the Richmond District for appliance repair?",
+        "answer": "We offer same-day service in the Richmond District. Call before noon and we can typically arrive the same afternoon."
+    },
+    {
+        "question": "What appliance brands do you service in the Richmond District?",
+        "answer": "We repair all major brands including Samsung, LG, Whirlpool, GE, Bosch, Maytag, KitchenAid, Frigidaire, and Electrolux."
+    },
+    {
+        "question": "Are your technicians licensed and insured in San Francisco?",
+        "answer": "Yes. All Smart Solution Appliances technicians are fully licensed, bonded, and insured in California."
+    },
+    {
+        "question": "Do you offer a warranty on appliance repairs in Richmond District?",
+        "answer": "Yes. All repairs come with a 90-day parts and labor warranty."
+    },
+]
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='LocalBusiness JSON-LD schema generator',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('--config', help='Path to business config JSON')
+    parser.add_argument('--type', choices=['local-business', 'service-area', 'faq'], default='local-business',
+                        help='Schema type to generate')
+    parser.add_argument('--neighborhood', help='Neighborhood (for service-area type)', default='')
+    parser.add_argument('--service', help='Service name (for service-area type)', default='Appliance Repair')
+    parser.add_argument('--faqs', help='Path to FAQs JSON (for faq type)')
+    parser.add_argument('--html', action='store_true', help='Output as <script> HTML tag')
+    args = parser.parse_args()
+
+    if args.config:
+        with open(args.config) as f:
+            config = json.load(f)
+    else:
+        config = SAMPLE_CONFIG
+        print('[INFO] No --config provided. Using sample data.\n')
+
+    faqs = None
+    if args.faqs:
+        with open(args.faqs) as f:
+            faqs = json.load(f)
+    elif args.type in ('service-area', 'faq'):
+        faqs = SAMPLE_FAQS
+
+    if args.type == 'local-business':
+        schemas = [build_local_business(config)]
+    elif args.type == 'service-area':
+        schemas = build_service_area_page_schemas(
+            config,
+            neighborhood=args.neighborhood or 'Richmond District',
+            primary_service=args.service,
+            faqs=faqs
+        )
+    elif args.type == 'faq':
+        schemas = [build_faq_page(faqs or SAMPLE_FAQS)]
+    else:
+        schemas = [build_local_business(config)]
+
+    for schema in schemas:
+        if args.html:
+            print(format_as_script_tag(schema))
+        else:
+            print(json.dumps(schema, indent=2))
+        print()
+
+    if not args.html:
+        print('─' * 65)
+        print('Paste each block inside a <script type="application/ld+json"> tag.')
+        print('Validate at: https://validator.schema.org/')
+        print('Test rich results at: https://search.google.com/test/rich-results')
+
+
+if __name__ == '__main__':
+    main()

--- a/marketing-skill/skills/local-seo-manager/scripts/service_area_generator.py
+++ b/marketing-skill/skills/local-seo-manager/scripts/service_area_generator.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+service_area_generator.py — Service area page content generator for local businesses.
+
+Generates a structured brief for a neighborhood-specific service area page,
+including word-count targets, uniqueness checklist, FAQ starters, and
+schema boilerplate for the page.
+
+Usage:
+    python3 service_area_generator.py [--config config.json] [--neighborhood "Richmond District"]
+    python3 service_area_generator.py  (runs sample demo)
+
+Output: Page brief as markdown, ready to hand to content-production skill or write directly.
+"""
+
+import json
+import sys
+import argparse
+from typing import Dict, List, Optional
+
+
+# ─── Page brief builder ───────────────────────────────────────────────────────
+
+def build_page_brief(
+    business_name: str,
+    business_type: str,
+    services: List[str],
+    primary_service: str,
+    neighborhood: str,
+    city: str,
+    state: str,
+    phone: str,
+    website: str,
+    years_in_business: int,
+    brands_serviced: Optional[List[str]] = None,
+    nearby_neighborhoods: Optional[List[str]] = None,
+    zip_code: str = '',
+    landmark: str = '',
+) -> str:
+    brands = brands_serviced or ['Samsung', 'LG', 'Whirlpool', 'GE', 'Bosch', 'Maytag', 'KitchenAid', 'Frigidaire']
+    nearby = nearby_neighborhoods or []
+    service_list = ', '.join(services)
+    brand_list = ', '.join(brands)
+
+    title = f"{primary_service} in {neighborhood}, {city} | {business_name}"
+    meta_desc = (
+        f"{business_name} provides professional {primary_service.lower()} in {neighborhood}, {city}. "
+        f"Same-day service available. Call {phone} or book online."
+    )
+
+    slug = f"{primary_service.lower().replace(' ', '-')}-{neighborhood.lower().replace(' ', '-')}-{city.lower().replace(' ', '-')}"
+
+    lines = []
+    lines.append(f"# Page Brief: {title}")
+    lines.append(f"\n**URL slug:** `/{slug}/`")
+    lines.append(f"**Target word count:** 1,000-1,500 words")
+    lines.append(f"**Primary keyword:** {primary_service} in {neighborhood}")
+    lines.append(f"**Secondary keywords:** {primary_service.lower()} {neighborhood.lower()}, {primary_service.lower()} near {neighborhood.lower()}, appliance repair {zip_code}")
+    lines.append(f"**Schema required:** LocalBusiness + Service + FAQPage")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(f"## SEO Metadata")
+    lines.append(f"")
+    lines.append(f"**Title tag:** {title}")
+    lines.append(f"**Meta description:** {meta_desc}")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(f"## Page Structure")
+    lines.append("")
+
+    lines.append(f"### H1: {primary_service} in {neighborhood}")
+    lines.append("")
+    lines.append(f"**Opening paragraph (~150 words):**")
+    lines.append(f"Write a unique intro for {neighborhood}. Must include:")
+    lines.append(f"- Neighborhood name in first sentence")
+    lines.append(f"- Primary service ({primary_service.lower()}) in first two sentences")
+    lines.append(f"- {business_name}'s years of experience ({years_in_business} years)")
+    lines.append(f"- One specific local reference (landmark, cross-street, or characteristic of {neighborhood})")
+    if landmark:
+        lines.append(f"- Suggested landmark to mention: {landmark}")
+    lines.append(f"- DO NOT use: 'look no further', 'your one-stop shop', 'we are proud to'")
+    lines.append("")
+
+    lines.append(f"### H2: Appliance Brands We Service in {neighborhood}")
+    lines.append(f"Write 1-2 sentences about each major brand. Brands: {brand_list}")
+    lines.append(f"Angle: our technicians are trained on [brand]-specific diagnostics and use OEM parts.")
+    lines.append("")
+
+    lines.append(f"### H2: Our {neighborhood} Service Area")
+    lines.append(f"Describe the coverage boundaries: streets, zip codes, adjacent areas.")
+    if zip_code:
+        lines.append(f"Mention zip code: {zip_code}")
+    if nearby:
+        lines.append(f"Mention nearby neighborhoods we also serve: {', '.join(nearby)}")
+        lines.append(f"(Include internal links to those service area pages if they exist)")
+    lines.append("")
+
+    lines.append(f"### H2: Common Appliance Problems in {neighborhood} Homes")
+    lines.append(f"Write 3-5 specific repair scenarios relevant to the area. Examples:")
+    lines.append(f"- Washer not draining (common in older building plumbing setups)")
+    lines.append(f"- Refrigerator not cooling (older homes with limited ventilation)")
+    lines.append(f"- Dryer overheating (lint buildup in older vented systems)")
+    lines.append(f"Add one 2-3 sentence explanation per scenario. This section drives local relevance.")
+    lines.append("")
+
+    lines.append(f"### H2: Why {neighborhood} Residents Choose {business_name}")
+    lines.append(f"3-4 differentiators. Be specific — no generic claims.")
+    lines.append(f"Examples: same-day availability, {years_in_business} years serving {city}, warranty on parts and labor,")
+    lines.append(f"certified technicians, upfront pricing before work begins.")
+    lines.append("")
+
+    lines.append(f"### H2: Frequently Asked Questions")
+    lines.append(f"Write 5 Q&A pairs. Use FAQPage schema on these.")
+    lines.append(f"Suggested questions:")
+    lines.append(f"1. How quickly can you reach {neighborhood} for appliance repair?")
+    lines.append(f"2. What {primary_service.lower()} services do you offer in {neighborhood}?")
+    lines.append(f"3. Do you offer same-day appliance repair in {neighborhood}?")
+    lines.append(f"4. Are your technicians licensed and insured in {city}?")
+    lines.append(f"5. How much does {primary_service.lower()} typically cost in {neighborhood}?")
+    lines.append("")
+
+    lines.append(f"### H2: Book {primary_service} in {neighborhood}")
+    lines.append(f"CTA section. Include:")
+    lines.append(f"- Phone: {phone}")
+    lines.append(f"- Website: {website}")
+    lines.append(f"- Hours (if known)")
+    lines.append(f"- Restate service area: '{business_name} serves {neighborhood} and surrounding areas in {city}.'")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("## Schema to Add")
+    lines.append("")
+    lines.append("Run `scripts/schema_generator.py` with `--type service-area` to generate the JSON-LD.")
+    lines.append("Required schema blocks for this page:")
+    lines.append("1. `LocalBusiness` — business entity (name, address, phone, url)")
+    lines.append("2. `Service` — the specific service on this page")
+    lines.append("3. `FAQPage` — wrap the FAQ H2 section")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("## Uniqueness Checklist")
+    lines.append("")
+    lines.append("Before publishing, verify:")
+    lines.append(f"- [ ] Opening paragraph is NOT copied from another neighborhood page")
+    lines.append(f"- [ ] At least 2 {neighborhood}-specific references (landmarks, streets, zip, characteristics)")
+    lines.append(f"- [ ] Internal links TO: main {primary_service.lower()} page + 2 nearby neighborhood pages")
+    lines.append(f"- [ ] Internal link FROM: at least the main {primary_service.lower()} page to this page")
+    lines.append(f"- [ ] Meta description is unique (not shared with any other page)")
+    lines.append(f"- [ ] FAQ questions are specific to this neighborhood (not generic)")
+    lines.append("")
+
+    return '\n'.join(lines)
+
+
+# ─── Sample data ──────────────────────────────────────────────────────────────
+
+SAMPLE_CONFIG = {
+    "business_name": "Smart Solution Appliances",
+    "business_type": "appliance repair",
+    "primary_service": "Appliance Repair",
+    "services": ["washer repair", "dryer repair", "refrigerator repair", "dishwasher repair", "oven repair", "microwave repair"],
+    "city": "San Francisco",
+    "state": "CA",
+    "phone": "(415) 555-0100",
+    "website": "https://smartsolutionappliances.com",
+    "years_in_business": 10,
+    "brands_serviced": ["Samsung", "LG", "Whirlpool", "GE", "Bosch", "Maytag", "KitchenAid", "Frigidaire", "Electrolux"]
+}
+
+SAMPLE_NEIGHBORHOODS = [
+    {"neighborhood": "Richmond District", "zip": "94118", "landmark": "Golden Gate Park", "nearby": ["Sunset District", "Presidio Heights", "Inner Richmond"]},
+    {"neighborhood": "Mission District", "zip": "94110", "landmark": "Dolores Park", "nearby": ["Bernal Heights", "Noe Valley", "Castro"]},
+    {"neighborhood": "Pacific Heights", "zip": "94115", "landmark": "Lafayette Park", "nearby": ["Cow Hollow", "Marina District", "Lower Pacific Heights"]},
+]
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Service area page brief generator',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('--config', help='Path to business config JSON')
+    parser.add_argument('--neighborhood', help='Neighborhood name to generate for')
+    parser.add_argument('--zip', help='Zip code for the neighborhood')
+    parser.add_argument('--landmark', help='Local landmark to reference', default='')
+    parser.add_argument('--nearby', help='Comma-separated nearby neighborhoods', default='')
+    parser.add_argument('--all-sample', action='store_true', help='Generate briefs for all sample neighborhoods')
+    args = parser.parse_args()
+
+    if args.config:
+        with open(args.config) as f:
+            config = json.load(f)
+    else:
+        config = SAMPLE_CONFIG
+        if not args.neighborhood:
+            print('[INFO] No --config or --neighborhood provided. Running sample demo.\n')
+
+    if args.all_sample:
+        for nb in SAMPLE_NEIGHBORHOODS:
+            brief = build_page_brief(
+                business_name=config['business_name'],
+                business_type=config['business_type'],
+                services=config['services'],
+                primary_service=config['primary_service'],
+                neighborhood=nb['neighborhood'],
+                city=config['city'],
+                state=config['state'],
+                phone=config['phone'],
+                website=config['website'],
+                years_in_business=config['years_in_business'],
+                brands_serviced=config.get('brands_serviced'),
+                nearby_neighborhoods=nb.get('nearby', []),
+                zip_code=nb.get('zip', ''),
+                landmark=nb.get('landmark', ''),
+            )
+            print(brief)
+            print('\n' + '=' * 65 + '\n')
+        return
+
+    neighborhood = args.neighborhood or SAMPLE_NEIGHBORHOODS[0]['neighborhood']
+    zip_code = args.zip or ''
+    landmark = args.landmark or ''
+    nearby = [n.strip() for n in args.nearby.split(',')] if args.nearby else []
+
+    brief = build_page_brief(
+        business_name=config['business_name'],
+        business_type=config['business_type'],
+        services=config['services'],
+        primary_service=config['primary_service'],
+        neighborhood=neighborhood,
+        city=config['city'],
+        state=config['state'],
+        phone=config['phone'],
+        website=config['website'],
+        years_in_business=config['years_in_business'],
+        brands_serviced=config.get('brands_serviced'),
+        nearby_neighborhoods=nearby,
+        zip_code=zip_code,
+        landmark=landmark,
+    )
+    print(brief)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds `local-seo-manager` — a new marketing skill for local service businesses (appliance repair, HVAC, plumbing, cleaning, electrical, and similar trades). This fills a gap in the current library: the upstream has strong engineering, marketing, and C-level skills, but nothing targeting businesses that serve customers in a geographic area.

## What's included

**7 files** in `marketing-skill/skills/local-seo-manager/`:

| File | Purpose |
|---|---|
| `SKILL.md` | 4-mode skill: GBP Audit, Service Area Content, NAP Consistency, Schema & Technical |
| `scripts/nap_checker.py` | NAP consistency scanner — checks Name/Address/Phone across directories, outputs tiered mismatch report |
| `scripts/service_area_generator.py` | Service area page brief generator — outputs 1,000-1,500 word content briefs per neighborhood |
| `scripts/schema_generator.py` | LocalBusiness + HomeAndConstructionBusiness JSON-LD generator |
| `references/local-seo-checklist.md` | 80-point local SEO checklist (GBP, NAP, on-page, reviews, technical) |
| `references/local-schema-types.md` | Schema.org types for local service businesses with examples |
| `references/review-response-templates.md` | Response templates by scenario (5-star to 1-star, appliance-specific, review request flows) |

## Why local service businesses

This is a distinct SEO domain from national/content SEO:
- Google Map Pack ranking (relevance + proximity + prominence) matters more than domain authority
- NAP consistency across directories directly affects Map Pack position
- Neighborhood-specific service area pages (1,000+ words) rank for high-intent "[service] in [neighborhood]" queries
- LocalBusiness + HomeAndConstructionBusiness schema is the primary entity signal

The skill was built for and tested against `smartsolutionappliances.com` (San Francisco appliance repair) but the content, scripts, and references are fully generic.

## Scripts

All 3 scripts are stdlib-only Python, CLI-first, support `--help` and run sample demos without config files. Consistent with existing skills in this folder.

## Checklist

- [x] Follows `SKILL-AUTHORING-STANDARD.md` structure (SKILL.md + scripts/ + references/)
- [x] All scripts stdlib-only, no external dependencies
- [x] All scripts pass `--help` and run demo with no config file
- [x] SKILL.md has `name`, `description`, `license`, `metadata` frontmatter
- [x] Description includes trigger keywords and related-skill disambiguation
- [x] Proactive triggers section included
- [x] Output artifacts table included
- [x] MIT license

🤖 Generated with [Claude Code](https://claude.ai/claude-code)