### PR TITLE
docs: fixed incorrect skills and script path in docs

### DIFF
--- a/.claude/commands/seo-auditor.md
+++ b/.claude/commands/seo-auditor.md
@@ -37,7 +37,7 @@ For each file with YAML frontmatter:
 
 Run SEO checker on built HTML pages:
 ```bash
-python3 marketing-skill/seo-audit/scripts/seo_checker.py --file site/{path}/index.html
+python3 marketing-skill/skills/seo-audit/scripts/seo_checker.py --file site/{path}/index.html
 ```
 
 ## Phase 3: Content Quality
@@ -46,13 +46,13 @@ python3 marketing-skill/seo-audit/scripts/seo_checker.py --file site/{path}/inde
 
 **Readability:** Run content scorer:
 ```bash
-python3 marketing-skill/content-production/scripts/content_scorer.py {file}
+python3 marketing-skill/skills/content-production/scripts/content_scorer.py {file}
 ```
 Target: readability ≥ 70, structure ≥ 60.
 
 **AI detection** (on non-generated files only):
 ```bash
-python3 marketing-skill/content-humanizer/scripts/humanizer_scorer.py {file}
+python3 marketing-skill/skills/content-humanizer/scripts/humanizer_scorer.py {file}
 ```
 Flag pages < 50. Fix AI clichés: "delve", "leverage", "it's important to note", "comprehensive".
 
@@ -87,7 +87,7 @@ mkdocs build
 
 Analyze the sitemap:
 ```bash
-python3 marketing-skill/site-architecture/scripts/sitemap_analyzer.py site/sitemap.xml
+python3 marketing-skill/skills/site-architecture/scripts/sitemap_analyzer.py site/sitemap.xml
 ```
 
 Verify all pages appear, no duplicates, no broken URLs.

--- a/docs/skills/product-team/product-team.md
+++ b/docs/skills/product-team/product-team.md
@@ -22,7 +22,7 @@ description: "10 product agent skills and plugins for Claude Code, Codex, Gemini
 
 ### Claude Code
 ```
-/read product-team/product-manager-toolkit/SKILL.md
+/read product-team/skills/product-manager-toolkit/SKILL.md
 ```
 
 ### Codex CLI


### PR DESCRIPTION
## Summary

Fixes incorrect skill paths in SEO auditor command and product team documentation after restructuring into skills/ subdirectory.

## Changes

### 1. `.claude/commands/seo-auditor.md`

Updated Python script paths in the SEO auditor command workflow to match the new directory structure:

- `marketing-skill/seo-audit/scripts/` → `marketing-skill/skills/seo-audit/scripts/`
- `marketing-skill/content-production/scripts/` → `marketing-skill/skills/content-production/scripts/`
- `marketing-skill/content-humanizer/scripts/` → `marketing-skill/skills/content-humanizer/scripts/`
- `marketing-skill/site-architecture/scripts/` → `marketing-skill/skills/site-architecture/scripts/`

**Impact:** Ensures SEO auditor command paths correctly reference skills under the `skills/` subdirectory.

### 2. `docs/skills/product-team/product-team.md`

Updated documentation path for the product-manager-toolkit skill:

- `product-team/product-manager-toolkit/SKILL.md` → `product-team/skills/product-manager-toolkit/SKILL.md`

**Impact:** Fixes documentation link to reflect the correct location of the product-manager-toolkit skill.

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [x] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [x] Scripts (if any) run with `--help` without errors
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [x] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation
- [ ] Infrastructure / CI

## Testing

- All referenced paths now correctly point to existing skill directories
- Command execution examples will work as documented
- Documentation links are accurate and accessible