### PR TITLE
Add excalidraw-skill — An agent skill that renders 64 types of hand-drawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,3 +386,5 @@ MIT — see [LICENSE](LICENSE) for details.
 ---
 
 **Built by [Alireza Rezvani](https://alirezarezvani.com)** · [Medium](https://alirezarezvani.medium.com) · [Twitter](https://twitter.com/nginitycloud)
+
+draw|- [excalidraw-skill](https://github.com/xiaoshuai1024/excalidraw-skill) - An agent skill that renders 64 types of hand-drawn Excalidraw diagrams (UML, ER, sequence, architecture) to editable SVG/PNG using the real Excalidraw engine. Works in Claude Code, Cursor, ZCode and 70+ agents.


### PR DESCRIPTION
Hi! This PR adds [excalidraw-skill](https://github.com/xiaoshuai1024/excalidraw-skill) to the list.

**What it is:** An agent skill that renders 64 types of hand-drawn Excalidraw diagrams (UML, ER, sequence, architecture) to editable SVG/PNG using the real Excalidraw engine. Works in Claude Code, Cursor, ZCode and 70+ agents.

I'm the author of this project and think it fits here. Happy to move the entry to a more appropriate section if needed, or close if it's out of scope. Thanks for maintaining this list!