### PR TITLE
feat(tooling): backport --sample to 6 more tools — completes #654 acceptance

### DIFF
--- a/business-growth/skills/customer-success-manager/scripts/health_score_calculator.py
+++ b/business-growth/skills/customer-success-manager/scripts/health_score_calculator.py
@@ -397,11 +397,38 @@ def format_json(results: List[Dict[str, Any]]) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Embedded synthetic fixture for --sample (two customers across segments).
+SAMPLE_DATA = {
+    "customers": [
+        {
+            "customer_id": "C-001",
+            "name": "Acme Corp",
+            "segment": "enterprise",
+            "arr": 240000,
+            "usage": {"dau_mau_ratio": 0.55, "license_utilization": 0.82},
+            "engagement": {"qbr_attendance": 1.0, "champion_engaged": True},
+            "support": {"open_tickets": 2, "csat": 4.6},
+            "relationship": {"nps": 9, "exec_sponsor": True},
+        },
+        {
+            "customer_id": "C-002",
+            "name": "Globex Ltd",
+            "segment": "smb",
+            "arr": 18000,
+            "usage": {"dau_mau_ratio": 0.12, "license_utilization": 0.35},
+            "engagement": {"qbr_attendance": 0.0, "champion_engaged": False},
+            "support": {"open_tickets": 7, "csat": 3.1},
+            "relationship": {"nps": 4, "exec_sponsor": False},
+        },
+    ]
+}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Calculate multi-dimensional customer health scores with trend analysis."
     )
-    parser.add_argument("input_file", help="Path to JSON file containing customer data")
+    parser.add_argument("input_file", nargs="?", help="Path to JSON file containing customer data")
     parser.add_argument(
         "--format",
         choices=["text", "json"],
@@ -409,17 +436,27 @@ def main() -> None:
         dest="output_format",
         help="Output format (default: text)",
     )
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Run with an embedded synthetic customer fixture (no input file needed)",
+    )
     args = parser.parse_args()
 
-    try:
-        with open(args.input_file, "r") as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        print(f"Error: File not found: {args.input_file}", file=sys.stderr)
-        sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"Error: Invalid JSON in {args.input_file}: {e}", file=sys.stderr)
-        sys.exit(1)
+    if args.sample:
+        data = SAMPLE_DATA
+    else:
+        if not args.input_file:
+            parser.error("input_file is required (or use --sample)")
+        try:
+            with open(args.input_file, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.input_file}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in {args.input_file}: {e}", file=sys.stderr)
+            sys.exit(1)
 
     customers = data.get("customers", [])
     if not customers:

--- a/business-growth/skills/customer-success-manager/scripts/health_score_calculator.py
+++ b/business-growth/skills/customer-success-manager/scripts/health_score_calculator.py
@@ -444,6 +444,8 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.sample:
+        if args.input_file:
+            print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
         data = SAMPLE_DATA
     else:
         if not args.input_file:

--- a/business-growth/skills/revenue-operations/scripts/pipeline_analyzer.py
+++ b/business-growth/skills/revenue-operations/scripts/pipeline_analyzer.py
@@ -448,6 +448,24 @@ def format_text_report(results: dict) -> str:
     return "\n".join(lines)
 
 
+# Embedded synthetic pipeline fixture for --sample.
+SAMPLE_DATA = {
+    "quota": 1000000,
+    "average_cycle_days": 45,
+    "stages": ["discovery", "demo", "proposal", "negotiation", "closed_won"],
+    "deals": [
+        {"id": "D-1", "name": "Acme renewal", "stage": "proposal",
+         "value": 120000, "age_days": 30, "close_date": "2026-07-15"},
+        {"id": "D-2", "name": "Globex new logo", "stage": "discovery",
+         "value": 80000, "age_days": 10, "close_date": "2026-08-01"},
+        {"id": "D-3", "name": "Initech expansion", "stage": "negotiation",
+         "value": 200000, "age_days": 70, "close_date": "2026-06-30"},
+        {"id": "D-4", "name": "Umbrella upsell", "stage": "closed_won",
+         "value": 60000, "age_days": 50, "close_date": "2026-05-20"},
+    ],
+}
+
+
 def main() -> None:
     """Main entry point for pipeline analyzer CLI."""
     parser = argparse.ArgumentParser(
@@ -455,7 +473,6 @@ def main() -> None:
     )
     parser.add_argument(
         "--input",
-        required=True,
         help="Path to JSON file containing pipeline data",
     )
     parser.add_argument(
@@ -464,18 +481,28 @@ def main() -> None:
         default="text",
         help="Output format: json or text (default: text)",
     )
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Analyze an embedded synthetic pipeline (no input file needed)",
+    )
 
     args = parser.parse_args()
 
-    try:
-        with open(args.input, "r") as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        print(f"Error: File not found: {args.input}", file=sys.stderr)
-        sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"Error: Invalid JSON in {args.input}: {e}", file=sys.stderr)
-        sys.exit(1)
+    if args.sample:
+        data = SAMPLE_DATA
+    else:
+        if not args.input:
+            parser.error("--input is required (or use --sample)")
+        try:
+            with open(args.input, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.input}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in {args.input}: {e}", file=sys.stderr)
+            sys.exit(1)
 
     # Validate required fields
     required_fields = ["deals", "quota", "stages"]

--- a/business-growth/skills/revenue-operations/scripts/pipeline_analyzer.py
+++ b/business-growth/skills/revenue-operations/scripts/pipeline_analyzer.py
@@ -458,6 +458,8 @@ SAMPLE_DATA = {
          "value": 120000, "age_days": 30, "close_date": "2026-07-15"},
         {"id": "D-2", "name": "Globex new logo", "stage": "discovery",
          "value": 80000, "age_days": 10, "close_date": "2026-08-01"},
+        # D-3 is intentionally stale (70d old vs 45d average cycle, closing
+        # imminently) so the fixture exercises the at-risk/aging detection.
         {"id": "D-3", "name": "Initech expansion", "stage": "negotiation",
          "value": 200000, "age_days": 70, "close_date": "2026-06-30"},
         {"id": "D-4", "name": "Umbrella upsell", "stage": "closed_won",
@@ -490,6 +492,8 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.sample:
+        if args.input:
+            print("Warning: --sample specified; ignoring --input", file=sys.stderr)
         data = SAMPLE_DATA
     else:
         if not args.input:

--- a/c-level-advisor/skills/cpo-advisor/scripts/pmf_scorer.py
+++ b/c-level-advisor/skills/cpo-advisor/scripts/pmf_scorer.py
@@ -556,6 +556,11 @@ def main():
         action="store_true",
         help="Output raw JSON instead of formatted report",
     )
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Run with the built-in sample data (no notice line — safe for JSON piping)",
+    )
     args = parser.parse_args()
 
     if args.input:
@@ -568,6 +573,8 @@ def main():
         except json.JSONDecodeError as e:
             print(f"Error: invalid JSON: {e}", file=sys.stderr)
             sys.exit(1)
+    elif args.sample:
+        data = sample_data()
     else:
         print("No input file provided — running with sample data.\n")
         data = sample_data()

--- a/c-level-advisor/skills/cpo-advisor/scripts/pmf_scorer.py
+++ b/c-level-advisor/skills/cpo-advisor/scripts/pmf_scorer.py
@@ -576,7 +576,8 @@ def main():
     elif args.sample:
         data = sample_data()
     else:
-        print("No input file provided — running with sample data.\n")
+        # Notice goes to stderr so `--json` output stays parseable when piped.
+        print("No input file provided — running with sample data.\n", file=sys.stderr)
         data = sample_data()
 
     result = run(data)

--- a/c-level-advisor/skills/cpo-advisor/scripts/pmf_scorer.py
+++ b/c-level-advisor/skills/cpo-advisor/scripts/pmf_scorer.py
@@ -563,7 +563,12 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.input:
+    if args.sample:
+        # --sample wins over --input, consistent with the other sample-pattern tools.
+        if args.input:
+            print("Warning: --sample specified; ignoring --input", file=sys.stderr)
+        data = sample_data()
+    elif args.input:
         try:
             with open(args.input) as f:
                 data = json.load(f)
@@ -573,8 +578,6 @@ def main():
         except json.JSONDecodeError as e:
             print(f"Error: invalid JSON: {e}", file=sys.stderr)
             sys.exit(1)
-    elif args.sample:
-        data = sample_data()
     else:
         # Notice goes to stderr so `--json` output stays parseable when piped.
         print("No input file provided — running with sample data.\n", file=sys.stderr)

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -535,15 +535,14 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.sample and args.input_file:
-        print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
-
     if args.input_file and not args.sample:
         with open(args.input_file) as f:
             data = json.load(f)
         current_state = data["current_state"]
         growth_targets = data["growth_targets"]
     else:
+        if args.sample and args.input_file:
+            print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
         current_state = {
             'headcount': 25,
             'velocity': 450,

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -561,10 +561,21 @@ if __name__ == "__main__":
         current_state = SAMPLE_CURRENT_STATE
         growth_targets = SAMPLE_GROWTH_TARGETS
     elif args.input_file:
-        with open(args.input_file) as f:
-            data = json.load(f)
-        current_state = data["current_state"]
-        growth_targets = data["growth_targets"]
+        try:
+            with open(args.input_file) as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: File not found: {args.input_file}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in {args.input_file}: {e}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            current_state = data["current_state"]
+            growth_targets = data["growth_targets"]
+        except KeyError as e:
+            print(f"Error: Missing required field {e} in {args.input_file}", file=sys.stderr)
+            sys.exit(1)
     else:
         current_state = SAMPLE_CURRENT_STATE
         growth_targets = SAMPLE_GROWTH_TARGETS

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -515,6 +515,26 @@ def calculate_team_scaling(current_state: Dict, growth_targets: Dict) -> str:
     
     return '\n'.join(output)
 
+# Embedded sample fixture (also the documented default when no input file
+# is given — silent fallback is intentional, pre-existing behavior).
+SAMPLE_CURRENT_STATE = {
+    'headcount': 25,
+    'velocity': 450,
+    'roles': {
+        'engineering_manager': 2,
+        'tech_lead': 3,
+        'senior_engineer': 8,
+        'mid_engineer': 10,
+        'junior_engineer': 2
+    },
+    'attrition_rate': 12,
+    'location': 'US'
+}
+SAMPLE_GROWTH_TARGETS = {
+    'target_headcount': 75,
+    'timeline_quarters': 4
+}
+
 if __name__ == "__main__":
     import argparse
 
@@ -535,31 +555,19 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.input_file and not args.sample:
+    if args.sample:
+        if args.input_file:
+            print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
+        current_state = SAMPLE_CURRENT_STATE
+        growth_targets = SAMPLE_GROWTH_TARGETS
+    elif args.input_file:
         with open(args.input_file) as f:
             data = json.load(f)
         current_state = data["current_state"]
         growth_targets = data["growth_targets"]
     else:
-        if args.sample and args.input_file:
-            print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
-        current_state = {
-            'headcount': 25,
-            'velocity': 450,
-            'roles': {
-                'engineering_manager': 2,
-                'tech_lead': 3,
-                'senior_engineer': 8,
-                'mid_engineer': 10,
-                'junior_engineer': 2
-            },
-            'attrition_rate': 12,
-            'location': 'US'
-        }
-        growth_targets = {
-            'target_headcount': 75,
-            'timeline_quarters': 4
-        }
+        current_state = SAMPLE_CURRENT_STATE
+        growth_targets = SAMPLE_GROWTH_TARGETS
 
     if args.json:
         calculator = TeamScalingCalculator()

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -528,9 +528,13 @@ if __name__ == "__main__":
         "--json", action="store_true",
         help="Output raw JSON instead of formatted report"
     )
+    parser.add_argument(
+        "--sample", action="store_true",
+        help="Run with the embedded sample data (ignores input_file)"
+    )
     args = parser.parse_args()
 
-    if args.input_file:
+    if args.input_file and not args.sample:
         with open(args.input_file) as f:
             data = json.load(f)
         current_state = data["current_state"]

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -5,6 +5,7 @@ Engineering Team Scaling Calculator - Optimize team growth and structure
 
 import json
 import math
+import sys
 from typing import Dict, List, Tuple
 
 class TeamScalingCalculator:
@@ -535,7 +536,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.sample and args.input_file:
-        import sys
         print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
 
     if args.input_file and not args.sample:

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -3,6 +3,7 @@
 Engineering Team Scaling Calculator - Optimize team growth and structure
 """
 
+import argparse
 import json
 import math
 import sys
@@ -536,8 +537,6 @@ SAMPLE_GROWTH_TARGETS = {
 }
 
 if __name__ == "__main__":
-    import argparse
-
     parser = argparse.ArgumentParser(
         description="Engineering Team Scaling Calculator - Optimize team growth and structure"
     )

--- a/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
+++ b/c-level-advisor/skills/cto-advisor/scripts/team_scaling_calculator.py
@@ -534,6 +534,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    if args.sample and args.input_file:
+        import sys
+        print("Warning: --sample specified; ignoring input_file", file=sys.stderr)
+
     if args.input_file and not args.sample:
         with open(args.input_file) as f:
             data = json.load(f)

--- a/engineering-team/a11y-audit/skills/a11y-audit/scripts/contrast_checker.py
+++ b/engineering-team/a11y-audit/skills/a11y-audit/scripts/contrast_checker.py
@@ -353,6 +353,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show example output with sample color pairs",
     )
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Alias for --demo (repo-wide embedded-sample convention)",
+    )
     return parser
 
 
@@ -360,8 +365,8 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
 
-    # --demo mode
-    if args.demo:
+    # --demo / --sample mode
+    if args.demo or args.sample:
         run_demo(args.json_output)
         return 0
 

--- a/engineering-team/a11y-audit/skills/a11y-audit/scripts/contrast_checker.py
+++ b/engineering-team/a11y-audit/skills/a11y-audit/scripts/contrast_checker.py
@@ -356,7 +356,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--sample",
         action="store_true",
-        help="Alias for --demo (repo-wide embedded-sample convention)",
+        help="Run with embedded sample color pairs (alias for --demo)",
     )
     return parser
 

--- a/engineering-team/skills/incident-response/scripts/incident_triage.py
+++ b/engineering-team/skills/incident-response/scripts/incident_triage.py
@@ -643,7 +643,8 @@ Exit codes:
     parser.add_argument(
         "--sample",
         action="store_true",
-        help="Triage an embedded synthetic ransomware event (no file/stdin needed)",
+        help="Triage an embedded synthetic ransomware event (no file/stdin needed; "
+             "note: exits 2 — the SEV1 exit-code signal is intentional)",
     )
 
     args = parser.parse_args()

--- a/engineering-team/skills/incident-response/scripts/incident_triage.py
+++ b/engineering-team/skills/incident-response/scripts/incident_triage.py
@@ -584,6 +584,19 @@ def _print_text_report(result: dict) -> None:
 # Main Entry Point
 # ---------------------------------------------------------------------------
 
+# Embedded synthetic security event for --sample (no file/stdin needed).
+SAMPLE_EVENT = {
+    "event_type": "ransomware",
+    "source_ip": "203.0.113.50",
+    "destination_ip": "10.0.4.21",
+    "user_account": "svc-backup",
+    "hostname": "fileserver-02",
+    "process_name": "encryptor.exe",
+    "first_seen": "2026-06-10T01:30:00Z",
+    "detected_at": "2026-06-10T09:30:00Z",
+}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Incident Classification, Triage, and Escalation",
@@ -627,12 +640,19 @@ Exit codes:
         choices=["sev1", "sev2", "sev3", "sev4"],
         help="Explicit severity override (skips taxonomy-derived severity)",
     )
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Triage an embedded synthetic ransomware event (no file/stdin needed)",
+    )
 
     args = parser.parse_args()
 
     # --- Load input ---
     try:
-        if args.input:
+        if args.sample:
+            raw_event = SAMPLE_EVENT
+        elif args.input:
             with open(args.input, "r", encoding="utf-8") as fh:
                 raw_event = json.load(fh)
         else:

--- a/engineering-team/skills/incident-response/scripts/incident_triage.py
+++ b/engineering-team/skills/incident-response/scripts/incident_triage.py
@@ -651,6 +651,8 @@ Exit codes:
     # --- Load input ---
     try:
         if args.sample:
+            if args.input:
+                print("Warning: --sample specified; ignoring --input", file=sys.stderr)
             raw_event = SAMPLE_EVENT
         elif args.input:
             with open(args.input, "r", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary

Completes issue #654's acceptance criteria by backporting the embedded `--sample` convention to 6 more tools across 3 domains, bringing G9 JSON-output coverage from 19 to **25 tools, 25/25 verified, 0 failures**.

### Tools updated
| Domain | Tool | Approach |
|---|---|---|
| business-growth | `health_score_calculator` | embedded 2-customer fixture (enterprise + smb) |
| business-growth | `pipeline_analyzer` | embedded 4-deal pipeline fixture (D-3 intentionally stale to exercise aging detection) |
| c-level-advisor | `pmf_scorer` | `--sample` flag for its existing `sample_data()` |
| c-level-advisor | `team_scaling_calculator` | `--sample` flag for its embedded defaults (hoisted to module constants) |
| engineering-team | `incident_triage` | embedded synthetic ransomware event (exit 2 = documented SEV1 signal; JSON still valid) |
| engineering-team | `contrast_checker` | `--sample` as alias of the existing `--demo` |

All six tools share uniform semantics: `--sample` wins over file input with a stderr warning when both are given; required-arg validation is unchanged when `--sample` is absent.

### 🐛 Bug fixes bundled (beyond the mechanical backport)
- **`pmf_scorer.py` stdout corruption**: the "No input file provided — running with sample data" notice previously printed to **stdout**, silently breaking `pmf_scorer.py --json | jq` even without `--sample`. It now goes to stderr. (Latent bug, surfaced by this work.)
- **`team_scaling_calculator.py` unhandled exceptions**: a missing/invalid input file or absent `current_state`/`growth_targets` keys previously produced raw tracebacks; now handled with clear stderr errors + exit 1.

### #654 acceptance status (with PR #839)
- [x] Decision on Options A/B/C → **Option A** (`--sample`, matching the repo's existing convention)
- [x] ≥20 representative tools supporting the pattern → **25 covered**
- [x] Audit harness → `scripts/smoke_json_output.py` (gate G9, wired into `ci-quality-gate.yml`)
- [x] Verification ≥90% PASS → **100%** of covered tools (25/25)

## Validation
- G9: 25 covered / 25 verified / 0 failed
- G8 help gate, dual-publish drift guard, path linter: all exit 0
- `py_compile` clean; default-invocation regressions checked on all 6 tools; all 7 review rounds addressed

Closes #654

https://claude.ai/code/session_01CUWsrUNZP9jpxvAwq67UiT