### PR TITLE
feat: add self-model-regeneration skill — 5-step mechanical feedback loop for AI identity persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ git clone https://github.com/alirezarezvani/claude-skills.git
 
 ## Multi-Tool Support (New)
 
-**Convert all 345 skills to 9 AI coding tools** with a single script:
+**Convert all 355 skills to 9 AI coding tools** with a single script:
 
 | Tool | Format | Install |
 |------|--------|---------|
@@ -139,7 +139,7 @@ find .cursor/rules -name "*.mdc" | wc -l  # Should show 346
 ```
 
 **Each tool gets:**
-- ✅ All 345 skills converted to native format
+- ✅ All 355 skills converted to native format
 - ✅ Per-tool README with install/verify/update steps
 - ✅ Support for scripts, references, templates where applicable
 - ✅ Zero manual conversion work
@@ -150,7 +150,7 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 
 ## Skills Overview
 
-**354 skills across 18 domains:**
+**355 skills across 18 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|
@@ -158,7 +158,7 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 | **⚡ Engineering — POWERFUL** | 80 | Agent designer, RAG architect, database designer, CI/CD builder, security auditor, MCP builder, AgentHub, Helm charts, Terraform, self-eval, llm-wiki, tc-tracker, autoresearch-agent, **reliability portfolio** (feature-flags-architect, kubernetes-operator, chaos-engineering, slo-architect), ship-gate, security-guidance PreToolUse hook, **Matt Pocock skills** (write-a-skill, caveman, grill-me, handoff, grill-with-docs), **zero-hallucination-coder** (Discuss→Map→Decompose→Execute→Verify) | [engineering/](engineering/) |
 | **🎯 Product** | 17 | Product manager, agile PO, strategist, UX researcher, UI design, landing pages, SaaS scaffolder, analytics, experiment designer, discovery, roadmap communicator, code-to-prd, apple-hig-expert | [product-team/](product-team/) |
 | **📣 Marketing** | 48 | 8 pods: Content, SEO + AEO (`aeo` — E-E-A-T audit, citation tracking across 5 LLMs) + local (`local-seo-manager` — GBP/NAP/Map-Pack), CRO, Channels, Growth, Intelligence, Sales + context foundation + orchestration router | [marketing-skill/](marketing-skill/) |
-| **🚀 Productivity** | 7 | `capture` (brain-dump-to-action), `email` pair (inbox-setup + inbox-triage), `reflect` (journal), `handoff` (Matt Pocock-inspired), `andreessen` (market-first decision mode), `roast` (5-angle idea panel → GO/RESHAPE/KILL) | [productivity/](productivity/) |
+| **🚀 Productivity** | 8 | `capture` (brain-dump-to-action), `email` pair (inbox-setup + inbox-triage), `reflect` (journal), `handoff` (Matt Pocock-inspired), `andreessen` (market-first decision mode), `roast` (5-angle idea panel → GO/RESHAPE/KILL), `self-model-regeneration` (AI identity persistence across sessions — SessionStart→Stop lifecycle) | [productivity/](productivity/) |
 | **🎨 Marketing (top-level)** | 1 | `landing` — single-file HTML landing-page generator (4 design styles, GSAP patterns, brand palette validator) | [marketing/](marketing/) |
 | **🔬 Research (academic)** | 9 | `research` orchestrator (hybrid router + fallback) + 8 specialists: `pulse`, `litreview`, `grants` (NIH), `dossier`, `patent`, `syllabus`, `notebooklm`, `deep-research` (rigor-first meta-research) | [research/](research/) |
 | **🧪 Research Operations** ✨v2.9.0 | 5 | Enterprise/cross-functional research: orchestrator + `clinical-research` (study design), `research-finance` (R&D program finance), `market-research` (sizing/survey/segmentation), `product-research` (user research) — each with onboarding + customization + opt-in autoresearch bridge | [research-ops/](research-ops/) |

--- a/productivity/self-model-regeneration/.claude-plugin/plugin.json
+++ b/productivity/self-model-regeneration/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "self-model-regeneration",
+  "description": "AI remembers who it is across sessions — a 5-step mechanical feedback loop that detects when the AI's self-model is stale and regenerates it from growth data at SessionStart. Complements handoff: handoff transfers WHAT was done; self-model maintains WHO is doing it.",
+  "version": "2.1.2",
+  "author": {
+    "name": "Yuhao Lin",
+    "url": "https://github.com/YuhaoLin2005"
+  },
+  "homepage": "https://github.com/alirezarezvani/claude-skills/tree/dev/productivity/self-model-regeneration",
+  "repository": "https://github.com/alirezarezvani/claude-skills",
+  "license": "MIT",
+  "skills": ["./"],
+  "source": {
+    "build_pattern": "Direct conversion. Self-model regeneration loop — 4 mechanized Python scripts + 1 AI synthesis step — for persistent AI identity across sessions via filesystem-based flag lifecycle.",
+    "distinct_from": "productivity/handoff transfers WHAT was done between agents; self-model-regeneration maintains WHO the agent is across sessions. They compose without conflict — handoff runs at session end, self-model regeneration runs at session start."
+  }
+}

--- a/productivity/self-model-regeneration/SKILL.md
+++ b/productivity/self-model-regeneration/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: self-model-regeneration
+description: AI remembers who it is across sessions — a 5-step mechanical feedback loop (4 mechanized + 1 AI-synthesized) that detects when the AI's self-model is stale and regenerates it from growth data at SessionStart. Complements handoff: handoff transfers WHAT was done; self-model maintains WHO is doing it.
+---
+
+# Self-Model Regeneration Loop
+
+A mechanical feedback loop that gives the AI agent persistent identity across sessions. The agent regenerates its own self-model — a structured document describing its capabilities, growth areas, warnings, and current goals — whenever new growth data makes the old model stale.
+
+**Core insight:** "Machines do the checking; humans (and AI) do the judging." Four of five steps in this loop are fully mechanized Python scripts. The AI only handles step 3 — the creative synthesis of new growth data into an updated self-model.
+
+## Quick Start (30 seconds)
+
+```bash
+# 1. Copy scripts to your Claude Code directory
+cp scripts/quality-gate.py ~/.claude/scripts/
+cp scripts/health-check.py ~/.claude/scripts/
+cp scripts/log-regeneration.py ~/.claude/scripts/
+
+# 2. Add hooks to your Claude Code config
+#    SessionStart: python ~/.claude/scripts/health-check.py
+#    Stop:         python ~/.claude/scripts/quality-gate.py
+
+# 3. Create your memory directory and initial self-model
+mkdir -p ~/.claude/memory/growth-log ~/.claude/memory/decisions
+#    Write ~/.claude/memory/self-model.md using the template below
+```
+
+After setup: write a growth-log entry after each meaningful session. When quality-gate detects staleness, the AI regenerates its self-model at next startup.
+
+**Platform support:** Core staleness detection works on all platforms (Windows, Linux, macOS). System health checks (RAM, GPU, temp files) are cross-platform via `platform.system()` dispatch.
+
+## Problem
+
+AI coding agents suffer from a fundamental amnesia problem. Each session starts fresh — the agent doesn't remember what it learned, what patterns it discovered, or what mistakes it's prone to. Handoff documents help transfer task context, but they don't maintain the agent's *self-knowledge*: its calibrated sense of its own capabilities, its accumulated warnings about cognitive biases, its evolving goals.
+
+Without persistent identity: growth patterns discovered in one session are forgotten in the next, and there's no cumulative learning — each session is a reset.
+
+## Solution
+
+A five-step mechanical feedback loop:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    THE SELF-MODEL LOOP                        │
+│                                                              │
+│  Session N                    Session N+1                    │
+│  ─────────                    ───────────                    │
+│                                                              │
+│  ① quality-gate.py (Stop)    ② health-check.py (Start)       │
+│     │                             │                          │
+│     │ checks: is self-model       │ detects .self-model-     │
+│     │ older than any growth-      │ stale flag → outputs     │
+│     │ log? If yes → writes        │ structured signal:       │
+│     │ .self-model-stale flag      │ REGENERATE_NEEDED        │
+│     │ exit 2 (hard block)         │ (never blocks)           │
+│     │                             │                          │
+│     ▼                             ▼                          │
+│  ┌──────────────────────────────────────────────────────┐    │
+│  │  ③ AI Regeneration (SessionStart, AI attention peak) │    │
+│  │     Reads growth-logs → synthesizes new self-model   │    │
+│  │     3-version rotation → meta-pattern induction      │    │
+│  └──────────────────────┬───────────────────────────────┘    │
+│                         │                                    │
+│                         ▼                                    │
+│              ④ log-regeneration.py                           │
+│                 Writes JSONL audit record FIRST              │
+│                 Deletes .self-model-stale flag SECOND        │
+│                 Crash-consistent ordering                    │
+│                         │                                    │
+│                         ▼                                    │
+│              ⑤ self-model.md (updated)                       │
+│                 → feeds into SessionStart sequence           │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Why regeneration at SessionStart, not Stop:** The AI's attention is freshest at startup. At session end, after hours of work, synthesis quality degrades.
+
+**Why 4 of 5 steps are mechanized:** The flag file is filesystem-verifiable causal evidence. quality-gate.py writes it when staleness is detected. health-check.py reads it and produces a machine-parseable signal. log-regeneration.py cleans it up and writes an audit trail. Only the content synthesis itself requires AI judgment.
+
+## Comparison with Handoff
+
+These skills are complementary, not competing:
+
+| Dimension | Handoff | Self-Model Regeneration |
+|-----------|---------|------------------------|
+| **What it transfers** | Task context, decisions, artifacts | Agent identity, capabilities, warnings |
+| **Trigger** | User says "hand this off" | Mechanical (quality-gate.py detects staleness) |
+| **Direction** | Session → Session | Growth data → Self-model → Future sessions |
+| **Content type** | WHAT was done | WHO is doing it |
+| **Freshness** | Per-handoff | Continuous (every session where growth occurred) |
+
+A session can generate both a handoff AND trigger a self-model regeneration. Handoff is the explicit pass; self-model regeneration is the implicit accumulation. They compose, never conflict.
+
+## Setup
+
+### 1. Directory Structure
+
+```
+~/.claude/
+├── memory/                    # Your knowledge base
+│   ├── self-model.md          # Current self-model (AI-maintained)
+│   ├── growth-log/            # Per-session growth entries (*.md)
+│   ├── ratings-tracker.md     # Capability ratings (0-5 scale)
+│   ├── decisions/
+│   │   └── log.md             # Decision log
+│   ├── output-index.md        # Cross-session artifact index
+│   └── persona-portrait*.md   # Stable persona description
+└── scripts/
+    ├── quality-gate.py        # Stop hook: staleness detection
+    ├── health-check.py        # SessionStart: flag detection + system health
+    └── log-regeneration.py    # Post-regeneration cleanup + audit
+```
+
+### 2. Hook Configuration
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "command": "python ~/.claude/scripts/health-check.py"
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "command": "python ~/.claude/scripts/quality-gate.py"
+      }
+    ]
+  }
+}
+```
+
+### 3. Initialize Your Self-Model
+
+Create `~/.claude/memory/self-model.md`:
+
+```markdown
+---
+version: 0.1.0
+generated: YYYY-MM-DD
+sources: []
+---
+
+# My Current Self-Understanding
+
+## Who I Am
+[Your role, context, core drive — 2-3 sentences]
+
+## What I'm Good At
+- **Capability 1 (L1-L5)**: Evidence + context
+
+## Where I Need to Grow
+- Gap 1: current state → target state
+
+## My Current Goals
+1. [Specific, measurable goal]
+
+## Recent Growth
+- [Empty initially — fills from growth-log entries]
+
+## Warnings
+- [Cognitive biases, known failure modes]
+
+## Self-Vision
+[1-2 sentences on trajectory]
+```
+
+The only required file is `self-model.md` in your memory directory. Files like SOUL.md or INTERFACE.md are optional extensions from the user's personal configuration.
+
+### 4. Create Your First Growth-Log Entry
+
+```bash
+mkdir -p ~/.claude/memory/growth-log
+```
+
+After each substantial session, write a growth-log entry:
+
+```markdown
+# Growth Log YYYY-MM-DD
+
+## What happened
+[Concrete events, decisions, outputs — no interpretation]
+
+## What I learned
+[Patterns recognized, methodology improvements, meta-cognition]
+
+## New capabilities demonstrated
+[Evidence of capability changes]
+
+## New warnings
+[Mistakes made, biases observed, near-misses]
+```
+
+## How It Works
+
+### Script 1: `quality-gate.py` (Stop Hook)
+
+Runs at session end. Checks five databases and self-model.md staleness:
+
+- **Database freshness**: Warns if any of the 5 databases hasn't been updated in 3+ days. Critical if 7+ days.
+- **Self-model staleness**: If any growth-log entry is newer than or equal to self-model.md (FAT32-safe `>=` comparison) → writes `.self-model-stale` flag → exits 2 (hard block).
+- **Flag consistency**: If flag exists but self-model is actually fresh → removes orphaned flag.
+
+**Exit codes:** 0 = clean, 1 = warnings (fixable retroactively), 2 = hard block (regeneration needed).
+
+**Design principle:** The boundary between exit 1 and exit 2 is *reversibility*. Stale databases can be backfilled. A stale self-model means the session built on outdated self-knowledge — that damage is done. Hence: block.
+
+### Script 2: `health-check.py` (SessionStart Hook)
+
+Runs at session start. Detects `.self-model-stale` flag and outputs structured signals:
+
+- **`REGENERATE_NEEDED`**: Flag exists AND self-model IS genuinely stale. Outputs JSON payload with action, reason, and source list.
+- **`CLEANED_ORPHAN`**: Flag exists BUT self-model is already fresh. Auto-removes the flag.
+- **No flag**: Self-model is current — no action needed.
+
+Also checks: disk space, RAM (cross-platform), GPU, temp file accumulation, script integrity, growth-log freshness, and skills count. **NEVER blocks** — always exits 0.
+
+### Script 3: `log-regeneration.py` (Post-Regeneration)
+
+Called by the AI AFTER it regenerates self-model.md. Crash-consistent:
+
+```bash
+python ~/.claude/scripts/log-regeneration.py \
+  --old v2 --new v3 \
+  --sources "2026-07-02,2026-07-01" \
+  --trigger flag
+```
+
+Crash-safe ordering:
+1. **First**: Appends JSONL audit record with `fl.flush(); os.fsync()` — if crash, flag persists
+2. **Then**: Deletes `.self-model-stale` flag — if crash, audit trail already exists
+3. **Verifies**: Log file exists and is non-empty
+
+### Known Limitations: Mtime-Based Detection
+
+| Scenario | Effect | Mitigation |
+|----------|--------|------------|
+| `git checkout` resets mtimes | Model appears fresh after switch | Don't version-control memory directory |
+| FAT32/exFAT (2s resolution) | Files within 2s have equal mtimes | `>=` comparison prevents false negatives |
+| `touch self-model.md` | Bypasses staleness detection | Useful for recovery; don't use casually |
+| System clock changes | Future timestamps possible | health-check.py warns on future mtimes |
+| Concurrent sessions | Two AIs may both regenerate | Flag acts as poor-man's mutex; v1.0 limit |
+
+## SessionStart Sequence
+
+```
+1. health-check.py detects .self-model-stale flag
+2. AI reads flag payload → identifies stale sources
+3. AI reads all growth-logs newer than self-model
+4. AI reads ratings-tracker for capability deltas
+5. AI executes 3-version rotation
+6. AI synthesizes new self-model.md
+7. AI calls log-regeneration.py (audit log + flag cleanup)
+8. AI reads new self-model.md → continues startup sequence
+9. Session proceeds with calibrated identity
+```
+
+## Design Principles
+
+1. **Mechanize everything that can be deterministic.** Flag write, detection, deletion, and audit logging are all scripts. Only creative synthesis requires AI.
+2. **Boundary by reversibility, not importance.** Stale databases → warn (can backfill). Stale self-model → block (damage already done).
+3. **Regenerate at attention peak, not attention trough.** SessionStart, not Stop.
+4. **Flag as filesystem-verifiable causal evidence.** A `.self-model-stale` file is unambiguous — no parsing, no heuristics.
+5. **Never block on startup.** health-check.py always exits 0. It informs; the AI decides.
+
+## Anti-Patterns
+
+- **Don't regenerate without new data.** The flag is the sole trigger.
+- **Don't treat self-model as a diary.** It's a calibrated assessment, not a chronological log.
+- **Don't skip the version rotation.** 3-version history is your only rollback mechanism.
+- **Don't hand-edit the flag file.** Manual flag manipulation breaks the causal chain.
+- **Don't conflate with handoff.** Handoff transfers task context; self-model maintains identity. They don't overlap.
+
+## Integration with Existing Skills
+
+- **handoff** (productivity) + **handoff-engineering** (engineering): Self-model handles identity persistence; handoff handles task context transfer. Use both.
+- **named-persona-adversarial-review** (engineering-team): Self-model warnings feed into adversarial review prompts — a reviewer that knows its biases catches fabrication others miss.
+- **self-improving-agent** (engineering-team): Self-model regeneration is the identity layer underneath self-improving-agent's memory curation.
+- **capture** (productivity): Growth-log entries start as captured insights; self-model regeneration turns fragments into a coherent self-portrait.
+
+## Token Economics
+
+| Scenario | Without Self-Model | With Self-Model |
+|----------|-------------------|-----------------|
+| Identity establishment/session | Re-derived from scratch | Reads cached self-model (~0 incremental) |
+| Regeneration (when triggered) | N/A | Amortized across 1-3 sessions |
+| Repeated mistake prevention | No warning memory | Warnings persist across sessions |
+| Cumulative self-knowledge | Reset each session | Compounding across sessions |
+
+Regeneration cost is amortized across sessions. After 2-3 sessions, the investment pays back through eliminated re-derivation and persistent warnings.
+
+## Cross-References
+
+- **Concept origin**: Hofstadter's "strange loop" (*Gödel, Escher, Bach*, 1979) — self-referential systems where observing and modifying the self are the same operation.
+- **Architecture pattern**: Dual-Layer Mechanical Gate — process layer (soft monitoring) + output layer (hard blocking). Boundary: "can this be fixed retroactively?"
+- **Regeneration timing**: SessionStart vs Stop — AI attention is freshest at startup. Emerged from expert review.
+- **Meta-skill lineage**: This skill was used to develop itself — version rotation, flag lifecycle, and crash-consistent logging were refined through adversarial expert review during the skill's own creation.
+
+## Files
+
+| File | Purpose | Hook |
+|------|---------|------|
+| `scripts/quality-gate.py` | Database freshness + staleness detection | Stop |
+| `scripts/health-check.py` | Flag detection + system health signals | SessionStart |
+| `scripts/log-regeneration.py` | Flag cleanup + JSONL audit log | Post-regeneration |
+| `scripts/tests/test_staleness.py` | Smoke tests for staleness logic | — |
+| `references/how-it-works.md` | Detailed docs and integration guide | — |

--- a/productivity/self-model-regeneration/references/how-it-works.md
+++ b/productivity/self-model-regeneration/references/how-it-works.md
@@ -1,0 +1,270 @@
+# How Self-Model Regeneration Works
+
+Detailed reference for the 5-step mechanical feedback loop. Read this if you're debugging the loop, adding integrations, or want to understand the architecture deeply.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     FLAG LIFECYCLE                               │
+│                                                                 │
+│  quality-gate.py (Stop)                                         │
+│    │                                                             │
+│    │ self-model stale? ──yes──► write .self-model-stale          │
+│    │                             exit 2                          │
+│    │                                                             │
+│    │ self-model fresh? ──yes──► cleanup orphaned flag            │
+│    │                             exit 0 or 1                     │
+│    │                                                             │
+│    ▼                                                             │
+│  .self-model-stale (on disk)                                     │
+│    │                                                             │
+│    ▼                                                             │
+│  health-check.py (SessionStart)                                  │
+│    │                                                             │
+│    │ flag exists + model stale? ──► REGENERATE_NEEDED            │
+│    │ flag exists + model fresh? ──► CLEANED_ORPHAN               │
+│    │ no flag?                    ──► nothing                     │
+│    │                                                             │
+│    ▼                                                             │
+│  AI Regeneration (SessionStart)                                  │
+│    │                                                             │
+│    │ 1. Read newer growth-logs                                   │
+│    │ 2. Read ratings-tracker                                     │
+│    │ 3. 3-version rotation                                       │
+│    │ 4. Synthesize new self-model.md                             │
+│    │                                                             │
+│    ▼                                                             │
+│  log-regeneration.py                                             │
+│    │                                                             │
+│    │ 1. Write JSONL audit record (fsync)                         │
+│    │ 2. Verify log exists                                        │
+│    │ 3. Delete .self-model-stale                                 │
+│    │                                                             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Script Reference
+
+### quality-gate.py
+
+**Purpose:** Stop hook. Detects when self-model is stale and writes the flag.
+
+**Input:** File system state (memory directory, growth-logs, self-model.md).
+
+**Output:** Exit code + stderr messages.
+- Exit 0: Clean. All databases fresh, self-model current.
+- Exit 1: Warnings. Some databases stale, but self-model is current. Fixable retroactively.
+- Exit 2: Hard block. Self-model is stale relative to growth data. Session ran with outdated identity.
+
+**`--json` flag:** Prints structured JSON to stdout:
+```json
+{
+  "exit_code": 2,
+  "exit_label": "hard_block",
+  "self_model": {
+    "stale": true,
+    "reason": "growth-log entries newer than self-model: 2026-07-02, 2026-07-01",
+    "sources": ["2026-07-02", "2026-07-01"]
+  },
+  "databases": [
+    {"name": "growth-log", "days": 0.5, "status": "ok"},
+    {"name": "decisions/log", "days": 2.1, "status": "ok"},
+    {"name": "output-index", "days": 4.0, "status": "warning"},
+    {"name": "ratings-tracker", "days": 2.0, "status": "ok"},
+    {"name": "persona-portrait", "days": 8.0, "status": "critical"}
+  ]
+}
+```
+
+**Staleness detection algorithm:**
+1. Get self-model.md mtime
+2. For each growth-log entry (YYYY-MM-DD*.md):
+   - If entry mtime >= self-model mtime → entry is newer
+3. If any entry is newer → stale → write flag → exit 2
+
+**Why `>=` and not `>`:** FAT32/exFAT filesystems have 2-second mtime resolution. A growth-log written within the same 2-second window as the self-model would appear "equal." Using `>=` ensures we flag staleness rather than missing it.
+
+**Flag cleanup:** If `.self-model-stale` exists but self-model is actually fresh (all growth-logs older), the script removes the orphaned flag. This handles the edge case where log-regeneration.py failed to delete the flag but the AI did regenerate.
+
+### health-check.py
+
+**Purpose:** SessionStart hook. Reads the flag file and emits structured signals.
+
+**Key contract:** **NEVER blocks.** Always exits 0. This is a soft monitoring layer — it informs, never prevents. The boundary between soft (health-check) and hard (quality-gate) is deliberate.
+
+**Signals (to stderr):**
+```
+SELF_MODEL:REGENERATE_NEEDED:model_missing
+SELF_MODEL:REGENERATE_NEEDED:empty_file
+SELF_MODEL:REGENERATE_NEEDED:growth_logs_newer(3):2026-07-02,2026-07-01,...
+SELF_MODEL:CLEANED_ORPHAN:model_fresh:flag_was_2026-07-02T12:00:00
+SELF_MODEL:WARN:future_mtime:3600s_ahead
+SELF_MODEL:WARN:truncated_file:20bytes
+SELF_MODEL:JSON:{"action":"regenerate","reason":"...","trigger":"flag","sources":[...]}
+```
+
+**Also checks (informational):**
+- **disk:** Free space in GB, warns at 50GB, refuses at 15GB
+- **ram:** Used percentage and free/total MB (cross-platform: wmic/Linux procfs/macOS vm_stat)
+- **gpu:** NVIDIA GPU temperature, utilization, VRAM (nvidia-smi, skipped if unavailable)
+- **tmp:** File count in temp directory, warns at 500 files
+- **config:** Integrity check for the three scripts (quality-gate, health-check, log-regeneration)
+- **growth:** Days since last growth-log entry, warns at 3 days
+- **skills:** Count of active skills
+
+**`--json` flag:** Collects all check results and prints structured JSON to stdout:
+```json
+{
+  "disk": {"name": "disk", "free_gb": 200, "level": "OK"},
+  "ram": {"name": "ram", "pct": 45, "free_mb": 8192, "total_mb": 16384},
+  "gpu": {"name": "gpu", "temp_c": 55, "util_pct": 30, "vram_used_mb": 2048, "vram_total_mb": 8192, "level": "OK"},
+  "tmp": {"name": "tmp", "count": 120, "level": "OK"},
+  "config": {"name": "config", "missing": [], "level": "OK"},
+  "growth": {"name": "growth-log", "latest": "2026-07-02", "days": 0, "level": "OK"},
+  "skills": {"name": "skills", "count": 8, "level": "OK"},
+  "self_model_flag": {"signal": "REGENERATE_NEEDED", "reason": "growth_logs_newer(2)", "action": "regenerate", "payload": {...}},
+  "exit_code": 0
+}
+```
+
+### log-regeneration.py
+
+**Purpose:** Post-regeneration cleanup and audit. Called by AI after synthesizing new self-model.md.
+
+**Usage:**
+```bash
+python log-regeneration.py \
+  --old v2 \
+  --new v3 \
+  --sources "2026-07-02,2026-07-01" \
+  --trigger flag
+```
+
+**Crash-consistent ordering:**
+1. **JSONL write + fsync FIRST** — If this crashes, flag persists → health-check re-detects next session
+2. **Log verification** — Confirms the log file exists and has content. If verification fails, exits 1 WITHOUT deleting flag.
+3. **Flag deletion SECOND** — If this crashes, audit trail exists → health-check cleans orphan next session
+
+**Audit trail format** (`.self-model-regeneration.jsonl`, one JSON object per line):
+```json
+{"timestamp": "2026-07-02T12:00:00+00:00", "trigger": "flag", "sources": ["2026-07-02", "2026-07-01"], "old_version": "v2", "new_version": "v3", "flag_cleaned": true}
+```
+
+**`--json` flag:** Outputs structured result:
+```json
+{
+  "success": true,
+  "timestamp": "2026-07-02T12:00:00+00:00",
+  "trigger": "flag",
+  "sources": ["2026-07-02", "2026-07-01"],
+  "old_version": "v2",
+  "new_version": "v3",
+  "flag_cleaned": true,
+  "log_appended": true,
+  "log_verified": true
+}
+```
+
+## SessionStart Sequence (Full)
+
+When health-check.py signals `REGENERATE_NEEDED`, the AI should:
+
+1. Parse the `SELF_MODEL:JSON:{...}` payload from stderr
+2. Read all growth-logs listed in `sources`
+3. Read `ratings-tracker.md` for capability deltas
+4. Execute 3-version rotation:
+   - `self-model.md` → `self-model.v1.md`
+   - `self-model.v1.md` → `self-model.v2.md`
+   - `self-model.v2.md` → `self-model.v3.md` (oldest rotates out)
+5. Write new `self-model.md` synthesizing growth data
+6. Call `log-regeneration.py --old <prev> --new <current> --sources "..." --trigger flag`
+7. Read the new self-model → continue normal startup
+
+## Integration Points
+
+### Hook Configuration
+
+The skill uses Claude Code's hook system:
+
+| Hook | Script | Purpose |
+|------|--------|---------|
+| SessionStart | health-check.py | Detect flag, system health |
+| Stop | quality-gate.py | Detect staleness, write flag |
+
+### Complementarity with handoff
+
+```
+Session N-1 (end)
+  ├── handoff: "Here's what I did and where I left off" → next agent
+  └── quality-gate.py: "Here's what I learned" → flag → next session's self
+
+Session N (start)
+  ├── health-check.py: detects flag → AI regenerates self-model
+  ├── self-model.md: "Here's who I am and what I know about myself"
+  └── handoff from previous: "Here's the task context"
+```
+
+Handoff is the explicit, intentional transfer of task context to a different agent. Self-model regeneration is the implicit, automatic accumulation of self-knowledge for the same agent across sessions. They compose, never conflict.
+
+## Design Decisions
+
+### Why SessionStart for regeneration, not Stop?
+
+The AI's attention is freshest at startup. At session end, after hours of work, synthesis quality degrades. Regenerating at SessionStart means the self-model benefits from the AI's peak cognitive state.
+
+This was a key finding from adversarial expert review: the original design regenerated at Stop, which produced degraded self-models that compounded errors across sessions.
+
+### Why filesystem flags instead of structured data?
+
+A `.self-model-stale` file on disk is unambiguous causal evidence. No parsing, no interpretation, no heuristics. The file exists → regeneration is needed. The file doesn't exist → self-model is current. This is the simplest possible interface — and therefore the hardest to break.
+
+### Why crash-consistent ordering (log before flag delete)?
+
+If we delete the flag first and then crash during log write, we lose both the flag (trigger) and the log (audit trail). The regeneration disappears without a trace. By writing the log first (with fsync), we guarantee that either:
+- Both succeed: normal lifecycle
+- Log succeeds, flag delete fails: orphaned flag → health-check cleans it
+- Log fails: flag persists → health-check re-detects next session
+
+No state combination results in lost data.
+
+### Why 3-version rotation?
+
+Self-model regeneration is creative synthesis — it can produce degraded models. The 3-version history provides a rollback mechanism. If the new self-model is worse than the previous version, the previous version is still available.
+
+## Known Limitations
+
+| Limitation | Impact | Planned Fix (v1.1) |
+|-----------|--------|-------------------|
+| Mtime-based detection | git checkout resets timestamps | Content-hash-based freshness |
+| Single-instance only | Two concurrent AIs may race | PID-based lock file |
+| No content validation | Regenerated model could be low quality | Mechanical quality checks |
+| No multi-agent support | One self-model for one agent | Agent-ID namespaced models |
+| Manual flag bypass (`touch`) | Users can defeat staleness detection | TTL-based secondary check |
+
+These are documented limitations, not bugs. A content-hash-based freshness check is planned for v1.1.
+
+## Testing
+
+Smoke tests are in `scripts/tests/test_staleness.py` (27 tests, 8 classes):
+
+```bash
+# Run with unittest (stdlib, no dependencies)
+python scripts/tests/test_staleness.py
+
+# Run with pytest
+python -m pytest scripts/tests/test_staleness.py -v
+```
+
+Test classes:
+- `TestDaysSince` — days_since() return type and edge cases
+- `TestFindPersona` — _find_persona() glob and fallback
+- `TestFlagLifecycle` — flag write → read → delete round-trip
+- `TestGrowthLogFilenameRegex` — date pattern validation
+- `TestMtimeStalenessLogic` — FAT32 resolution, clock skew
+- `TestLogRegenerationOrdering` — crash-consistent write ordering
+- `TestExitCodes` — quality-gate.py exit code semantics
+- `TestHealthCheckSignals` — REGENERATE_NEEDED and CLEANED_ORPHAN signals
+- `TestLogRegenerationScript` — CLI interface and crash-safety
+
+All tests use stdlib only (`unittest`, `tempfile`, `subprocess`, `importlib`).

--- a/productivity/self-model-regeneration/scripts/health-check.py
+++ b/productivity/self-model-regeneration/scripts/health-check.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""SessionStart health check — disk/ram/gpu/config/growth + self-model flag detection.
+
+NEVER blocks, always exits 0. Outputs structured signals to stderr for AI consumption.
+
+Part of the self-model regeneration loop:
+  - Detects .self-model-stale flag (written by quality-gate.py at Stop)
+  - Outputs REGENERATE_NEEDED or CLEANED_ORPHAN signals
+  - Also checks system health: disk, RAM, GPU, temp files, config integrity
+
+Configuration:
+  - MEMORY_DIR env var: path to memory directory (default: ~/.claude/memory)
+  - CLAUDE_DIR env var: path to .claude directory (default: ~/.claude)
+  - WARN_DISK_GB: disk free space warn threshold (default: 50)
+  - BLOCK_DISK_GB: disk free space critical threshold (default: 15)
+"""
+
+import os
+import sys
+import shutil
+import subprocess
+import json
+import argparse
+import platform
+from pathlib import Path
+from datetime import date, datetime, timezone
+
+HOME = Path.home()
+CLAUDE = Path(os.environ.get("CLAUDE_DIR", str(HOME / ".claude")))
+MEMORY = Path(os.environ.get("MEMORY_DIR", str(CLAUDE / "memory")))
+STALE_FLAG = MEMORY / ".self-model-stale"
+SELF_MODEL = MEMORY / "self-model.md"
+GROWTH_LOG_DIR = MEMORY / "growth-log"
+SCRIPTS_DIR = CLAUDE / "scripts"
+
+WARN_DISK_GB = int(os.environ.get("WARN_DISK_GB", "50"))
+BLOCK_DISK_GB = int(os.environ.get("BLOCK_DISK_GB", "15"))
+WARN_TMP_FILES = int(os.environ.get("WARN_TMP_FILES", "500"))
+WARN_GPU_TEMP_C = int(os.environ.get("WARN_GPU_TEMP_C", "80"))
+WARN_GPU_VRAM_PCT = int(os.environ.get("WARN_GPU_VRAM_PCT", "90"))
+STALE_GROWTH_DAYS = int(os.environ.get("STALE_GROWTH_DAYS", "3"))
+
+if platform.system() == "Windows" and hasattr(sys.stderr, "reconfigure"):
+    try:
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+
+def check_disk():
+    usage = shutil.disk_usage(HOME)
+    free_gb = usage.free // (1024 ** 3)
+    if free_gb < BLOCK_DISK_GB:
+        level = "REFUSE"
+    elif free_gb < WARN_DISK_GB:
+        level = "WARN"
+    else:
+        level = "OK"
+    print(f"DISK:{free_gb}GB:{level}", file=sys.stderr)
+    return {"name": "disk", "free_gb": free_gb, "level": level}
+
+
+def check_tmp():
+    p = platform.system()
+    if p == "Windows":
+        tmp = HOME / "AppData" / "Local" / "Temp"
+    else:
+        tmp = Path(os.environ.get("TMPDIR", "/tmp"))
+    try:
+        count = len(os.listdir(tmp))
+    except OSError:
+        return {"name": "tmp", "count": 0, "level": "OK"}
+    level = "WARN" if count > WARN_TMP_FILES else "OK"
+    if count > WARN_TMP_FILES:
+        print(f"TMP:{count}:WARN", file=sys.stderr)
+    return {"name": "tmp", "count": count, "level": level}
+
+
+def check_ram():
+    p = platform.system()
+    try:
+        if p == "Windows":
+            out = subprocess.run(
+                ["wmic", "OS", "get", "TotalVisibleMemorySize,FreePhysicalMemory", "/format:list"],
+                capture_output=True, text=True, timeout=10
+            )
+            total_kb = free_kb = None
+            for line in out.stdout.strip().split("\n"):
+                line = line.strip()
+                if "TotalVisibleMemorySize" in line:
+                    total_kb = int(line.split("=")[-1].strip())
+                elif "FreePhysicalMemory" in line:
+                    free_kb = int(line.split("=")[-1].strip())
+            if total_kb and free_kb:
+                pct = 100 - (free_kb * 100 // total_kb)
+                print(f"RAM:{pct}%:{free_kb // 1024}MB:{total_kb // 1024}MB", file=sys.stderr)
+                return {"name": "ram", "pct": pct, "free_mb": free_kb // 1024, "total_mb": total_kb // 1024}
+        elif p == "Linux":
+            mem = {}
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    if "MemTotal" in line or "MemAvailable" in line:
+                        parts = line.split(":")
+                        key = parts[0].strip()
+                        mem[key] = int(parts[1].strip().split()[0])
+            if "MemTotal" in mem and "MemAvailable" in mem:
+                used = mem["MemTotal"] - mem["MemAvailable"]
+                pct = used * 100 // mem["MemTotal"]
+                print(f"RAM:{pct}%:{mem['MemAvailable'] // 1024}MB:{mem['MemTotal'] // 1024}MB", file=sys.stderr)
+                return {"name": "ram", "pct": pct, "free_mb": mem["MemAvailable"] // 1024, "total_mb": mem["MemTotal"] // 1024}
+        elif p == "Darwin":
+            out = subprocess.run(["sysctl", "-n", "hw.memsize"], capture_output=True, text=True, timeout=5)
+            total_bytes = int(out.stdout.strip())
+            total_mb = total_bytes // (1024 * 1024)
+            out = subprocess.run(["vm_stat"], capture_output=True, text=True, timeout=5)
+            page_size = 4096
+            free_pages = 0
+            for line in out.stdout.strip().split("\n"):
+                if any(k in line for k in ("Pages free", "Pages speculative", "Pages inactive")):
+                    free_pages += int(line.strip().split(":")[-1].strip().rstrip("."))
+            free_mb = (free_pages * page_size) // (1024 * 1024)
+            pct = 100 - (free_mb * 100 // total_mb) if total_mb else 0
+            print(f"RAM:{pct}%:{free_mb}MB:{total_mb}MB", file=sys.stderr)
+            return {"name": "ram", "pct": pct, "free_mb": free_mb, "total_mb": total_mb}
+    except Exception:
+        pass
+    return None
+
+
+def check_gpu():
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=temperature.gpu,utilization.gpu,memory.used,memory.total",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10
+        )
+        parts = out.stdout.strip().split(",")
+        if len(parts) >= 4:
+            temp = int(parts[0].strip())
+            gpu_pct = int(parts[1].strip())
+            vram_used = int(parts[2].strip())
+            vram_total = int(parts[3].strip())
+            vram_pct = vram_used * 100 // vram_total
+            state = "WARN" if temp > WARN_GPU_TEMP_C or vram_pct > WARN_GPU_VRAM_PCT else "OK"
+            print(f"GPU:{temp}C:{gpu_pct}%:{vram_used}/{vram_total}MB:{state}", file=sys.stderr)
+            return {"name": "gpu", "temp_c": temp, "util_pct": gpu_pct,
+                    "vram_used_mb": vram_used, "vram_total_mb": vram_total, "level": state}
+    except Exception:
+        pass
+    return None
+
+
+def check_config():
+    files = ["quality-gate.py", "health-check.py", "log-regeneration.py"]
+    missing = []
+    for f in files:
+        if not (SCRIPTS_DIR / f).exists():
+            missing.append(f)
+    if missing:
+        print(f"CONFIG:MISSING:{','.join(missing)}", file=sys.stderr)
+    else:
+        print("CONFIG:ALL:OK", file=sys.stderr)
+    return {"name": "config", "missing": missing, "level": "WARN" if missing else "OK"}
+
+
+def check_growth():
+    import re
+    if not GROWTH_LOG_DIR.is_dir():
+        print("GROWTH:NO_DIR", file=sys.stderr)
+        return {"name": "growth-log", "status": "no_dir", "level": "WARN"}
+    today = date.today()
+    latest = None
+    date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}")
+    for f in GROWTH_LOG_DIR.iterdir():
+        if f.suffix == ".md":
+            m = date_pattern.match(f.name)
+            if not m:
+                continue
+            try:
+                d = date.fromisoformat(m.group())
+                if latest is None or d > latest:
+                    latest = d
+            except ValueError:
+                continue
+    if latest:
+        days = (today - latest).days
+        state = "WARN" if days > STALE_GROWTH_DAYS else "OK"
+        print(f"GROWTH:{latest}:{days}d:{state}", file=sys.stderr)
+        return {"name": "growth-log", "latest": str(latest), "days": days, "level": state}
+    else:
+        print("GROWTH:EMPTY:WARN", file=sys.stderr)
+        return {"name": "growth-log", "latest": None, "days": None, "level": "WARN"}
+
+
+def check_skills():
+    skills_dir = CLAUDE / "skills"
+    count = 0
+    if skills_dir.is_dir():
+        for name in skills_dir.iterdir():
+            if name.is_dir() and (name / "SKILL.md").exists():
+                count += 1
+    print(f"SKILLS:{count}:OK", file=sys.stderr)
+    return {"name": "skills", "count": count, "level": "OK"}
+
+
+def check_self_model_flag():
+    if not STALE_FLAG.exists():
+        return None
+    flag_mtime = datetime.fromtimestamp(STALE_FLAG.stat().st_mtime, tz=timezone.utc)
+    if not SELF_MODEL.exists():
+        print("SELF_MODEL:REGENERATE_NEEDED:model_missing", file=sys.stderr)
+        payload = json.dumps({"action": "regenerate", "reason": "self-model.md missing", "trigger": "flag"})
+        print(f"SELF_MODEL:JSON:{payload}", file=sys.stderr)
+        return {"signal": "REGENERATE_NEEDED", "reason": "model_missing", "action": "regenerate", "payload": json.loads(payload)}
+    try:
+        size = SELF_MODEL.stat().st_size
+        if size == 0:
+            print("SELF_MODEL:REGENERATE_NEEDED:empty_file", file=sys.stderr)
+            return {"signal": "REGENERATE_NEEDED", "reason": "empty_file", "action": "regenerate"}
+        if size < 50:
+            print(f"SELF_MODEL:WARN:truncated_file:{size}bytes", file=sys.stderr)
+    except OSError:
+        pass
+    model_mtime = datetime.fromtimestamp(SELF_MODEL.stat().st_mtime, tz=timezone.utc)
+    now = datetime.now(timezone.utc)
+    if model_mtime > now:
+        future_sec = (model_mtime - now).total_seconds()
+        print(f"SELF_MODEL:WARN:future_mtime:{future_sec:.0f}s_ahead", file=sys.stderr)
+    newer_logs = []
+    if GROWTH_LOG_DIR.is_dir():
+        for f in GROWTH_LOG_DIR.iterdir():
+            if f.suffix == ".md":
+                if datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc) >= model_mtime:
+                    newer_logs.append(f.stem)
+    if newer_logs:
+        newer_logs.sort()
+        print(f"SELF_MODEL:REGENERATE_NEEDED:growth_logs_newer({len(newer_logs)}):{','.join(newer_logs[:5])}",
+              file=sys.stderr)
+        payload = json.dumps({"action": "regenerate",
+                              "reason": f"growth-log entries newer than self-model: {', '.join(newer_logs)}",
+                              "trigger": "flag", "sources": newer_logs})
+        print(f"SELF_MODEL:JSON:{payload}", file=sys.stderr)
+        return {"signal": "REGENERATE_NEEDED", "reason": f"growth_logs_newer({len(newer_logs)})",
+                "action": "regenerate", "payload": json.loads(payload)}
+    else:
+        try:
+            STALE_FLAG.unlink()
+        except OSError:
+            pass
+        print(f"SELF_MODEL:CLEANED_ORPHAN:model_fresh:flag_was_{flag_mtime.strftime('%Y-%m-%dT%H:%M:%S')}",
+              file=sys.stderr)
+        return {"signal": "CLEANED_ORPHAN", "reason": "model_fresh", "action": "cleaned",
+                "flag_mtime": flag_mtime.isoformat()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SessionStart health check")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON to stdout")
+    args = parser.parse_args()
+
+    print("--- health ---", file=sys.stderr)
+    checks = {}
+    checks["disk"] = check_disk()
+    ram_result = check_ram()
+    if ram_result:
+        checks["ram"] = ram_result
+    gpu_result = check_gpu()
+    if gpu_result:
+        checks["gpu"] = gpu_result
+    checks["tmp"] = check_tmp()
+    checks["config"] = check_config()
+    checks["growth"] = check_growth()
+    checks["skills"] = check_skills()
+    flag_result = check_self_model_flag()
+    checks["self_model_flag"] = flag_result if flag_result else {"signal": "none", "action": "none"}
+    checks["exit_code"] = 0
+
+    if args.json:
+        print(json.dumps(checks, ensure_ascii=False, indent=2))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/productivity/self-model-regeneration/scripts/log-regeneration.py
+++ b/productivity/self-model-regeneration/scripts/log-regeneration.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Log a self-model regeneration event and clean up the .self-model-stale flag.
+
+Called by AI after regenerating self-model.md.
+This is the MECHANICAL step that replaces the prose-based "delete flag" instruction.
+
+Usage:
+  python log-regeneration.py --old v1 --new v2 --sources "2026-07-02,2026-07-01" --trigger flag
+
+The script (crash-consistent ordering):
+  1. Appends JSONL audit record FIRST (so a crash here leaves the flag intact)
+  2. Deletes the .self-model-stale flag SECOND (so recovery is always possible)
+  3. Verifies the log file exists after write
+
+If step 1 crashes: flag persists → health-check.py re-detects next session.
+If step 2 crashes: audit already exists → health-check.py cleans orphaned flag.
+
+Together with quality-gate.py (writes flag) and health-check.py (SessionStart detection),
+this forms the complete mechanical lifecycle of the strange-loop flag.
+
+Configuration:
+  - MEMORY_DIR env var: path to memory directory (default: ~/.claude/memory)
+"""
+
+import os
+import sys
+import json
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+MEMORY = Path(os.environ.get("MEMORY_DIR", Path.home() / ".claude" / "memory"))
+REGENERATION_LOG = MEMORY / ".self-model-regeneration.jsonl"
+STALE_FLAG = MEMORY / ".self-model-stale"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Log self-model regeneration event and clean up stale flag"
+    )
+    parser.add_argument("--old", required=True, help="Old self-model version (e.g. v1)")
+    parser.add_argument("--new", required=True, help="New self-model version (e.g. v2)")
+    parser.add_argument("--sources", required=True,
+                        help="Comma-separated source identifiers (growth-log entry dates)")
+    parser.add_argument("--trigger", default="flag",
+                        help="What triggered regeneration (default: flag)")
+    parser.add_argument("--json", action="store_true",
+                        help="Output results as JSON to stdout")
+    args = parser.parse_args()
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+
+    result = {
+        "success": True,
+        "timestamp": timestamp,
+        "trigger": args.trigger,
+        "sources": sources,
+        "old_version": args.old,
+        "new_version": args.new,
+        "flag_cleaned": False,
+        "log_appended": False,
+        "log_verified": False,
+    }
+
+    # 1. Append JSONL audit record FIRST (crash-safe: flag persists if this fails)
+    record = {
+        "timestamp": timestamp,
+        "trigger": args.trigger,
+        "sources": sources,
+        "old_version": args.old,
+        "new_version": args.new,
+        "flag_cleaned": STALE_FLAG.exists(),
+    }
+    try:
+        with open(REGENERATION_LOG, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        result["log_appended"] = True
+        if not args.json:
+            print(f"REGEN_LOG: appended (v{args.old} → v{args.new})")
+    except OSError as e:
+        result["success"] = False
+        result["error"] = str(e)
+        if not args.json:
+            print(f"REGEN_LOG:ERROR: {e}", file=sys.stderr)
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        sys.exit(1)
+
+    # 2. Verify the log write succeeded before we touch the flag
+    if REGENERATION_LOG.exists():
+        result["log_verified"] = True
+        if not args.json:
+            print(f"REGEN_LOG: verified ({REGENERATION_LOG.stat().st_size} bytes)")
+    else:
+        result["success"] = False
+        result["error"] = "log file not found after write"
+        if not args.json:
+            print("REGEN_LOG:WARN: log file not found after write", file=sys.stderr)
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        sys.exit(1)
+
+    # 3. Delete the .self-model-stale flag SECOND (audit record is already safe)
+    if STALE_FLAG.exists():
+        try:
+            STALE_FLAG.unlink()
+            result["flag_cleaned"] = True
+            if not args.json:
+                print("REGEN_FLAG: deleted .self-model-stale")
+        except OSError as e:
+            result["error"] = str(e)
+            if not args.json:
+                print(f"REGEN_FLAG:ERROR: {e}", file=sys.stderr)
+    else:
+        result["flag_cleaned"] = False
+        if not args.json:
+            print("REGEN_FLAG: not found (already cleaned or never existed)")
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/productivity/self-model-regeneration/scripts/quality-gate.py
+++ b/productivity/self-model-regeneration/scripts/quality-gate.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Stop hook — checks 5 databases + self-model staleness. Exits 2 (hard block) when stale.
+
+Part of the self-model regeneration loop:
+  - Compares self-model.md mtime against all growth-log entries
+  - Uses >= comparison for FAT32 2s resolution safety
+  - Writes .self-model-stale flag if growth data is newer than self-model
+  - Exit codes: 0=clean, 1=warnings (backfillable), 2=hard block (regeneration needed)
+
+Configuration:
+  - MEMORY_DIR env var: path to memory directory (default: ~/.claude/memory)
+  - STALE_DAYS_WARN: days before a database is considered stale (default: 3)
+  - STALE_DAYS_CRITICAL: days before stale is critical (default: 7)
+"""
+
+import os
+import sys
+import json
+import argparse
+import platform
+from pathlib import Path
+from datetime import datetime, timezone
+
+# ── Configuration ──────────────────────────────────────────────────────────
+
+HOME = Path.home()
+MEMORY_DIR = Path(os.environ.get("MEMORY_DIR", str(HOME / ".claude" / "memory")))
+STALE_FLAG = MEMORY_DIR / ".self-model-stale"
+STALE_DAYS_WARN = int(os.environ.get("STALE_DAYS_WARN", "3"))
+STALE_DAYS_CRITICAL = int(os.environ.get("STALE_DAYS_CRITICAL", "7"))
+
+# Fix Windows GBK encoding
+if platform.system() == "Windows" and hasattr(sys.stderr, "reconfigure"):
+    try:
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def days_since(dt):
+    """Return days since given datetime, or None if dt is None."""
+    if dt is None:
+        return None
+    return (datetime.now(timezone.utc) - dt).total_seconds() / 86400.0
+
+
+def _mtime_or_none(path):
+    """Return mtime as UTC datetime, or None if file doesn't exist."""
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+
+
+def _find_persona():
+    """Find persona-portrait file, falling back to underscore variant."""
+    candidates = sorted(MEMORY_DIR.glob("persona-portrait*.md"))
+    if not candidates:
+        candidates = sorted(MEMORY_DIR.glob("persona_portrait*.md"))
+    if candidates:
+        return candidates[-1]
+    return MEMORY_DIR / "persona_portrait.md"
+
+
+# ── Database Checks ────────────────────────────────────────────────────────
+
+def check_databases():
+    """Check freshness of all 5 databases. Returns list of (name, days, level)."""
+    dbs = {
+        "growth-log": MEMORY_DIR / "growth-log",
+        "decisions/log": MEMORY_DIR / "decisions" / "log.md",
+        "output-index": MEMORY_DIR / "output-index.md",
+        "ratings-tracker": MEMORY_DIR / "ratings-tracker.md",
+        "persona-portrait": _find_persona(),
+    }
+    results = []
+    for name, path in dbs.items():
+        if name == "growth-log":
+            # Directory: check newest file
+            latest = None
+            if path.is_dir():
+                import re
+                date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}")
+                for f in sorted(path.iterdir()):
+                    if f.suffix == ".md" and date_pattern.match(f.name):
+                        try:
+                            mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc)
+                            if latest is None or mtime > latest:
+                                latest = mtime
+                        except (OSError, ValueError):
+                            continue
+            age = days_since(latest)
+        else:
+            age = days_since(_mtime_or_none(path))
+
+        if age is None:
+            results.append((name, None, "missing"))
+        elif age > STALE_DAYS_CRITICAL:
+            results.append((name, round(age, 1), "critical"))
+        elif age > STALE_DAYS_WARN:
+            results.append((name, round(age, 1), "warning"))
+        else:
+            results.append((name, round(age, 1), "ok"))
+    return results
+
+
+def check_self_model():
+    """Compare self-model.md mtime against all growth-log entries.
+
+    Returns (stale: bool, reason: str, newer_logs: list).
+    Uses >= comparison for FAT32 2s resolution safety.
+    """
+    model = MEMORY_DIR / "self-model.md"
+    growth_dir = MEMORY_DIR / "growth-log"
+
+    if not model.exists():
+        return True, "self-model.md missing", []
+
+    model_mtime = _mtime_or_none(model)
+    if model_mtime is None:
+        return True, "cannot read self-model.md mtime", []
+
+    # Check for future mtimes (clock skew)
+    now = datetime.now(timezone.utc)
+    if model_mtime > now:
+        future_sec = (model_mtime - now).total_seconds()
+        print(f"⚠ self-model.md mtime is {future_sec:.0f}s in the future (clock skew?)",
+              file=sys.stderr)
+
+    # Find growth-log entries newer than or equal to self-model
+    newer_logs = []
+    if growth_dir.is_dir():
+        import re
+        date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}")
+        for f in sorted(growth_dir.iterdir()):
+            if f.suffix == ".md" and date_pattern.match(f.name):
+                try:
+                    f_mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc)
+                    if f_mtime >= model_mtime:
+                        newer_logs.append(f.stem)
+                except (OSError, ValueError):
+                    continue
+
+    if newer_logs:
+        return True, f"growth-log entries newer than self-model: {', '.join(newer_logs)}", newer_logs
+    return False, "self-model is current", []
+
+
+# ── Flag Operations ────────────────────────────────────────────────────────
+
+def write_stale_flag(reason, sources):
+    """Write .self-model-stale flag with timestamp and reason."""
+    STALE_FLAG.parent.mkdir(parents=True, exist_ok=True)
+    content = (
+        f"# Self-Model Stale Flag\n"
+        f"# Generated: {datetime.now(timezone.utc).isoformat()}\n"
+        f"# Reason: {reason}\n"
+        f"# Sources: {', '.join(sources) if sources else 'none'}\n"
+        f"# Action: AI should regenerate self-model.md at next SessionStart\n"
+    )
+    try:
+        STALE_FLAG.write_text(content, encoding="utf-8")
+        print(f"🔴 Wrote .self-model-stale flag: {reason}", file=sys.stderr)
+        return True
+    except OSError as e:
+        print(f"❌ Failed to write stale flag: {e}", file=sys.stderr)
+        return False
+
+
+def cleanup_orphaned_flag():
+    """Remove stale flag if self-model is actually fresh."""
+    if STALE_FLAG.exists():
+        try:
+            STALE_FLAG.unlink()
+            print("🧹 Cleaned orphaned .self-model-stale flag (model was fresh)", file=sys.stderr)
+        except OSError:
+            pass
+
+
+# ── Main ───────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Quality gate — check database freshness and self-model staleness"
+    )
+    parser.add_argument("--json", action="store_true",
+                        help="Output results as JSON to stdout")
+    args = parser.parse_args()
+
+    # Check databases
+    db_results = check_databases()
+    stale, reason, sources = check_self_model()
+
+    # Determine exit code
+    has_critical = any(r[2] == "critical" for r in db_results)
+    has_warning = any(r[2] in ("warning", "missing") for r in db_results)
+
+    exit_code = 0
+    if stale:
+        exit_code = 2
+    elif has_critical or has_warning:
+        exit_code = 1
+
+    # Collect structured result
+    result = {
+        "exit_code": exit_code,
+        "exit_label": {0: "clean", 1: "warnings", 2: "hard_block"}[exit_code],
+        "self_model": {
+            "stale": stale,
+            "reason": reason,
+            "sources": sources,
+        },
+        "databases": [
+            {"name": name, "days": age, "status": level}
+            for name, age, level in db_results
+        ],
+    }
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        # Human-readable output to stderr
+        print("=== quality-gate ===", file=sys.stderr)
+        for name, age, level in db_results:
+            icon = {"ok": "✅", "warning": "⚠️", "critical": "🔴", "missing": "❌"}[level]
+            if age is not None:
+                print(f"  {icon} {name}: {age}d ({level})", file=sys.stderr)
+            else:
+                print(f"  {icon} {name}: missing", file=sys.stderr)
+
+        if stale:
+            print(f"  🔴 Self-model: STALE — {reason}", file=sys.stderr)
+        else:
+            print(f"  ✅ Self-model: current", file=sys.stderr)
+
+        labels = {0: "clean", 1: "warnings", 2: "hard block"}
+        print(f"Exit {exit_code} ({labels[exit_code]})", file=sys.stderr)
+
+    # Act on results
+    if stale:
+        write_stale_flag(reason, sources)
+    else:
+        cleanup_orphaned_flag()
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/productivity/self-model-regeneration/scripts/tests/test_staleness.py
+++ b/productivity/self-model-regeneration/scripts/tests/test_staleness.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Smoke tests for self-model regeneration staleness detection logic.
+
+These tests validate the core staleness detection, flag lifecycle, and edge cases
+without requiring a full memory directory structure. Each test creates temporary
+files and cleans up after itself.
+
+Usage:
+    python -m pytest scripts/tests/test_staleness.py -v
+    python scripts/tests/test_staleness.py           # runs with built-in unittest
+"""
+
+import os
+import sys
+import json
+import tempfile
+import unittest
+import subprocess
+import importlib
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+
+# Add scripts dir to path for imports
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+# quality-gate.py has a hyphen — import via importlib
+_quality_gate = importlib.import_module("quality-gate")
+days_since = _quality_gate.days_since
+_find_persona = _quality_gate._find_persona
+MEMORY_DIR = _quality_gate.MEMORY_DIR
+
+
+class TestDaysSince(unittest.TestCase):
+    """quality-gate.py: days_since() return type and edge cases."""
+
+    def test_none_input_returns_none(self):
+        """days_since(None) must return None, not float('inf')."""
+        result = days_since(None)
+        self.assertIsNone(result, "days_since(None) should return None, not inf")
+
+    def test_recent_date_returns_small_number(self):
+        """days_since on a recent datetime returns a small float."""
+        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        result = days_since(recent)
+        self.assertIsNotNone(result)
+        self.assertLess(result, 1.0, "1 hour ago should be < 1 day")
+
+    def test_old_date_returns_large_number(self):
+        """days_since on an old datetime returns a large float."""
+        old = datetime.now(timezone.utc) - timedelta(days=30)
+        result = days_since(old)
+        self.assertIsNotNone(result)
+        self.assertGreater(result, 29.0, "30 days ago should be > 29 days")
+
+
+class TestFindPersona(unittest.TestCase):
+    """quality-gate.py: _find_persona() glob and fallback."""
+
+    def test_fallback_path_uses_underscore(self):
+        """Fallback path must be persona_portrait.md (underscore), not persona-portrait.md (hyphen)."""
+        # _find_persona returns a Path; verify the fallback name
+        result = _find_persona()
+        # When no files exist in a real MEMORY_DIR, falls back to persona_portrait.md
+        self.assertEqual(result.name, "persona_portrait.md",
+                         "Fallback must use underscore, not hyphen")
+        self.assertIn("persona_portrait", str(result))
+
+    def test_returns_path_object(self):
+        """_find_persona must return a Path object."""
+        result = _find_persona()
+        self.assertIsInstance(result, Path)
+
+
+class TestFlagLifecycle(unittest.TestCase):
+    """Flag write → read → delete round-trip."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.flag_path = Path(self.tmpdir.name) / ".self-model-stale"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_write_and_read_flag(self):
+        """Flag written by quality-gate style write should be readable."""
+        reason = "test: self-model is stale"
+        content = (
+            f"# Self-Model Stale Flag\n"
+            f"# Generated: {datetime.now(timezone.utc).isoformat()}\n"
+            f"# Reason: {reason}\n"
+            f"# Action: AI should regenerate self-model.md\n"
+        )
+        self.flag_path.write_text(content, encoding="utf-8")
+        self.assertTrue(self.flag_path.exists(), "Flag should exist after write")
+        read_back = self.flag_path.read_text(encoding="utf-8")
+        self.assertIn(reason, read_back, "Flag content should contain reason")
+
+    def test_delete_flag(self):
+        """Flag deletion should remove the file."""
+        self.flag_path.write_text("test", encoding="utf-8")
+        self.assertTrue(self.flag_path.exists())
+        self.flag_path.unlink()
+        self.assertFalse(self.flag_path.exists(), "Flag should not exist after unlink")
+
+    def test_delete_nonexistent_flag_raises(self):
+        """Deleting a nonexistent flag should raise FileNotFoundError."""
+        with self.assertRaises(FileNotFoundError):
+            self.flag_path.unlink()
+
+    def test_empty_flag_detected(self):
+        """health-check should detect empty flag file as REGENERATE_NEEDED."""
+        self.flag_path.write_text("", encoding="utf-8")
+        self.assertEqual(self.flag_path.stat().st_size, 0,
+                         "Empty flag should have size 0")
+
+
+class TestGrowthLogFilenameRegex(unittest.TestCase):
+    """health-check.py: check_growth() filename pattern validation."""
+
+    def test_valid_date_names(self):
+        """Files like '2026-07-02.md' should match."""
+        import re
+        pattern = re.compile(r'^\d{4}-\d{2}-\d{2}')
+        valid = [
+            "2026-07-02.md",
+            "2024-01-01.md",
+            "2026-12-31.md",
+        ]
+        for name in valid:
+            m = pattern.match(name)
+            self.assertIsNotNone(m, f"'{name}' should match date pattern")
+            # Verify it's a parseable date
+            datetime.fromisoformat(m.group())
+
+    def test_invalid_names_rejected(self):
+        """Files like 'README.md' or '2026-07-02-style.md' should not match as dates."""
+        import re
+        pattern = re.compile(r'^\d{4}-\d{2}-\d{2}')
+        invalid_prefix = [
+            "README.md",
+            "index.md",
+            "growth-log.md",
+            "style-2026-07-02.md",
+        ]
+        for name in invalid_prefix:
+            m = pattern.match(name)
+            self.assertIsNone(m, f"'{name}' should NOT match date pattern (doesn't start with date)")
+
+    def test_suffix_variants_still_match(self):
+        """Files with date prefix plus suffix should match the date part."""
+        import re
+        pattern = re.compile(r'^\d{4}-\d{2}-\d{2}')
+        # These start with valid dates but have suffixes — the regex matches
+        # the date prefix, but check_growth should still validate via fromisoformat
+        with_suffix = [
+            "2026-07-02-style.md",
+            "2026-07-02-review.md",
+            "2026-07-02.md",
+        ]
+        for name in with_suffix:
+            m = pattern.match(name)
+            self.assertIsNotNone(m, f"'{name}' should match date prefix pattern")
+
+
+class TestMtimeStalenessLogic(unittest.TestCase):
+    """Staleness detection edge cases: FAT32 resolution, equality, clock skew."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_equal_mtime_is_stale(self):
+        """FAT32 2s resolution: when mtimes are equal, self-model IS stale (>=)."""
+        # Create two files
+        a = self.base / "growth-log" / "2026-07-02.md"
+        b = self.base / "self-model.md"
+        a.parent.mkdir(exist_ok=True)
+        a.write_text("growth entry")
+        b.write_text("self model")
+
+        # On most filesystems these get different (sub-second) mtimes
+        # but we test the comparison logic directly
+        a_mtime = datetime.fromtimestamp(a.stat().st_mtime, tz=timezone.utc)
+        b_mtime = datetime.fromtimestamp(b.stat().st_mtime, tz=timezone.utc)
+
+        # The >= check ensures: if a_mtime >= b_mtime → stale
+        is_stale = a_mtime >= b_mtime
+        # Both files just created; should be close
+        self.assertIsInstance(is_stale, bool)
+
+    def test_newer_growth_log_is_stale(self):
+        """Growth log newer than self-model → definitely stale."""
+        model = self.base / "self-model.md"
+        growth = self.base / "growth-log" / "2026-07-02.md"
+        growth.parent.mkdir(exist_ok=True)
+
+        model.write_text("old model")
+        # Small delay to ensure different mtimes
+        import time
+        time.sleep(0.01)
+        growth.write_text("new growth entry")
+
+        model_mtime = datetime.fromtimestamp(model.stat().st_mtime, tz=timezone.utc)
+        growth_mtime = datetime.fromtimestamp(growth.stat().st_mtime, tz=timezone.utc)
+
+        self.assertGreater(growth_mtime, model_mtime,
+                           "Growth log should be newer than self-model")
+        is_stale = growth_mtime >= model_mtime
+        self.assertTrue(is_stale, "Newer growth log → self-model is stale")
+
+    def test_older_growth_log_is_not_stale(self):
+        """Growth log older than self-model → NOT stale."""
+        model = self.base / "self-model.md"
+        growth = self.base / "growth-log" / "2026-07-01.md"
+        growth.parent.mkdir(exist_ok=True)
+
+        growth.write_text("old growth entry")
+        import time
+        time.sleep(0.01)
+        model.write_text("new self model")
+
+        model_mtime = datetime.fromtimestamp(model.stat().st_mtime, tz=timezone.utc)
+        growth_mtime = datetime.fromtimestamp(growth.stat().st_mtime, tz=timezone.utc)
+
+        self.assertGreater(model_mtime, growth_mtime,
+                           "Self-model should be newer than growth log")
+        is_stale = growth_mtime >= model_mtime
+        self.assertFalse(is_stale, "Older growth log → self-model is NOT stale")
+
+
+class TestLogRegenerationOrdering(unittest.TestCase):
+    """log-regeneration.py: crash-consistent write ordering verification."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmpdir.name)
+        self.log_path = self.base / ".self-model-regeneration.jsonl"
+        self.flag_path = self.base / ".self-model-stale"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_jsonl_write_produces_valid_json(self):
+        """JSONL record should be valid JSON with required fields."""
+        record = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "trigger": "flag",
+            "sources": ["2026-07-02", "2026-07-01"],
+            "old_version": "v2",
+            "new_version": "v3",
+            "flag_cleaned": True,
+        }
+        self.log_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+        # Read back and parse
+        content = self.log_path.read_text(encoding="utf-8")
+        lines = [l for l in content.strip().split("\n") if l.strip()]
+        self.assertEqual(len(lines), 1, "Should have exactly one JSONL line")
+
+        parsed = json.loads(lines[0])
+        self.assertEqual(parsed["old_version"], "v2")
+        self.assertEqual(parsed["new_version"], "v3")
+        self.assertEqual(parsed["trigger"], "flag")
+        self.assertEqual(len(parsed["sources"]), 2)
+        self.assertIn("timestamp", parsed)
+
+    def test_jsonl_before_flag_delete_pattern(self):
+        """Verify the crash-safe pattern: write JSONL first, then delete flag."""
+        record = {"test": True}
+        # Step 1: Write log FIRST
+        self.log_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        self.assertTrue(self.log_path.exists(), "JSONL must exist before flag delete")
+
+        # Step 2: Delete flag SECOND (simulated — flag may or may not exist)
+        self.flag_path.write_text("stale", encoding="utf-8")
+        self.assertTrue(self.flag_path.exists())
+
+        # Verify log exists before deleting flag
+        self.assertTrue(self.log_path.exists())
+        self.flag_path.unlink()
+        self.assertFalse(self.flag_path.exists())
+
+        # Verify log still exists after flag delete
+        self.assertTrue(self.log_path.exists(),
+                        "JSONL must survive flag deletion")
+
+    def test_crash_before_flag_delete_recovers(self):
+        """If crash occurs after JSONL write but before flag delete, data is safe."""
+        # Simulate: JSONL written, flag still exists (crash scenario)
+        record = {"recovery_test": True}
+        self.log_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        self.flag_path.write_text("stale", encoding="utf-8")
+
+        # Recovery: flag exists → health-check.py re-detects it
+        self.assertTrue(self.flag_path.exists(),
+                        "Flag should persist if delete didn't happen")
+        # Audit trail is intact
+        self.assertTrue(self.log_path.exists(),
+                        "Audit log should survive crash")
+        log_content = self.log_path.read_text(encoding="utf-8")
+        self.assertIn("recovery_test", log_content)
+
+    def test_crash_before_jsonl_write_flag_persists(self):
+        """If crash before JSONL write, flag persists so regeneration retries."""
+        # Neither JSONL nor flag delete happened
+        self.flag_path.write_text("stale", encoding="utf-8")
+        self.assertFalse(self.log_path.exists(),
+                         "JSONL shouldn't exist if write never happened")
+        self.assertTrue(self.flag_path.exists(),
+                        "Flag should persist so health-check re-detects")
+
+
+class TestExitCodes(unittest.TestCase):
+    """quality-gate.py exit code semantics."""
+
+    def _run(self, *args, **kwargs):
+        """Run a subprocess with UTF-8 encoding on Windows."""
+        env = kwargs.pop("env", None) or os.environ
+        return subprocess.run(
+            [sys.executable, *args],
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            env=env,
+            **kwargs
+        )
+
+    def get_script(self):
+        return str(SCRIPTS_DIR / "quality-gate.py")
+
+    def test_help_exits_zero(self):
+        """--help should exit 0."""
+        result = self._run(self.get_script(), "--help")
+        self.assertIsInstance(result.returncode, int)
+
+    def test_empty_memory_dir_exits_two(self):
+        """No self-model.md + no growth-log → exit 2 (model missing = stale)."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            (tmp / "growth-log").mkdir()
+            (tmp / "decisions").mkdir()
+            env = {**os.environ, "MEMORY_DIR": str(tmp)}
+            result = self._run(self.get_script(), env=env)
+            self.assertIn(result.returncode, [0, 1, 2],
+                          "Exit code should be 0, 1, or 2")
+            # With no self-model.md, should be exit 2
+            self.assertEqual(result.returncode, 2,
+                             f"Missing self-model should trigger exit 2, got {result.returncode}\nstderr: {result.stderr[-300:]}")
+
+
+class TestHealthCheckSignals(unittest.TestCase):
+    """health-check.py: REGENERATE_NEEDED and CLEANED_ORPHAN signal integrity."""
+
+    def _run(self, *args, **kwargs):
+        """Run a subprocess with UTF-8 encoding on Windows."""
+        env = kwargs.pop("env", None) or os.environ
+        return subprocess.run(
+            [sys.executable, *args],
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            env=env,
+            **kwargs
+        )
+
+    def get_script(self):
+        return str(SCRIPTS_DIR / "health-check.py")
+
+    def test_always_exits_zero(self):
+        """health-check.py must always exit 0, even with stale flag."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            (tmp / "growth-log").mkdir()
+            (tmp / "decisions").mkdir()
+            # Create a stale flag
+            flag = tmp / ".self-model-stale"
+            flag.write_text("test flag")
+            env = {**os.environ, "MEMORY_DIR": str(tmp)}
+            result = self._run(self.get_script(), env=env)
+            self.assertEqual(result.returncode, 0,
+                             f"health-check.py must ALWAYS exit 0 (never blocks)\nstderr: {result.stderr[-500:]}")
+
+    def test_regenerate_needed_when_model_missing(self):
+        """REGENERATE_NEEDED signal when self-model.md is missing."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            (tmp / "growth-log").mkdir()
+            (tmp / "decisions").mkdir()
+            flag = tmp / ".self-model-stale"
+            flag.write_text("test flag")
+            env = {**os.environ, "MEMORY_DIR": str(tmp)}
+            result = self._run(self.get_script(), env=env)
+            stderr = result.stderr
+            self.assertIn("REGENERATE_NEEDED", stderr,
+                          f"Should signal REGENERATE_NEEDED when model missing\nstderr: {stderr[-300:]}")
+
+    def test_cleaned_orphan_when_flag_stale_but_model_fresh(self):
+        """CLEANED_ORPHAN when flag exists but model is actually fresh."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            (tmp / "growth-log").mkdir()
+            (tmp / "decisions").mkdir()
+            # Create fresh self-model (newer than flag)
+            model = tmp / "self-model.md"
+            model.write_text("# Self Model\n\nTest content for smoke testing.")
+            # Create an older flag (simulates orphaned flag from prior session)
+            flag = tmp / ".self-model-stale"
+            flag.write_text("old flag")
+            env = {**os.environ, "MEMORY_DIR": str(tmp)}
+            result = self._run(self.get_script(), env=env)
+            stderr = result.stderr
+            # Should either clean orphan or signal regenerate
+            self.assertTrue(
+                "CLEANED_ORPHAN" in stderr or "REGENERATE_NEEDED" in stderr,
+                f"Should produce a valid signal, got: {stderr[-300:]}"
+            )
+
+
+class TestLogRegenerationScript(unittest.TestCase):
+    """log-regeneration.py: command-line interface and crash-safety."""
+
+    def _run(self, *args, **kwargs):
+        """Run a subprocess with UTF-8 encoding on Windows."""
+        env = kwargs.pop("env", None) or os.environ
+        return subprocess.run(
+            [sys.executable, *args],
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            env=env,
+            **kwargs
+        )
+
+    def get_script(self):
+        return str(SCRIPTS_DIR / "log-regeneration.py")
+
+    def test_help_exits_zero(self):
+        """--help should print usage and exit 0."""
+        result = self._run(self.get_script(), "--help")
+        # argparse always exits 0 for --help
+        self.assertEqual(result.returncode, 0)
+
+    def test_missing_required_args_fails(self):
+        """Missing --old, --new, --sources should exit non-zero."""
+        result = self._run(self.get_script())
+        self.assertNotEqual(result.returncode, 0,
+                            f"Missing required args should fail, got {result.returncode}")
+
+    def test_successful_log_write(self):
+        """Full invocation writes JSONL and cleans flag."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            # Create a flag to clean
+            flag = tmp / ".self-model-stale"
+            flag.write_text("test flag")
+            env = {**os.environ, "MEMORY_DIR": str(tmp)}
+            result = self._run(
+                self.get_script(),
+                "--old", "v1", "--new", "v2",
+                "--sources", "2026-07-02,2026-07-01",
+                "--trigger", "flag",
+                env=env
+            )
+            self.assertEqual(result.returncode, 0,
+                             f"Should succeed, got stderr: {result.stderr}")
+
+            # Verify JSONL was written
+            log = tmp / ".self-model-regeneration.jsonl"
+            self.assertTrue(log.exists(), "JSONL audit log should be created")
+
+            # Verify JSONL content
+            content = log.read_text(encoding="utf-8").strip()
+            self.assertTrue(content, "JSONL should not be empty")
+            record = json.loads(content)
+            self.assertEqual(record["old_version"], "v1")
+            self.assertEqual(record["new_version"], "v2")
+            self.assertEqual(record["trigger"], "flag")
+            self.assertTrue(record["flag_cleaned"])
+
+            # Verify flag was deleted
+            self.assertFalse(flag.exists(), "Flag should be deleted after successful log")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What This Skill Does

**Self-Model Regeneration** gives AI coding agents persistent identity across sessions — a 5-step mechanical feedback loop where 4 steps are fully mechanized Python scripts and only 1 step (content synthesis) requires AI judgment.

### The Loop

```
Session N (end)                  Session N+1 (start)
─────────────────                ────────────────────
① quality-gate.py (Stop)         ② health-check.py (Start)
   detects stale self-model          reads .self-model-stale flag
   writes flag → exit 2              emits REGENERATE_NEEDED signal
                                     (never blocks — always exit 0)
                                          │
③ AI Regeneration ◄──────────────────────┘
   reads growth-logs → synthesizes new self-model.md
   3-version rotation for rollback
                                          │
④ log-regeneration.py ◄──────────────────┘
   writes JSONL audit record FIRST (fsync)
   deletes flag SECOND
   crash-consistent ordering
                                          │
⑤ self-model.md (updated) ◄──────────────┘
   feeds into SessionStart sequence
```

**Core insight:** "Machines do the checking; humans (and AI) do the judging." Flag write, detection, deletion, and audit logging are all deterministic scripts. Only creative synthesis requires AI.

### Key Design Decisions

- **Regeneration at SessionStart, not Stop** — AI attention is freshest at startup
- **`>=` comparison for staleness** — FAT32/exFAT-safe: 2-second mtime resolution won't produce false negatives
- **Crash-consistent ordering** — JSONL write + fsync BEFORE flag delete; no state combination loses data
- **Boundary by reversibility** — stale databases → warn (can backfill); stale self-model → block (damage already done)
- **3-version rotation** — `self-model.md` → v1 → v2 → v3, provides rollback if regeneration degrades quality

## Complementarity: What This Adds to the Repo

### vs. Handoff (productivity/handoff)

| Dimension | Handoff | Self-Model Regeneration |
|-----------|---------|------------------------|
| **What it transfers** | Task context, decisions, artifacts | Agent identity, capabilities, warnings |
| **Content type** | WHAT was done | WHO is doing it |
| **Trigger** | User says "hand this off" | Mechanical (quality-gate detects staleness) |
| **Direction** | Session → Session (explicit) | Growth data → Self-model (implicit) |

They compose, never conflict. Handoff is the explicit task handover; self-model regeneration is the implicit identity accumulation.

## Files Changed

| File | Purpose |
|------|---------|
| `productivity/self-model-regeneration/SKILL.md` | Main skill doc (~312 lines, no frontmatter beyond name+description) |
| `productivity/self-model-regeneration/scripts/quality-gate.py` | Stop hook — staleness detection (5 DBs + self-model, exits 0/1/2) |
| `productivity/self-model-regeneration/scripts/health-check.py` | SessionStart hook — flag detection + system health (always exits 0) |
| `productivity/self-model-regeneration/scripts/log-regeneration.py` | Post-regeneration cleanup + JSONL audit (crash-consistent) |
| `productivity/self-model-regeneration/scripts/tests/test_staleness.py` | 27 smoke tests across 9 test classes (stdlib only) |
| `productivity/self-model-regeneration/.claude-plugin/plugin.json` | Plugin manifest v2.1.2 |
| `productivity/self-model-regeneration/references/how-it-works.md` | Architecture reference + integration guide |

## Testing

All 27 smoke tests pass (stdlib only: `unittest`, `tempfile`, `subprocess`, `importlib`):

```
Ran 27 tests in 1.107s — OK
```

## Repo Conventions

- ✅ PR targets `dev` branch
- ✅ SKILL.md frontmatter: ONLY `name` + `description`
- ✅ SKILL.md under 500 lines (~312 lines)
- ✅ Scripts are stdlib-only with `--help` and `--json` flags
- ✅ `plugin.json` v2.1.2 with author as object
- ✅ Flat directory structure: `productivity/self-model-regeneration/`