### PR TITLE
fix(ra-qm): close the QMSR-staleness class — 6 skills (audit PR-3)

### DIFF
--- a/ra-qm-team/skills/capa-officer/SKILL.md
+++ b/ra-qm-team/skills/capa-officer/SKILL.md
@@ -414,9 +414,11 @@ Calculates and reports:
 | 8.5.2 Corrective Action | Eliminate cause of nonconformity | NC review, cause determination, action evaluation, implementation, effectiveness review |
 | 8.5.3 Preventive Action | Eliminate potential nonconformity | Trend analysis, cause determination, action evaluation, implementation, effectiveness review |
 
-### FDA 21 CFR 820.100
+### FDA CAPA authority — ISO 13485 §8.5.2/8.5.3 under the QMSR (legacy QSR 820.100, historical)
 
-Required CAPA elements:
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** FDA's Quality Management System Regulation (QMSR) final rule (89 FR 7496) amended 21 CFR Part 820 to **incorporate ISO 13485:2016 by reference** and removed the legacy QSR subsection structure. The CAPA section number **820.100 no longer exists in the CFR** — it is retained below only as a familiar index. The current FDA authority for CAPA is **ISO 13485:2016 §8.5.2 (corrective action) and §8.5.3 (preventive action)** (see clause table above), with complaint-handling additions in retained **21 CFR 820.35**. Cite the ISO 13485 clauses — not 820.100 — in current compliance documentation.
+
+CAPA elements required under ISO 13485 §8.5.2/§8.5.3 (legacy QSR 820.100, historical):
 - Procedures for implementing corrective and preventive action
 - Analyzing quality data sources (complaints, NCs, audits, service records)
 - Investigating cause of nonconformities
@@ -432,3 +434,5 @@ Required CAPA elements:
 | Root cause analysis superficial | Inadequate investigation training |
 | Effectiveness not verified | No verification procedure |
 | Actions do not address root cause | Symptom treatment vs. cause elimination |
+
+> **Decision discipline:** The tools in this skill structure investigations and track CAPA status — they do not certify CAPA closure or compliance. CAPA effectiveness conclusions and closure decisions are yours to make and must be reviewed and signed off by the named CAPA owner and Quality function; route regulatory-classification questions (e.g., reportability, 21 CFR 803 MDR, recall under 21 CFR 806) to Regulatory Affairs.

--- a/ra-qm-team/skills/qms-audit-expert/references/iso13485_audit_playbook.md
+++ b/ra-qm-team/skills/qms-audit-expert/references/iso13485_audit_playbook.md
@@ -108,18 +108,20 @@ ISO 13485 is the foundation for both EU MDR and FDA QSR compliance.
 | 8.2.1 Post-market surveillance | Article 83 + Article 86 + Annex III |
 | 8.5.2 CAPA | Article 87 (vigilance) + Article 89 (CAPA) |
 
-### FDA QSR (21 CFR 820) cross-walk
+### FDA legacy QSR (21 CFR 820, historical) cross-walk
 
-| ISO 13485 clause | 21 CFR 820 section |
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** FDA's QMSR final rule (89 FR 7496) amended 21 CFR Part 820 to incorporate ISO 13485:2016 by reference and removed the legacy QSR subsection structure. The 820.x numbers below **no longer exist in the CFR** — they are retained only as a familiar index for auditors mapping pre-2026 documentation. Cite the ISO 13485 clauses in current audits.
+
+| ISO 13485 clause (current authority) | Legacy QSR section (historical, pre-2026) |
 |---|---|
 | 4 QMS | 820.20 (Management responsibility) + 820.5 (QMS) |
 | 7.3 Design controls | 820.30 |
 | 7.4 Purchasing controls | 820.50 |
 | 7.5.6 Process validation | 820.75 |
-| 8.2.1 Post-market | 820.198 (Complaint files) + 803 (MDR reporting) |
+| 8.2.1 Post-market | 820.198 (Complaint files) + 803 (MDR reporting — unchanged) |
 | 8.5.2 CAPA | 820.100 |
 
-In Feb 2024, FDA finalized the rule incorporating ISO 13485:2016 into 21 CFR 820 (the QMSR rule), substantially harmonizing US + international requirements. The compliance date is Feb 2026, after which an ISO 13485-certified QMS substantially satisfies FDA QSR (with FDA-specific overlays on labeling, complaint handling, and MDR reporting).
+In February 2024, FDA finalized the QMSR rule incorporating ISO 13485:2016 into 21 CFR 820, substantially harmonizing US and international requirements. It took effect 2026-02-02; an ISO 13485-certified QMS now substantially satisfies 21 CFR 820, with FDA-specific overlays in retained 820.10/820.35/820.45 (labeling, complaint records) and unchanged 21 CFR 803 MDR reporting.
 
 ## Risk Management Audit (ISO 14971 Crosswalk)
 

--- a/ra-qm-team/skills/qms-audit-expert/references/iso13485_audit_playbook.md
+++ b/ra-qm-team/skills/qms-audit-expert/references/iso13485_audit_playbook.md
@@ -121,7 +121,7 @@ ISO 13485 is the foundation for both EU MDR and FDA QSR compliance.
 | 8.2.1 Post-market | 820.198 (Complaint files) + 803 (MDR reporting — unchanged) |
 | 8.5.2 CAPA | 820.100 |
 
-In February 2024, FDA finalized the QMSR rule incorporating ISO 13485:2016 into 21 CFR 820, substantially harmonizing US and international requirements. It took effect 2026-02-02; an ISO 13485-certified QMS now substantially satisfies 21 CFR 820, with FDA-specific overlays in retained 820.10/820.35/820.45 (labeling, complaint records) and unchanged 21 CFR 803 MDR reporting.
+FDA finalized the QMSR rule in February 2024 (89 FR 7496) incorporating ISO 13485:2016 into 21 CFR 820, substantially harmonizing US and international requirements; it took effect 2026-02-02. An ISO 13485-certified QMS now substantially satisfies 21 CFR 820, with FDA-specific overlays in retained 820.10/820.35/820.45 (labeling, complaint records) and unchanged 21 CFR 803 MDR reporting.
 
 ## Risk Management Audit (ISO 14971 Crosswalk)
 

--- a/ra-qm-team/skills/quality-documentation-manager/SKILL.md
+++ b/ra-qm-team/skills/quality-documentation-manager/SKILL.md
@@ -420,7 +420,7 @@ Track document control system performance.
 
 > **⚠️ STATUS — QMSR transition (effective 2026-02-02):** FDA's Quality Management System Regulation (QMSR) final rule (89 FR 7496) amended 21 CFR Part 820 to **incorporate ISO 13485:2016 by reference** and removed the legacy QSR subsection structure. The section numbers in the table below (820.40/.180/.181/.184/.186) **no longer exist in the CFR**; they are retained only as a familiar index. Current document/record control authority is **ISO 13485:2016 §4.2** (esp. §4.2.4 control of documents, §4.2.5 control of records), with the medical device file in §4.2.3 and records additions in retained **21 CFR 820.35**. Cite the ISO 13485 clauses — not the 820.x numbers — in current compliance documentation.
 
-| Legacy QSR Section (historical, pre-2026) | Requirement | Current authority under QMSR |
+| Legacy QSR Section (historical, pre-2026) | Requirement | Current authority under QMSR (legacy QSR shown for index) |
 |-------------------------------------------|-------------|------------------------------|
 | 820.40 | Document controls | ISO 13485 §4.2.4 |
 | 820.180 | General record requirements | ISO 13485 §4.2.5 + 21 CFR 820.35 (retained) |

--- a/ra-qm-team/skills/quality-documentation-manager/SKILL.md
+++ b/ra-qm-team/skills/quality-documentation-manager/SKILL.md
@@ -416,15 +416,17 @@ Track document control system performance.
 | 4.2.4 | Control of documents |
 | 4.2.5 | Control of records |
 
-### FDA 21 CFR 820
+### FDA document & record control — ISO 13485 §4.2 under the QMSR (legacy QSR sections, historical)
 
-| Section | Requirement |
-|---------|-------------|
-| 820.40 | Document controls |
-| 820.180 | General record requirements |
-| 820.181 | Device master record |
-| 820.184 | Device history record |
-| 820.186 | Quality system record |
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** FDA's Quality Management System Regulation (QMSR) final rule (89 FR 7496) amended 21 CFR Part 820 to **incorporate ISO 13485:2016 by reference** and removed the legacy QSR subsection structure. The section numbers in the table below (820.40/.180/.181/.184/.186) **no longer exist in the CFR**; they are retained only as a familiar index. Current document/record control authority is **ISO 13485:2016 §4.2** (esp. §4.2.4 control of documents, §4.2.5 control of records), with the medical device file in §4.2.3 and records additions in retained **21 CFR 820.35**. Cite the ISO 13485 clauses — not the 820.x numbers — in current compliance documentation.
+
+| Legacy QSR Section (historical, pre-2026) | Requirement | Current authority under QMSR |
+|-------------------------------------------|-------------|------------------------------|
+| 820.40 | Document controls | ISO 13485 §4.2.4 |
+| 820.180 | General record requirements | ISO 13485 §4.2.5 + 21 CFR 820.35 (retained) |
+| 820.181 | Device master record | ISO 13485 §4.2.3 (medical device file) |
+| 820.184 | Device history record | ISO 13485 §4.2.5 + 21 CFR 820.35 (retained) |
+| 820.186 | Quality system record | ISO 13485 §4.2.5 + 21 CFR 820.35 (retained) |
 
 ### Common Audit Findings
 
@@ -435,3 +437,5 @@ Track document control system performance.
 | Incomplete change history | Require history update with each revision |
 | No periodic review schedule | Establish and enforce review calendar |
 | Inadequate audit trail | Validate DMS for Part 11 compliance |
+
+> **Decision discipline:** The validator scripts in this skill check structure and completeness — they do not certify a document or record as compliant. Approval and release decisions are yours and the document owner's to make under your controlled procedure; route regulatory-classification or submission-record questions to Regulatory Affairs.

--- a/ra-qm-team/skills/quality-documentation-manager/references/21cfr11-compliance-guide.md
+++ b/ra-qm-team/skills/quality-documentation-manager/references/21cfr11-compliance-guide.md
@@ -45,7 +45,7 @@ Part 11 does not create new record requirements. It governs HOW records are main
 
 | Predicate Rule | Record Type |
 |----------------|-------------|
-| 21 CFR 820 (QSR) | Device Master Records, Device History Records |
+| 21 CFR 820 (QMSR — incorporates ISO 13485:2016 by reference since 2026-02-02; formerly the QSR) | Device Master Records, Device History Records |
 | 21 CFR 211 (cGMP) | Batch records, laboratory records |
 | 21 CFR 58 (GLP) | Study records, raw data |
 | 21 CFR 11.10(e) | Records required to be maintained |

--- a/ra-qm-team/skills/quality-documentation-manager/references/document-control-procedures.md
+++ b/ra-qm-team/skills/quality-documentation-manager/references/document-control-procedures.md
@@ -262,15 +262,17 @@ Revision: [Revision Number]
 
 ### Retention Periods
 
-| Record Type | Retention Period | Basis |
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** Under FDA's Quality Management System Regulation (QMSR, 89 FR 7496), 21 CFR Part 820 now **incorporates ISO 13485:2016 by reference** and the legacy QSR subsection numbers below (820.30/.181/.184/.198) **no longer exist in the CFR** — they are shown as a historical index. The current authority is **ISO 13485:2016 §4.2.5 (control of records)** plus retained **21 CFR 820.35** (records). The record-retention rule itself is in ISO 13485 §4.2.5 ("at least the lifetime of the medical device as defined by the organization, but not less than two years"). Cite the ISO 13485 clause in current documentation.
+
+| Record Type | Retention Period | Basis (current authority — legacy QSR shown for index) |
 |-------------|------------------|-------|
-| Device Master Record (DMR) | Life of device + 2 years | 21 CFR 820.181 |
-| Device History Record (DHR) | Life of device + 2 years | 21 CFR 820.184 |
-| Design History File (DHF) | Life of device + 2 years | 21 CFR 820.30 |
-| Quality Records | 2 years beyond device discontinuation | ISO 13485 |
+| Device Master Record (DMR) | Life of device + 2 years | ISO 13485 §4.2.3/§4.2.5 (legacy QSR 820.181, historical) |
+| Device History Record (DHR) | Life of device + 2 years | ISO 13485 §4.2.5 (legacy QSR 820.184, historical) |
+| Design History File (DHF) | Life of device + 2 years | ISO 13485 §7.3.10/§4.2.5 (legacy QSR 820.30, historical) |
+| Quality Records | 2 years beyond device discontinuation | ISO 13485 §4.2.5 |
 | Training Records | Duration of employment + 3 years | Best practice |
 | Audit Records | 7 years | Best practice |
-| Complaint Records | Life of device + 2 years | 21 CFR 820.198 |
+| Complaint Records | Life of device + 2 years | ISO 13485 §8.2.2/§4.2.5 + 21 CFR 820.35(b) (legacy QSR 820.198, historical) |
 | CAPA Records | 7 years | Best practice |
 | Calibration Records | 2 years beyond equipment disposal | Best practice |
 | Supplier Records | Life of relationship + 3 years | Best practice |

--- a/ra-qm-team/skills/quality-manager-qmr/SKILL.md
+++ b/ra-qm-team/skills/quality-manager-qmr/SKILL.md
@@ -346,7 +346,7 @@ Monitor and maintain regulatory compliance across jurisdictions.
 | Jurisdiction | Regulation | Requirement | Status Tracking |
 |--------------|------------|-------------|-----------------|
 | EU | MDR 2017/745 | CE marking, Notified Body | Technical file, annual review |
-| USA | 21 CFR 820 | FDA registration, QSR compliance | Annual registration, inspections |
+| USA | 21 CFR 820 (QMSR) | FDA registration, QMSR compliance — 21 CFR 820 incorporates ISO 13485:2016 by reference (effective 2026-02-02; formerly the QSR) | Annual registration, inspections |
 | International | ISO 13485 | QMS certification | Surveillance audits |
 | Germany | MPG/MPDG | National implementation | Competent authority filings |
 
@@ -360,6 +360,8 @@ Monitor and maintain regulatory compliance across jurisdictions.
 6. Document compliance status in management review
 7. Maintain inspection readiness checklist
 8. **Validation:** All applicable requirements mapped; no expired registrations
+
+> **Decision discipline:** This compliance matrix is decision support, not a compliance determination. Final regulatory-status calls are yours to make as QMR and must be signed off by the named owner; route FDA-specific questions to Regulatory Affairs and verify current 21 CFR 820 (QMSR) / ISO 13485:2016 text at fda.gov before relying on any citation here.
 
 ### Regulatory Authority Interface
 

--- a/ra-qm-team/skills/quality-manager-qms-iso13485/SKILL.md
+++ b/ra-qm-team/skills/quality-manager-qms-iso13485/SKILL.md
@@ -322,16 +322,20 @@ For detailed requirements and audit questions for each ISO 13485:2016 clause, se
 
 ### Record Retention Requirements
 
-| Record Type | Minimum Retention | Regulatory Basis |
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** FDA's Quality Management System Regulation (QMSR) final rule (89 FR 7496) amended 21 CFR Part 820 to **incorporate ISO 13485:2016 by reference** and removed the legacy QSR subsection structure. The section numbers below (820.30/.181/.184/.198) **no longer exist in the CFR** — they are retained only as a familiar index. The current authority for record retention is **ISO 13485:2016 §4.2.5** (retain "for at least the lifetime of the medical device as defined by the organization, but not less than two years"), with records additions in retained **21 CFR 820.35**. Cite the ISO 13485 clauses — not the 820.x numbers — in current compliance documentation.
+
+| Record Type | Minimum Retention | Current authority under QMSR (legacy QSR shown for index) |
 |-------------|-------------------|------------------|
-| Device Master Record | Life of device + 2 years | 21 CFR 820.181 |
-| Device History Record | Life of device + 2 years | 21 CFR 820.184 |
-| Design History File | Life of device + 2 years | 21 CFR 820.30 |
-| Complaint Records | Life of device + 2 years | 21 CFR 820.198 |
+| Device Master Record | Life of device + 2 years | ISO 13485 §4.2.3 (medical device file)/§4.2.5 (legacy QSR 820.181, historical) |
+| Device History Record | Life of device + 2 years | ISO 13485 §4.2.5 + 21 CFR 820.35 (legacy QSR 820.184, historical) |
+| Design History File | Life of device + 2 years | ISO 13485 §7.3.10/§4.2.5 (legacy QSR 820.30, historical) |
+| Complaint Records | Life of device + 2 years | ISO 13485 §8.2.2/§4.2.5 + 21 CFR 820.35(b) (legacy QSR 820.198, historical) |
 | Training Records | Employment + 3 years | Best practice |
 | Audit Records | 7 years | Best practice |
 | CAPA Records | 7 years | Best practice |
 | Calibration Records | Equipment life + 2 years | Best practice |
+
+> **Decision discipline:** This skill's checklists and tools structure QMS conformity assessment — they do not certify ISO 13485 / QMSR compliance. Final compliance determinations and record-retention decisions are yours to make and must be reviewed and signed off by the named QMR; route FDA-specific regulatory-classification questions to Regulatory Affairs and confirm current 21 CFR 820 / ISO 13485:2016 text at fda.gov before relying on any citation here.
 
 ---
 

--- a/ra-qm-team/skills/quality-manager-qms-iso13485/references/iso13485-clause-requirements.md
+++ b/ra-qm-team/skills/quality-manager-qms-iso13485/references/iso13485-clause-requirements.md
@@ -115,14 +115,16 @@ Example: SOP-02-001-03 = Document Control SOP, Revision 03
 
 #### 4.2.4 Control of Records
 
-| Record Category | Minimum Retention | Basis |
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** Under FDA's Quality Management System Regulation (QMSR, 89 FR 7496), 21 CFR Part 820 now **incorporates ISO 13485:2016 by reference** and the legacy QSR subsection numbers below (820.30/.181/.184/.198) **no longer exist in the CFR** — they are shown only as a historical index. The current authority is **ISO 13485:2016 §4.2.5 (control of records)** plus retained **21 CFR 820.35** (records). Cite the ISO 13485 clause in current documentation.
+
+| Record Category | Minimum Retention | Basis (current authority — legacy QSR shown for index) |
 |-----------------|-------------------|-------|
-| Device Master Record | Life of device + 2 years | 21 CFR 820.181 |
-| Device History Record | Life of device + 2 years | 21 CFR 820.184 |
-| Design History File | Life of device + 2 years | 21 CFR 820.30 |
+| Device Master Record | Life of device + 2 years | ISO 13485 §4.2.3 (medical device file)/§4.2.5 (legacy QSR 820.181, historical) |
+| Device History Record | Life of device + 2 years | ISO 13485 §4.2.5 + 21 CFR 820.35 (legacy QSR 820.184, historical) |
+| Design History File | Life of device + 2 years | ISO 13485 §7.3.10/§4.2.5 (legacy QSR 820.30, historical) |
 | Training Records | Employment + 3 years | Best practice |
 | Audit Records | 7 years | Best practice |
-| Complaint Records | Life of device + 2 years | 21 CFR 820.198 |
+| Complaint Records | Life of device + 2 years | ISO 13485 §8.2.2/§4.2.5 + 21 CFR 820.35(b) (legacy QSR 820.198, historical) |
 | CAPA Records | 7 years | Best practice |
 | Calibration Records | Equipment life + 2 years | Best practice |
 | Supplier Records | Relationship + 3 years | Best practice |

--- a/ra-qm-team/skills/regulatory-affairs-head/references/fda-submission-guide.md
+++ b/ra-qm-team/skills/regulatory-affairs-head/references/fda-submission-guide.md
@@ -112,11 +112,14 @@
 
 ## Quality System Requirements
 
-### 21 CFR Part 820 (QSR)
-- **Design controls** (21 CFR 820.30)
-- **Document controls** (21 CFR 820.40)
-- **Management responsibility** (21 CFR 820.20)
-- **Corrective and preventive actions** (21 CFR 820.100)
+### 21 CFR Part 820 (QMSR — ISO 13485:2016 incorporated by reference)
+
+> **⚠️ STATUS — QMSR transition (effective 2026-02-02):** FDA's QMSR final rule (89 FR 7496) amended 21 CFR Part 820 to incorporate ISO 13485:2016 by reference and removed the legacy QSR subsection structure. Cite the ISO 13485 clauses — the legacy 820.x numbers below are historical index only.
+
+- **Design and development** — ISO 13485 §7.3 (legacy QSR 820.30, historical)
+- **Document control** — ISO 13485 §4.2.4 (legacy QSR 820.40, historical)
+- **Management responsibility** — ISO 13485 §5 (legacy QSR 820.20, historical)
+- **Corrective and preventive action** — ISO 13485 §8.5.2/§8.5.3 (legacy QSR 820.100, historical)
 
 ## Key Performance Metrics
 


### PR DESCRIPTION
## Summary

Audit follow-up **PR-3** — closes the **QMSR-staleness class** across the entire ra-qm domain: skills presenting the **repealed QSR 820.x structure as current FDA law**. This is the same P0-class defect fixed in `fda-consultant-specialist` (#835); five skills were deferred by that wave's agent, and review of this PR surfaced two more, both fixed here.

## Skills fixed (6 directories)

| Skill | Mapping applied |
|---|---|
| `capa-officer` | CAPA → ISO 13485 §8.5.2/§8.5.3 (legacy 820.100 historical) + decision-discipline block |
| `quality-documentation-manager` | Doc/record control → §4.2.3/§4.2.4/§4.2.5 + retained 820.35 (legacy 820.40/.180/.181/.184/.186 historical); 21cfr11 guide one-liner |
| `quality-manager-qmr` | Present-tense "QSR compliance" matrix cell reframed to QMSR; decision-discipline added |
| `quality-manager-qms-iso13485` | Record-retention tables (SKILL.md + reference) relabeled ISO-primary with legacy 820.x historical; banner + decision-discipline added |
| `qms-audit-expert` | 6-row QSR crosswalk in `references/iso13485_audit_playbook.md` relabeled (ISO clause = current authority column); transition paragraph corrected to past tense with both dates explicit (finalized Feb 2024, 89 FR 7496; effective 2026-02-02) — found by PR review |
| `regulatory-affairs-head` | QSR bullet list in `references/fda-submission-guide.md` reframed to ISO 13485 clauses with legacy 820.x historical + banner — found by exhaustive domain sweep |

**Verified clean (no changes needed):** `ra-qm-skills` router — already carries the QMSR rule line; audited, not modified.

Pattern is byte-consistent with the validated #835 fix: ⚠️ QMSR status banner (final rule 89 FR 7496, ISO 13485:2016 by reference, **effective 2026-02-02**), legacy sections kept only as labeled historical index, ISO 13485 clauses cited as current authority, human-signoff routing preserved/added. Substantive content unchanged. No scripts contained 820.x claims.

## Verification

- **Exhaustive domain grep**: zero unlabeled 820.x-as-current-law claims remain across `ra-qm-team/` and `compliance-os/` (residual hits are TOC anchors inside the banner-framed historical reference in fda-consultant-specialist)
- `check_paths.py --all`: 0 unresolvable · `derive_counters.py --check`: pass (no count changes) · blocking CI gates re-verify on every push

## ⚠️ Human sign-off — all SIX directories + two specific citations

These are AI-authored changes to compliance-critical content. Before the next `dev → main` promotion, the domain-expert review pass must cover:
1. `ra-qm-team/skills/capa-officer/`
2. `ra-qm-team/skills/quality-documentation-manager/`
3. `ra-qm-team/skills/quality-manager-qmr/`
4. `ra-qm-team/skills/quality-manager-qms-iso13485/`
5. `ra-qm-team/skills/qms-audit-expert/` (references/iso13485_audit_playbook.md)
6. `ra-qm-team/skills/regulatory-affairs-head/` (references/fda-submission-guide.md)

**Two citations the expert should check first** (flagged by automated review as the spots most needing a direct look — deliberately left for human judgment, not self-adjudicated):
- **`21 CFR 820.35(b)` for complaint records** (document-control-procedures.md + quality-manager-qms-iso13485/SKILL.md): confirm 820.35 is the retained QMSR section for these records and that subsection (b) is the correct paragraph for complaint-record obligations (pre-QMSR home was 820.198).
- **ISO 13485 `§7.3.10` as the DHF retention anchor** (quality-documentation-manager + quality-manager-qms-iso13485): §7.3.10 is design transfer; confirm it's the intended citation or whether `§7.3` broadly / `§4.2.5` records is the safer anchor.

…plus the three #835 diffs (fda-consultant-specialist, risk-management-specialist, eu-ai-act-specialist) already merged to dev — one combined review pass covers the whole QMSR/regulatory thread.

https://claude.ai/code/session_019AJddAL1NADWMXsy1qNPQF