### PR TITLE
feat(ra-qm-team): agent-decision-receipts — post-quantum receipts for agent actions

### DIFF
--- a/ra-qm-team/agent-decision-receipts/SKILL.md
+++ b/ra-qm-team/agent-decision-receipts/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "agent-decision-receipts"
+description: "Mint a tamper-evident, post-quantum-signed receipt for a consequential agent action (deploy, delete, pay, grant-access, model decision) so it can be verified later from the certificate alone. Use when an autonomous agent takes a side-effecting action you may need to prove later, or when satisfying EU AI Act Article 12 record-keeping. Three decisions: does it need a receipt, mint it, verify it. Delegates the signing to the open-source OpenAgentOntology package. NOT after-the-fact log analysis; NOT a hosted notary; NOT a legal opinion."
+---
+
+# Agent Decision Receipts
+
+## Overview
+
+A log says an action happened. A **receipt is tamper-evident**: it records who, what, under which policy, and is signed, so any later edit breaks the signature. This skill mints one for a consequential agent action and verifies it later from the certificate alone: no database, no network, no trusting the issuer.
+
+The crypto is not in this skill. It is the open-source **OpenAgentOntology** receipt primitive (Apache-2.0), which signs every receipt with Ed25519 **and** the post-quantum legs ML-DSA-65 (FIPS 204) + SLH-DSA (FIPS 205) when the post-quantum backend is installed. This skill is the decision layer: when to mint, what to put in, how to verify. One install, no per-skill crypto.
+
+**Three decisions, nothing else:**
+
+1. **Does this action need a receipt?** -- side-effecting + consequential + later-provable = yes.
+2. **Mint the receipt** -- build the action manifest, sign it with the OAO primitive.
+3. **Verify it** -- recompute the hash, check each signature leg, from the cert alone.
+
+This skill is **NOT log analysis.** Logs describe what happened and can be silently edited. A receipt is minted before/at execution and breaks if edited. Use logs for debugging; use receipts for evidence.
+
+This skill is **NOT a hosted notary.** It mints a LOCAL, self-signed receipt anyone can verify offline. Cross-organization verification (one org proving to another) is a separate hosted service, out of scope here.
+
+This skill is **NOT a legal opinion.** It produces evidence shaped to support FRE 902(13)/(14)-style certification and EU AI Act Article 12 record-keeping. Whether a given receipt is admitted is a question for counsel.
+
+## Keywords
+
+agent receipt, decision receipt, agent governance, agent audit trail, AI agent evidence, tamper-evident agent log, sign agent action, Ed25519 agent, post-quantum signature, ML-DSA-65, SLH-DSA, FIPS 204, FIPS 205, EU AI Act Article 12, record-keeping AI, OWASP Agentic Top 10, excessive agency, FRE 902, self-authenticating evidence, verify from certificate, offline verification, agent accountability, prove what the agent did, AI insurance evidence, OpenAgentOntology, OAO receipt, quantum-resistant signature
+
+## Quick Start
+
+```bash
+# Install the open-source receipt primitive (Apache-2.0). Add [pq] for the post-quantum legs.
+pip install "openagentontology[pq]"
+
+# 1. Build + validate an action manifest (stdlib only, no crypto, no network)
+python scripts/build_action_manifest.py --agent my-deploy-agent --operation deploy \
+    --target prod/api --policy "EU AI Act Art 12" --out action.json
+
+# 2. Mint the receipt over it (Ed25519 + post-quantum legs)
+python -c "import json,openagentontology.receipt as r; \
+  print(json.dumps(r.mint_receipt(json.load(open('action.json')), decision='ACTION_GOVERNED')))" > receipt.json
+
+# 3. Verify from the cert alone (no DB, no network)
+python -c "import json,openagentontology.receipt as r; \
+  print(r.verify_receipt(json.load(open('receipt.json'))))"
+# -> {'ok': True, 'sig_ok': True, ... 'reason': 'verified from the cert alone via: ed25519, ml_dsa, slh_dsa'}
+```
+
+## Core Workflow
+
+The three decisions below are the skill: decide whether to receipt, mint, then verify.
+
+## Decision 1: Does this action need a receipt?
+
+Mint a receipt when the action is **all three** of:
+
+| Test | Mint if... |
+|------|-----------|
+| Side-effecting | it writes, sends, deploys, deletes, pays, grants access, or changes external state |
+| Consequential | a wrong call costs money, breaks compliance, or harms a person |
+| Later-provable | someone (auditor, insurer, regulator, court, counterparty) may ask "what did the agent do and why?" |
+
+Read-only, reversible, trivial actions do **not** need a receipt. Receipt everything and you drown the signal; receipt nothing and you cannot prove the one call that mattered.
+
+High-signal triggers (mint by default): `deploy`, `delete`, `pay`/`wire`/`refund`, `grant_access`, `export`/`egress`, `approve`/`deny` a claim, any model decision that affects a person under a high-risk AI system.
+
+## Decision 2: Mint the receipt
+
+The action manifest is any ASCII-safe dict describing what the agent did. Required keys this skill enforces (via `build_action_manifest.py`):
+
+| Key | What it carries |
+|-----|-----------------|
+| `agent_id` | the acting agent |
+| `operation` | the verb (deploy / delete / pay / decide / ...) |
+| `target` | what it acted on |
+| `policy` | the rule that governs it (e.g. "EU AI Act Art 12", "internal change-control") |
+| `inputs_hash` | a hash of the inputs, so the full payload need not be stored in the clear |
+
+`mint_receipt(manifest, decision=...)` hashes the full manifest into the receipt evidence, signs the canonical body, and returns a receipt that carries: `evidence_hash`, `signature_b64` (Ed25519), and -- when `[pq]` is installed -- `ml_dsa_signature_b64` + `slh_dsa_signature_b64`. Each leg signs the same bytes; any one verifying proves authenticity.
+
+> See [references/receipt-fields.md](references/receipt-fields.md) for the full receipt schema and the post-quantum rationale.
+
+## Decision 3: Verify it
+
+`verify_receipt(receipt)` recomputes `sha256(canonical(evidence))`, compares it to `evidence_hash`, then checks every signature leg it has a backend for. It returns `{ok, hash_ok, sig_ok, legs, reason}`. A single edited byte anywhere in the action breaks `hash_ok`; a forged signature breaks the leg. Verification needs only the receipt -- no call back to the issuer.
+
+This is the property that makes it evidence: a reviewer who distrusts you can still confirm the receipt is intact and authentic, entirely offline.
+
+## Anti-Patterns
+
+- **Receipt the log, not the decision.** Minting a receipt over a log line you wrote after the fact proves nothing. Mint at the point of action, over the action.
+- **Storing the signing key next to the receipts.** If the key is compromised, signatures mean nothing. Treat the key like any signing secret; never commit it.
+- **Ed25519-only when the post-quantum legs are available.** A receipt is long-lived evidence. Sign it once with the post-quantum legs (ML-DSA-65 + SLH-DSA) so it stays verifiable if a future quantum computer could break Ed25519. Install `[pq]`.
+- **Putting raw secrets or PII in the manifest.** The manifest is hashed into evidence and is recoverable from the receipt. Carry hashes (`inputs_hash`), not the cleartext.
+- **Calling it "admissible."** It is evidence shaped to *support* FRE 902(13)/(14)-style certification. Admissibility is a court's decision, not the tool's claim.
+- **Faking a signature when crypto is missing.** The primitive emits an explicit `unsigned` flag instead. Never present an unsigned receipt as signed.
+
+## Cross-References
+
+- `ra-qm-team/compliance-team-eu-ai-act/` -- decide the AI system's risk tier and Article 12 obligations; this skill mints the per-action record those obligations require.
+- `ra-qm-team/compliance-team-iso42001/` -- the AI management-system controls; receipts are the per-decision evidence those controls call for.
+- OpenAgentOntology (Apache-2.0): https://github.com/CWNApps/openagentontology -- the open receipt primitive this skill drives.

--- a/ra-qm-team/agent-decision-receipts/references/receipt-fields.md
+++ b/ra-qm-team/agent-decision-receipts/references/receipt-fields.md
@@ -21,6 +21,7 @@ A minted receipt is an ASCII-only, JSON-safe dict:
 | `ml_dsa_signature_b64` | ML-DSA-65 (FIPS 204) leg, present when `[pq]` is installed |
 | `slh_dsa_signature_b64` | SLH-DSA (FIPS 205) leg, present when `[pq]` is installed |
 | `signature_alg` | names every leg actually on the receipt |
+| `kid` | `sha256(verify_pubkey_b64)[:32]` -- 128-bit key identifier. Lets a verifier comparing two receipts answer "signed by the same notary?" offline, without any registry. |
 
 ## Canonicalization (why the hash reproduces anywhere)
 
@@ -60,3 +61,27 @@ authenticity from whichever leg it can check. This is post-quantum *cryptography
 resistant signatures on classical computers), not quantum computing -- label it precisely.
 
 Install both legs: `pip install "openagentontology[pq]"`.
+
+## PQ-required verification (strict mode, recommended)
+
+A verifier that accepts Ed25519-only receipts can be fooled by an attacker who strips the
+post-quantum legs from a hybrid-signed receipt -- the residual Ed25519 leg still verifies,
+but the long-lived guarantee is gone. The standing pattern across the CWN distribution:
+
+```python
+def verify_strict(receipt, *, require_pq: bool | None = None):
+    must = require_pq if require_pq is not None else (
+        os.environ.get("TRUST_GATE_REQUIRE_PQ", "true").lower() in ("1","true","yes","on"))
+    out = oao.verify_receipt(receipt)
+    if must and out.get("ok") and out.get("signed"):
+        legs = out.get("legs", {})
+        missing = [n for n in ("ml_dsa", "slh_dsa") if legs.get(n) != "ok"]
+        if missing:
+            out["ok"] = False
+            out["reason"] = f"PQ-required: missing {missing}"
+    return out
+```
+
+`TRUST_GATE_REQUIRE_PQ` defaults to `true`. Set it to `false` only when you must verify
+legacy Ed25519-only receipts (e.g. archival data). The same gate is built into the SalesGPT,
+OpenOutreach, and Trust Gate MCP integrations.

--- a/ra-qm-team/agent-decision-receipts/references/receipt-fields.md
+++ b/ra-qm-team/agent-decision-receipts/references/receipt-fields.md
@@ -1,0 +1,62 @@
+# Receipt fields + the post-quantum rationale
+
+Detailed reference for the `agent-decision-receipts` skill. The receipt is produced by the
+OpenAgentOntology `mint_receipt` primitive (Apache-2.0); this documents what comes back and why.
+
+## The receipt schema
+
+A minted receipt is an ASCII-only, JSON-safe dict:
+
+| Field | Meaning |
+|-------|---------|
+| `atom_id` | stable id derived from the action source + the evidence-hash prefix |
+| `type` | `AgentGovernanceReceipt` |
+| `decision` | the verdict label you passed (e.g. `ACTION_GOVERNED`, `DEPLOY_APPROVED`) |
+| `evidence_hash` | `sha256(canonical(evidence))` -- the commitment to the full action manifest |
+| `signed_at` | ISO-8601 timestamp (in the signed body, never in the hashed evidence) |
+| `evidence` | `{summary, ontology}` -- the full action manifest is under `evidence.ontology` |
+| `signature_b64` | Ed25519 signature over `canonical(body)` |
+| `verify_pubkey_b64` | the Ed25519 public key, so the receipt verifies offline |
+| `signed` | bool -- false + an explicit flag if the crypto backend is absent (never faked) |
+| `ml_dsa_signature_b64` | ML-DSA-65 (FIPS 204) leg, present when `[pq]` is installed |
+| `slh_dsa_signature_b64` | SLH-DSA (FIPS 205) leg, present when `[pq]` is installed |
+| `signature_alg` | names every leg actually on the receipt |
+
+## Canonicalization (why the hash reproduces anywhere)
+
+`canonical(obj) = json.dumps(obj, sort_keys=True, separators=(",",":"), ensure_ascii=True, allow_nan=False)`.
+
+Because the evidence is sorted, separator-fixed, ASCII, and finite, a verifier in any language
+recomputes the identical `sha256` byte-for-byte. There are no timestamps inside the hashed
+evidence, so the hash is deterministic; the timestamp lives in the signed body instead.
+
+## Verification result
+
+`verify_receipt(receipt)` returns:
+
+| Field | Meaning |
+|-------|---------|
+| `hash_ok` | recomputed `sha256(canonical(evidence))` equals `evidence_hash` |
+| `legs` | per-leg status: `ok` / `fail` (tamper) / `absent` / `unverifiable` (no backend) |
+| `sig_ok` | at least one signature leg verified |
+| `ok` | `hash_ok` AND no leg failed AND (`sig_ok` OR the receipt is honestly unsigned) |
+| `reason` | human-readable verdict |
+
+A one-byte edit to the action breaks `hash_ok`. A forged signature flips a leg to `fail`. An
+older Ed25519-only receipt still verifies; the post-quantum legs are simply `absent`.
+
+## Why post-quantum, by default
+
+A receipt is long-lived evidence -- an insurer, a regulator, or an auditor may verify it years
+after the action. A cryptographically-relevant quantum computer could forge Ed25519 signatures,
+so a signature that must stay trustworthy for years needs an algorithm that resists that. The
+post-quantum legs are NIST-standardized signatures designed for exactly this:
+
+- **ML-DSA-65** (FIPS 204) -- lattice-based; the size/performance default for hot paths.
+- **SLH-DSA** (FIPS 205) -- hash-based, stateless; smaller assumptions, good for long archival.
+
+Each leg signs the same canonical body, so a verifier with only one backend can still prove
+authenticity from whichever leg it can check. This is post-quantum *cryptography* (quantum-
+resistant signatures on classical computers), not quantum computing -- label it precisely.
+
+Install both legs: `pip install "openagentontology[pq]"`.

--- a/ra-qm-team/agent-decision-receipts/scripts/build_action_manifest.py
+++ b/ra-qm-team/agent-decision-receipts/scripts/build_action_manifest.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""build_action_manifest.py -- build + validate an agent action manifest for receipt minting.
+
+Standard library only (argparse, hashlib, json, sys). No crypto, no network, no pip deps.
+The actual signing is done by the OpenAgentOntology receipt primitive (pip install
+"openagentontology[pq]"); this helper just assembles a well-formed, ASCII-safe action manifest
+and prints the exact mint command, so the manifest can never be malformed when it reaches the
+signer.
+
+Usage:
+  python build_action_manifest.py --agent A --operation deploy --target prod/api \\
+      --policy "EU AI Act Art 12" --inputs "service=api;version=1.4.2" --out action.json
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+
+# Side-effecting / consequential verbs. An action carrying one of these is the kind this
+# skill exists to receipt. Used only to advise (never to block) -- the caller decides.
+HIGH_SIGNAL = {
+    "deploy", "release", "delete", "drop", "purge", "pay", "wire", "transfer", "refund",
+    "grant", "grant_access", "export", "egress", "send", "approve", "deny", "decide",
+    "provision", "migrate", "reconfigure", "escalate",
+}
+
+REQUIRED = ("agent_id", "operation", "target", "policy")
+
+
+def _hash(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode("utf-8")).hexdigest()[:16]
+
+
+def _ascii_safe(obj) -> bool:
+    """Evidence must be ASCII so the receipt hash reproduces in any language."""
+    try:
+        json.dumps(obj, ensure_ascii=True).encode("ascii")
+        return True
+    except (UnicodeEncodeError, TypeError):
+        return False
+
+
+def build(agent_id, operation, target, policy, inputs, decision) -> dict:
+    manifest = {
+        "agent_id": agent_id,
+        "operation": operation,
+        "target": target,
+        "policy": policy,
+        "inputs_hash": _hash(inputs or ""),
+        "decision_label": decision,
+    }
+    missing = [k for k in REQUIRED if not manifest.get(k)]
+    if missing:
+        raise ValueError(f"missing required field(s): {', '.join(missing)}")
+    if not _ascii_safe(manifest):
+        raise ValueError("manifest contains non-ASCII; the receipt hash must be reproducible")
+    return manifest
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Build a validated agent action manifest for receipt minting.")
+    p.add_argument("--agent", required=True, help="acting agent id")
+    p.add_argument("--operation", required=True, help="the verb: deploy / delete / pay / decide / ...")
+    p.add_argument("--target", required=True, help="what the action acts on")
+    p.add_argument("--policy", required=True, help="the governing rule, e.g. 'EU AI Act Art 12'")
+    p.add_argument("--inputs", default="", help="inputs to hash (kept as a hash, not stored in clear)")
+    p.add_argument("--decision", default="ACTION_GOVERNED", help="the receipt decision label")
+    p.add_argument("--out", default="action.json", help="output manifest path")
+    a = p.parse_args(argv)
+
+    try:
+        manifest = build(a.agent, a.operation, a.target, a.policy, a.inputs, a.decision)
+    except ValueError as e:
+        print(f"REJECTED: {e}", file=sys.stderr)
+        return 2
+
+    with open(a.out, "w", encoding="ascii") as f:
+        json.dump(manifest, f, indent=2)
+
+    op = a.operation.lower()
+    advice = "HIGH-SIGNAL: receipt this by default." if op in HIGH_SIGNAL else \
+        "low-signal: receipt only if it is consequential + later-provable."
+    print(f"manifest -> {a.out}")
+    print(f"  operation: {a.operation}  ({advice})")
+    print(f"  policy:    {a.policy}")
+    print(f"  inputs_hash: {manifest['inputs_hash']}")
+    print()
+    print("Mint the receipt (Ed25519 + post-quantum legs):")
+    print(f'  python -c "import json,openagentontology.receipt as r; '
+          f"print(json.dumps(r.mint_receipt(json.load(open('{a.out}')), decision='{a.decision}')))\" > receipt.json")
+    print("Verify it from the cert alone:")
+    print('  python -c "import json,openagentontology.receipt as r; '
+          "print(r.verify_receipt(json.load(open('receipt.json'))))\"")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

A new `ra-qm-team` skill: **agent-decision-receipts**. It mints a tamper-evident, post-quantum-signed receipt for a consequential agent action (deploy, delete, pay, grant-access, model decision) and verifies it from the certificate alone — no database, no network.

## Why

The existing `compliance-team-eu-ai-act` / `compliance-team-iso42001` skills decide *what* governance an AI system needs. This skill produces the *per-action evidence* those obligations call for (EU AI Act Article 12 record-keeping, OWASP Agentic excessive-agency).

## How it fits the repo

- The script in `scripts/` is **stdlib-only** (the convention): it builds + validates an action manifest. The actual signing is delegated to the open-source `openagentontology` package (Apache-2.0) the user installs, so **no pip dependency is added to this repo**.
- Under 500 lines; detail moved to `references/`.
- Targets `dev` per CONTRIBUTING.
- **Frontmatter note:** I used the two-field frontmatter (name + description) per CONVENTIONS.md section 2. Several existing skills (e.g. `eu-ai-act-specialist`) carry a fuller `license` + `metadata` block — happy to match whichever you prefer; just say which is current.

## Verified

Ran end-to-end: the manifest builds, the receipt mints with Ed25519 + ML-DSA-65 + SLH-DSA legs, verifies from the cert alone, and a one-byte edit to the action breaks verification.
