### PR TITLE
chore(engineering): agent-harness review cleanups + README badge CI gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The most comprehensive open-source library of Claude Code skills and agent plugi
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Skills](https://img.shields.io/badge/Skills-355-brightgreen?style=for-the-badge)](#skills-overview)
-[![Agents](https://img.shields.io/badge/Agents-96-blue?style=for-the-badge)](#agents)
+[![Agents](https://img.shields.io/badge/Agents-97-blue?style=for-the-badge)](#agents)
 [![Personas](https://img.shields.io/badge/Personas-7-purple?style=for-the-badge)](#personas)
-[![Commands](https://img.shields.io/badge/Commands-102-orange?style=for-the-badge)](#commands)
+[![Commands](https://img.shields.io/badge/Commands-103-orange?style=for-the-badge)](#commands)
 [![Stars](https://img.shields.io/github/stars/alirezarezvani/claude-skills?style=for-the-badge)](https://github.com/alirezarezvani/claude-skills/stargazers)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1?style=for-the-badge)](https://getskillcheck.com)
 

--- a/engineering/agent-harness/skills/agent-harness/SKILL.md
+++ b/engineering/agent-harness/skills/agent-harness/SKILL.md
@@ -76,6 +76,10 @@ python3 scripts/harness_manifest_builder.py --domain engineering-team \
    its own session against the durable state.
 7. **State lives in `.agent-harness/`** — never in `.agenthub/`, `.autoresearch/`, or
    `docs/TC/` (those belong to sibling skills).
+8. **Plan and state files are a trust boundary.** `verify` shell-executes each task's
+   check command; only run the harness on plan/state files you or `goal_compiler.py`
+   produced, never on files from untrusted input (see
+   [references/verification_discipline.md](references/verification_discipline.md)).
 
 ## Forcing questions (ask before compiling; one per turn, with a recommended answer)
 

--- a/engineering/agent-harness/skills/agent-harness/references/verification_discipline.md
+++ b/engineering/agent-harness/skills/agent-harness/references/verification_discipline.md
@@ -70,3 +70,16 @@ never evidence. The controller's design decisions trace to these sources.
   into a success, only a human can waive it — and `close --waive` demands a reason that is
   written permanently into the handoff.
 - `close` with any unverified, unwaived task is exit 4. There is no force flag.
+
+## Trust boundary: plan and state files
+
+`loop_controller.py verify` shell-executes each task's `verification[].cmd` string via
+`subprocess.run(..., shell=True)`. In the documented flow those commands are template-
+generated from repo-scanned script paths (`harness_manifest_builder.py` → `goal_compiler.py`),
+so they are not attacker-reachable. But the controller does **not** re-validate a `--state`
+or `--plan` file's contents before shelling out — a hand-crafted or tampered plan/state file
+is therefore effectively arbitrary local command execution, the same trust model as a
+Makefile or a CI config. **Treat `plan.json` and `state.json` as a trust boundary: only
+run the harness on plan/state files you (or the `goal_compiler`) produced, never on files
+sourced from untrusted input.** This matters because the harness is designed to be driven by
+an agent (`harness-runner`) that could in principle be handed a malicious plan.

--- a/engineering/agent-harness/skills/agent-harness/scripts/loop_controller.py
+++ b/engineering/agent-harness/skills/agent-harness/scripts/loop_controller.py
@@ -32,7 +32,6 @@ import argparse
 import datetime
 import json
 import os
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -185,7 +184,7 @@ def cmd_record(args):
     save(state, args.state)
     d, dcode = directive(state)
     result["directive"] = d
-    return emit(result, max(code, dcode if dcode != 0 else 0) if code == 0 else code)
+    return emit(result, code if code != 0 else dcode)
 
 
 def _fail(task):

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -222,6 +222,34 @@ def check_domain_table(root: Path) -> list:
     return problems
 
 
+# README shields.io badges of the form ![Skills](.../Skills-355-brightgreen...).
+# Validated separately from prose CLAIM_PATTERNS: badges are a fixed
+# `<Label>-<count>-<color>` shape, so a per-label regex is exact and cannot
+# over-match surrounding prose. Covers the counters that ship as badges.
+BADGE_PATTERNS = {
+    "skills": re.compile(r"Skills-(\d+)-"),
+    "agents": re.compile(r"Agents-(\d+)-"),
+    "commands": re.compile(r"Commands-(\d+)-"),
+}
+
+
+def check_readme_badges(root: Path, derived: dict) -> list:
+    """Return mismatch strings between README shield badges and derived counts."""
+    readme = root / "README.md"
+    if not readme.is_file():
+        return []
+    text = readme.read_text(encoding="utf-8")
+    out = []
+    for key, pattern in BADGE_PATTERNS.items():
+        match = pattern.search(text)
+        if match and int(match.group(1)) != derived[key]:
+            out.append(
+                f"README badge: '{key}' badge claims {match.group(1)}, "
+                f"derived {key}={derived[key]}"
+            )
+    return out
+
+
 def run_check(root: Path, derived: dict) -> int:
     sources = []
 
@@ -246,7 +274,7 @@ def run_check(root: Path, derived: dict) -> int:
             print(f"FAIL: cannot parse marketplace.json: {exc}")
             return 1
 
-    mismatches = []
+    mismatches: list = []
     for label, text in sources:
         claims = extract_claims(text)
         if not claims:
@@ -260,6 +288,7 @@ def run_check(root: Path, derived: dict) -> int:
                 )
 
     mismatches.extend(check_domain_table(root))
+    mismatches.extend(check_readme_badges(root, derived))
 
     if mismatches:
         print("COUNTER CHECK FAILED — headline claims disagree with derived values:")

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -274,7 +274,7 @@ def run_check(root: Path, derived: dict) -> int:
             print(f"FAIL: cannot parse marketplace.json: {exc}")
             return 1
 
-    mismatches: list = []
+    mismatches = []
     for label, text in sources:
         claims = extract_claims(text)
         if not claims:

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -242,7 +242,15 @@ def check_readme_badges(root: Path, derived: dict) -> list:
     out = []
     for key, pattern in BADGE_PATTERNS.items():
         match = pattern.search(text)
-        if match and int(match.group(1)) != derived[key]:
+        if not match:
+            # Fail loudly rather than skip: a renamed/removed badge would
+            # otherwise silently drop out of the gate (mirrors run_check's
+            # "no recognizable counter claims found" precedent).
+            out.append(
+                f"README badge: '{key}' badge not found "
+                f"(expected a '{key.capitalize()}-<n>-' shield)"
+            )
+        elif int(match.group(1)) != derived[key]:
             out.append(
                 f"README badge: '{key}' badge claims {match.group(1)}, "
                 f"derived {key}={derived[key]}"


### PR DESCRIPTION
## Summary

Follow-up to the merged agent-harness PR (#890), applying the automated review's valid nits plus closing the CI blind spot that let one of them ship.

- **`loop_controller.py`** — drop the unused `import shlex`; simplify `cmd_record`'s exit-code expression to the clearer form already used in `cmd_verify` (verified behavior-equivalent).
- **Trust-boundary docs** — `SKILL.md` (new hard rule 8) and `references/verification_discipline.md` now state that plan/state files are a trust boundary: `verify` shell-executes their `cmd` strings, so the harness must only run on files produced by `goal_compiler`, never untrusted input. Not attacker-reachable in the documented flow, but the harness is agent-driven, so it's worth explicit.
- **README badges** — bump `Agents` 96→97 and `Commands` 102→103 (drift the previous PR missed).
- **`scripts/derive_counters.py`** — new `check_readme_badges()` validates the Skills/Agents/Commands shield badges against derived counts. This is the root-cause fix: the previous PR's badge drift shipped precisely because `--check` didn't look at these badges. Verified the gate fails (exit 1) on drift and passes when correct.

## Checklist

- [x] **Target branch is `dev`**
- [x] Scripts run with `--help`/`--sample` without errors
- [x] No hardcoded secrets
- [x] Stdlib-only

## Type of Change

- [x] Bug fix (README badge drift, unused import)
- [x] Improvement to existing skill (trust-boundary docs)
- [x] Infrastructure / CI (badge validation gate)

## Testing

Full gate suite green: `check_plugin_json.py` (83 OK), `smoke_scripts.py` (600 pass), `smoke_json_output.py` (0 fail), `check_paths.py` (0 findings), `derive_counters.py --check` (pass). Regression-checked the new badge gate: reverting a badge to the wrong count makes `--check` exit 1 with a `README badge:` mismatch; restoring it passes. Re-ran the harness end-to-end (manifest → compile → init → record → verify) to confirm the `loop_controller.py` edits are behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4JerbGv6vqitUMhqHPA9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4JerbGv6vqitUMhqHPA9g)_