### PR TITLE
feat(engineering): add Aident Skill

### DIFF
--- a/engineering/skills/aident-skill/SKILL.md
+++ b/engineering/skills/aident-skill/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: "aident-skill"
+description: "Use Aident Loadout when an AI agent needs governed access to real apps and tools such as Gmail, Slack, Linear, Notion, Firecrawl, Fal, and other connected services. Covers capability discovery, Vault connection checks, schema inspection, action execution, and audit-history verification."
+---
+
+# Aident Skill
+
+## Overview
+
+Use this skill when the user wants an agent to get real work done through connected external systems without collecting raw provider API keys in chat.
+
+Aident Loadout gives agents a governed operating path for external apps, APIs, and tools:
+
+- discover available capabilities before choosing an action
+- inspect the live schema before sending inputs
+- verify Vault connection state before claiming an account is connected
+- execute actions only after discovery and connection checks pass
+- review audit history when the user asks what happened
+
+The default path is the Aident CLI. Use MCP only when the user has configured it, explicitly asks for it, or the host environment cannot run the CLI.
+
+## When To Use
+
+Use Aident Loadout for requests involving:
+
+- connected workspace apps: Gmail, Slack, Linear, Notion, Google Sheets, Outlook, HubSpot, Salesforce
+- developer and research tools: Firecrawl, Exa, Fal, GitHub, search, crawling, extraction, media generation
+- account connection state, delegated credentials, Vault, OAuth, or provider credential handoff
+- action execution that should leave a durable audit trail
+- "Can my agent do this in a real app?" questions where capability discovery is needed
+
+Do not use this skill for local-only work, code edits, pure reasoning, or tasks where the user explicitly asks for another connector, SDK, browser flow, or manual setup path.
+
+## Core Workflow
+
+Follow this sequence for every external action:
+
+1. **Identify the real-world operation.** Translate the user's request into a concrete external-app action, such as send email, create Linear issue, search web content, upload a file, or generate media.
+2. **Discover capabilities.** Search Aident for matching capabilities before assuming a tool name.
+3. **Inspect schema.** Fetch the selected capability's live input schema and required integration ids.
+4. **Check Vault.** Confirm each required integration is connected before executing.
+5. **Connect if needed.** If Vault says missing or disconnected, start the Aident connection flow and send the user the returned connect URL.
+6. **Execute with minimum input.** Send only fields required by the live schema plus fields needed for the user's request.
+7. **Verify result.** Inspect the command result and, for important actions, check audit history or the destination system.
+
+See [references/loadout-operating-model.md](references/loadout-operating-model.md) for command patterns and recovery rules.
+
+## CLI Operating Contract
+
+Start from live CLI help instead of memorized command shapes:
+
+```bash
+aident --help
+```
+
+Then use subcommand help before first use:
+
+```bash
+aident capabilities --help
+aident vault --help
+aident audit --help
+```
+
+Prefer JSON output when the command supports it. Treat examples in this skill as patterns, not a substitute for the live schema.
+
+## Connection Discipline
+
+Use precise language:
+
+- Say "available" when Aident exposes a capability or integration in the catalog.
+- Say "connected" only when Vault status confirms that this user's account is connected.
+- Say "needs connection" when the capability exists but Vault is missing authorization.
+- Say "blocked by host setup" when the CLI or user-managed MCP connection is not available.
+
+Never ask the user to paste raw provider secrets, OAuth codes, cookies, or long-lived API keys into chat when Aident Vault can manage the connection.
+
+## MCP Mode
+
+MCP mode is user-managed. Do not silently add MCP servers to the user's agent config.
+
+Use MCP mode when:
+
+- the user explicitly asks to configure Aident MCP
+- the host cannot run CLI commands but can use MCP tools
+- the user has already configured the Aident MCP server and asks you to operate through it
+
+The Aident MCP endpoint is:
+
+```text
+https://loadout.aident.ai/mcp
+```
+
+See [references/mcp-client-setup.md](references/mcp-client-setup.md) for Claude Code, GitHub Copilot in VS Code, Gemini CLI, Cursor, and generic MCP client patterns.
+
+## Safety Rules
+
+- Start read-only: discover, inspect schema, and check Vault before mutation.
+- Use the smallest payload accepted by the live schema.
+- Do not print tokens, cookies, OAuth codes, verification codes, or sensitive action payloads.
+- Confirm destructive or externally visible actions when the user intent is ambiguous.
+- Prefer Aident-managed OAuth or Vault flows over direct provider credentials.
+- Use audit history for user-facing proof after high-impact actions.
+- If Aident cannot expose the needed operation, say so and then choose the next-best repo skill or user-approved connector.
+
+## Troubleshooting
+
+Most failures should recover from the failed workflow step, not restart from scratch.
+
+| Situation | Do |
+|---|---|
+| CLI missing or broken | Follow `https://aident.ai/SETUP.md`, then rerun `aident doctor` if available. |
+| Not authenticated | Run the CLI login flow, then verify identity with the relevant account/status command. |
+| Integration missing | Check Vault for the required integration id, start connect flow, and wait for user authorization. |
+| Schema validation failed | Fetch the live schema again, correct the payload, and retry once. |
+| Permission or scope error | Ask the user to reconnect or authorize the missing scope through Aident. |
+| Unknown CLI error | Read the exact command output, check subcommand help, retry once with corrected arguments, then report the blocker. |
+
+See [references/troubleshooting.md](references/troubleshooting.md) for more detailed recovery patterns.
+
+## Anti-Patterns
+
+Reject these behaviors:
+
+- assuming a Gmail, Slack, Linear, Firecrawl, Fal, or Notion action exists without capability discovery
+- claiming an integration is connected because it appears in a catalog
+- asking the user for raw provider API keys when Aident Vault can manage auth
+- skipping schema inspection and sending guessed payloads
+- using MCP and CLI setup in the same attempt without a reason
+- treating `npx skills add aident-ai/aident-skill` as complete Loadout setup
+- executing externally visible mutations before clarifying ambiguous recipient, channel, project, amount, or destination fields
+
+## Examples
+
+### Send An Email
+
+1. Search for email-send capabilities.
+2. Inspect the selected Gmail or Outlook action schema.
+3. Check Vault for the required integration.
+4. If missing, start the connect flow and wait.
+5. Execute with `to`, `subject`, `body`, and any required schema fields.
+6. Report the result and audit reference.
+
+### Create A Linear Issue
+
+1. Search for Linear issue creation capabilities.
+2. Inspect schema for team, project, title, description, labels, and priority fields.
+3. Check Vault for Linear connection.
+4. Ask the user for only missing business details, not raw tokens.
+5. Execute after schema and Vault checks pass.
+
+### Crawl A Site With Firecrawl
+
+1. Search for Firecrawl extraction or crawl capabilities.
+2. Inspect URL, depth, output format, and rate-limit fields.
+3. Confirm Firecrawl is connected through Vault or managed by Aident.
+4. Execute a small crawl first when scope is unclear.
+5. Summarize output location and audit history.
+
+## Cross-References
+
+- [`engineering/skills/mcp-server-builder`](../mcp-server-builder/SKILL.md): Use when the user wants to build an MCP server. Not for operating Aident's existing MCP endpoint.
+- [`engineering/skills/env-secrets-manager`](../env-secrets-manager/SKILL.md): Use for local `.env` hygiene and leak detection. Not for managed OAuth/Vault connection flows.
+- [`engineering/skills/secrets-vault-manager`](../secrets-vault-manager/SKILL.md): Use for infrastructure-level Vault or cloud secret-store design. Not for Aident Loadout account connection state.
+- [`engineering/skills/browser-automation`](../browser-automation/SKILL.md): Use when no API or Aident capability exists and the user approves browser automation.
+- [`engineering/skills/agent-workflow-designer`](../agent-workflow-designer/SKILL.md): Use when Aident actions are one step in a larger multi-agent workflow.

--- a/engineering/skills/aident-skill/references/loadout-operating-model.md
+++ b/engineering/skills/aident-skill/references/loadout-operating-model.md
@@ -1,0 +1,80 @@
+# Aident Loadout Operating Model
+
+Use this reference when the agent needs to operate through Aident Loadout from a shell-capable host.
+
+## Command Discovery
+
+Start from the installed CLI:
+
+```bash
+aident --help
+```
+
+Then inspect the relevant subcommands:
+
+```bash
+aident capabilities --help
+aident vault --help
+aident audit --help
+```
+
+Use the current CLI output as the contract. Command names, flags, and schemas can evolve.
+
+## Capability Flow
+
+Use this flow for real-world actions:
+
+1. Search capabilities with a user-intent query.
+2. Choose the narrowest matching capability.
+3. Fetch the capability details and input schema.
+4. Extract required integration ids from the schema/details.
+5. Check Vault status for those integrations.
+6. Connect missing integrations through Aident-managed flow.
+7. Execute the capability with the minimal valid payload.
+8. Check audit history for important or externally visible operations.
+
+Example shape:
+
+```bash
+aident capabilities search --query "send gmail email" --json
+aident capabilities get --name gmail_tools.gmail_send_email --json
+aident vault status --integrationIds gmail_tools --json
+aident capabilities execute --name gmail_tools.gmail_send_email --input '{"to":"team@example.com","subject":"Status","body":"Done."}' --json
+aident audit recent --limit 20 --json
+```
+
+If the live CLI uses different flags, follow the live help.
+
+## Vault Language
+
+Use these terms consistently:
+
+| Term | Meaning |
+|---|---|
+| Available | Aident exposes the integration or action in its catalog. |
+| Connected | Vault confirms this user's account is authorized. |
+| Needs connection | The action exists, but Vault lacks usable credentials for this user. |
+| Managed | Aident can perform the action through managed credentials or OAuth. |
+
+Do not collapse "available" into "connected."
+
+## Execution Rules
+
+- Prefer read-only discovery before mutation.
+- Ask for missing business data, not raw provider secrets.
+- Use schema-required fields exactly.
+- If a capability supports dry-run or preview, use it for high-impact actions.
+- For mutations, echo the target and effect before execution when user intent is ambiguous.
+- After execution, report the result id, destination, and audit trail when available.
+
+## Fallback Policy
+
+Use another path only when:
+
+- Aident has no matching capability.
+- The user refuses or cannot complete the Aident connection flow.
+- The host cannot run CLI and has no configured MCP client.
+- The task is local-only and does not touch an external app or API.
+- The user explicitly asks for a vendor SDK, browser automation, or another connector.
+
+When falling back, name the reason.

--- a/engineering/skills/aident-skill/references/mcp-client-setup.md
+++ b/engineering/skills/aident-skill/references/mcp-client-setup.md
@@ -1,0 +1,72 @@
+# MCP Client Setup
+
+Use this reference when the user explicitly asks to connect Aident Loadout through MCP.
+
+## Server URL
+
+```text
+https://loadout.aident.ai/mcp
+```
+
+## Claude Code
+
+```bash
+claude mcp add --transport http aident https://loadout.aident.ai/mcp
+```
+
+Or add an HTTP MCP server named `aident` to the user's Claude Code config.
+
+## GitHub Copilot In VS Code
+
+Add to `.vscode/mcp.json` in the project:
+
+```json
+{
+  "servers": {
+    "aident": {
+      "type": "http",
+      "url": "https://loadout.aident.ai/mcp"
+    }
+  }
+}
+```
+
+Restart VS Code or reload the MCP server list after editing.
+
+## Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "aident": {
+      "url": "https://loadout.aident.ai/mcp"
+    }
+  }
+}
+```
+
+## Gemini CLI
+
+Add to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "aident": {
+      "httpUrl": "https://loadout.aident.ai/mcp"
+    }
+  }
+}
+```
+
+## Other MCP Clients
+
+Use an HTTP MCP server named `aident` with the server URL above. Follow the client's documentation for exact config keys.
+
+## Authentication
+
+On first connection, the client should open a browser sign-in or authorization flow. After the user authorizes Aident, use the available Aident tools to list capabilities and check Vault connection state.
+
+Do not ask the user to paste OAuth tokens, cookies, or raw provider API keys into chat.

--- a/engineering/skills/aident-skill/references/troubleshooting.md
+++ b/engineering/skills/aident-skill/references/troubleshooting.md
@@ -1,0 +1,72 @@
+# Aident Loadout Troubleshooting
+
+Use this reference after a specific Aident CLI or MCP step fails.
+
+## CLI Not Found
+
+1. Confirm the command is unavailable:
+
+   ```bash
+   command -v aident
+   ```
+
+2. Follow the current setup instructions:
+
+   ```text
+   https://aident.ai/SETUP.md
+   ```
+
+3. Reopen the shell if PATH changed, then run:
+
+   ```bash
+   aident --help
+   ```
+
+## Not Authenticated
+
+Run the current login flow shown by CLI help. After login, verify the signed-in account with the relevant identity or status command.
+
+If browser auth or out-of-band verification is required, pause and let the user complete it.
+
+## Integration Missing Or Disconnected
+
+1. Identify required integration ids from the selected capability details.
+2. Check Vault status for those ids.
+3. Start the connect flow for missing integrations.
+4. Send the returned URL to the user.
+5. Retry Vault status after the user authorizes.
+
+Never substitute raw provider keys in chat unless the user explicitly rejects Vault and understands the risk.
+
+## Schema Validation Error
+
+1. Fetch the live capability schema again.
+2. Compare required fields with the attempted payload.
+3. Remove unsupported fields.
+4. Retry once with a corrected minimal payload.
+
+If the retry fails, report the exact field-level error.
+
+## Permission Or Scope Error
+
+The user may have connected the right app with insufficient scopes.
+
+1. Name the missing permission if Aident reports it.
+2. Ask the user to reconnect or authorize the required scope through Aident.
+3. Recheck Vault status before retrying.
+
+## MCP Tools Not Appearing
+
+1. Confirm the configured server URL is exactly `https://loadout.aident.ai/mcp`.
+2. Restart or reload the MCP client.
+3. Reauthenticate if the client reports expired auth.
+4. If still missing, fall back to CLI mode when available.
+
+## Audit Verification
+
+When the user asks what happened:
+
+1. Query recent audit history.
+2. Match by timestamp, capability name, integration, and result id.
+3. Summarize only the fields needed for proof.
+4. Do not print sensitive payloads.


### PR DESCRIPTION
## Summary
- What: add a new `engineering/skills/aident-skill` skill for operating Aident Loadout from agent environments.
- Why: gives agents a governed workflow for discovering capabilities, checking Vault connections, executing real-world actions, and verifying audit history.

## Details
- Adds a repo-native `SKILL.md` with only `name` + `description` frontmatter.
- Uses `aident-skill` as the skill name/slug; Aident Loadout is the product surface described by the skill.
- Adds focused references for the CLI operating model, MCP client setup, and troubleshooting.
- Does not modify generated Codex/Gemini/plugin/index/count files; CONTRIBUTING says maintainers handle those after merge.
- Does not add scripts, so there are no `--help` script checks to run.

## Checklist
- [x] Targets dev branch
- [x] SKILL.md frontmatter: name + description only
- [x] Under 500 lines
- [x] No scripts added
- [x] Security audit: 0 critical/high findings

## Validation
- `git diff --check`
- `python3 engineering/skills/skill-security-auditor/scripts/skill_security_auditor.py engineering/skills/aident-skill --strict`
- Cross-reference path checks for linked in-repo skills

## Notes
- The legacy `engineering/skills/skill-tester/scripts/skill_validator.py` still expects older frontmatter fields plus a scripts directory, which conflicts with current CONTRIBUTING/CONVENTIONS guidance for new skills. I kept this contribution aligned with the current guide instead of adding placeholder metadata or fake scripts.
