### PR TITLE
fix: resolve open issues #805 #806 #807 #748 #785

### DIFF
--- a/c-level-advisor/README.md
+++ b/c-level-advisor/README.md
@@ -36,10 +36,10 @@ npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor --agent
 
 ```bash
 # CEO Advisor
-npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/ceo-advisor
+npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/skills/ceo-advisor
 
 # CTO Advisor
-npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/cto-advisor
+npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/skills/cto-advisor
 ```
 
 **Supported Agents:** Claude Code, Cursor, VS Code, Copilot, Goose, Amp, Codex
@@ -148,7 +148,7 @@ This C-Level advisory skills collection provides executive leadership guidance f
 
 1. **Install CEO Advisor:**
    ```bash
-   npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/ceo-advisor
+   npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/skills/ceo-advisor
    ```
 
 2. **Evaluate Strategic Initiative:**
@@ -170,7 +170,7 @@ This C-Level advisory skills collection provides executive leadership guidance f
 
 1. **Install CTO Advisor:**
    ```bash
-   npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/cto-advisor
+   npx ai-agent-skills install alirezarezvani/claude-skills/c-level-advisor/skills/cto-advisor
    ```
 
 2. **Analyze Technical Debt:**

--- a/engineering-team/README.md
+++ b/engineering-team/README.md
@@ -23,30 +23,30 @@ npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team --agen
 
 ```bash
 # Core Engineering
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-architect
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-frontend
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-backend
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-fullstack
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-qa
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-devops
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-secops
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/code-reviewer
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-security
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-architect
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-frontend
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-backend
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-fullstack
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-qa
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-devops
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-secops
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/code-reviewer
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-security
 
 # Cloud & Enterprise
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/aws-solution-architect
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/ms365-tenant-manager
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/aws-solution-architect
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/ms365-tenant-manager
 
 # Development Tools
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/tdd-guide
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/tech-stack-evaluator
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/tdd-guide
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/tech-stack-evaluator
 
 # AI/ML/Data
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-data-scientist
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-data-engineer
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-ml-engineer
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-prompt-engineer
-npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/senior-computer-vision
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-data-scientist
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-data-engineer
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-ml-engineer
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-prompt-engineer
+npx ai-agent-skills install alirezarezvani/claude-skills/engineering-team/skills/senior-computer-vision
 ```
 
 **Supported Agents:** Claude Code, Cursor, VS Code, Copilot, Goose, Amp, Codex

--- a/engineering-team/skills/senior-devops/SKILL.md
+++ b/engineering-team/skills/senior-devops/SKILL.md
@@ -20,8 +20,8 @@ python scripts/pipeline_generator.py ./app --platform=github --stages=build,test
 # Script 2: Terraform Scaffolder — generates and validates IaC modules for AWS/GCP/Azure
 python scripts/terraform_scaffolder.py ./infra --provider=aws --module=ecs-service --verbose
 
-# Script 3: Deployment Manager — orchestrates container deployments with rollback support
-python3 scripts/deployment_manager.py ./deploy --verbose --json
+# Script 3: Deployment Manager — generates deployment manifests + runbooks with rollback support
+python3 scripts/deployment_manager.py deploy --env=staging --image=app:1.2.3 --strategy=blue-green --verbose --json
 ```
 
 ## Core Capabilities
@@ -147,7 +147,7 @@ python scripts/terraform_scaffolder.py <target-path> --provider=aws|gcp|azure --
 
 ### 3. Deployment Manager
 
-Orchestrates deployments with blue/green or rolling strategies, health-check gates, and automatic rollback on failure.
+Generates Kubernetes deployment manifests and ordered kubectl runbooks for blue/green or rolling strategies, with health-check gates before traffic switches and rollback runbooks. The tool writes manifests and prints the commands — it never applies them to a cluster itself, so every change gets a human review.
 
 **Example — Kubernetes blue/green deployment (blue-slot specific elements):**
 ```yaml

--- a/engineering-team/skills/senior-devops/scripts/deployment_manager.py
+++ b/engineering-team/skills/senior-devops/scripts/deployment_manager.py
@@ -1,114 +1,273 @@
 #!/usr/bin/env python3
 """
 Deployment Manager
-Automated tool for senior devops tasks
+Generates blue/green or rolling Kubernetes deployment manifests plus an ordered
+runbook of kubectl commands, and audits existing manifests. It never talks to a
+cluster itself — review the manifests and run the printed commands yourself.
+
+Subcommands:
+  deploy    --env --image [--strategy] [--health-check-url] — write manifests + runbook
+  rollback  --env --to-version                              — write a rollback runbook
+  analyze   --env                                           — audit manifests on disk
 """
 
-import os
-import sys
-import json
 import argparse
+import json
+import re
+import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
-class DeploymentManager:
-    """Main class for deployment manager functionality"""
-    
-    def __init__(self, target_path: str, verbose: bool = False):
-        self.target_path = Path(target_path)
-        self.verbose = verbose
-        self.results = {}
-    
-    def run(self) -> Dict:
-        """Execute the main functionality"""
-        print(f"🚀 Running {self.__class__.__name__}...")
-        print(f"📁 Target: {self.target_path}")
-        
-        try:
-            self.validate_target()
-            self.analyze()
-            self.generate_report()
-            
-            print("✅ Completed successfully!")
-            return self.results
-            
-        except Exception as e:
-            print(f"❌ Error: {e}")
-            sys.exit(1)
-    
-    def validate_target(self):
-        """Validate the target path exists and is accessible"""
-        if not self.target_path.exists():
-            raise ValueError(f"Target path does not exist: {self.target_path}")
-        
-        if self.verbose:
-            print(f"✓ Target validated: {self.target_path}")
-    
-    def analyze(self):
-        """Perform the main analysis or operation"""
-        if self.verbose:
-            print("📊 Analyzing...")
-        
-        # Main logic here
-        self.results['status'] = 'success'
-        self.results['target'] = str(self.target_path)
-        self.results['findings'] = []
-        
-        # Add analysis results
-        if self.verbose:
-            print(f"✓ Analysis complete: {len(self.results.get('findings', []))} findings")
-    
-    def generate_report(self):
-        """Generate and display the report"""
-        print("\n" + "="*50)
-        print("REPORT")
-        print("="*50)
-        print(f"Target: {self.results.get('target')}")
-        print(f"Status: {self.results.get('status')}")
-        print(f"Findings: {len(self.results.get('findings', []))}")
-        print("="*50 + "\n")
+DEPLOYMENT_TEMPLATE = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {name}
+  namespace: {env}
+  labels:
+    app: {app}{slot_label}
+spec:
+  replicas: {replicas}
+  selector:
+    matchLabels:
+      app: {app}{slot_label_indented}
+  template:
+    metadata:
+      labels:
+        app: {app}{slot_label_indented2}
+    spec:
+      containers:
+        - name: app
+          image: {image}
+          readinessProbe:
+            httpGet:
+              path: {health_path}
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+"""
+
+SERVICE_TEMPLATE = """apiVersion: v1
+kind: Service
+metadata:
+  name: {app}-svc
+  namespace: {env}
+spec:
+  selector:
+    app: {app}{slot_selector}
+  ports:
+    - port: 80
+      targetPort: 8080
+"""
+
+
+def app_name_from_image(image: str) -> str:
+    """ghcr.io/org/my-app:1.2.3 -> my-app"""
+    repo = image.rsplit(":", 1)[0]
+    return repo.rsplit("/", 1)[-1] or "app"
+
+
+def render_deployment(app: str, env: str, image: str, replicas: int,
+                      health_path: str, slot: str = "") -> str:
+    return DEPLOYMENT_TEMPLATE.format(
+        name=f"{app}-{slot}" if slot else app,
+        env=env,
+        app=app,
+        image=image,
+        replicas=replicas,
+        health_path=health_path,
+        slot_label=f"\n    slot: {slot}" if slot else "",
+        slot_label_indented=f"\n      slot: {slot}" if slot else "",
+        slot_label_indented2=f"\n        slot: {slot}" if slot else "",
+    )
+
+
+def cmd_deploy(args) -> Dict:
+    app = args.app or app_name_from_image(args.image)
+    health_path = "/healthz"
+    if args.health_check_url:
+        match = re.search(r"https?://[^/]+(/.*)", args.health_check_url)
+        if match:
+            health_path = match.group(1)
+
+    out_dir = Path(args.output_dir) / args.env
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written: List[str] = []
+    runbook: List[str] = []
+
+    if args.strategy == "blue-green":
+        slot = args.slot
+        manifest = out_dir / f"deployment-{slot}.yaml"
+        manifest.write_text(
+            render_deployment(app, args.env, args.image, args.replicas, health_path, slot),
+            encoding="utf-8",
+        )
+        written.append(str(manifest))
+
+        service = out_dir / "service.yaml"
+        if not service.exists():
+            # service starts pointing at the OTHER slot; traffic switches in the runbook
+            other = "green" if slot == "blue" else "blue"
+            service.write_text(SERVICE_TEMPLATE.format(
+                app=app, env=args.env, slot_selector=f"\n    slot: {other}"), encoding="utf-8")
+            written.append(str(service))
+
+        runbook = [
+            f"kubectl apply -f {manifest}",
+            f"kubectl rollout status deployment/{app}-{slot} -n {args.env}",
+        ]
+        if args.health_check_url:
+            runbook.append(f"curl -sf {args.health_check_url} || echo 'HEALTH CHECK FAILED — do not switch traffic'")
+        runbook += [
+            f"# switch traffic to the {slot} slot only after the checks above pass:",
+            f"kubectl patch service {app}-svc -n {args.env} "
+            f"-p '{{\"spec\":{{\"selector\":{{\"app\":\"{app}\",\"slot\":\"{slot}\"}}}}}}'",
+        ]
+    else:  # rolling
+        manifest = out_dir / "deployment.yaml"
+        manifest.write_text(
+            render_deployment(app, args.env, args.image, args.replicas, health_path),
+            encoding="utf-8",
+        )
+        written.append(str(manifest))
+
+        service = out_dir / "service.yaml"
+        if not service.exists():
+            service.write_text(SERVICE_TEMPLATE.format(
+                app=app, env=args.env, slot_selector=""), encoding="utf-8")
+            written.append(str(service))
+
+        runbook = [
+            f"kubectl apply -f {manifest}",
+            f"kubectl rollout status deployment/{app} -n {args.env}",
+        ]
+        if args.health_check_url:
+            runbook.append(f"curl -sf {args.health_check_url} || kubectl rollout undo deployment/{app} -n {args.env}")
+
+    return {
+        "status": "success",
+        "action": "deploy",
+        "env": args.env,
+        "app": app,
+        "image": args.image,
+        "strategy": args.strategy,
+        "manifests_written": written,
+        "runbook": runbook,
+    }
+
+
+def cmd_rollback(args) -> Dict:
+    app = args.app
+    runbook = [
+        f"# Option 1 — pin the previous image version explicitly:",
+        f"kubectl set image deployment/{app} app={app}:{args.to_version} -n {args.env}",
+        f"kubectl rollout status deployment/{app} -n {args.env}",
+        f"# Option 2 — revert to the previous ReplicaSet:",
+        f"kubectl rollout undo deployment/{app} -n {args.env}",
+        f"# Verify:",
+        f"kubectl get pods -n {args.env} -l app={app}",
+    ]
+    return {
+        "status": "success",
+        "action": "rollback",
+        "env": args.env,
+        "app": app,
+        "to_version": args.to_version,
+        "runbook": runbook,
+    }
+
+
+def cmd_analyze(args) -> Dict:
+    env_dir = Path(args.output_dir) / args.env
+    deployments = []
+    if env_dir.is_dir():
+        for manifest in sorted(env_dir.glob("deployment*.yaml")):
+            text = manifest.read_text(encoding="utf-8")
+            image = re.search(r"image:\s*(\S+)", text)
+            replicas = re.search(r"replicas:\s*(\d+)", text)
+            slot = re.search(r"slot:\s*(\S+)", text)
+            deployments.append({
+                "manifest": str(manifest),
+                "image": image.group(1) if image else "unknown",
+                "replicas": int(replicas.group(1)) if replicas else 0,
+                "slot": slot.group(1) if slot else None,
+            })
+    return {
+        "status": "success" if deployments else "empty",
+        "action": "analyze",
+        "env": args.env,
+        "manifest_dir": str(env_dir),
+        "deployments": deployments,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate deployment manifests and runbooks (blue/green or rolling)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    deploy = sub.add_parser("deploy", help="Generate deployment manifests + runbook")
+    deploy.add_argument("--env", required=True, help="Target environment / namespace")
+    deploy.add_argument("--image", required=True, help="Container image (repo:tag)")
+    deploy.add_argument("--strategy", default="rolling", choices=["blue-green", "rolling"])
+    deploy.add_argument("--health-check-url", help="Health check URL gating traffic switch")
+    deploy.add_argument("--app", help="App name (default: derived from image)")
+    deploy.add_argument("--slot", default="blue", choices=["blue", "green"],
+                        help="Slot to deploy into (blue-green only)")
+    deploy.add_argument("--replicas", type=int, default=3)
+    deploy.add_argument("--output-dir", default="./deploy", help="Manifest output directory")
+
+    rollback = sub.add_parser("rollback", help="Generate a rollback runbook")
+    rollback.add_argument("--env", required=True)
+    rollback.add_argument("--to-version", required=True, help="Version to roll back to")
+    rollback.add_argument("--app", default="app", help="App / deployment name")
+
+    analyze = sub.add_parser("analyze", help="Audit deployment manifests on disk")
+    analyze.add_argument("--env", required=True)
+    analyze.add_argument("--output-dir", default="./deploy", help="Manifest directory")
+
+    for p in (deploy, rollback, analyze):
+        p.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output")
+        p.add_argument("--json", action="store_true", help="Output results as JSON")
+        p.add_argument("--output", "-o", help="Write JSON results to this file")
+    return parser
+
 
 def main():
-    """Main entry point"""
-    parser = argparse.ArgumentParser(
-        description="Deployment Manager"
-    )
-    parser.add_argument(
-        'target',
-        help='Target path to analyze or process'
-    )
-    parser.add_argument(
-        '--verbose', '-v',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    parser.add_argument(
-        '--json',
-        action='store_true',
-        help='Output results as JSON'
-    )
-    parser.add_argument(
-        '--output', '-o',
-        help='Output file path'
-    )
-    
-    args = parser.parse_args()
-    
-    tool = DeploymentManager(
-        args.target,
-        verbose=args.verbose
-    )
-    
-    results = tool.run()
-    
-    if args.json:
+    # support the documented `--analyze --env=...` flag form as an alias
+    argv = ["analyze" if a == "--analyze" else a for a in sys.argv[1:]]
+    args = build_parser().parse_args(argv)
+
+    handlers = {"deploy": cmd_deploy, "rollback": cmd_rollback, "analyze": cmd_analyze}
+    results = handlers[args.command](args)
+
+    print(f"🚀 {results['action']} ({results['env']}) — status: {results['status']}")
+    for manifest in results.get("manifests_written", []):
+        print(f"✓ Wrote {manifest}")
+    for dep in results.get("deployments", []):
+        slot = f" slot={dep['slot']}" if dep["slot"] else ""
+        print(f"  - {dep['manifest']}: image={dep['image']} replicas={dep['replicas']}{slot}")
+    if results.get("runbook"):
+        print("\nRunbook — review, then execute in order:")
+        for step in results["runbook"]:
+            print(f"  {step}")
+
+    if args.json or args.output:
         output = json.dumps(results, indent=2)
         if args.output:
-            with open(args.output, 'w') as f:
-                f.write(output)
+            Path(args.output).write_text(output, encoding="utf-8")
             print(f"Results written to {args.output}")
         else:
             print(output)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/engineering-team/skills/senior-devops/scripts/pipeline_generator.py
+++ b/engineering-team/skills/senior-devops/scripts/pipeline_generator.py
@@ -1,114 +1,238 @@
 #!/usr/bin/env python3
 """
 Pipeline Generator
-Automated tool for senior devops tasks
+Scaffolds CI/CD pipeline configurations for GitHub Actions or CircleCI with
+build, test, security, and deploy stages. Detects node/python/go projects to
+pick sensible default commands.
 """
 
-import os
-import sys
-import json
 import argparse
+import json
+import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
-class PipelineGenerator:
-    """Main class for pipeline generator functionality"""
-    
-    def __init__(self, target_path: str, verbose: bool = False):
-        self.target_path = Path(target_path)
-        self.verbose = verbose
-        self.results = {}
-    
-    def run(self) -> Dict:
-        """Execute the main functionality"""
-        print(f"🚀 Running {self.__class__.__name__}...")
-        print(f"📁 Target: {self.target_path}")
-        
-        try:
-            self.validate_target()
-            self.analyze()
-            self.generate_report()
-            
-            print("✅ Completed successfully!")
-            return self.results
-            
-        except Exception as e:
-            print(f"❌ Error: {e}")
-            sys.exit(1)
-    
-    def validate_target(self):
-        """Validate the target path exists and is accessible"""
-        if not self.target_path.exists():
-            raise ValueError(f"Target path does not exist: {self.target_path}")
-        
-        if self.verbose:
-            print(f"✓ Target validated: {self.target_path}")
-    
-    def analyze(self):
-        """Perform the main analysis or operation"""
-        if self.verbose:
-            print("📊 Analyzing...")
-        
-        # Main logic here
-        self.results['status'] = 'success'
-        self.results['target'] = str(self.target_path)
-        self.results['findings'] = []
-        
-        # Add analysis results
-        if self.verbose:
-            print(f"✓ Analysis complete: {len(self.results.get('findings', []))} findings")
-    
-    def generate_report(self):
-        """Generate and display the report"""
-        print("\n" + "="*50)
-        print("REPORT")
-        print("="*50)
-        print(f"Target: {self.results.get('target')}")
-        print(f"Status: {self.results.get('status')}")
-        print(f"Findings: {len(self.results.get('findings', []))}")
-        print("="*50 + "\n")
+VALID_STAGES = ["build", "test", "security", "deploy"]
+
+
+def detect_runtime(project: Path) -> str:
+    if (project / "package.json").exists():
+        return "node"
+    if (project / "pyproject.toml").exists() or (project / "requirements.txt").exists():
+        return "python"
+    if (project / "go.mod").exists():
+        return "go"
+    return "generic"
+
+
+RUNTIME_COMMANDS: Dict[str, Dict[str, List[str]]] = {
+    "node": {
+        "setup": ["npm ci"],
+        "build": ["npm run build --if-present"],
+        "test": ["npm run lint --if-present", "npm test"],
+    },
+    "python": {
+        "setup": ["pip install -r requirements.txt"],
+        "build": ["python -m compileall ."],
+        "test": ["python -m ruff check .", "python -m pytest"],
+    },
+    "go": {
+        "setup": ["go mod download"],
+        "build": ["go build ./..."],
+        "test": ["go vet ./...", "go test ./..."],
+    },
+    "generic": {
+        "setup": ["echo 'add setup commands here'"],
+        "build": ["echo 'add build commands here'"],
+        "test": ["echo 'add test commands here'"],
+    },
+}
+
+GITHUB_SETUP_STEPS = {
+    "node": """      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'""",
+    "python": """      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'""",
+    "go": """      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'""",
+    "generic": "",
+}
+
+CIRCLECI_IMAGES = {
+    "node": "cimg/node:20.11",
+    "python": "cimg/python:3.12",
+    "go": "cimg/go:1.22",
+    "generic": "cimg/base:current",
+}
+
+
+def github_job(name: str, runtime: str, commands: List[str], needs: List[str],
+               extra: str = "") -> str:
+    lines = [f"  {name}:"]
+    if needs:
+        lines.append(f"    needs: [{', '.join(needs)}]")
+    if name == "deploy":
+        lines.append("    if: github.ref == 'refs/heads/main'")
+    lines.append("    runs-on: ubuntu-latest")
+    lines.append("    steps:")
+    lines.append("      - uses: actions/checkout@v4")
+    setup = GITHUB_SETUP_STEPS[runtime]
+    if setup and name in ("build", "test"):
+        lines.append(setup)
+        for cmd in RUNTIME_COMMANDS[runtime]["setup"]:
+            lines.append(f"      - run: {cmd}")
+    for cmd in commands:
+        lines.append(f"      - run: {cmd}")
+    if extra:
+        lines.append(extra)
+    return "\n".join(lines)
+
+
+def generate_github(stages: List[str], runtime: str) -> str:
+    jobs = []
+    prev: List[str] = []
+    for stage in stages:
+        if stage == "build":
+            jobs.append(github_job("build", runtime, RUNTIME_COMMANDS[runtime]["build"], prev))
+        elif stage == "test":
+            jobs.append(github_job("test", runtime, RUNTIME_COMMANDS[runtime]["test"], prev))
+        elif stage == "security":
+            extra = """      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'"""
+            jobs.append(github_job("security", runtime, [], prev, extra=extra))
+        elif stage == "deploy":
+            extra = """      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      - name: Deploy
+        run: echo 'replace with your deploy command (e.g. aws ecs update-service / kubectl apply)'"""
+            jobs.append(github_job("deploy", runtime, [], prev, extra=extra))
+        prev = [stage]
+
+    return f"""name: CI/CD Pipeline
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+{chr(10).join(jobs)}
+"""
+
+
+def generate_circleci(stages: List[str], runtime: str) -> str:
+    image = CIRCLECI_IMAGES[runtime]
+    job_blocks = []
+    workflow_jobs = []
+    prev = None
+    for stage in stages:
+        if stage == "security":
+            commands = ["echo 'add security scanner here (e.g. trivy fs .)'"]
+        elif stage == "deploy":
+            commands = ["echo 'replace with your deploy command'"]
+        else:
+            commands = RUNTIME_COMMANDS[runtime]["setup"] + RUNTIME_COMMANDS[runtime][stage]
+        steps = "\n".join(f"      - run: {cmd}" for cmd in commands)
+        job_blocks.append(f"""  {stage}:
+    docker:
+      - image: {image}
+    steps:
+      - checkout
+{steps}""")
+        if prev:
+            workflow_jobs.append(f"""      - {stage}:
+          requires: [{prev}]""")
+        else:
+            workflow_jobs.append(f"      - {stage}")
+        prev = stage
+
+    return f"""version: 2.1
+
+jobs:
+{chr(10).join(job_blocks)}
+
+workflows:
+  ci:
+    jobs:
+{chr(10).join(workflow_jobs)}
+"""
+
 
 def main():
-    """Main entry point"""
     parser = argparse.ArgumentParser(
-        description="Pipeline Generator"
+        description="Generate a CI/CD pipeline config for GitHub Actions or CircleCI."
     )
-    parser.add_argument(
-        'target',
-        help='Target path to analyze or process'
-    )
-    parser.add_argument(
-        '--verbose', '-v',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    parser.add_argument(
-        '--json',
-        action='store_true',
-        help='Output results as JSON'
-    )
-    parser.add_argument(
-        '--output', '-o',
-        help='Output file path'
-    )
-    
+    parser.add_argument("target", help="Project path to scaffold the pipeline into")
+    parser.add_argument("--platform", default="github", choices=["github", "circleci"],
+                        help="CI platform (default: github)")
+    parser.add_argument("--stages", default="build,test,deploy",
+                        help=f"Comma-separated stages from: {','.join(VALID_STAGES)}")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing config")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON")
+    parser.add_argument("--output", "-o", help="Write JSON results to this file")
     args = parser.parse_args()
-    
-    tool = PipelineGenerator(
-        args.target,
-        verbose=args.verbose
-    )
-    
-    results = tool.run()
-    
-    if args.json:
+
+    project = Path(args.target)
+    if not project.is_dir():
+        print(f"❌ Error: target path is not a directory: {project}", file=sys.stderr)
+        sys.exit(1)
+
+    stages = [s.strip() for s in args.stages.split(",") if s.strip()]
+    invalid = [s for s in stages if s not in VALID_STAGES]
+    if invalid or not stages:
+        print(f"❌ Error: invalid stages {invalid or '(none)'}; "
+              f"choose from {','.join(VALID_STAGES)}", file=sys.stderr)
+        sys.exit(1)
+
+    runtime = detect_runtime(project)
+    if args.verbose:
+        print(f"📊 Detected runtime: {runtime}")
+
+    if args.platform == "github":
+        config = generate_github(stages, runtime)
+        config_path = project / ".github" / "workflows" / "ci.yml"
+    else:
+        config = generate_circleci(stages, runtime)
+        config_path = project / ".circleci" / "config.yml"
+
+    if config_path.exists() and not args.force:
+        print(f"❌ Error: {config_path} already exists (use --force to overwrite)", file=sys.stderr)
+        sys.exit(1)
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(config, encoding="utf-8")
+    print(f"✅ Pipeline written: {config_path} (platform={args.platform}, "
+          f"stages={','.join(stages)}, runtime={runtime})")
+
+    results = {
+        "status": "success",
+        "platform": args.platform,
+        "stages": stages,
+        "runtime": runtime,
+        "config_path": str(config_path),
+    }
+    if args.json or args.output:
         output = json.dumps(results, indent=2)
         if args.output:
-            with open(args.output, 'w') as f:
-                f.write(output)
+            Path(args.output).write_text(output, encoding="utf-8")
             print(f"Results written to {args.output}")
         else:
             print(output)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/engineering-team/skills/senior-devops/scripts/terraform_scaffolder.py
+++ b/engineering-team/skills/senior-devops/scripts/terraform_scaffolder.py
@@ -1,114 +1,490 @@
 #!/usr/bin/env python3
 """
 Terraform Scaffolder
-Automated tool for senior devops tasks
+Generates provider-specific Terraform module skeletons (main.tf, variables.tf,
+outputs.tf, versions.tf) and optionally runs `terraform fmt`/`validate` when the
+terraform binary is available.
 """
 
-import os
-import sys
-import json
 import argparse
+import json
+import shutil
+import subprocess
+import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict
 
-class TerraformScaffolder:
-    """Main class for terraform scaffolder functionality"""
-    
-    def __init__(self, target_path: str, verbose: bool = False):
-        self.target_path = Path(target_path)
-        self.verbose = verbose
-        self.results = {}
-    
-    def run(self) -> Dict:
-        """Execute the main functionality"""
-        print(f"🚀 Running {self.__class__.__name__}...")
-        print(f"📁 Target: {self.target_path}")
-        
-        try:
-            self.validate_target()
-            self.analyze()
-            self.generate_report()
-            
-            print("✅ Completed successfully!")
-            return self.results
-            
-        except Exception as e:
-            print(f"❌ Error: {e}")
-            sys.exit(1)
-    
-    def validate_target(self):
-        """Validate the target path exists and is accessible"""
-        if not self.target_path.exists():
-            raise ValueError(f"Target path does not exist: {self.target_path}")
-        
-        if self.verbose:
-            print(f"✓ Target validated: {self.target_path}")
-    
-    def analyze(self):
-        """Perform the main analysis or operation"""
-        if self.verbose:
-            print("📊 Analyzing...")
-        
-        # Main logic here
-        self.results['status'] = 'success'
-        self.results['target'] = str(self.target_path)
-        self.results['findings'] = []
-        
-        # Add analysis results
-        if self.verbose:
-            print(f"✓ Analysis complete: {len(self.results.get('findings', []))} findings")
-    
-    def generate_report(self):
-        """Generate and display the report"""
-        print("\n" + "="*50)
-        print("REPORT")
-        print("="*50)
-        print(f"Target: {self.results.get('target')}")
-        print(f"Status: {self.results.get('status')}")
-        print(f"Findings: {len(self.results.get('findings', []))}")
-        print("="*50 + "\n")
+# module -> required provider
+MODULE_PROVIDERS = {
+    "ecs-service": "aws",
+    "gke-deployment": "gcp",
+    "aks-service": "azure",
+}
+
+ECS_MAIN = '''resource "aws_ecs_task_definition" "app" {
+  family                   = var.service_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+
+  container_definitions = jsonencode([{
+    name      = var.service_name
+    image     = var.container_image
+    essential = true
+    portMappings = [{
+      containerPort = var.container_port
+      protocol      = "tcp"
+    }]
+    environment = [for k, v in var.env_vars : { name = k, value = v }]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = "/ecs/${var.service_name}"
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "ecs"
+      }
+    }
+  }])
+}
+
+resource "aws_ecs_service" "app" {
+  name            = var.service_name
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = var.security_group_ids
+    assign_public_ip = false
+  }
+}
+'''
+
+ECS_VARIABLES = '''variable "service_name" {
+  description = "Name of the ECS service"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "ECS cluster ID"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image (repo:tag)"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+  default     = 8080
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units"
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Fargate task memory (MiB)"
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "Desired task count"
+  type        = number
+  default     = 2
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the service"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs for the service"
+  type        = list(string)
+}
+
+variable "env_vars" {
+  description = "Environment variables for the container"
+  type        = map(string)
+  default     = {}
+}
+'''
+
+ECS_OUTPUTS = '''output "service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.app.name
+}
+
+output "task_definition_arn" {
+  description = "ARN of the task definition"
+  value       = aws_ecs_task_definition.app.arn
+}
+'''
+
+GKE_MAIN = '''resource "kubernetes_deployment" "app" {
+  metadata {
+    name      = var.app_name
+    namespace = var.namespace
+    labels    = { app = var.app_name }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = { app = var.app_name }
+    }
+
+    template {
+      metadata {
+        labels = { app = var.app_name }
+      }
+
+      spec {
+        container {
+          name  = var.app_name
+          image = var.container_image
+
+          port {
+            container_port = var.container_port
+          }
+
+          readiness_probe {
+            http_get {
+              path = var.health_check_path
+              port = var.container_port
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 5
+          }
+
+          resources {
+            requests = {
+              cpu    = var.cpu_request
+              memory = var.memory_request
+            }
+            limits = {
+              cpu    = var.cpu_limit
+              memory = var.memory_limit
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "app" {
+  metadata {
+    name      = var.app_name
+    namespace = var.namespace
+  }
+
+  spec {
+    selector = { app = var.app_name }
+
+    port {
+      port        = 80
+      target_port = var.container_port
+    }
+
+    type = "ClusterIP"
+  }
+}
+'''
+
+GKE_VARIABLES = '''variable "app_name" {
+  description = "Application name"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace"
+  type        = string
+  default     = "default"
+}
+
+variable "container_image" {
+  description = "Container image (repo:tag)"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+  default     = 8080
+}
+
+variable "replicas" {
+  description = "Number of replicas"
+  type        = number
+  default     = 3
+}
+
+variable "health_check_path" {
+  description = "Readiness probe path"
+  type        = string
+  default     = "/healthz"
+}
+
+variable "cpu_request" {
+  description = "CPU request"
+  type        = string
+  default     = "250m"
+}
+
+variable "memory_request" {
+  description = "Memory request"
+  type        = string
+  default     = "256Mi"
+}
+
+variable "cpu_limit" {
+  description = "CPU limit"
+  type        = string
+  default     = "500m"
+}
+
+variable "memory_limit" {
+  description = "Memory limit"
+  type        = string
+  default     = "512Mi"
+}
+'''
+
+GKE_OUTPUTS = '''output "deployment_name" {
+  description = "Name of the deployment"
+  value       = kubernetes_deployment.app.metadata[0].name
+}
+
+output "service_name" {
+  description = "Name of the service"
+  value       = kubernetes_service.app.metadata[0].name
+}
+'''
+
+AKS_MAIN = '''resource "azurerm_kubernetes_cluster" "this" {
+  name                = var.cluster_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  dns_prefix          = var.cluster_name
+
+  default_node_pool {
+    name       = "default"
+    node_count = var.node_count
+    vm_size    = var.vm_size
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = var.tags
+}
+'''
+
+AKS_VARIABLES = '''variable "cluster_name" {
+  description = "AKS cluster name"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Default node pool size"
+  type        = number
+  default     = 3
+}
+
+variable "vm_size" {
+  description = "Node VM size"
+  type        = string
+  default     = "Standard_D2s_v5"
+}
+
+variable "tags" {
+  description = "Resource tags"
+  type        = map(string)
+  default     = {}
+}
+'''
+
+AKS_OUTPUTS = '''output "cluster_name" {
+  description = "AKS cluster name"
+  value       = azurerm_kubernetes_cluster.this.name
+}
+
+output "kube_config" {
+  description = "Raw kube config for the cluster"
+  value       = azurerm_kubernetes_cluster.this.kube_config_raw
+  sensitive   = true
+}
+'''
+
+VERSIONS = {
+    "aws": '''terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+''',
+    "gcp": '''terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+}
+''',
+    "azure": '''terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0"
+    }
+  }
+}
+''',
+}
+
+MODULE_FILES: Dict[str, Dict[str, str]] = {
+    "ecs-service": {"main.tf": ECS_MAIN, "variables.tf": ECS_VARIABLES, "outputs.tf": ECS_OUTPUTS},
+    "gke-deployment": {"main.tf": GKE_MAIN, "variables.tf": GKE_VARIABLES, "outputs.tf": GKE_OUTPUTS},
+    "aks-service": {"main.tf": AKS_MAIN, "variables.tf": AKS_VARIABLES, "outputs.tf": AKS_OUTPUTS},
+}
+
+
+def run_terraform_checks(module_dir: Path, verbose: bool) -> Dict:
+    """Run terraform fmt/validate when the binary exists; otherwise skip."""
+    checks = {"terraform_available": False, "fmt": "skipped", "validate": "skipped"}
+    if not shutil.which("terraform"):
+        if verbose:
+            print("ℹ️  terraform binary not found — skipping fmt/validate")
+        return checks
+
+    checks["terraform_available"] = True
+    fmt = subprocess.run(
+        ["terraform", "fmt", "-recursive", str(module_dir)],
+        capture_output=True, text=True,
+    )
+    checks["fmt"] = "passed" if fmt.returncode == 0 else f"failed: {fmt.stderr.strip()}"
+
+    init = subprocess.run(
+        ["terraform", f"-chdir={module_dir}", "init", "-backend=false", "-input=false"],
+        capture_output=True, text=True,
+    )
+    if init.returncode == 0:
+        validate = subprocess.run(
+            ["terraform", f"-chdir={module_dir}", "validate"],
+            capture_output=True, text=True,
+        )
+        checks["validate"] = "passed" if validate.returncode == 0 else f"failed: {validate.stderr.strip()}"
+    else:
+        checks["validate"] = f"init failed: {init.stderr.strip()}"
+    return checks
+
+
+def scaffold(target: Path, provider: str, module: str, force: bool, verbose: bool) -> Dict:
+    expected_provider = MODULE_PROVIDERS[module]
+    if provider != expected_provider:
+        raise ValueError(
+            f"Module '{module}' targets provider '{expected_provider}', not '{provider}'. "
+            f"Valid pairs: " + ", ".join(f"{m} → {p}" for m, p in MODULE_PROVIDERS.items())
+        )
+
+    module_dir = target / "modules" / module
+    module_dir.mkdir(parents=True, exist_ok=True)
+
+    files = dict(MODULE_FILES[module])
+    files["versions.tf"] = VERSIONS[provider]
+
+    written, skipped = [], []
+    for name, content in sorted(files.items()):
+        path = module_dir / name
+        if path.exists() and not force:
+            skipped.append(str(path))
+            if verbose:
+                print(f"⏭️  Exists, skipping (use --force to overwrite): {path}")
+            continue
+        path.write_text(content, encoding="utf-8")
+        written.append(str(path))
+        if verbose:
+            print(f"✓ Wrote {path}")
+
+    return {
+        "status": "success",
+        "provider": provider,
+        "module": module,
+        "module_dir": str(module_dir),
+        "files_written": written,
+        "files_skipped": skipped,
+        "checks": run_terraform_checks(module_dir, verbose),
+    }
+
 
 def main():
-    """Main entry point"""
     parser = argparse.ArgumentParser(
-        description="Terraform Scaffolder"
+        description="Generate a Terraform module skeleton for AWS/GCP/Azure."
     )
-    parser.add_argument(
-        'target',
-        help='Target path to analyze or process'
-    )
-    parser.add_argument(
-        '--verbose', '-v',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    parser.add_argument(
-        '--json',
-        action='store_true',
-        help='Output results as JSON'
-    )
-    parser.add_argument(
-        '--output', '-o',
-        help='Output file path'
-    )
-    
+    parser.add_argument("target", help="Target infrastructure directory (e.g. ./infra)")
+    parser.add_argument("--provider", required=True, choices=["aws", "gcp", "azure"],
+                        help="Cloud provider")
+    parser.add_argument("--module", required=True, choices=sorted(MODULE_PROVIDERS),
+                        help="Module template to scaffold")
+    parser.add_argument("--force", action="store_true",
+                        help="Overwrite existing files")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON")
+    parser.add_argument("--output", "-o", help="Write JSON results to this file")
     args = parser.parse_args()
-    
-    tool = TerraformScaffolder(
-        args.target,
-        verbose=args.verbose
-    )
-    
-    results = tool.run()
-    
-    if args.json:
+
+    print(f"🚀 Scaffolding {args.provider}/{args.module} module under {args.target} ...")
+    try:
+        results = scaffold(Path(args.target), args.provider, args.module, args.force, args.verbose)
+    except ValueError as exc:
+        print(f"❌ Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"✅ Module ready: {results['module_dir']} "
+          f"({len(results['files_written'])} written, {len(results['files_skipped'])} skipped)")
+
+    if args.json or args.output:
         output = json.dumps(results, indent=2)
         if args.output:
-            with open(args.output, 'w') as f:
-                f.write(output)
+            Path(args.output).write_text(output, encoding="utf-8")
             print(f"Results written to {args.output}")
         else:
             print(output)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/engineering/skills/ci-cd-pipeline-builder/scripts/pipeline_generator.py
+++ b/engineering/skills/ci-cd-pipeline-builder/scripts/pipeline_generator.py
@@ -168,6 +168,21 @@ def github_yaml(stack: Dict[str, Any]) -> str:
             ]
         )
 
+    if not any(lang in langs for lang in ("node", "python", "go")):
+        # terraform/docker-only (or unrecognized) stacks: run detected commands directly
+        lines.extend(
+            [
+                "  ci:",
+                "    runs-on: ubuntu-latest",
+                "    steps:",
+                "      - uses: actions/checkout@v4",
+            ]
+        )
+        if "terraform" in langs:
+            lines.append("      - uses: hashicorp/setup-terraform@v3")
+        for cmd in lint_cmds + test_cmds + build_cmds:
+            lines.append(f"      - run: {cmd}")
+
     return "\n".join(lines) + "\n"
 
 
@@ -250,6 +265,22 @@ def gitlab_yaml(stack: Dict[str, Any]) -> str:
                 "    - go build ./...",
             ]
         )
+
+    if not any(lang in langs for lang in ("node", "python", "go")):
+        # terraform/docker-only (or unrecognized) stacks: run detected commands directly
+        image = "hashicorp/terraform:1.9" if "terraform" in langs else "alpine:3.20"
+        for stage, cmds in (("lint", lint_cmds), ("test", test_cmds), ("build", build_cmds)):
+            lines.extend(
+                [
+                    "",
+                    f"generic_{stage}:",
+                    f"  image: {image}",
+                    f"  stage: {stage}",
+                    "  script:",
+                ]
+            )
+            for cmd in cmds:
+                lines.append(f"    - {cmd}")
 
     return "\n".join(lines) + "\n"
 

--- a/engineering/skills/ci-cd-pipeline-builder/scripts/stack_detector.py
+++ b/engineering/skills/ci-cd-pipeline-builder/scripts/stack_detector.py
@@ -82,6 +82,7 @@ def detect(repo: Path) -> StackReport:
         "requirements": (repo / "requirements.txt").exists(),
         "go_mod": (repo / "go.mod").exists(),
         "dockerfile": (repo / "Dockerfile").exists(),
+        "terraform": any(repo.glob("*.tf")) or (repo / "terraform").is_dir(),
         "vercel": (repo / "vercel.json").exists(),
         "helm": (repo / "helm").exists() or (repo / "charts").exists(),
         "k8s": (repo / "k8s").exists() or (repo / "kubernetes").exists(),
@@ -107,6 +108,12 @@ def detect(repo: Path) -> StackReport:
     if signals["go_mod"]:
         languages.append("go")
 
+    if signals["terraform"]:
+        languages.append("terraform")
+
+    if signals["dockerfile"]:
+        languages.append("docker")
+
     scripts = read_package_scripts(repo)
     lint_commands: List[str] = []
     test_commands: List[str] = []
@@ -127,6 +134,16 @@ def detect(repo: Path) -> StackReport:
         lint_commands.append("go vet ./...")
         test_commands.append("go test ./...")
         build_commands.append("go build ./...")
+
+    if "terraform" in languages:
+        tf_dir = "terraform" if (repo / "terraform").is_dir() and not any(repo.glob("*.tf")) else "."
+        lint_commands.append(f"terraform -chdir={tf_dir} fmt -check -recursive")
+        test_commands.append(f"terraform -chdir={tf_dir} validate")
+        build_commands.append(f"terraform -chdir={tf_dir} plan -input=false")
+
+    if "docker" in languages:
+        lint_commands.append("hadolint Dockerfile")
+        build_commands.append("docker build -t app:ci .")
 
     return StackReport(
         repo=str(repo.resolve()),

--- a/engineering/skills/pr-review-expert/SKILL.md
+++ b/engineering/skills/pr-review-expert/SKILL.md
@@ -247,19 +247,32 @@ grep -n "new Array([0-9]\{4,\}\|Buffer\.alloc" /tmp/pr-$PR.diff | grep "^+"
 gh pr view $PR --json body | jq -r '.body' | \
   grep -oE "(PROJ-[0-9]+|[A-Z]+-[0-9]+|https://linear\.app/[^)\"]+)" | sort -u
 
-# Verify Jira ticket exists (requires JIRA_API_TOKEN)
+# Verify Jira ticket exists (requires JIRA_API_TOKEN to be SET in the environment).
+# Credentials are fed to curl via a config read from stdin (-K -) so the token
+# never appears in argv — `ps aux` / /proc/*/cmdline can't see it, and nothing
+# secret lands in shell history. Never paste the raw token on the command line.
 TICKET="PROJ-123"
-curl -s -u "user@company.com:$JIRA_API_TOKEN" \
-  "https://your-org.atlassian.net/rest/api/3/issue/$TICKET" | \
+: "${JIRA_API_TOKEN:?JIRA_API_TOKEN must be set}"
+curl -s -K - "https://your-org.atlassian.net/rest/api/3/issue/$TICKET" <<EOF | \
   jq '{key, summary: .fields.summary, status: .fields.status.name}'
+user = "user@company.com:$JIRA_API_TOKEN"
+EOF
 
-# Linear ticket
+# Linear ticket — same pattern: the Authorization header goes through the
+# stdin config, not a -H flag, to keep the key out of the process list.
 LINEAR_ID="abc-123"
-curl -s -H "Authorization: $LINEAR_API_KEY" \
-  -H "Content-Type: application/json" \
+: "${LINEAR_API_KEY:?LINEAR_API_KEY must be set}"
+curl -s -K - -H "Content-Type: application/json" \
   --data "{\"query\": \"{ issue(id: \\\"$LINEAR_ID\\\") { title state { name } } }\"}" \
-  https://api.linear.app/graphql | jq .
+  https://api.linear.app/graphql <<EOF | jq .
+header = "Authorization: $LINEAR_API_KEY"
+EOF
 ```
+
+> **Security note:** for repeated Jira use, prefer a `~/.netrc` entry
+> (`machine your-org.atlassian.net login user@company.com password <token>`,
+> `chmod 600 ~/.netrc`) and call `curl -s --netrc …` — no secret material in
+> the command at all.
 
 ---
 

--- a/marketing-skill/README.md
+++ b/marketing-skill/README.md
@@ -39,22 +39,22 @@ npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill --agent
 
 ```bash
 # Content Creator
-npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/content-creator
+npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/skills/content-creator
 
 # Demand Generation & Acquisition
-npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/marketing-demand-acquisition
+npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/skills/marketing-demand-acquisition
 
 # Product Marketing Strategy
-npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/marketing-strategy-pmm
+npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/skills/marketing-strategy-pmm
 
 # App Store Optimization
-npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/app-store-optimization
+npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/skills/app-store-optimization
 
 # Social Media Analyzer
-npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/social-media-analyzer
+npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/skills/social-media-analyzer
 
 # Campaign Analytics
-npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/campaign-analytics
+npx ai-agent-skills install alirezarezvani/claude-skills/marketing-skill/skills/campaign-analytics
 ```
 
 **Supported Agents:** Claude Code, Cursor, VS Code, Copilot, Goose, Amp, Codex

--- a/project-management/README.md
+++ b/project-management/README.md
@@ -38,22 +38,22 @@ npx ai-agent-skills install alirezarezvani/claude-skills/project-management --ag
 
 ```bash
 # Senior Project Manager Expert
-npx ai-agent-skills install alirezarezvani/claude-skills/project-management/senior-pm
+npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/senior-pm
 
 # Scrum Master Expert
-npx ai-agent-skills install alirezarezvani/claude-skills/project-management/scrum-master
+npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/scrum-master
 
 # Atlassian Jira Expert
-npx ai-agent-skills install alirezarezvani/claude-skills/project-management/jira-expert
+npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/jira-expert
 
 # Atlassian Confluence Expert
-npx ai-agent-skills install alirezarezvani/claude-skills/project-management/confluence-expert
+npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/confluence-expert
 
 # Atlassian Administrator
-npx ai-agent-skills install alirezarezvani/claude-skills/project-management/atlassian-admin
+npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/atlassian-admin
 
 # Atlassian Template Creator
-npx ai-agent-skills install alirezarezvani/claude-skills/project-management/atlassian-templates
+npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/atlassian-templates
 ```
 
 **Supported Agents:** Claude Code, Cursor, VS Code, Copilot, Goose, Amp, Codex
@@ -298,7 +298,7 @@ mcp__atlassian__search_issues jql="project = PROJ AND status = 'In Progress'"
 
 1. **Install Senior PM Expert:**
    ```bash
-   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/senior-pm
+   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/senior-pm
    ```
 
 2. **Use project charter template** from Atlassian Templates skill
@@ -309,7 +309,7 @@ mcp__atlassian__search_issues jql="project = PROJ AND status = 'In Progress'"
 
 1. **Install Scrum Master Expert:**
    ```bash
-   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/scrum-master
+   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/scrum-master
    ```
 
 2. **Use sprint planning template** for next sprint
@@ -320,7 +320,7 @@ mcp__atlassian__search_issues jql="project = PROJ AND status = 'In Progress'"
 
 1. **Install Jira Expert:**
    ```bash
-   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/jira-expert
+   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/jira-expert
    ```
 
 2. **Configure custom workflows** for your team
@@ -331,7 +331,7 @@ mcp__atlassian__search_issues jql="project = PROJ AND status = 'In Progress'"
 
 1. **Install Confluence Expert:**
    ```bash
-   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/confluence-expert
+   npx ai-agent-skills install alirezarezvani/claude-skills/project-management/skills/confluence-expert
    ```
 
 2. **Design space architecture** for your organization

--- a/ra-qm-team/README.md
+++ b/ra-qm-team/README.md
@@ -40,26 +40,26 @@ npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team --agent curs
 
 ```bash
 # Strategic Leadership
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/regulatory-affairs-head
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/quality-manager-qmr
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/regulatory-affairs-head
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/quality-manager-qmr
 
 # Quality Systems
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/quality-manager-qms-iso13485
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/capa-officer
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/quality-documentation-manager
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/quality-manager-qms-iso13485
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/capa-officer
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/quality-documentation-manager
 
 # Risk & Security
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/risk-management-specialist
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/information-security-manager-iso27001
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/risk-management-specialist
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/information-security-manager-iso27001
 
 # Regulatory Specialists
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/mdr-745-specialist
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/fda-consultant-specialist
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/mdr-745-specialist
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/fda-consultant-specialist
 
 # Audit & Compliance
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/qms-audit-expert
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/isms-audit-expert
-npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/gdpr-dsgvo-expert
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/qms-audit-expert
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/isms-audit-expert
+npx ai-agent-skills install alirezarezvani/claude-skills/ra-qm-team/skills/gdpr-dsgvo-expert
 ```
 
 **Supported Agents:** Claude Code, Cursor, VS Code, Copilot, Goose, Amp, Codex

--- a/scripts/sync-codebuff-skills.py
+++ b/scripts/sync-codebuff-skills.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+sync-codebuff-skills.py — Install claude-code-skills into Codebuff.
+
+Codebuff (https://codebuff.com) discovers agent skills from ~/.agents/skills/
+using the agentskills.io standard (SKILL.md with YAML frontmatter) — the same
+format this repo uses, so no conversion is needed.
+
+This is a thin wrapper around sync-vibe-skills.py: identical discovery and
+flat-layout sync logic, different default target directory.
+
+Usage:
+    python scripts/sync-codebuff-skills.py                  # full sync
+    python scripts/sync-codebuff-skills.py --verbose         # show each skill
+    python scripts/sync-codebuff-skills.py --domain engineering  # one domain
+    python scripts/sync-codebuff-skills.py --dry-run          # preview only
+    python scripts/sync-codebuff-skills.py --copy             # copy instead of symlink
+
+Codebuff skill directory: ~/.agents/skills/
+Skills land flat:          ~/.agents/skills/<skill-name>/
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+CODEBUFF_SKILLS_DIR = Path.home() / ".agents" / "skills"
+
+
+def load_vibe_module():
+    """Load sync-vibe-skills.py (hyphenated filename) as a module."""
+    path = Path(__file__).resolve().parent / "sync-vibe-skills.py"
+    spec = importlib.util.spec_from_file_location("sync_vibe_skills", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    vibe = load_vibe_module()
+    # Reuse the vibe CLI wholesale with a codebuff default target.
+    if not any(arg.startswith("--target") for arg in sys.argv[1:]):
+        sys.argv.extend(["--target", str(CODEBUFF_SKILLS_DIR)])
+    vibe.VIBE_SKILLS_DIR = CODEBUFF_SKILLS_DIR
+    vibe.TOOL_NAME = "Codebuff"
+    vibe.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-vibe-skills.py
+++ b/scripts/sync-vibe-skills.py
@@ -11,14 +11,25 @@ Both tools use the agentskills.io standard (SKILL.md with YAML frontmatter),
 so no format conversion is needed — just symlink the directories.
 
 Usage:
-    python scripts/sync-vibe-skills.py                   # full sync
+    python scripts/sync-vibe-skills.py                   # full sync (flat layout)
     python scripts/sync-vibe-skills.py --verbose          # show each skill
     python scripts/sync-vibe-skills.py --domain engineering  # one domain
     python scripts/sync-vibe-skills.py --dry-run          # preview only
     python scripts/sync-vibe-skills.py --copy             # copy instead of symlink
+    python scripts/sync-vibe-skills.py --nested           # legacy namespaced layout
 
 Vibe skill directory: ~/.vibe/skills/
-Our skills land under:  ~/.vibe/skills/claude-skills/<domain>/<skill-name>/
+
+Layouts:
+    flat (default)  ~/.vibe/skills/<skill-name>/
+        Vibe only discovers skills one directory below each configured
+        skill path, so this is the layout Vibe actually picks up out of
+        the box (issue #748). Name collisions across domains are resolved
+        as <domain>-<skill-name>.
+    nested (--nested)  ~/.vibe/skills/claude-skills/<domain>/<skill-name>/
+        Legacy layout. Requires adding each domain directory to
+        `skill_paths` in ~/.vibe/config.toml, e.g.:
+            skill_paths = ["~/.vibe/skills/claude-skills/engineering"]
 """
 from __future__ import annotations
 
@@ -32,6 +43,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VIBE_SKILLS_DIR = Path.home() / ".vibe" / "skills"
 TARGET_SUBDIR = "claude-skills"  # namespace to avoid collisions with Vibe built-in skills
+TOOL_NAME = "Vibe"  # overridden by wrapper scripts (e.g. sync-codebuff-skills.py)
 
 # Domain directories that contain skills (each subdirectory with a SKILL.md)
 DOMAIN_DIRS = [
@@ -146,9 +158,33 @@ def read_frontmatter(skill_md):
         return {}
 
 
-def sync_skill(skill, target_root, use_copy, verbose, dry_run):
+def assign_flat_names(skills):
+    """Give each skill a unique directory name for the flat layout.
+
+    First skill keeps its bare name; collisions across domains become
+    <domain>-<skill-name> (and gain a numeric suffix in the unlikely case
+    that still collides).
+    """
+    taken: set = set()
+    for s in skills:
+        candidate = s["name"]
+        if candidate in taken:
+            candidate = f"{s['domain']}-{s['name']}"
+        n = 2
+        while candidate in taken:
+            candidate = f"{s['domain']}-{s['name']}-{n}"
+            n += 1
+        taken.add(candidate)
+        s["flat_name"] = candidate
+    return skills
+
+
+def sync_skill(skill, target_root, use_copy, verbose, dry_run, nested):
     """Create a symlink or copy for one skill."""
-    target = target_root / skill["domain"] / skill["name"]
+    if nested:
+        target = target_root / skill["domain"] / skill["name"]
+    else:
+        target = target_root / skill["flat_name"]
 
     if target.exists() or target.is_symlink():
         if verbose:
@@ -179,10 +215,11 @@ def sync_skill(skill, target_root, use_copy, verbose, dry_run):
     return "new"
 
 
-def write_index(target_root, skills):
-    """Write a skills-index.json for quick lookup."""
+def write_index(target_root, skills, nested):
+    """Write a skills index JSON for quick lookup."""
     index = {
         "source": "claude-code-skills",
+        "layout": "nested" if nested else "flat",
         "total_skills": len(skills),
         "domains": {},
     }
@@ -194,9 +231,12 @@ def write_index(target_root, skills):
         index["domains"][d].append({
             "name": s["name"],
             "description": fm.get("description", ""),
-            "path": f"{d}/{s['name']}",
+            "path": f"{d}/{s['name']}" if nested else s["flat_name"],
         })
-    index_path = target_root / "skills-index.json"
+    # In flat mode target_root is ~/.vibe/skills itself — use a namespaced
+    # filename so we never clobber anything Vibe owns.
+    filename = "skills-index.json" if nested else "claude-skills-index.json"
+    index_path = target_root / filename
     index_path.write_text(json.dumps(index, indent=2), encoding="utf-8")
     return index_path
 
@@ -216,15 +256,24 @@ def main():
     p.add_argument("--copy", action="store_true", help="Copy files instead of symlink")
     p.add_argument("--json", action="store_true", help="JSON output")
     p.add_argument(
+        "--nested",
+        action="store_true",
+        help="Legacy layout under claude-skills/<domain>/ — requires skill_paths "
+             "entries in ~/.vibe/config.toml; Vibe does NOT discover it by default",
+    )
+    p.add_argument(
         "--target",
         default=str(VIBE_SKILLS_DIR),
         help=f"Override Vibe skills dir (default: {VIBE_SKILLS_DIR})",
     )
     args = p.parse_args()
 
-    target_root = Path(args.target).expanduser() / TARGET_SUBDIR
+    base = Path(args.target).expanduser()
+    target_root = base / TARGET_SUBDIR if args.nested else base
     domains = [args.domain] if args.domain else None
     skills = discover_skills(REPO_ROOT, domains)
+    if not args.nested:
+        assign_flat_names(skills)
 
     if not skills:
         msg = f"No skills found in {REPO_ROOT}"
@@ -239,18 +288,19 @@ def main():
 
     counts = {"new": 0, "skip": 0, "would": 0}
     for s in skills:
-        result = sync_skill(s, target_root, args.copy, args.verbose, args.dry_run)
+        result = sync_skill(s, target_root, args.copy, args.verbose, args.dry_run, args.nested)
         counts[result] += 1
 
     # Write index
     if not args.dry_run:
-        idx_path = write_index(target_root, skills)
+        idx_path = write_index(target_root, skills, args.nested)
     else:
-        idx_path = target_root / "skills-index.json"
+        idx_path = target_root / ("skills-index.json" if args.nested else "claude-skills-index.json")
 
     summary = {
         "status": "ok",
         "target": str(target_root),
+        "layout": "nested" if args.nested else "flat",
         "total_skills": len(skills),
         "new": counts["new"],
         "skipped": counts["skip"],
@@ -271,7 +321,12 @@ def main():
     if not args.dry_run:
         print(f"  Index: {idx_path}")
     print()
-    print("Vibe will discover these skills via /skills or /<skill-name>.")
+    if args.nested:
+        print(f"NOTE: the nested layout is NOT discovered by {TOOL_NAME} out of the box.")
+        print("Add each domain to skill_paths in ~/.vibe/config.toml, e.g.:")
+        print('  skill_paths = ["~/.vibe/skills/claude-skills/engineering"]')
+    else:
+        print(f"{TOOL_NAME} will discover these skills via /skills or /<skill-name>.")
     print("No format conversion needed — both tools use agentskills.io SKILL.md standard.")
 
 


### PR DESCRIPTION
## Summary

Resolves five open issues, each fix validated individually.

### #805 — README install paths missing `skills/` segment
All per-skill `npx ai-agent-skills install` commands across 5 domain READMEs (engineering-team, project-management, marketing-skill, c-level-advisor, ra-qm-team) now include the `skills/` path segment. Rewrites were applied only where the corrected target directory actually exists on disk; a post-pass verified every install path resolves.

### #806 — API tokens exposed via curl flags (pr-review-expert)
The Jira/Linear examples in `engineering/skills/pr-review-expert/SKILL.md` now feed credentials through a curl config read from stdin (`-K -` + heredoc), so the token never appears in argv (`ps aux` / `/proc/*/cmdline`) or shell history. Added `:?` guards that fail fast when the env var is unset, plus a `~/.netrc` note for repeated use. The heredoc pattern was smoke-tested.

### #807 — senior-devops no-op stubs + stack_detector blind to Terraform/Docker
- **senior-devops**: the three byte-identical stubs are replaced with real implementations matching the documented interfaces:
  - `terraform_scaffolder.py` — generates aws/gcp/azure module skeletons (`main.tf`/`variables.tf`/`outputs.tf`/`versions.tf`) for `ecs-service`/`gke-deployment`/`aks-service`, enforces provider/module pairing, runs `terraform fmt`/`validate` when the binary exists. The documented `--provider=aws --module=ecs-service --verbose` invocation from the issue now works.
  - `pipeline_generator.py` — emits GitHub Actions or CircleCI configs for `build,test,security,deploy` stages with node/python/go runtime detection. The documented `--platform=github --stages=build,test,deploy` invocation now works.
  - `deployment_manager.py` — `deploy`/`rollback`/`analyze` subcommands (plus the documented `--analyze` flag alias) generating blue-green/rolling K8s manifests and ordered kubectl runbooks. SKILL.md updated to match (the tool writes manifests and prints commands; it never applies to a cluster).
- **ci-cd-pipeline-builder**: `stack_detector.py` now detects Terraform (`*.tf` or `terraform/`) and uses the Dockerfile signal it already collected, emitting `terraform fmt/validate/plan`, `hadolint`, and `docker build` commands. The issue's exact repro now reports `languages: docker, terraform`. Downstream `pipeline_generator.py` gained a generic CI job for non-node/python/go stacks so Terraform-only repos no longer produce empty pipelines. Node/python/go detection verified unregressed; generated YAML for both platforms parses.

### #748 — Vibe shows 0 skills after sync
Root cause: Vibe only discovers skills one directory below `~/.vibe/skills/`, but the sync nested them three levels deep. `sync-vibe-skills.py` now defaults to a flat layout (`~/.vibe/skills/<skill-name>/`) with collision-safe naming (`<domain>-<skill>` on clash, e.g. `productivity-handoff`), and keeps the old layout behind `--nested` with a config.toml hint. Validated: 341 skills at depth 1, all with SKILL.md, idempotent re-runs.

### #785 — Codebuff agent support
New `scripts/sync-codebuff-skills.py` syncs all 341 skills into Codebuff's `~/.agents/skills/` using the same flat-layout machinery (thin wrapper over the vibe sync module).

## Validation
- Every documented invocation from issues #807/#748 reproduced before and re-run after the fix
- `scripts/check_plugin_json.py --all` passes (77 OK, exit 0)
- `py_compile` clean on all touched Python files
- Regression checks: node-repo detection, empty-repo detection, nested vibe layout, downstream pipeline generation for node repos

Closes #805, closes #806, closes #807, closes #748, closes #785

https://claude.ai/code/session_01CUWsrUNZP9jpxvAwq67UiT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUWsrUNZP9jpxvAwq67UiT)_