### PR TITLE
docs: harden llms.txt footer URL join against site_url without trailing slash

### DIFF
--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -13,11 +13,15 @@
         {{ config.copyright }}
       </div>
     {% endif %}
+    {#- trim('/') strips a trailing slash from site_url so the join stays
+        correct whether or not site_url ends in "/" (defensive against future
+        config edits). It only strips '/' from the ends, so "https://" is safe. -#}
+    {% set ai_base = (config.site_url or '') | trim('/') %}
     <div class="md-copyright__ai">
       For AI agents:
-      <a href="{{ (config.site_url or '') ~ 'llms.txt' }}" title="Machine-readable site index (llms.txt convention)">llms.txt</a>
+      <a href="{{ ai_base ~ '/llms.txt' }}" title="Machine-readable site index (llms.txt convention)">llms.txt</a>
       ·
-      <a href="{{ (config.site_url or '') ~ 'llms-full.txt' }}" title="Full repository description for AI agents">llms-full.txt</a>
+      <a href="{{ ai_base ~ '/llms-full.txt' }}" title="Full repository description for AI agents">llms-full.txt</a>
     </div>
     {% if not config.extra.generator == false %}
       Made with


### PR DESCRIPTION
## Summary

Follow-up to the llms.txt footer links merged in #879. The automated review on that PR flagged one minor, non-blocking robustness note: the footer URL join `(config.site_url or '') ~ 'llms.txt'` assumed `site_url` ends in a trailing slash. It works today (it does end in `/`), but would silently produce `https://…/claude-skillsllms.txt` if `site_url` were ever changed to a bare origin.

This computes the base once with Jinja's `trim('/')` filter so the links stay correct whether or not `site_url` has a trailing slash. `trim('/')` only strips `/` from the ends of the string, leaving `https://` intact.

```jinja
{% set ai_base = (config.site_url or '') | trim('/') %}
<a href="{{ ai_base ~ '/llms.txt' }}">llms.txt</a>
<a href="{{ ai_base ~ '/llms-full.txt' }}">llms-full.txt</a>
```

Single-file change to `docs/overrides/partials/copyright.html`.

## Checklist

- [x] **Target branch is `dev`** (not `main`)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter — N/A (docs/theme-only change)
- [ ] Scripts run with `--help` — N/A (no scripts)
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [x] Follows existing directory structure (`docs/overrides/partials/`)

## Type of Change

- [x] Documentation
- [x] Infrastructure / CI (theme override)

## Testing

- Rebuilt the site with `mkdocs build` — exit 0.
- Verified the footer links resolve to the correct absolute URLs on a nested page (`skills/index.html`): `https://alirezarezvani.github.io/claude-skills/llms.txt` and `.../llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy9WFFurEjL8gjCp9fs7bp)_