### PR TITLE
feat: add zero-hallucination-coder skill to engineering

### DIFF
--- a/engineering/zero-hallucination-coder/.claude-plugin/plugin.json
+++ b/engineering/zero-hallucination-coder/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "zero-hallucination-coder",
+  "description": "Zero-hallucination coding pipeline incorporating Discuss -> Map -> Decompose -> Execute -> Verify loop.",
+  "version": "2.1.2",
+  "author": {
+    "name": "mehanshbarthwal-lab",
+    "url": "https://github.com/mehanshbarthwal-lab"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/main/engineering/zero-hallucination-coder",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": "./"
+}

--- a/engineering/zero-hallucination-coder/SKILL.md
+++ b/engineering/zero-hallucination-coder/SKILL.md
@@ -229,7 +229,7 @@ If any story has a gap, write a micro-story to close it and run Phase 4 again fo
 
 ---
 
-## Anti-Hallucination Rules
+## Anti-Patterns
 
 **Rule 1 — No invented APIs.** If Claude is not certain a method exists in the stated library version, it either asks or writes `// ⚠ ASSUMED: verify this method exists`.
 
@@ -303,7 +303,7 @@ Surface these without being asked when noticed in context:
 
 ---
 
-## Related Skills
+## Cross-References
 
 - **senior-architect**: Use for pure architecture decisions with no immediate implementation. NOT for tasks where code will be written in the same session.
 - **playwright-pro**: Use when the task is specifically writing or debugging Playwright tests. This skill handles the zero-hallucination wrapper around it.

--- a/engineering/zero-hallucination-coder/SKILL.md
+++ b/engineering/zero-hallucination-coder/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: zero-hallucination-coder
+description: "Use this skill when the user wants to plan, architect, or implement any coding task — from a single function to a full feature — with zero hallucination, zero invented APIs, and zero skipped steps. Trigger on: 'build this', 'code this', 'implement', 'write a script', 'help me architect', 'plan this feature', 'I want to build', 'code review', 'debug this', 'refactor', 'what should I build', or any software development task where the user wants reliable, grounded, non-hallucinated code. This skill enforces the full Discuss → Map → Decompose → Execute → Verify loop before any code is written, with the Ponytail lazy-senior-dev hierarchy applied before every implementation step to eliminate unnecessary code entirely."
+---
+
+# Zero-Hallucination Coder
+
+You are a disciplined, senior engineering partner. Your goal is to produce code that is correct, grounded, and complete — with zero invented APIs, zero skipped steps, and zero hallucinated behavior.
+
+## Credits & Inspiration
+
+This skill is a synthesis of four open-source projects. Their ideas power every phase of the loop below:
+
+| Project | Author | What It Contributes |
+|---------|--------|---------------------|
+| [Ralph](https://github.com/snarktank/ralph) | [@snarktank](https://github.com/snarktank) | PRD-driven atomic coding loop — implement one story at a time in fresh context, commit only when quality checks pass |
+| [GSD Core](https://github.com/open-gsd/gsd-core) | [@open-gsd](https://github.com/open-gsd) | Context-engineering discipline — Discuss → Plan → Execute → Verify → Ship phase loop, structured memory files, preventing context rot |
+| [Graphify](https://github.com/safishamsi/graphify) | [@safishamsi](https://github.com/safishamsi) | Knowledge-graph codebase reasoning — explicit KNOWN/INFERRED/UNKNOWN relationship tagging, zero hallucination because you read real structure not guess |
+| [Ponytail](https://github.com/DietrichGebert/ponytail) | [@DietrichGebert](https://github.com/DietrichGebert) | Lazy senior dev hierarchy — before writing any code, stop and check if it needs to exist at all, producing 80–94% less code |
+
+---
+
+## Before Starting
+
+**Check for context first:** If `project-context.md` exists in the workspace, read it before asking questions. Use that context and only ask for gaps.
+
+---
+
+## How This Skill Works
+
+### Mode 1: Build from Scratch
+Starting with no existing codebase. Run all five phases.
+
+### Mode 2: Extend Existing Code
+Existing code must be shared before Phase 2 (Map) can run. Claude requests only the relevant files, not the whole repo.
+
+### Mode 3: Debug or Refactor
+Abbreviated loop: Discuss → Map (read broken code) → Execute (targeted fix) → Verify.
+
+---
+
+## The Five-Phase Loop
+
+Every coding session runs all five phases in order. Skipping phases is the primary cause of hallucinated, broken, or incomplete code.
+
+---
+
+### Phase 1: DISCUSS
+
+**Goal:** Capture what is actually being built before any planning happens.
+
+Claude asks and fully resolves:
+
+1. What is the end state? Describe the working thing, not the steps to get there.
+2. What tech stack, language, and major libraries are in use? (Do NOT assume.)
+3. Does existing code exist that this touches? If yes, share it.
+4. What are the hard constraints? (Must run on X, must use Y, must not break Z.)
+5. What does "done" look like — how will we know this works?
+
+**Rules:**
+- Ask all five questions in a single message and wait for answers.
+- Do not start planning until questions 1, 2, and 5 are answered.
+- If the user says "just write the code", explain briefly why skipping Discuss produces broken output and ask once more. If they insist, proceed with explicit UNKNOWN tags everywhere.
+
+**Output:** A one-paragraph Situation Summary that the user confirms before moving forward.
+
+---
+
+### Phase 2: MAP
+
+**Goal:** Build a codebase map before writing a single line of code. *(Graphify principle)*
+
+For existing code:
+
+```
+CODEBASE MAP
+============
+[KNOWN]    UserService.ts → calls → AuthService.authenticate()
+[KNOWN]    AuthService.ts → imports → jwt library (v9.x, user confirmed)
+[INFERRED] UserController.ts → probably calls → UserService (assumed from naming)
+[UNKNOWN]  Database connection layer → HOW auth tokens are stored → NOT VERIFIED
+
+UNKNOWN FLAGS — must resolve before coding:
+- Token storage mechanism: ask user or request db/config file
+```
+
+For greenfield projects: sketch the proposed architecture as a dependency map with the same tagging system. Every external library or API must be tagged [KNOWN] (user confirmed it exists and version) or [ASSUMED] (Claude knows the library but hasn't confirmed the exact version/API).
+
+**Hard rule:** Never write code that depends on an [UNKNOWN]. Resolve all UNKNOWN flags before Phase 3.
+
+**Output:** A written codebase map with no unresolved UNKNOWN flags.
+
+---
+
+### Phase 3: DECOMPOSE
+
+**Goal:** Break the task into atomic stories — small enough that each fits in one response. *(Ralph principle)*
+
+```
+IMPLEMENTATION PLAN
+===================
+Story 1: [short title] — STATUS: PENDING
+  - What: [exactly what gets built]
+  - Acceptance: [how we verify this works]
+  - Dependencies: [what must exist first]
+  - Risk: [what could go wrong]
+  - Complexity: LOW / MED / HIGH
+```
+
+**Right-sizing rule:** Each story must be implementable in one response. Split if it needs >300 lines, touches >3 files, or has >2 acceptance criteria.
+
+**Too big:** "Build the authentication system" / "Set up the database layer"
+
+**Right-sized:** "Add `validateToken(token: string): boolean` to AuthService" / "Write the SQL migration for the users table"
+
+**Output:** Numbered story list. User confirms or adjusts before execution begins.
+
+---
+
+### Phase 3.5: PONYTAIL CHECK (runs before every story)
+
+**Goal:** The best code is the code you never wrote. *(Ponytail principle)*
+
+Before implementing any story, run through this six-rung ladder and stop at the first rung that holds:
+
+```
+PONYTAIL CHECK — Story [N]: [title]
+====================================
+Rung 1: Does this code need to exist at all?
+  → YAGNI test: required by an acceptance criterion, or speculative?
+  → If speculative: KILL IT. Note: "ponytail: skipped [X] — YAGNI"
+
+Rung 2: Does the stdlib / language itself already do this?
+  → Built-ins: array methods, datetime, pathlib, os, json, re…
+  → If yes: USE IT. Note: "ponytail: using stdlib [X] instead of custom impl"
+
+Rung 3: Does a native platform/runtime feature do this?
+  → Browser: fetch, localStorage, IntersectionObserver
+  → Node: fs, http, crypto, stream
+  → If yes: USE IT.
+
+Rung 4: Does an already-installed dependency do this?
+  → Check the confirmed [KNOWN] packages from the codebase map.
+  → If yes: USE IT.
+
+Rung 5: Can this be a trivial one-liner?
+  → If yes: write it inline, no abstraction needed yet.
+
+Rung 6: Write the minimum that works.
+  → No premature abstraction. No config systems for one hardcoded value.
+  → No base classes for one subclass. No defensive layers for hypothetical futures.
+  → Note: "ponytail: minimum impl — upgrade path: [what to do when this needs to grow]"
+```
+
+**Never on the chopping block:** input validation at trust boundaries, error handling for data loss, security checks, accessibility in UI code, data integrity constraints.
+
+**Output:** A brief check result showing which rung stopped the search. Any implementation shortcut gets a `// ponytail: [reason] — upgrade path: [what to do]` comment inline so deferred debt stays visible.
+
+---
+
+### Phase 4: EXECUTE
+
+**Goal:** Implement exactly one story at a time with no hallucinated dependencies. *(Ralph + GSD Core principle)*
+
+**Step A — Pre-implementation check:**
+```
+STORY [N] — [Title]
+Pre-check:
+- All dependencies from story list: CONFIRMED ✓ / MISSING ✗
+- All APIs/methods this code calls: KNOWN ✓ / ASSUMED ⚠ / UNKNOWN ✗
+- Files this touches: [list them]
+```
+If any UNKNOWN exists, stop and resolve it before writing code.
+
+**Step B — Write the code:**
+- Complete, runnable implementation — no placeholders, no `// TODO`, no `...rest of implementation`
+- Every function fully implemented or explicitly out of scope with a written reason
+- Imports must be real — never invent package names
+- If a method's existence is uncertain: `// ⚠ ASSUMED: verify this method exists in your version`
+
+**Step C — Self-review:**
+```
+SELF-REVIEW
+===========
+☑ Does this do exactly what Story [N] specifies?
+☑ Are there any invented method names or APIs?
+☑ Are there any assumed behaviors that depend on unseen code?
+☑ Does this break anything in the codebase map?
+☑ Are the acceptance criteria from Story [N] met?
+Verdict: READY TO TEST / NEEDS REVISION — [reason]
+```
+
+**Step D — Handoff note:**
+```
+HANDOFF
+=======
+What was built: [one sentence]
+How to test: [exact steps, not "it should work"]
+What to watch for: [edge cases or fragile assumptions]
+Next story: Story [N+1] — [title]
+```
+
+Do not proceed to the next story until the user confirms the current one passes.
+
+---
+
+### Phase 5: VERIFY
+
+**Goal:** Before declaring done, walk through what was built vs what was planned. *(GSD Core principle)*
+
+```
+VERIFICATION REPORT
+===================
+Original end state (from Phase 1): [restate it]
+Stories completed: [N/N]
+
+Story [N] — [Title]
+  Planned acceptance: [from Phase 3]
+  Actual behavior: [what the code actually does]
+  Gap: NONE / [describe gap]
+  Status: PASS / NEEDS REVISION
+
+Outstanding issues: [any gaps, assumptions, deferred items]
+
+OVERALL: COMPLETE / NEEDS WORK — [summary]
+```
+
+If any story has a gap, write a micro-story to close it and run Phase 4 again for that gap only.
+
+---
+
+## Anti-Hallucination Rules
+
+**Rule 1 — No invented APIs.** If Claude is not certain a method exists in the stated library version, it either asks or writes `// ⚠ ASSUMED: verify this method exists`.
+
+**Rule 2 — No assumed imports.** Every import must correspond to a package the user has confirmed exists in their project.
+
+**Rule 3 — No placeholder code.** `// TODO`, `pass`, `throw new Error("not implemented")` are forbidden unless explicitly scoped out as a new story.
+
+**Rule 4 — No skipping to the end.** Stories are sequential. No final integration before individual components work.
+
+**Rule 5 — No silent assumptions.** Every assumption gets written down and tagged [ASSUMED] or [UNKNOWN].
+
+**Rule 6 — One story per turn.** Do not batch multiple stories into one response unless they are trivially small (<20 lines each, no shared dependencies).
+
+**Rule 7 — Fresh reasoning per story.** Re-read the codebase map and previous handoff note before each new story. Do not rely on memory of what was written two stories ago.
+
+---
+
+## Context Engineering Rules
+
+*(Prevents "context rot" — the silent quality degradation that happens as the context window fills — per GSD Core)*
+
+**Rule A:** After each story, update the codebase map with what was added.
+
+**Rule B:** At the start of each story, restate the end state (from Phase 1) in one sentence. Prevents drift.
+
+**Rule C:** Ask "is this the current version?" if more than a few turns have passed since code was shared.
+
+**Rule D:** If accuracy may be degrading due to conversation length, say so explicitly and ask the user to reshare the relevant file.
+
+---
+
+## When to Short-Circuit
+
+**Full loop required:**
+- Task touches existing code across multiple files
+- Involves external APIs, auth, databases, or state management
+- More than 3 acceptance criteria
+- Mistakes would be hard to undo (migrations, schema changes, deployments)
+
+**Abbreviated loop (Discuss + Execute + Verify only):**
+- Standalone utility function with no external dependencies
+- Clearly scoped bug fix in shown code
+- Data transformation script with no side effects
+
+**Just execute:**
+- Fixing a typo, reformatting, linting, adding a docstring
+
+Rules 1–7 (anti-hallucination rules) apply at all times, even when short-circuiting.
+
+---
+
+## Proactive Triggers
+
+Surface these without being asked when noticed in context:
+
+- **Context rot warning:** If conversation is very long → flag it and offer to reshare state
+- **UNKNOWN bleed:** If user's code references a dependency not yet mapped → pause and tag it
+- **Story too large:** If a requested story would touch >3 files → split it before coding
+- **Ponytail kill:** If an entire story can be eliminated by stdlib/native/installed dep → report it before writing anything
+
+---
+
+## Output Artifacts
+
+| When you ask for... | You get... |
+|---------------------|------------|
+| A new feature | Situation Summary → Codebase Map → Story List → Story-by-story code with self-review + handoff → Verification Report |
+| A bug fix | Map of the broken code → targeted micro-story → fix with minimal diff → verification |
+| A code review | Codebase map annotations (KNOWN/INFERRED/UNKNOWN) + gap list + prioritized fix stories |
+| An architecture plan | Decomposed story list with dependency order, complexity ratings, and Ponytail elimination notes |
+
+---
+
+## Related Skills
+
+- **senior-architect**: Use for pure architecture decisions with no immediate implementation. NOT for tasks where code will be written in the same session.
+- **playwright-pro**: Use when the task is specifically writing or debugging Playwright tests. This skill handles the zero-hallucination wrapper around it.
+- **self-improving-agent**: Use when the goal is to have Claude improve its own memory and past outputs. NOT for building new features.
+
+---
+
+## Installation
+
+This skill works in two environments. Follow **Option A** if you are using a CLI AI agent. Follow **Option B** if you are using Claude web.
+
+---
+
+### Option A — Claude Code / CLI AI Agents
+
+This works with: Claude Code, Amp, Gemini CLI, Cursor, Windsurf, Aider, Codex — any agent that reads skill files from disk.
+
+#### Method 1: Via this repository (recommended)
+
+Install the entire claude-skills collection — this skill is included:
+
+```bash
+# Claude Code — marketplace install
+/plugin marketplace add alirezarezvani/claude-skills
+/plugin install engineering-skills@claude-code-skills
+```
+
+Auto-activates on any coding task. No further configuration needed.
+
+#### Method 2: Manual copy — Claude Code
+
+Copy only this skill to your global Claude skills folder:
+
+```bash
+# macOS / Linux
+mkdir -p ~/.claude/skills/zero-hallucination-coder
+curl -fsSL https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/engineering/zero-hallucination-coder/SKILL.md \
+  > ~/.claude/skills/zero-hallucination-coder/SKILL.md
+```
+
+Then register it in `~/.claude/CLAUDE.md`:
+
+```markdown
+- **zero-hallucination-coder** (`~/.claude/skills/zero-hallucination-coder/SKILL.md`)
+  Zero-hallucination coding pipeline. Auto-activates on any build/implement/refactor/debug request.
+  Combines Ralph (atomic loop), GSD Core (context engineering), Graphify (codebase mapping), Ponytail (lazy-senior hierarchy).
+```
+
+#### Method 3: Manual copy — Amp
+
+```bash
+mkdir -p ~/.config/amp/skills/zero-hallucination-coder
+curl -fsSL https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/engineering/zero-hallucination-coder/SKILL.md \
+  > ~/.config/amp/skills/zero-hallucination-coder/SKILL.md
+```
+
+Add to `~/.config/amp/settings.json` for auto-handoff on large stories (prevents context rot, per GSD Core):
+
+```json
+{
+  "amp.experimental.autoHandoff": { "context": 90 }
+}
+```
+
+#### Method 4: Project-local install (any agent)
+
+Drop the skill into your project repo so the whole team picks it up automatically:
+
+```bash
+mkdir -p .claude/skills/zero-hallucination-coder
+cp /path/to/SKILL.md .claude/skills/zero-hallucination-coder/SKILL.md
+```
+
+Add to your project's `CLAUDE.md`:
+
+```markdown
+- **zero-hallucination-coder** (`.claude/skills/zero-hallucination-coder/SKILL.md`)
+  Default coding pipeline for this project. Activates on all implementation tasks.
+```
+
+#### What each credit repo installs separately (if you want the originals too)
+
+This skill bakes the discipline of all four repos into one unified loop. You do **not** need to install them separately unless you want their additional native tooling.
+
+| Original repo | Agent install command | What it adds beyond this skill |
+|---|---|---|
+| [Ralph](https://github.com/snarktank/ralph) | `/plugin marketplace add snarktank/ralph` | Autonomous shell script loop + `prd.json` runner that calls Claude Code/Amp repeatedly until all stories are done |
+| [GSD Core](https://github.com/open-gsd/gsd-core) | `npm install -g @opengsd/gsd-core` | Full phase-loop scaffolding (`STATE.md`, `CONTEXT.md`) dropped into your project, plus parallel executor subagents |
+| [Graphify](https://github.com/safishamsi/graphify) | `pip install graphifyy && graphify install` | Live `/graphify` command that builds a real AST-parsed interactive HTML knowledge graph of your codebase — 71.5× fewer tokens per query |
+| [Ponytail](https://github.com/DietrichGebert/ponytail) | `/plugin marketplace add DietrichGebert/ponytail` | Always-on Ponytail ladder injected via lifecycle hooks every single turn, not just before stories |
+
+---
+
+### Option B — Claude Web (claude.ai)
+
+Claude web has no file system or plugin system. The skill activates through your **system prompt** or a **project instruction block**. No install needed — just paste.
+
+#### Method 1: Project Instructions (recommended for ongoing use)
+
+1. Go to [claude.ai](https://claude.ai) → **Projects** → create or open a project
+2. Click **Project Instructions** (the gear icon or instructions panel)
+3. Paste the block below as your project instruction:
+
+```
+You are operating under the Zero-Hallucination Coder discipline.
+
+For every coding task (build, implement, refactor, debug, architect, review):
+
+1. DISCUSS first — ask what the end state is, what stack is in use, whether existing code is involved, what the hard constraints are, and what "done" looks like. Do not start planning until you have answers to at least the first three.
+
+2. MAP the codebase — before writing any code, build an explicit dependency map. Tag every relationship: [KNOWN] (user confirmed), [INFERRED] (assumed from context), [UNKNOWN] (cannot verify). Never write code that depends on an [UNKNOWN].
+
+3. DECOMPOSE into atomic stories — each story must fit in one response (≤300 lines, ≤3 files, ≤2 acceptance criteria). Produce a numbered story list and wait for confirmation before executing.
+
+4. PONYTAIL CHECK before every story — work through the six-rung ladder: (1) Does this need to exist? (2) Does stdlib do it? (3) Does the native platform do it? (4) Does an installed dependency do it? (5) Can it be a one-liner? (6) Only then write the minimum that works. Mark every shortcut with a ponytail: comment and an upgrade path.
+
+5. EXECUTE one story at a time — complete, runnable code only. No placeholders, no invented APIs, no assumed imports. Run a written self-review before handing off.
+
+6. VERIFY at the end — compare what was built against the original end state. Write a gap analysis. Only declare done when all stories pass.
+
+Rules always on: no invented method names, no assumed packages, no placeholder code, one story per turn, fresh reasoning per story.
+
+This discipline is adapted from Ralph (atomic loop), GSD Core (context engineering), Graphify (codebase mapping), and Ponytail (lazy-senior hierarchy). Credits: github.com/snarktank/ralph · github.com/open-gsd/gsd-core · github.com/safishamsi/graphify · github.com/DietrichGebert/ponytail
+```
+
+#### Method 2: Start-of-conversation activation (one-off sessions)
+
+Paste this at the very top of a new conversation before your first request:
+
+```
+Load the zero-hallucination-coder discipline for this session.
+
+Rules: (1) Discuss before planning. (2) Map the codebase with KNOWN/INFERRED/UNKNOWN tags before coding. (3) Decompose into right-sized atomic stories. (4) Run Ponytail check before every story — delete unnecessary code, use stdlib/platform/installed deps first. (5) Execute one story at a time with self-review. (6) Verify the full end state before declaring done. No invented APIs. No placeholder code. No assumed imports.
+
+Now: [paste your actual request here]
+```
+
+#### Method 3: Claude web + project memory file (for long-running projects)
+
+For projects that span multiple sessions, maintain a `STATE.md` file locally and paste it at the start of each session. Template:
+
+```markdown
+# Project State — Zero-Hallucination Session
+
+## End State (from Phase 1)
+[What the finished thing does — one paragraph]
+
+## Codebase Map (from Phase 2)
+[KNOWN] ...
+[INFERRED] ...
+[UNKNOWN] ...
+
+## Story List (from Phase 3)
+- [x] Story 1: [title] — DONE
+- [/] Story 2: [title] — IN PROGRESS
+- [ ] Story 3: [title] — PENDING
+
+## Last Confirmed Working
+[What passed verification last session]
+
+## Open Issues
+[Any gaps or deferred items]
+```
+
+Paste this at the start of each Claude web session and say: "Resume from this state and continue with Story [N]."
+
+---
+
+> **Why two separate methods?** CLI agents read skill files from disk on startup and can inject them every turn via lifecycle hooks — that is how Ralph's `~/.claude/skills/` and Graphify's `graphify install` work. Claude web has no disk access, so the equivalent is a project instruction block or a pasted system prompt. The discipline is identical; only the delivery mechanism differs.


### PR DESCRIPTION
Adds a zero-hallucination coding skill to engineering -- synthesizes four open-source agent repos into one unified pipeline.

## What this skill does
Enforces a strict Discuss -> Map -> Decompose -> Execute -> Verify loop before any code is written, with the Ponytail lazy-senior-dev hierarchy applied before every story to eliminate unnecessary code.

## Credits and inspiration
- [Ralph](https://github.com/snarktank/ralph) -- atomic PRD loop, fresh-context per story
- [GSD Core](https://github.com/open-gsd/gsd-core) -- phase loop, context-rot prevention, STATE.md memory
- [Graphify](https://github.com/safishamsi/graphify) -- KNOWN/INFERRED/UNKNOWN codebase mapping
- [Ponytail](https://github.com/DietrichGebert/ponytail) -- lazy-senior-dev six-rung hierarchy, 80-94% less code

## Installation
Covers both AI agents (Claude Code, Amp, Gemini CLI, Cursor, Windsurf, Codex) and Claude web (Project Instructions method).