### PR TITLE
feat(engineering): add i18n-localization skill

### DIFF
--- a/engineering/i18n-localization/SKILL.md
+++ b/engineering/i18n-localization/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: i18n-localization
+description: Use when adding or editing user-facing text, translation keys, or locale files; building a language switcher or locale-prefixed routing; formatting numbers, dates, or currency for display; or auditing locale files for drift. Triggers on "i18n", "internationalization", "localization", "translations", "locale files", "react-i18next", "i18next", "language switcher", "Intl.NumberFormat", "RTL", "missing translation key". Ships a stdlib locale-key-drift scanner.
+---
+
+# i18n / Localization
+
+Every user-facing string is translatable, present in **all** locales, and rendered through the i18n layer — never hardcoded. The cost of i18n is near-zero when designed in from the first component and enormous when retrofitted. This skill makes that discipline executable and gives you a scanner that fails CI on locale drift.
+
+Library-agnostic; examples use i18next / react-i18next and the platform `Intl` APIs. The principles port to any stack.
+
+## When to use
+
+- Adding or editing any user-facing text (labels, buttons, toasts, validation, `aria-label`s, empty/error states, titles, meta)
+- Adding a new translation key or a new locale file
+- Building language switching or locale-prefixed routing (`/:lang/...`)
+- Formatting numbers, dates, times, or currency for display
+- Rendering enum values or dynamic labels from the backend
+- Auditing locale files before a release (run the scanner)
+
+**When NOT to use:** internal logs, machine-readable error codes, telemetry, developer-only CLI output. Don't internationalize text no user reads.
+
+## Core principle: route every string through one layer
+
+```
+source string -> t('semantic.key') -> per-locale JSON -> rendered UI
+                           |
+                 Intl.* for numbers/dates/currency (NOT translation keys)
+```
+
+A hardcoded label is a bug waiting for the second locale. A key present in one locale file but missing from another is a silent fallback gap only the missing-locale user sees.
+
+## Quick start
+
+```bash
+# Audit locale files for drift before shipping (CI-friendly: exit 1 on drift)
+python scripts/locale_key_drift.py ./public/locales --base en
+python scripts/locale_key_drift.py ./src/locales --json > i18n-drift.json
+```
+
+The scanner reports, per locale, the four failure modes that ship broken translations: **missing keys**, **extra keys**, **empty values**, and **placeholder mismatches** (e.g. base `{{count}}` vs translation `{{cnt}}`). Exit `0` = in sync, `1` = drift, `2` = error.
+
+## The seven rules
+
+1. **No hardcoded user-facing strings.** Route every label/message through `t('...')` / `<Trans>`. This includes placeholders, `aria-label`s, toasts, validation messages, and empty/error states.
+2. **One source of truth for languages.** Keep the supported-language list and the default/fallback in a single config module and import it. Validate any language code read from storage or the URL before use.
+3. **Every key lives in every locale.** Adding a key means adding it to all locale files in the same commit. The scanner enforces this.
+4. **Stable, semantic keys.** Dot-path nesting grouped by feature (`cargo.searchPlaceholder`) plus a shared bucket (`common.save`). camelCase keys; reserve `UPPER_SNAKE_CASE` for enum-value keys.
+5. **Interpolation, not concatenation.** Use `{{var}}` placeholders so word order can vary per language. Never build sentences with `+`.
+6. **Pluralization via the library.** Use i18next plural suffixes (`items_one` / `items_other`), not hand-rolled singular/plural keys.
+7. **Format with `Intl`, not keys.** Numbers, dates, and currency go through `Intl.NumberFormat` / `Intl.DateTimeFormat` with a BCP-47 locale — never stored as translation strings.
+
+## Setup (i18next example)
+
+```ts
+export const LANGS = ['en', 'ru', 'es'] as const;
+export type Lang = (typeof LANGS)[number];
+export const DEFAULT_LANG: Lang = 'en';
+export const isLang = (v: string): v is Lang => (LANGS as readonly string[]).includes(v);
+
+i18n.use(httpBackend).use(initReactI18next).init({
+  supportedLngs: LANGS,
+  fallbackLng: DEFAULT_LANG,
+  lng: isLang(saved) ? saved : DEFAULT_LANG,      // validated on read
+  interpolation: { escapeValue: false },           // the view layer already escapes
+  backend: { loadPath: '/locales/{{lng}}.json' },  // lazy-load per language
+});
+```
+
+## Consuming translations
+
+```tsx
+const { t } = useTranslation();
+<input placeholder={t('cargo.searchPlaceholder')} />
+<span>{t('items.count', { count })}</span>          // interpolation + plural
+t('actions.reset', { defaultValue: 'Reset' });       // inline fallback for safety
+```
+
+Rich text with embedded markup uses `<Trans i18nKey="...">`.
+
+## Backend enums / dynamic labels
+
+Never render a raw enum string from the API. Normalize it and look up a key with a graceful default:
+
+```ts
+export function enumLabel(t: TFunction, group: string, raw: string): string {
+  const key = raw.trim().toUpperCase().replace(/[\s-]+/g, '_');
+  return key ? t(`${group}.${key}`, { defaultValue: raw.replace(/_/g, ' ') }) : '—';
+}
+```
+
+When the backend localizes a value itself (`{ name_en, name_ru }`), select by current language with a fallback chain (`current → default → first available`).
+
+## Number / date / currency
+
+```ts
+new Intl.NumberFormat(bcp47, { style: 'currency', currency: 'USD' }).format(amount);
+new Intl.DateTimeFormat(bcp47, { dateStyle: 'medium' }).format(date);
+```
+
+Map app language codes to BCP-47 locales (`en → en-US`).
+
+## Workflows
+
+### Workflow 1: Add a translated string
+```
+1. Pick a semantic key (feature.thing), not the English text as the key
+2. Add it to EVERY locale file (translate or copy English as placeholder)
+3. Render via t('feature.thing') — never the literal
+4. Run locale_key_drift.py — must be in sync before commit
+```
+
+### Workflow 2: Pre-release locale audit
+```
+1. python scripts/locale_key_drift.py ./public/locales --base en --json > drift.json
+2. Fix every missing key (add translation), extra key (remove or re-add to base),
+   empty value (translate), placeholder mismatch (align tokens to base)
+3. Re-run until exit 0; wire the command into CI as a required check
+```
+
+## Anti-patterns
+
+- **Hardcoded string "just this once"** — the first one sets the pattern; wire `t()` from day one.
+- **Adding a key to only the English file** — ships a silent fallback gap. Add to all locales in the same commit.
+- **English text as the key** (`t('Save changes')`) — breaks when the copy changes; use semantic keys.
+- **Concatenating sentences** (`t('You have') + count + t('items')`) — untranslatable word order; use interpolation.
+- **Formatting dates/numbers with template strings** — locale rules differ; use `Intl`.
+- **Rendering raw API enum values** — map them through a helper with a fallback.
+- **Trusting a language code from the URL/storage unvalidated** — validate against the supported list, fall back to default.
+
+## Verifiable success
+
+- `locale_key_drift.py --base <default>` returns exit 0 (zero missing/extra/empty/placeholder issues) and runs in CI
+- No user-facing string literal bypasses the translation layer (grep the diff for quoted UI text)
+- All locale files share an identical key set; counts/plurals use interpolation
+- Numbers, dates, and currency render through `Intl` with a BCP-47 locale
+
+## References
+
+- `references/i18n-patterns.md` — namespaces vs flat files, RTL handling, locale routing, SSR/Next.js notes, pluralization details
+
+## Cross-references
+
+- `engineering-team/a11y-audit` — pair i18n with accessibility (translated `aria-label`s, RTL + screen readers)
+- `engineering-team/senior-frontend` — broader frontend architecture this slots into
+- `product-team/ui-design-system` — design tokens and components that consume localized strings

--- a/engineering/i18n-localization/references/i18n-patterns.md
+++ b/engineering/i18n-localization/references/i18n-patterns.md
@@ -1,0 +1,83 @@
+# i18n Patterns — detailed reference
+
+Detailed material that backs the workflows in `SKILL.md`. Library-agnostic; examples use i18next / react-i18next and the platform `Intl` APIs.
+
+## Namespaces vs a single flat file
+
+Decide up front and stay consistent:
+
+| Approach | Use when | Trade-off |
+|---|---|---|
+| **Single flat file** per language (dot-path nesting) | Small/medium apps, < ~500 keys | Simplest; one HTTP request per language |
+| **Namespaces** (multiple files per language, e.g. `common`, `dashboard`, `billing`) | Large apps, code-split routes | Lazy-load per route; more files to keep in sync |
+
+With namespaces, load the namespace a route needs rather than the whole catalog. Keep file *shapes* identical across languages within each namespace.
+
+## Key naming
+
+- Group by screen/feature: `cargo.list.searchPlaceholder`, `billing.invoice.downloadCta`.
+- Shared/reusable strings go in `common.*` (`common.save`, `common.cancel`, `common.loading`).
+- camelCase segments. Reserve `UPPER_SNAKE_CASE` for enum-value keys so they line up with backend enums.
+- Never use the English copy as the key — semantic keys survive copy edits.
+
+## Pluralization
+
+i18next selects the plural form from the `count` option using CLDR plural categories:
+
+```jsonc
+// en.json
+{ "items_one": "{{count}} item", "items_other": "{{count}} items" }
+// ru.json — Russian has one/few/many
+{ "items_one": "{{count}} элемент", "items_few": "{{count}} элемента", "items_many": "{{count}} элементов" }
+```
+
+```ts
+t('items', { count }); // picks _one / _few / _many / _other automatically
+```
+
+Never hand-roll `if (count === 1)` in the component — let the library apply the locale's CLDR rules.
+
+## Number / date / currency with Intl
+
+```ts
+const bcp47 = { en: 'en-US', ru: 'ru-RU', es: 'es-ES' }[lang];
+
+new Intl.NumberFormat(bcp47).format(1234567.89);                       // 1,234,567.89 / 1 234 567,89
+new Intl.NumberFormat(bcp47, { style: 'currency', currency: 'EUR' }).format(9.9);
+new Intl.DateTimeFormat(bcp47, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
+new Intl.RelativeTimeFormat(bcp47, { numeric: 'auto' }).format(-1, 'day'); // "yesterday"
+```
+
+Currency code is data, not locale — pass it explicitly. Map app language codes to BCP-47 once, in your language config.
+
+## Locale-prefixed routing
+
+When the language lives in the URL (`/:lang/...`):
+
+1. A provider reads the `:lang` segment.
+2. Validates it against the supported list (`isLang`).
+3. Calls `changeLanguage(lang)` and persists it.
+4. Redirects bare or invalid paths to a valid prefix (`/` → `/en/`).
+
+Build internal links through typed path helpers that inject the active prefix — never hardcode `/en/...`.
+
+Send the active language to the backend via a request header (`Accept-Language` or a custom `X-Language`) so server-rendered messages match the client. If a language isn't supported server-side yet, map it to a supported one for the header while still localizing fully on the client.
+
+## Right-to-left (RTL)
+
+- Set `dir="rtl"` on `<html>` for RTL languages (ar, he, fa, ur); drive it from the language config, not per-component.
+- Use CSS logical properties (`margin-inline-start`, `padding-inline-end`, `inset-inline`) instead of physical `left`/`right` so layouts mirror automatically.
+- RTL detection belongs in the same single language config as the supported-language list.
+- Legitimate RTL text uses the inherent directionality of the script — do **not** insert explicit Unicode bidi override characters to "fix" rendering.
+
+## SSR / Next.js notes
+
+- Initialize i18n per request on the server; never share a mutable language instance across requests (it leaks one user's language to another).
+- Pass the resolved language and the needed namespace(s) to the client to avoid a flash of the default language.
+- Prefer Server Components for static localized content; keep the `t` usage that needs interactivity in client components.
+
+## Missing-key strategy
+
+- In development, configure the library to surface missing keys loudly (a `missingKeyHandler` that logs).
+- In production, fall back to the default language and log to telemetry — never render the raw key to the user.
+- Gate merges on `scripts/locale_key_drift.py` so missing keys are caught before they ship, not in production logs.

--- a/engineering/i18n-localization/scripts/locale_key_drift.py
+++ b/engineering/i18n-localization/scripts/locale_key_drift.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""locale_key_drift — detect drift between i18n locale files.
+
+Compares every locale file against a base locale and reports:
+  - missing keys   (in base, absent from a translation -> silent fallback gap)
+  - extra keys     (in a translation, absent from base -> dead/renamed key)
+  - empty values   (key present but value is "" / null)
+  - placeholder mismatches ({{var}} / {var} tokens differ from the base)
+
+Stdlib only. CLI-first. Exit codes: 0 = in sync, 1 = drift found, 2 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# Matches {{var}} (i18next/handlebars) and {var} (ICU / format) interpolation tokens.
+_TOKEN_RE = re.compile(r"\{\{\s*([\w.-]+)\s*\}\}|\{\s*([\w.-]+)\s*\}")
+
+
+def flatten(obj, prefix=""):
+    """Flatten a nested dict into {dot.path: value}. Lists are treated as leaf values."""
+    out = {}
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            if isinstance(value, dict):
+                out.update(flatten(value, path))
+            else:
+                out[path] = value
+    else:
+        out[prefix] = obj
+    return out
+
+
+def tokens(value):
+    """Return the set of interpolation token names in a string value."""
+    if not isinstance(value, str):
+        return set()
+    return {m.group(1) or m.group(2) for m in _TOKEN_RE.finditer(value)}
+
+
+def discover_files(path):
+    """Resolve the input path to a sorted list of locale JSON files."""
+    if os.path.isdir(path):
+        return sorted(
+            os.path.join(path, f) for f in os.listdir(path) if f.lower().endswith(".json")
+        )
+    if os.path.isfile(path):
+        return [path]
+    return []
+
+
+def pick_base(files, base_arg):
+    """Choose the base file: explicit --base (stem or path), else 'en', else first."""
+    if base_arg:
+        for f in files:
+            stem = os.path.splitext(os.path.basename(f))[0]
+            if base_arg in (stem, f, os.path.basename(f)):
+                return f
+        return None
+    for f in files:
+        if os.path.splitext(os.path.basename(f))[0].lower() in ("en", "en-us", "en_us"):
+            return f
+    return files[0]
+
+
+def analyze(files, base_file, ignore_empty):
+    """Compare every non-base file to the base; return a results dict."""
+    loaded = {}
+    errors = []
+    for f in files:
+        try:
+            with open(f, encoding="utf-8") as fh:
+                loaded[f] = flatten(json.load(fh))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append({"file": f, "error": str(exc)})
+
+    base_keys = set(loaded.get(base_file, {}))
+    base_map = loaded.get(base_file, {})
+    locales = []
+    for f, flat in loaded.items():
+        if f == base_file:
+            continue
+        keys = set(flat)
+        missing = sorted(base_keys - keys)
+        extra = sorted(keys - base_keys)
+        empty = (
+            []
+            if ignore_empty
+            else sorted(k for k, v in flat.items() if v is None or v == "")
+        )
+        placeholder = []
+        for k in sorted(base_keys & keys):
+            bt, lt = tokens(base_map[k]), tokens(flat[k])
+            if bt != lt:
+                placeholder.append(
+                    {"key": k, "base_tokens": sorted(bt), "locale_tokens": sorted(lt)}
+                )
+        locales.append(
+            {
+                "file": os.path.basename(f),
+                "missing": missing,
+                "extra": extra,
+                "empty": empty,
+                "placeholder_mismatch": placeholder,
+                "in_sync": not (missing or extra or empty or placeholder),
+            }
+        )
+    return {
+        "base": os.path.basename(base_file) if base_file else None,
+        "base_key_count": len(base_keys),
+        "locales": locales,
+        "errors": errors,
+    }
+
+
+def render_text(report):
+    lines = [f"Base locale: {report['base']} ({report['base_key_count']} keys)", ""]
+    for loc in report["locales"]:
+        status = "OK" if loc["in_sync"] else "DRIFT"
+        lines.append(f"[{status}] {loc['file']}")
+        for label in ("missing", "extra", "empty"):
+            if loc[label]:
+                shown = ", ".join(loc[label][:10])
+                more = f" (+{len(loc[label]) - 10} more)" if len(loc[label]) > 10 else ""
+                lines.append(f"    {label}: {len(loc[label])} -> {shown}{more}")
+        for pm in loc["placeholder_mismatch"][:10]:
+            lines.append(
+                f"    placeholder: {pm['key']} base={pm['base_tokens']} locale={pm['locale_tokens']}"
+            )
+    for err in report["errors"]:
+        lines.append(f"[ERROR] {err['file']}: {err['error']}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect drift (missing/extra/empty keys, placeholder mismatches) across i18n locale files."
+    )
+    parser.add_argument("path", help="Directory of locale JSON files, or a single JSON file")
+    parser.add_argument(
+        "--base", help="Base locale to compare against (stem like 'en' or a path). Default: en, else first."
+    )
+    parser.add_argument(
+        "--ignore-empty", action="store_true", help="Do not flag empty-string / null values"
+    )
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args()
+
+    files = discover_files(args.path)
+    if not files:
+        msg = {"error": f"no locale JSON files found at {args.path!r}"}
+        print(json.dumps(msg) if args.json else f"error: {msg['error']}", file=sys.stderr)
+        return 2
+    if len(files) < 2:
+        msg = {"error": "need at least 2 locale files to compare"}
+        print(json.dumps(msg) if args.json else f"error: {msg['error']}", file=sys.stderr)
+        return 2
+
+    base_file = pick_base(files, args.base)
+    if base_file is None:
+        msg = {"error": f"base locale {args.base!r} not found among files"}
+        print(json.dumps(msg) if args.json else f"error: {msg['error']}", file=sys.stderr)
+        return 2
+
+    report = analyze(files, base_file, args.ignore_empty)
+    print(json.dumps(report, indent=2) if args.json else render_text(report))
+
+    if report["errors"]:
+        return 2
+    return 0 if all(loc["in_sync"] for loc in report["locales"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds an internationalization/localization engineering skill — a gap in the repo (i18n was only mentioned incidentally inside email-template-builder and cmo-advisor; no dedicated implementation skill existed).

Covers the discipline end to end: route every user-facing string through one i18n layer, keep all locale files in sync, format numbers/dates/currency via Intl (not translation keys), backend-enum mapping, locale-prefixed routing, pluralization, and RTL.

Ships a stdlib-only Python tool, scripts/locale_key_drift.py, that detects the four failure modes that ship broken translations across locale files: missing keys, extra keys, empty values, and placeholder mismatches ({{count}} vs {{cnt}}). CLI-first with --help/--json and exit codes 0/1/2, so it can gate CI.

- SKILL.md: name+description frontmatter only, 146 lines, opinionated, anti-patterns + cross-references sections
- references/i18n-patterns.md: namespaces vs flat files, pluralization, Intl, locale routing, RTL, SSR/Next.js, missing-key strategy

## Summary

<!-- What does this PR add or change? -->

## Checklist

- [ ] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [ ] Scripts (if any) run with `--help` without errors
- [ ] No hardcoded API keys, tokens, or secrets
- [ ] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

<!-- How did you verify this works? -->
