### PR TITLE
feat(engineering): add named-persona-adversarial-review — philosophy-grounded code review

### DIFF
--- a/engineering-team/skills/named-persona-adversarial-review/SKILL.md
+++ b/engineering-team/skills/named-persona-adversarial-review/SKILL.md
@@ -5,7 +5,7 @@ description: "Code review through the lens of real engineers' documented philoso
 
 # Named-Persona Adversarial Review
 
-> **TL;DR:** Abstract roles find abstract problems. Named people with searchable, citable philosophies find problems you would actually fix. This upgrades your review beyond what bots and generic reviewers can provide.
+> **TL;DR:** Abstract roles find abstract problems. Named people with searchable, citable philosophies find problems you would actually fix.
 
 **Triggers:** "review this PR with real engineers" | "named persona review" | "用真人的哲学审查这个PR"
 
@@ -21,7 +21,7 @@ Verdict: CONCERNS — fix CRITICAL before merge.
 
 ## Problem
 
-Generic adversarial review produces generic findings. This grounds each persona in real, searchable philosophy — what Linus Torvalds actually said about good taste, not what an AI thinks a "security auditor" might say.
+Abstract adversarial review can produce generic findings when personas lack grounding. This skill grounds each persona in real, searchable philosophy — what Linus Torvalds actually said about good taste, not what an AI imagines a reviewer might say.
 
 **Before/after:** `adversarial-reviewer` → "Consider adding error handling here." Named-persona → "Linus would ask: why is this even a special case? Eliminate the special case and the error handling disappears."
 
@@ -100,7 +100,6 @@ Merge duplicates. Cross-persona → severity upgrade. Post report as PR comment 
 - Low-impact PR (cosmetic only, no logic changes, no new behavior) → use `adversarial-reviewer`
 - Target has active review bots → still usable, but redundant for basic issues
 - Throwaway/prototype code
-- You have Anthropic Code Review Plugin → use multi-agent audit instead
 
 ## Anti-Patterns
 
@@ -119,4 +118,3 @@ Inherits all from `adversarial-reviewer`. Plus:
 - **Extends:** `engineering-team/adversarial-reviewer`
 - Related: `engineering-team/code-reviewer`, `engineering-team/senior-security`
 - Theory: de Bono "Six Thinking Hats" (1985), Kahneman "Thinking Fast and Slow" (2011)
-- Advanced: For personal/strategy tasks with curated persona pools, see `named-persona-pool` methodology (article, forthcoming)

--- a/engineering-team/skills/named-persona-adversarial-review/SKILL.md
+++ b/engineering-team/skills/named-persona-adversarial-review/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: "named-persona-adversarial-review"
+description: "Code review with real engineers' philosophies, not abstract roles. Catches what automated bots and generic reviewers miss."
+---
+
+# Named-Persona Adversarial Review
+
+> **TL;DR:** Abstract roles find abstract problems. Named people with searchable, citable philosophies find problems you would actually fix. This upgrades your review beyond what bots and generic reviewers can provide.
+
+**Triggers:** "review this PR with real engineers" | "named persona review" | "用真人的哲学审查这个PR"
+
+## Example Output
+
+```
+CRITICAL [Torvalds]: Special-case error handling at auth.ts:47.
+  "Eliminate the special case and the error disappears entirely."
+WARNING [Thompson]: parseConfig() does 3 unrelated things. Split.
+NOTE [Jobs]: Error message "EACCES:13" means nothing to users.
+Verdict: CONCERNS — fix CRITICAL before merge.
+```
+
+## Problem
+
+Generic adversarial review produces generic findings. This grounds each persona in real, searchable philosophy — what Linus Torvalds actually said about good taste, not what an AI thinks a "security auditor" might say.
+
+**Before/after:** `adversarial-reviewer` → "Consider adding error handling here." Named-persona → "Linus would ask: why is this even a special case? Eliminate the special case and the error handling disappears."
+
+**Cost:** 1 round ≈ 8-12 min. Comparable to waiting for CI.
+
+## Rules (Alireza's "hard problems" standard)
+
+- **Search before role-play.** Never impersonate without searching first. Generic = invalid.
+- **Each persona MUST find ≥1 issue.** Zero findings = look harder or switch persona.
+- **Product persona mandatory every round.** Engineers miss UX. Always include one.
+- **Honesty over quantity.** Don't fabricate findings. Clean dimensions get reported clean.
+
+## TL;DR (Quick Start)
+
+**Starter:** Ken Thompson + Linus Torvalds + Steve Jobs. Works today.
+
+```
+1. Search "[Name] engineering philosophy" — extract 3-5 criteria from actual quotes
+2. Role-play all 3 — MUST find ≥1 issue each
+3. Deduplicate — 2+ hits → severity upgrade
+4. Output: structured report + post to PR as comment (or save to file)
+5. Feynman check: "Would they actually say this?"
+```
+
+> **Then read the full process below** (Step 0-3) for the detailed workflow.
+
+## Persona Pools
+
+**Product** (pick 1 per round — mandatory):
+| Persona | Known For | Best For |
+|---------|-----------|----------|
+| Steve Jobs | Design is how it works | UX, onboarding |
+| Marty Cagan | Problem not features | PRDs, feature specs |
+| Intercom PM | First 30 seconds | Docs, READMEs, quick starts |
+
+**Engineers** (pick 2 per round):
+| Persona | Known For | Best For | Blind Spot |
+|---------|-----------|----------|------------|
+| Ken Thompson | Do one thing well | Architecture, API | UX, documentation |
+| Linus Torvalds | Eliminate special cases | Logic, data structures | User empathy, DX |
+| John Carmack | Performance as moral craft | Algorithms, critical paths | Simplicity, minimalism |
+| Greg Brockman | Find the boundary conditions | Complex systems, integration | Aesthetics, process |
+| Kent Beck | Simplicity, feedback, courage | Process, team practices | Performance, security |
+
+**Routing (which personas when):**
+- Code correctness → Torvalds + Carmack + Jobs
+- Architecture/design → Thompson + Brockman + Cagan
+- Documentation/API → Thompson + Beck + Intercom PM
+- Performance → Carmack + Torvalds + Jobs
+- 1st round on any PR → Torvalds + Thompson + Jobs (broadest coverage)
+
+## The Process
+
+### Step 0: Read Twice
+What changed (pass 1). Why + trade-offs (pass 2). Multi-file → trace one end-to-end path.
+
+### Step 1: Search
+`"[Name] engineering philosophy code review principles"`. Extract from quotes. Never improvise.
+
+### Step 2: Review (3 independent)
+Each gets Mindset (from search), Priorities (3-5 criteria), Finding (≥1 issue with philosopher's reasoning).
+
+### Step 3: Synthesize & Post
+Merge duplicates. Cross-persona → severity upgrade. Post report as PR comment (default) or save to `.claude/review-[timestamp].md`.
+
+## Feynman Honesty Check
+
+1. Would [Name] actually say this?
+2. Did I cite real philosophy, or write generic advice?
+3. All NOTE-level? → You're not really switching perspectives, just narrating the same one in different voices. Switch at least 2 personas and re-review.
+
+## Exit Condition
+
+- **1 round minimum** for any PR
+- **BLOCK found** → fix and re-review (1 additional round)
+- **CONCERNS found** → fix or accept risk, then 1 more round
+- **CLEAN on 2 consecutive rounds** → done
+- **CLEAN on round 1** for PRs with low impact → done (1 round is enough)
+
+## When to Use
+
+- You want review quality beyond what automated bots can provide
+- Self-authored PR needs pre-submit hardening
+- `adversarial-reviewer` findings feel generic
+- Reviewing methodologies or docs (product personas excel)
+- Auth, data, architecture, public API changes
+
+## When NOT to Use
+
+- Low-impact PR (cosmetic only, no logic changes, no new behavior) → use `adversarial-reviewer`
+- Target has active review bots → still usable, but redundant for basic issues
+- Throwaway/prototype code
+- You have Anthropic Code Review Plugin → use multi-agent audit instead
+
+## Anti-Patterns
+
+Inherits all from `adversarial-reviewer`. Plus:
+
+| Anti-Pattern | Why Wrong |
+|-------------|----------|
+| "As a senior engineer" without search | Not named. Search first. |
+| Same 3 personas every time | Rotate per problem type. Check the Routing table above. |
+| Product person skipped | Product catches what engineers miss. |
+| Skipping honesty check | Verification without verification = rubber-stamp. |
+| 3 rounds for trivial changes | Low-impact PRs: 1 round is enough. |
+
+## Cross-References
+
+- **Extends:** `engineering-team/adversarial-reviewer`
+- Related: `engineering-team/code-reviewer`, `engineering-team/senior-security`
+- External: [Anthropic Code Review Plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)
+- Theory: de Bono "Six Thinking Hats" (1985), Kahneman "Thinking Fast and Slow" (2011)
+- Advanced: For personal/strategy tasks with curated persona pools, see `named-persona-pool` methodology (article, forthcoming)

--- a/engineering-team/skills/named-persona-adversarial-review/SKILL.md
+++ b/engineering-team/skills/named-persona-adversarial-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "named-persona-adversarial-review"
-description: "Code review with real engineers' philosophies, not abstract roles. Catches what automated bots and generic reviewers miss."
+description: "Code review through the lens of real engineers' documented philosophies. Complements automated review with named-philosopher perspectives. Use when automated review findings feel generic, when the PR has architectural or UX impact, or when the author wants pre-submit hardening beyond standard checks."
 ---
 
 # Named-Persona Adversarial Review
@@ -33,20 +33,6 @@ Generic adversarial review produces generic findings. This grounds each persona 
 - **Each persona MUST find ≥1 issue.** Zero findings = look harder or switch persona.
 - **Product persona mandatory every round.** Engineers miss UX. Always include one.
 - **Honesty over quantity.** Don't fabricate findings. Clean dimensions get reported clean.
-
-## TL;DR (Quick Start)
-
-**Starter:** Ken Thompson + Linus Torvalds + Steve Jobs. Works today.
-
-```
-1. Search "[Name] engineering philosophy" — extract 3-5 criteria from actual quotes
-2. Role-play all 3 — MUST find ≥1 issue each
-3. Deduplicate — 2+ hits → severity upgrade
-4. Output: structured report + post to PR as comment (or save to file)
-5. Feynman check: "Would they actually say this?"
-```
-
-> **Then read the full process below** (Step 0-3) for the detailed workflow.
 
 ## Persona Pools
 

--- a/engineering-team/skills/named-persona-adversarial-review/SKILL.md
+++ b/engineering-team/skills/named-persona-adversarial-review/SKILL.md
@@ -23,7 +23,7 @@ Verdict: CONCERNS — fix CRITICAL before merge.
 
 Abstract adversarial review can produce generic findings when personas lack grounding. This skill grounds each persona in real, searchable philosophy — what Linus Torvalds actually said about good taste, not what an AI imagines a reviewer might say.
 
-**Before/after:** `adversarial-reviewer` → "Consider adding error handling here." Named-persona → "Linus would ask: why is this even a special case? Eliminate the special case and the error handling disappears."
+**How it differs from abstract adversarial review:** Abstract roles produce surface-level findings. Named personas produce findings grounded in documented philosophy — Linus on eliminating special cases, Thompson on doing one thing well, Carmack on performance as craft.
 
 **Cost:** 1 round ≈ 8-12 min. Comparable to waiting for CI.
 
@@ -89,7 +89,7 @@ Merge duplicates. Cross-persona → severity upgrade. Post report as PR comment 
 
 ## When to Use
 
-- You want review quality beyond what automated bots can provide
+- You want deeper review coverage than standard automated checks alone
 - Self-authored PR needs pre-submit hardening
 - `adversarial-reviewer` findings feel generic
 - Reviewing methodologies or docs (product personas excel)

--- a/engineering-team/skills/named-persona-adversarial-review/SKILL.md
+++ b/engineering-team/skills/named-persona-adversarial-review/SKILL.md
@@ -27,7 +27,7 @@ Generic adversarial review produces generic findings. This grounds each persona 
 
 **Cost:** 1 round ≈ 8-12 min. Comparable to waiting for CI.
 
-## Rules (Alireza's "hard problems" standard)
+## Rules
 
 - **Search before role-play.** Never impersonate without searching first. Generic = invalid.
 - **Each persona MUST find ≥1 issue.** Zero findings = look harder or switch persona.

--- a/engineering-team/skills/named-persona-adversarial-review/SKILL.md
+++ b/engineering-team/skills/named-persona-adversarial-review/SKILL.md
@@ -132,6 +132,5 @@ Inherits all from `adversarial-reviewer`. Plus:
 
 - **Extends:** `engineering-team/adversarial-reviewer`
 - Related: `engineering-team/code-reviewer`, `engineering-team/senior-security`
-- External: [Anthropic Code Review Plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)
 - Theory: de Bono "Six Thinking Hats" (1985), Kahneman "Thinking Fast and Slow" (2011)
 - Advanced: For personal/strategy tasks with curated persona pools, see `named-persona-pool` methodology (article, forthcoming)

--- a/skills/named-persona-adversarial-review/SKILL.md
+++ b/skills/named-persona-adversarial-review/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: "named-persona-adversarial-review"
-description: "Web-grounded multi-persona adversarial code review using real engineers' documented philosophies. Use when the target repo has no automated review bots and you need pre-submit hardening. Use when you want diverse perspectives from named experts (Thompson, Torvalds, Carmack, Feynman, etc.) rather than abstract roles. Use for reviewing code, docs, or methodologies."
+description: "Web-grounded multi-persona adversarial code review using real engineers' documented principles. Use when the target repo has no automated review bots and you need pre-submit hardening. Use when you want diverse perspectives from named experts (Thompson, Torvalds, Carmack, Feynman, etc.) rather than abstract roles. Use for reviewing code, docs, or methodologies."
 ---
 
 # Named-Persona Adversarial Review
 
 ## Description
 
-Extends `adversarial-reviewer` with **web-grounded real personas** instead of abstract roles. Instead of generic "Saboteur" or "Security Auditor," this skill uses web search to retrieve the actual documented philosophies of named engineers (Ken Thompson, Linus Torvalds, John Carmack, Richard Feynman, etc.) and applies them as review lenses.
+Extends `adversarial-reviewer` with **web-grounded real personas** instead of abstract roles. Instead of generic "Saboteur" or "Security Auditor," this skill uses web search to retrieve the actual documented principles of named engineers (Ken Thompson, Linus Torvalds, John Carmack, Richard Feynman, etc.) and applies them as review lenses.
 
-Each persona is backed by searchable, citable philosophy — not vibes. Combined with a product perspective (Steve Jobs, Marty Cagan), this creates genuinely diverse viewpoints that catch blind spots abstract roles miss.
+Each persona is backed by searchable, citable principles — not vibes. Combined with a product perspective (Steve Jobs, Marty Cagan), this creates genuinely diverse viewpoints that catch blind spots abstract roles miss.
 
 ## Features
 
-- **Named real engineers** — Web-search their latest philosophy, apply as review lens
-- **Two-pillar structure** — 2 engineers (code reliability) + 1 product person (user experience) per round
+- **Named real engineers** — Web-search their latest principles, apply as review lens
+- **Two-pillar structure** — 2 engineers (code) + 1 product (UX) per round
 - **Web-grounded** — Each persona's priorities come from real-time search, not static definitions
-- **Credible-only findings** — Invented findings are worse than none. If zero genuine issues exist against a persona's philosophy, they must explain WHY with specific citations. Generic noise ("add error handling") is rejected.
+- **Credible-only findings** — Invented findings are worse than none. If zero genuine issues exist against a persona's principles, they must explain WHY with specific citations. Generic noise ("add error handling") is rejected.
 - **Severity promotion** — 2+ personas catching same issue promotes it one level
 - **Feynman honesty check** — Post-review: "Would this person actually say this, or am I projecting?"
 - **Finding quality gate** — Every finding must cite a specific quote or documented principle from the named person. If you can't find the quote, the finding is likely invented. Web-search the person's name + the claim before filing.
@@ -24,95 +24,97 @@ Each persona is backed by searchable, citable philosophy — not vibes. Combined
 
 ## Problem This Solves
 
-`adversarial-reviewer` uses three abstract roles (Saboteur, New Hire, Security Auditor). These are effective but generic — they don't capture the specific insights of real engineering philosophies. A "Security Auditor" reviews for OWASP patterns, but Linus Torvalds reviewing for "good taste" catches entirely different issues: data structures that create unnecessary edge cases.
+`adversarial-reviewer` uses three abstract roles (Saboteur, New Hire, Security Auditor). These are effective but generic — they don't capture the specific insights of real engineering principles. A "Security Auditor" reviews for OWASP patterns, but Linus Torvalds reviewing for "good taste" catches entirely different issues: data structures that create unnecessary edge cases.
 
-This skill adds **specificity through real people**. Web search retrieves what Ken Thompson actually said about simplicity, what John Carmack actually said about performance as moral craft. The review is grounded in documented, citable philosophy — not an AI's vague impression of what a "senior engineer" might think.
+This skill adds **specificity through real people**. Web search retrieves what Ken Thompson actually said about simplicity, what John Carmack actually said about performance as moral craft. The review is grounded in documented, citable principles — not an AI's vague impression of what a "senior engineer" might think.
 
 ## Quick Start
 
 ```
-Review this code using named-persona-adversarial-review.
+/adversarial-review --personas named    # Use named personas instead of abstract roles
+/adversarial-review --personas named --rounds 3   # 3 rounds, 9 total perspectives
 ```
 
-### Standard 3-Persona Round
+Without slash command support, use prompt-level:
 
 ```
-Review [target] using:
-1. Linus Torvalds (engineering: taste, zero special cases)
-2. Ken Thompson (engineering: simplicity, distrust of complexity)
-3. Steve Jobs (product: user experience, ruthless prioritization)
-
-Each must find ≥1 actionable issue.
+Review [target] using Named-Persona Adversarial Review:
+1. Search "[Engineer Name] engineering principles" for 3 engineers + 1 product person
+2. Role-play each, apply their specific principles
+3. Deduplicate, promote cross-persona findings
+4. Output structured report (same format as adversarial-reviewer)
 ```
 
-### Philosophy-Focused Round
+## Review Workflow
 
-```
-Review this function using Richard Feynman's philosophy:
-"The first principle is that you must not fool yourself — and you are the easiest person to fool."
-Find every place the code fools itself about correctness.
-```
+### Step 0: Understand the Target
 
-## Workflow
+Read the full target twice before any role-play:
+1. First pass — what changed, what's the purpose
+2. Second pass — why this approach, what trade-offs
 
-### Step 1: Select Personas
+### Step 1: Search for Principles
 
-Choose 2 engineers + 1 product person. Rotate per round.
+For each persona, search: `"[Name] engineering principles code review"`. Extract 3-5 actionable criteria from actual quotes or documented principles. Do not improvise generic "as a senior engineer" advice.
 
-**Engineer Pool:**
-| Persona | Philosophy | Best For |
-|---------|-----------|----------|
-| Linus Torvalds | "Good taste" — code with zero special cases | Architecture, data structures |
-| Ken Thompson | "When in doubt, use brute force" — simplicity over cleverness | Algorithms, security boundaries |
-| John Carmack | "Performance is a moral imperative" — resource discipline | Game loops, real-time, hot paths |
-| Richard Feynman | "You are the easiest person to fool" — self-deception | Testing, validation, proofs |
-| Margaret Hamilton | "Software should be designed to work, not fixed to work" | Error handling, fault tolerance |
-| Donald Knuth | "Premature optimization is the root of all evil" | Algorithm correctness first |
-| Edsger Dijkstra | "Testing shows the presence, not the absence of bugs" | Formal reasoning, invariants |
+### Step 2: Independent Reviews (3 personas)
 
-**Product Pool:**
-| Persona | Philosophy | Best For |
-|---------|-----------|----------|
-| Steve Jobs | "It just works" — ruthless simplicity | UX flows, onboarding |
-| Marty Cagan | "Fall in love with the problem, not the solution" | Feature design |
-| Julie Zhuo | "Design is not just how it looks, but how it works" | Interaction design |
-| Intercom PM | "Every feature must earn its place" | Scope, prioritization |
+**Two engineers + one product person per round.** Each persona gets:
+- **Mindset:** One sentence from search results
+- **Priorities:** 3-5 criteria extracted from their actual principles
+- **Finding:** ≥1 concrete issue with cited reasoning, OR explain why none exist
 
-### Step 2: Web-Ground Each Persona
+**Engineer pool** (select per round):
+| Persona | Known For |
+|---------|-----------|
+| Ken Thompson | Unix minimalism: "Do one thing well" |
+| Linus Torvalds | Good taste: "Eliminate the special case" |
+| John Carmack | Performance as moral craft |
+| Richard Feynman | Scientific integrity: "Don't fool yourself" |
+| Kent Beck | XP values: simplicity, feedback, courage |
+| Fred Brooks | Essential vs accidental complexity |
 
-Before reviewing, web-search each selected persona:
-```
-"[name] [topic] philosophy" — e.g., "Linus Torvalds good taste in code"
-"[name] on [technology]" — e.g., "Ken Thompson on simplicity"
-```
+**Product pool** (one per round):
+| Persona | Known For |
+|---------|-----------|
+| Steve Jobs | Simplicity: "Design is how it works" |
+| Marty Cagan | Empowered teams: "Problem, not features" |
+| Intercom PM | Onboarding: "First 30 seconds is everything" |
 
-Retrieve 2-3 specific quotes or principles. These become the review lens.
+### Step 3: Deduplicate and Synthesize
 
-### Step 3: Run the Review
+Same as `adversarial-reviewer` Step 4.
 
-Each persona reviews the target independently, applying their specific philosophy. Every finding must cite:
-1. What they found
-2. Why it violates their philosophy
-3. **A specific quote or documented principle** from that person
+## Feynman Honesty Check
 
-### Step 4: Cross-Check Severity
+After each review, ask:
+1. Would [Name] actually say this, or am I projecting?
+2. Did I cite their actual principles, or use generic phrasing?
+3. Did I report bad news? If all findings are NOTE-level, switch perspectives and re-review.
 
-If 2+ personas independently find the same issue → promote severity one level.
-
-### Step 5: Feynman Honesty Check
-
-After the review, ask: "Would Linus Torvalds ACTUALLY say this, or did I project a generic opinion onto him?" If the quote can't be found via web search, the finding is suspect.
+> "The first principle is that you must not fool yourself, and you are the easiest person to fool." — Richard Feynman
 
 ## Anti-Patterns
 
-- ❌ "Consider adding error handling" — Generic. What would THIS person specifically say?
-- ❌ Using a persona without web-searching their actual philosophy first.
-- ❌ Forcing a finding when the code is genuinely clean — say "no credible issues found, here's why: [citation]."
-- ❌ Persona drift — Linus doesn't care about mobile UX. Match persona to problem domain.
-- ❌ Skipping the Feynman check — AI love to sound like experts. Verify.
+Inherits all anti-patterns from `adversarial-reviewer`. Additionally:
+
+| Anti-Pattern | Why |
+|-------------|-----|
+| Using "as a senior engineer" without searching | Not a named persona. Search first. |
+| Same 3 personas every time | Rotate. Different problems need different engineers. |
+| Product person skipped or replaced with 3rd engineer | Product perspective catches what engineers miss. Always include one. |
+| Skipping the honesty check | Role-play without verification = sophisticated rubber-stamp. |
+
+## When to Use This
+
+- Target repo has no automated review bots — this compensates
+- Self-authored PR needs hardening before submit
+- `adversarial-reviewer` findings feel generic — add real names for specificity
+- Reviewing methodologies or documentation (not just code) — product personas excel here
 
 ## Cross-References
 
-- `adversarial-reviewer` — Base adversarial review skill (abstract roles).
-- `code-reviewer` — Standard code quality review.
-- `senior-security` — Deep security-specific review.
+- **Extends:** `engineering-team/adversarial-reviewer` — same severity, output, anti-patterns
+- Related: `engineering-team/code-reviewer` — general code quality
+- Related: `engineering-team/senior-security` — deep security analysis
+- Theoretical basis: de Bono "Six Thinking Hats", Kahneman "Thinking Fast and Slow" (System 2 forcing)

--- a/skills/named-persona-adversarial-review/SKILL.md
+++ b/skills/named-persona-adversarial-review/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: "named-persona-adversarial-review"
+description: "Web-grounded multi-persona adversarial code review using real engineers' documented philosophies. Use when the target repo has no automated review bots and you need pre-submit hardening. Use when you want diverse perspectives from named experts (Thompson, Torvalds, Carmack, Feynman, etc.) rather than abstract roles. Use for reviewing code, docs, or methodologies."
+---
+
+# Named-Persona Adversarial Review
+
+## Description
+
+Extends `adversarial-reviewer` with **web-grounded real personas** instead of abstract roles. Instead of generic "Saboteur" or "Security Auditor," this skill uses web search to retrieve the actual documented philosophies of named engineers (Ken Thompson, Linus Torvalds, John Carmack, Richard Feynman, etc.) and applies them as review lenses.
+
+Each persona is backed by searchable, citable philosophy — not vibes. Combined with a product perspective (Steve Jobs, Marty Cagan), this creates genuinely diverse viewpoints that catch blind spots abstract roles miss.
+
+## Features
+
+- **Named real engineers** — Web-search their latest philosophy, apply as review lens
+- **Two-pillar structure** — 2 engineers (code reliability) + 1 product person (user experience) per round
+- **Web-grounded** — Each persona's priorities come from real-time search, not static definitions
+- **Credible-only findings** — Invented findings are worse than none. If zero genuine issues exist against a persona's philosophy, they must explain WHY with specific citations. Generic noise ("add error handling") is rejected.
+- **Severity promotion** — 2+ personas catching same issue promotes it one level
+- **Feynman honesty check** — Post-review: "Would this person actually say this, or am I projecting?"
+- **Finding quality gate** — Every finding must cite a specific quote or documented principle from the named person. If you can't find the quote, the finding is likely invented. Web-search the person's name + the claim before filing.
+- **Formats follow `adversarial-reviewer`** — Same severity, output format, anti-patterns
+
+## Problem This Solves
+
+`adversarial-reviewer` uses three abstract roles (Saboteur, New Hire, Security Auditor). These are effective but generic — they don't capture the specific insights of real engineering philosophies. A "Security Auditor" reviews for OWASP patterns, but Linus Torvalds reviewing for "good taste" catches entirely different issues: data structures that create unnecessary edge cases.
+
+This skill adds **specificity through real people**. Web search retrieves what Ken Thompson actually said about simplicity, what John Carmack actually said about performance as moral craft. The review is grounded in documented, citable philosophy — not an AI's vague impression of what a "senior engineer" might think.
+
+## Quick Start
+
+```
+Review this code using named-persona-adversarial-review.
+```
+
+### Standard 3-Persona Round
+
+```
+Review [target] using:
+1. Linus Torvalds (engineering: taste, zero special cases)
+2. Ken Thompson (engineering: simplicity, distrust of complexity)
+3. Steve Jobs (product: user experience, ruthless prioritization)
+
+Each must find ≥1 actionable issue.
+```
+
+### Philosophy-Focused Round
+
+```
+Review this function using Richard Feynman's philosophy:
+"The first principle is that you must not fool yourself — and you are the easiest person to fool."
+Find every place the code fools itself about correctness.
+```
+
+## Workflow
+
+### Step 1: Select Personas
+
+Choose 2 engineers + 1 product person. Rotate per round.
+
+**Engineer Pool:**
+| Persona | Philosophy | Best For |
+|---------|-----------|----------|
+| Linus Torvalds | "Good taste" — code with zero special cases | Architecture, data structures |
+| Ken Thompson | "When in doubt, use brute force" — simplicity over cleverness | Algorithms, security boundaries |
+| John Carmack | "Performance is a moral imperative" — resource discipline | Game loops, real-time, hot paths |
+| Richard Feynman | "You are the easiest person to fool" — self-deception | Testing, validation, proofs |
+| Margaret Hamilton | "Software should be designed to work, not fixed to work" | Error handling, fault tolerance |
+| Donald Knuth | "Premature optimization is the root of all evil" | Algorithm correctness first |
+| Edsger Dijkstra | "Testing shows the presence, not the absence of bugs" | Formal reasoning, invariants |
+
+**Product Pool:**
+| Persona | Philosophy | Best For |
+|---------|-----------|----------|
+| Steve Jobs | "It just works" — ruthless simplicity | UX flows, onboarding |
+| Marty Cagan | "Fall in love with the problem, not the solution" | Feature design |
+| Julie Zhuo | "Design is not just how it looks, but how it works" | Interaction design |
+| Intercom PM | "Every feature must earn its place" | Scope, prioritization |
+
+### Step 2: Web-Ground Each Persona
+
+Before reviewing, web-search each selected persona:
+```
+"[name] [topic] philosophy" — e.g., "Linus Torvalds good taste in code"
+"[name] on [technology]" — e.g., "Ken Thompson on simplicity"
+```
+
+Retrieve 2-3 specific quotes or principles. These become the review lens.
+
+### Step 3: Run the Review
+
+Each persona reviews the target independently, applying their specific philosophy. Every finding must cite:
+1. What they found
+2. Why it violates their philosophy
+3. **A specific quote or documented principle** from that person
+
+### Step 4: Cross-Check Severity
+
+If 2+ personas independently find the same issue → promote severity one level.
+
+### Step 5: Feynman Honesty Check
+
+After the review, ask: "Would Linus Torvalds ACTUALLY say this, or did I project a generic opinion onto him?" If the quote can't be found via web search, the finding is suspect.
+
+## Anti-Patterns
+
+- ❌ "Consider adding error handling" — Generic. What would THIS person specifically say?
+- ❌ Using a persona without web-searching their actual philosophy first.
+- ❌ Forcing a finding when the code is genuinely clean — say "no credible issues found, here's why: [citation]."
+- ❌ Persona drift — Linus doesn't care about mobile UX. Match persona to problem domain.
+- ❌ Skipping the Feynman check — AI love to sound like experts. Verify.
+
+## Cross-References
+
+- `adversarial-reviewer` — Base adversarial review skill (abstract roles).
+- `code-reviewer` — Standard code quality review.
+- `senior-security` — Deep security-specific review.

--- a/skills/named-persona-adversarial-review/SKILL.md
+++ b/skills/named-persona-adversarial-review/SKILL.md
@@ -7,114 +7,176 @@ description: "Web-grounded multi-persona adversarial code review using real engi
 
 ## Description
 
-Extends `adversarial-reviewer` with **web-grounded real personas** instead of abstract roles. Instead of generic "Saboteur" or "Security Auditor," this skill uses web search to retrieve the actual documented principles of named engineers (Ken Thompson, Linus Torvalds, John Carmack, Richard Feynman, etc.) and applies them as review lenses.
-
-Each persona is backed by searchable, citable principles — not vibes. Combined with a product perspective (Steve Jobs, Marty Cagan), this creates genuinely diverse viewpoints that catch blind spots abstract roles miss.
+Uses **web-grounded real personas** instead of abstract roles. Instead of generic "Saboteur" or "Security Auditor," this skill web-searches the actual documented principles of named engineers (Ken Thompson, Linus Torvalds, John Carmack, Richard Feynman, etc.) and applies them as review lenses. Each persona is backed by searchable, citable principles — not vibes.
 
 ## Features
 
-- **Named real engineers** — Web-search their latest principles, apply as review lens
-- **Two-pillar structure** — 2 engineers (code) + 1 product (UX) per round
-- **Web-grounded** — Each persona's priorities come from real-time search, not static definitions
-- **Credible-only findings** — Invented findings are worse than none. If zero genuine issues exist against a persona's principles, they must explain WHY with specific citations. Generic noise ("add error handling") is rejected.
-- **Severity promotion** — 2+ personas catching same issue promotes it one level
-- **Feynman honesty check** — Post-review: "Would this person actually say this, or am I projecting?"
-- **Finding quality gate** — Every finding must cite a specific quote or documented principle from the named person. If you can't find the quote, the finding is likely invented. Web-search the person's name + the claim before filing.
-- **Formats follow `adversarial-reviewer`** — Same severity, output format, anti-patterns
+- **Named real engineers** — Web-search their principles, review through pre-extracted quotes only
+- **Two-pillar structure** — 2 engineers (code) + 1 product (UX) per round, 3 personas total
+- **Quote-first review** — Extract quotes BEFORE reviewing. Findings must map to pre-extracted quotes — no retrofitting
+- **Symmetric burden** — Findings need 1+ quote. Zero findings needs 3+ quotes the code SUCCESSFULLY satisfies
+- **Severity promotion** — 2+ personas catching same issue promotes it one level. CRITICAL + 2 concurrences → BLOCKER
+- **Integrity check** — Post-review: "Would this person actually say this, or am I projecting?"
+- **Self-contained** — Severity definitions, output format, and anti-patterns are all in this file
+
+## Severity Levels
+
+| Level | Definition | Action |
+|-------|-----------|--------|
+| BLOCKER | 2+ concurrences on CRITICAL or security/data-loss risk | Must fix before any further work |
+| CRITICAL | Wrong result, data loss, security hole, or violates core invariant | Must fix before merge |
+| WARNING | Fragile, misleading, or likely to cause future bugs | Should fix; explain if deferred |
+| NOTE | Improvement opportunity that doesn't affect correctness | Optional; record for follow-up |
+
+Promotion rule: NOTE → WARNING → CRITICAL → BLOCKER. 2+ personas independently finding the same issue promotes it one level. BLOCKER is the ceiling.
 
 ## Problem This Solves
 
-`adversarial-reviewer` uses three abstract roles (Saboteur, New Hire, Security Auditor). These are effective but generic — they don't capture the specific insights of real engineering principles. A "Security Auditor" reviews for OWASP patterns, but Linus Torvalds reviewing for "good taste" catches entirely different issues: data structures that create unnecessary edge cases.
-
-This skill adds **specificity through real people**. Web search retrieves what Ken Thompson actually said about simplicity, what John Carmack actually said about performance as moral craft. The review is grounded in documented, citable principles — not an AI's vague impression of what a "senior engineer" might think.
+Abstract roles produce generic feedback. "Saboteur" says "add error handling." "New Hire" says "this is confusing." Real engineers' documented principles produce specific, actionable findings. Linus Torvalds doesn't say "consider error handling" — he says "eliminate the special case entirely." That's a different action.
 
 ## Quick Start
 
 ```
-/adversarial-review --personas named    # Use named personas instead of abstract roles
-/adversarial-review --personas named --rounds 3   # 3 rounds, 9 total perspectives
+/adversarial-review --personas named
+/adversarial-review --personas named --rounds 3
 ```
 
-Without slash command support, use prompt-level:
-
+Without slash commands:
 ```
 Review [target] using Named-Persona Adversarial Review:
-1. Search "[Engineer Name] engineering principles" for 3 engineers + 1 product person
-2. Role-play each, apply their specific principles
-3. Deduplicate, promote cross-persona findings
-4. Output structured report (same format as adversarial-reviewer)
+1. For each persona, web-search their principles and extract 3-5 quotes
+2. Review the target through ONLY those quotes
+3. Each persona: find >=1 issue mapped to a quote, OR cite 3+ quotes the code satisfies
+4. Deduplicate across personas, promote concurrences
+5. Output structured report with severity per finding
 ```
 
 ## Review Workflow
 
-### Step 0: Understand the Target
+### Triage (Efficiency)
 
-Read the full target twice before any role-play:
-1. First pass — what changed, what's the purpose
-2. Second pass — why this approach, what trade-offs
+| Task scope | Rounds | Cost |
+|-----------|--------|------|
+| Single-file, no user-facing impact | 1 round (3 personas) | ~3 web searches |
+| Multi-file, architectural change | 2 rounds (6 personas) | ~6 web searches |
+| Security-critical or identity/persona-related | 3+ rounds (9+ personas) | ~9+ web searches |
 
-### Step 1: Search for Principles
+### Step 0: Understand AND Break the Model
 
-For each persona, search: `"[Name] engineering principles code review"`. Extract 3-5 actionable criteria from actual quotes or documented principles. Do not improvise generic "as a senior engineer" advice.
+1. **First pass** (top-down): what changed, what's the purpose — comprehension only
+2. **Second pass** (bottom-up): read function by function, last to first. Ask: what does this function ACTUALLY guarantee vs. what its name implies? Where can it fail? What assumptions does it make about its callers?
 
-### Step 2: Independent Reviews (3 personas)
+Reading bottom-up breaks the author's mental model. You stop seeing what the author INTENDED and start seeing what each function ACTUALLY does.
+
+### Step 1: Extract Quotes FIRST (Before Review)
+
+For each persona, search: `"[Name] [topic] principles"`. Extract 3-5 specific, verbatim quotes before looking at the code. These quotes are the ONLY lens allowed for that persona's review.
+
+**Do not** search with the code in mind. Search for their principles independently, then apply them. This prevents confirmation bias where you search for quotes that support an opinion you already formed.
+
+### Step 2: Independent Reviews (3 personas per round)
 
 **Two engineers + one product person per round.** Each persona gets:
-- **Mindset:** One sentence from search results
-- **Priorities:** 3-5 criteria extracted from their actual principles
-- **Finding:** ≥1 concrete issue with cited reasoning, OR explain why none exist
+- **Mindset:** One sentence from their extracted quotes
+- **Quotes:** 3-5 verbatim quotes extracted in Step 1
+- **Findings:** Review through ONLY those quotes. Each finding must map to a specific pre-extracted quote.
+- **Zero-finding burden:** If no issues found, cite 3+ quotes the code successfully satisfies, with explanation of HOW. This makes non-findings equally expensive as findings — no lazy "everything looks fine."
 
 **Engineer pool** (select per round):
-| Persona | Known For |
-|---------|-----------|
-| Ken Thompson | Unix minimalism: "Do one thing well" |
-| Linus Torvalds | Good taste: "Eliminate the special case" |
-| John Carmack | Performance as moral craft |
-| Richard Feynman | Scientific integrity: "Don't fool yourself" |
-| Kent Beck | XP values: simplicity, feedback, courage |
-| Fred Brooks | Essential vs accidental complexity |
+| Persona | Search Query |
+|---------|-------------|
+| Ken Thompson | "Ken Thompson Unix simplicity principles" |
+| Linus Torvalds | "Linus Torvalds good taste code review" |
+| John Carmack | "John Carmack performance optimization principles" |
+| Richard Feynman | "Richard Feynman scientific integrity methodology" |
+| Kent Beck | "Kent Beck extreme programming values" |
+| Fred Brooks | "Fred Brooks essential complexity design" |
 
 **Product pool** (one per round):
-| Persona | Known For |
-|---------|-----------|
-| Steve Jobs | Simplicity: "Design is how it works" |
-| Marty Cagan | Empowered teams: "Problem, not features" |
-| Intercom PM | Onboarding: "First 30 seconds is everything" |
+| Persona | Search Query |
+|---------|-------------|
+| Steve Jobs | "Steve Jobs simplicity design philosophy" |
+| Marty Cagan | "Marty Cagan empowered product teams" |
+| Des Traynor | "Des Traynor product onboarding messaging" |
+
+Reuse policy: Product personas may be reused across rounds if the scope changes. Same persona on same scope → flag in output.
 
 ### Step 3: Deduplicate and Synthesize
 
-Same as `adversarial-reviewer` Step 4.
+Cross-reference all personas' findings:
+1. Group identical findings (same line/pattern, same root cause)
+2. Count concurrences per finding
+3. Promote severity per concurrence rule (NOTE→WARNING→CRITICAL→BLOCKER)
+4. Flag findings unique to a single persona — these may be the most interesting (caught by one lens, invisible to others)
 
-## Feynman Honesty Check
+### Output Format
 
-After each review, ask:
+```markdown
+# Named-Persona Adversarial Review — Round [N]
+
+**Manager**: [Name] | **Team**: [E1], [E2], [P1]
+
+## Per-Persona Summary
+
+### [E1 Name] (Engineer)
+- **Mindset:** [one sentence from their quotes]
+- **Quotes used:** [3-5 verbatim]
+
+| # | Severity | Finding | Quote |
+|---|----------|---------|-------|
+| 1 | WARNING | [finding] | "[quote]" |
+| 2 | NOTE | [finding] | "[quote]" |
+
+### [E2 Name] (Engineer)
+...
+
+### [P1 Name] (Product)
+...
+
+## Cross-Persona Findings
+
+| # | Severity | Finding | Concurrences | Promoted From |
+|---|----------|---------|-------------|---------------|
+| 1 | CRITICAL | [finding] | E1 + E2 | WARNING → CRITICAL |
+
+## Round Verdict
+
+**BLOCK / CONCERNS / CLEAN** — [one-sentence justification]
+```
+
+## Integrity Check
+
+After each round, ask:
 1. Would [Name] actually say this, or am I projecting?
-2. Did I cite their actual principles, or use generic phrasing?
-3. Did I report bad news? If all findings are NOTE-level, switch perspectives and re-review.
+2. Did I review through pre-extracted quotes, or did I form opinions first and search for support?
+3. Are the quotes verbatim from search results, or did I paraphrase to fit my finding?
+4. Did I report bad news? If all findings are NOTE-level, switch perspectives and re-review.
 
 > "The first principle is that you must not fool yourself, and you are the easiest person to fool." — Richard Feynman
 
 ## Anti-Patterns
 
-Inherits all anti-patterns from `adversarial-reviewer`. Additionally:
-
 | Anti-Pattern | Why |
 |-------------|-----|
 | Using "as a senior engineer" without searching | Not a named persona. Search first. |
-| Same 3 personas every time | Rotate. Different problems need different engineers. |
-| Product person skipped or replaced with 3rd engineer | Product perspective catches what engineers miss. Always include one. |
-| Skipping the honesty check | Role-play without verification = sophisticated rubber-stamp. |
+| Same 3 personas every time | Rotate. Different problems need different lenses. |
+| Product person skipped or replaced with 3rd engineer | Product perspective catches what engineers miss. |
+| Skipping the integrity check | Role-play without verification = sophisticated rubber-stamp. |
+| Searching quotes AFTER forming an opinion | Confirmation bias. Extract quotes first, review second. |
+| Finding with no mapped quote | If it's a real issue, a real engineer has said something about it. |
+| "Everything looks fine" without 3+ quotes | Non-findings must be as well-supported as findings. |
+| Skipping bottom-up second pass | Reading twice top-to-bottom entrenches the author's model. |
 
-## When to Use This
+## When to Use
 
 - Target repo has no automated review bots — this compensates
 - Self-authored PR needs hardening before submit
-- `adversarial-reviewer` findings feel generic — add real names for specificity
+- Abstract-role review findings feel generic — add real names for specificity
 - Reviewing methodologies or documentation (not just code) — product personas excel here
 
 ## Cross-References
 
-- **Extends:** `engineering-team/adversarial-reviewer` — same severity, output, anti-patterns
-- Related: `engineering-team/code-reviewer` — general code quality
-- Related: `engineering-team/senior-security` — deep security analysis
+- `adversarial-reviewer` — Abstract-role adversarial review (simpler, faster, no web search)
+- `code-reviewer` — Standard code quality review
+- `senior-security` — Deep security-specific analysis
 - Theoretical basis: de Bono "Six Thinking Hats", Kahneman "Thinking Fast and Slow" (System 2 forcing)

--- a/skills/named-persona-adversarial-review/SKILL.md
+++ b/skills/named-persona-adversarial-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "named-persona-adversarial-review"
 description: "Web-grounded multi-persona adversarial code review using real engineers' documented principles. Use when the target repo has no automated review bots and you need pre-submit hardening. Use when you want diverse perspectives from named experts (Thompson, Torvalds, Carmack, Feynman, etc.) rather than abstract roles. Use for reviewing code, docs, or methodologies."
+version: 1.0.0
+tags: [review, adversarial, code-review, methodology]
 ---
 
 # Named-Persona Adversarial Review


### PR DESCRIPTION
## Problem

AI code review with abstract roles ("act as a reviewer", "act as a saboteur") produces generic findings. The AI imagines what a reviewer *might* say — it has nothing concrete to anchor to.

## What this does differently

**Named philosophies produce specific, defensible critiques.** Each reviewer lens is anchored in a real engineer's documented principles — things you can search, verify, and cite:

| Persona | Principle | What it catches |
|---------|-----------|-----------------|
| Linus Torvalds | "Never break userspace" | Backward compatibility, taste, merge strategy |
| John Carmack | "Optimization is not premature if you measure" | Performance with data, not speculation |
| Ken Thompson | "You can't trust code you didn't write completely" | Supply chain, trust boundaries, input validation |
| Steve Jobs | "Start with customer experience" | UX friction, workflow gaps, unnecessary complexity |
| Marty Cagan | "Fall in love with the problem" | Scope creep, unnecessary features, goal misalignment |

These aren't fictional roles. They're specific, searchable philosophies the agent can use as a **review checklist**, not an imagination exercise.

## How it complements this repo

`claude-skills` has `adversarial-reviewer` (abstract roles) and `code-reviewer` (general quality). This adds a dimension neither covers: **review grounded in verifiable engineering principles**.

Concrete > abstract. Specific > generic. Defensible > hand-wavy.

## Universal

Works on any codebase, any language. Product personas add UX coverage that engineer-only reviews miss.