### PR TITLE
Add reusable social media agency multi-agent scaffold

### DIFF
--- a/social-media-agency-system/agents/analytics/examples/input.json
+++ b/social-media-agency-system/agents/analytics/examples/input.json
@@ -1,0 +1,7 @@
+{
+  "period": "monthly",
+  "platforms": ["LinkedIn", "Email"],
+  "kpi_priority": "leads",
+  "raw_data_source": "api-export.json",
+  "operational_cost": 1800
+}

--- a/social-media-agency-system/agents/analytics/examples/output.md
+++ b/social-media-agency-system/agents/analytics/examples/output.md
@@ -1,0 +1,14 @@
+# Sample output - Agent Analytics
+
+## Resumen
+- Leads generados: 22 (+37% vs mes anterior)
+- CPL estimado: USD 81.8
+- ROI estimado: 2.3x
+
+## Top 3 piezas
+1. Caso de estudio sector retail (LinkedIn)
+2. Checklist de pipeline en PDF (LinkedIn)
+3. Email "3 errores en prospeccion B2B"
+
+## Recomendacion principal
+Mantener foco en contenido de prueba social y migrar 20% de piezas educativas a formato carrusel para mejorar retencion.

--- a/social-media-agency-system/agents/analytics/instructions.md
+++ b/social-media-agency-system/agents/analytics/instructions.md
@@ -1,0 +1,38 @@
+# AGENT ANALYTICS - Analista de Datos
+
+## Rol
+Medir rendimiento, calcular ROI y recomendar optimizaciones accionables por plataforma.
+
+## Responsabilidades
+1. Consolidar datos de redes y email.
+2. Calcular metricas estandar y personalizadas.
+3. Identificar top/bottom contenido.
+4. Entregar recomendaciones por impacto esperado.
+
+## Inputs requeridos
+- periodo
+- plataformas
+- metricas_objetivo
+- datos_brutos_api
+- costo_operativo
+
+## Outputs obligatorios
+1. Tabla de metricas por red
+2. Top 3 contenidos por engagement
+3. ROI total y por canal
+4. Comparativo vs periodo anterior
+5. Recomendaciones concretas
+6. Forecast simple para siguiente periodo
+
+## Metricas minimas
+- Instagram: reach, impressions, engagement_rate, saves, shares, ctr, growth_rate.
+- LinkedIn: impressions, clicks, engagement_rate, conversion_rate, comments_sentiment.
+- TikTok: views, completion_rate, avg_watch_time, follower_growth.
+- Email: open_rate, click_rate, conversion_rate, unsubscribe_rate.
+
+## Preguntas obligatorias si faltan datos
+- KPI mas importante.
+- Meta de revenue mensual.
+- Frecuencia de reporte.
+- Historial para benchmark.
+- Receptores del reporte.

--- a/social-media-agency-system/agents/analytics/metadata.yaml
+++ b/social-media-agency-system/agents/analytics/metadata.yaml
@@ -1,0 +1,17 @@
+agent_id: analytics
+display_name: Agent Analytics
+version: 1.0.0
+language: es
+report_frequency_default: weekly
+inputs:
+  - platform_metrics
+outputs:
+  - performance-report.md
+  - metrics-table.csv
+  - optimization-plan.json
+handoff_to:
+  - strategy
+quality_rules:
+  - include_period_comparison
+  - include_actionable_recommendations
+  - include_data_quality_notes

--- a/social-media-agency-system/agents/analytics/tools.json
+++ b/social-media-agency-system/agents/analytics/tools.json
@@ -1,0 +1,25 @@
+{
+  "agent": "analytics",
+  "tools": [
+    {
+      "name": "metrics_aggregator",
+      "type": "function",
+      "description": "Normaliza y consolida metricas de multiples plataformas."
+    },
+    {
+      "name": "roi_calculator",
+      "type": "function",
+      "description": "Calcula ROI total y por canal usando costo y conversion."
+    },
+    {
+      "name": "top_post_ranker",
+      "type": "function",
+      "description": "Ordena contenidos por impacto segun KPI objetivo."
+    },
+    {
+      "name": "optimization_recommender",
+      "type": "function",
+      "description": "Sugiere acciones con impacto esperado y prioridad."
+    }
+  ]
+}

--- a/social-media-agency-system/agents/community/examples/input.json
+++ b/social-media-agency-system/agents/community/examples/input.json
@@ -1,0 +1,7 @@
+{
+  "message": "Me interesa su servicio, pero no veo precios en la web. Tienen planes para pymes?",
+  "post_context": "Post de LinkedIn sobre optimizacion de pipeline",
+  "interaction_type": "pregunta con intencion comercial",
+  "brand_tone": "profesional consultivo",
+  "escalation_policy": "leads calificados a ventas en menos de 1 hora"
+}

--- a/social-media-agency-system/agents/community/examples/output.md
+++ b/social-media-agency-system/agents/community/examples/output.md
@@ -1,0 +1,12 @@
+# Sample output - Agent Community
+
+## Respuesta sugerida
+Gracias por escribirnos. Si, tenemos planes para pymes y se ajustan segun objetivo comercial y etapa de crecimiento.
+
+Si quieres, te comparto por DM una guia rapida de rangos y te ayudo a elegir la opcion mas conveniente para tu caso.
+
+## Clasificacion
+- tipo: lead
+- prioridad: alta
+- accion: escalar a ventas
+- sla: 60 minutos

--- a/social-media-agency-system/agents/community/instructions.md
+++ b/social-media-agency-system/agents/community/instructions.md
@@ -1,0 +1,37 @@
+# AGENT COMMUNITY - Community Manager
+
+## Rol
+Gestionar interacciones, moderar comunidad y escalar oportunidades o riesgos.
+
+## Responsabilidades
+1. Responder comentarios y mensajes.
+2. Clasificar interacciones (lead, feedback, critica, spam, crisis).
+3. Escalar casos a ventas o soporte.
+4. Proteger tono y reputacion de marca.
+
+## Inputs requeridos
+- comentario_o_mensaje
+- contexto_post
+- tipo_interaccion
+- brand_guidelines
+- politica_escalacion
+
+## Outputs obligatorios
+1. Respuesta sugerida
+2. Clasificacion de interaccion
+3. Prioridad y tiempo recomendado
+4. Accion de escalacion (si aplica)
+
+## Protocolos operativos
+- Preguntas: respuesta en <= 2 horas.
+- Feedback positivo: agradecer + reforzar relacion.
+- Feedback negativo: empatia -> propuesta de solucion -> mover a DM.
+- Lead identificado: enviar ficha a ventas.
+- Spam: ocultar/bloquear segun politica.
+- Crisis: escalacion inmediata.
+
+## Preguntas obligatorias si faltan datos
+- Horario de atencion.
+- Responsable de escalaciones.
+- Politica de bloqueo/eliminacion.
+- Keywords para lead calificado.

--- a/social-media-agency-system/agents/community/metadata.yaml
+++ b/social-media-agency-system/agents/community/metadata.yaml
@@ -1,0 +1,20 @@
+agent_id: community
+display_name: Agent Community
+version: 1.0.0
+language: es
+response_sla_minutes:
+  high_priority: 30
+  normal: 120
+inputs:
+  - inbound_interaction
+outputs:
+  - response.md
+  - interaction-classification.json
+  - escalation-ticket.json
+handoff_to:
+  - analytics
+  - strategy
+quality_rules:
+  - always_preserve_brand_tone
+  - never_ignore_negative_feedback
+  - crisis_must_escalate_immediately

--- a/social-media-agency-system/agents/community/tools.json
+++ b/social-media-agency-system/agents/community/tools.json
@@ -1,0 +1,25 @@
+{
+  "agent": "community",
+  "tools": [
+    {
+      "name": "response_generator",
+      "type": "function",
+      "description": "Genera respuesta coherente con tono y contexto."
+    },
+    {
+      "name": "comment_classifier",
+      "type": "function",
+      "description": "Clasifica interacciones en lead, critica, spam, consulta o crisis."
+    },
+    {
+      "name": "lead_extractor",
+      "type": "function",
+      "description": "Estructura datos de prospectos para handoff a ventas."
+    },
+    {
+      "name": "escalation_router",
+      "type": "function",
+      "description": "Define destino de escalacion y prioridad de atencion."
+    }
+  ]
+}

--- a/social-media-agency-system/agents/content/examples/input.json
+++ b/social-media-agency-system/agents/content/examples/input.json
@@ -1,0 +1,8 @@
+{
+  "topic": "Como reducir ciclos de venta en pymes B2B",
+  "platform": "LinkedIn",
+  "buyer_persona": "Gerente comercial",
+  "keywords": ["ventas B2B", "pipeline", "conversion"],
+  "brand_tone": "profesional consultivo",
+  "goal": "generacion de leads"
+}

--- a/social-media-agency-system/agents/content/examples/output.md
+++ b/social-media-agency-system/agents/content/examples/output.md
@@ -1,0 +1,24 @@
+# Sample output - Agent Content
+
+## Post final (LinkedIn)
+La mayoria de pymes B2B no tiene un problema de leads, tiene un problema de friccion comercial.
+
+Si tu ciclo de venta supera 60 dias, revisa 3 puntos:
+1) Falta de criterio de calificacion.
+2) Seguimiento inconsistente.
+3) Propuesta de valor poco concreta.
+
+En nuestros ultimos proyectos, estandarizar esos 3 pasos redujo entre 18% y 27% el tiempo de cierre.
+
+Quieres una matriz simple para detectar cuellos de botella en tu pipeline?
+Escribe "MATRIZ" y te la comparto.
+
+## Variantes A/B
+- A: Hook con dato cuantitativo.
+- B: Hook con pregunta de diagnostico.
+
+## Hashtags
+#VentasB2B #Pipeline #CrecimientoComercial #OperacionComercial #LeadGeneration
+
+## Hora sugerida
+Martes a jueves, 8:30-10:00 AM.

--- a/social-media-agency-system/agents/content/instructions.md
+++ b/social-media-agency-system/agents/content/instructions.md
@@ -1,0 +1,55 @@
+# AGENT CONTENT - Creador de Contenido
+
+## Rol
+Generar contenido listo para publicar, optimizado por plataforma y alineado al plan de STRATEGY.
+
+## Responsabilidades
+1. Redactar posts por plataforma.
+2. Crear variantes A/B.
+3. Proponer hashtags y horario recomendado.
+4. Definir hook y CTA.
+5. Mantener tono de marca.
+
+## Inputs requeridos
+- tema
+- plataforma
+- buyer_persona
+- keywords
+- brand_guidelines
+- objetivo_de_contenido
+
+## Outputs obligatorios
+1. Post final
+2. 2 variantes A/B
+3. Hashtags recomendados
+4. Mejor hora de publicacion
+5. Hook principal
+6. CTA sugerido
+7. Metricas estimadas
+
+## Plantillas por plataforma
+### LinkedIn
+- 1500-2000 caracteres
+- Hook -> Problema -> Solucion -> CTA
+- Hashtags: 5-10
+
+### Instagram
+- 150-300 caracteres
+- Hook -> Beneficio -> Curiosidad -> CTA
+- Hashtags: 20-30
+
+### TikTok
+- 150-250 caracteres
+- Hook 3s -> Contenido -> CTA
+- Hashtags: 5-10
+
+### Email
+- Asunto: 40-50
+- Preview: ~40
+- Cuerpo: 150-200 palabras
+
+## Preguntas obligatorias si faltan datos
+- Tono de voz de marca.
+- Objetivo final de la pieza.
+- Promocion o descuento vigente.
+- Restricciones de contenido.

--- a/social-media-agency-system/agents/content/metadata.yaml
+++ b/social-media-agency-system/agents/content/metadata.yaml
@@ -1,0 +1,25 @@
+agent_id: content
+display_name: Agent Content
+version: 1.0.0
+language: es
+default_tone: profesional-consultivo
+platform_priority:
+  - linkedin
+  - instagram
+  - tiktok
+  - email
+inputs:
+  - content_brief
+outputs:
+  - post-final.md
+  - variants-ab.md
+  - content-metadata.json
+handoff_to:
+  - community
+  - analytics
+sla:
+  draft_hours: 8
+quality_rules:
+  - must_have_clear_cta
+  - must_match_brand_voice
+  - no_clickbait_without_value

--- a/social-media-agency-system/agents/content/tools.json
+++ b/social-media-agency-system/agents/content/tools.json
@@ -1,0 +1,25 @@
+{
+  "agent": "content",
+  "tools": [
+    {
+      "name": "copy_generator",
+      "type": "function",
+      "description": "Genera copy optimizado por plataforma y objetivo."
+    },
+    {
+      "name": "ab_variant_builder",
+      "type": "function",
+      "description": "Crea dos variaciones de hook y CTA para pruebas A/B."
+    },
+    {
+      "name": "hashtag_researcher",
+      "type": "function",
+      "description": "Sugiere hashtags por intencion de busqueda y nicho."
+    },
+    {
+      "name": "publish_time_advisor",
+      "type": "function",
+      "description": "Recomienda horarios por plataforma y audiencia objetivo."
+    }
+  ]
+}

--- a/social-media-agency-system/agents/strategy/examples/editorial-calendar-30-60-90.csv
+++ b/social-media-agency-system/agents/strategy/examples/editorial-calendar-30-60-90.csv
@@ -1,0 +1,7 @@
+phase,week,platform,content_pillar,topic,format,cta,kpi_target
+30,1,LinkedIn,Autoridad,"3 errores comunes en pipeline B2B",Post,"Comenta 'CHECKLIST' para recibir recurso",CTR >= 1.5%
+30,2,LinkedIn,Prueba social,"Mini caso: +22% reuniones calificadas",Post,"Solicita diagnostico de 20 minutos",MQL >= 3
+60,5,LinkedIn,Educacion,"Como calificar leads sin perder velocidad",Documento,"Descargar plantilla de scoring",CTR >= 2.0%
+60,7,LinkedIn,Objeciones,"No tenemos presupuesto: como responder",Post,"Enviar DM para guion de objeciones",Tasa DM >= 15%
+90,10,LinkedIn,Conversion,"Framework para reducir ciclo comercial",Carrusel,"Agenda llamada diagnostico",SQL >= 4
+90,12,LinkedIn,Prueba social,"Caso completo antes/despues",Articulo,"Pedir auditoria comercial",Conversion >= 4%

--- a/social-media-agency-system/agents/strategy/examples/input.json
+++ b/social-media-agency-system/agents/strategy/examples/input.json
@@ -1,0 +1,18 @@
+{
+  "business_name": "Template B2B Services",
+  "industry": "B2B servicios/profesional",
+  "product_services": [
+    "Consultoria de procesos",
+    "Implementacion CRM",
+    "Capacitacion comercial"
+  ],
+  "target_audience_general": "Directores comerciales y gerentes de operaciones en pymes de 20-200 empleados",
+  "priority_platform": "LinkedIn",
+  "main_objective": "Generacion de leads",
+  "monthly_budget_reference": "Sin pauta pagada",
+  "competitors": [
+    "Competidor A",
+    "Competidor B",
+    "Competidor C"
+  ]
+}

--- a/social-media-agency-system/agents/strategy/examples/output.md
+++ b/social-media-agency-system/agents/strategy/examples/output.md
@@ -1,0 +1,16 @@
+# Sample output - Agent Strategy
+
+## Resumen estrategico
+- Foco: LinkedIn organico para lead generation B2B.
+- Cadencia: 4 posts por semana + 1 pieza larga quincenal.
+- Pilares: autoridad, casos reales, objeciones de compra, prueba social.
+
+## KPI iniciales (30 dias)
+- MQLs: 15
+- CTR promedio: 1.8%
+- Tasa de respuesta a DM: 20%
+
+## Entregables handoff a CONTENT
+1. 12 temas priorizados por etapa del funnel.
+2. Tono de voz: profesional consultivo, directo, basado en evidencia.
+3. CTA principal: "Agenda una llamada diagnostico de 20 minutos".

--- a/social-media-agency-system/agents/strategy/instructions.md
+++ b/social-media-agency-system/agents/strategy/instructions.md
@@ -1,0 +1,50 @@
+# AGENT STRATEGY - Gestor Estrategico
+
+## Rol
+Convertir un business brief en una estrategia de contenido accionable para 30/60/90 dias.
+
+## Responsabilidades
+1. Analizar contexto de negocio y oferta.
+2. Definir buyer personas operativas.
+3. Recomendar mix de plataformas.
+4. Crear calendario editorial por etapa (30/60/90).
+5. Definir KPIs mensuales y objetivos por canal.
+6. Entregar analisis competitivo utilizable por CONTENT y COMMUNITY.
+
+## Inputs requeridos
+- business_name
+- industry
+- product_services (max 5)
+- target_audience_general
+- priority_platform
+- main_objective
+- monthly_budget_reference
+- competitors (max 5)
+
+## Outputs obligatorios
+1. `strategic-plan.md`
+2. `buyer-personas.md`
+3. `kpi-matrix.json`
+4. `platform-recommendations.json`
+5. `editorial-calendar-30-60-90.csv`
+6. `tone-of-voice-guide.md`
+
+## Flujo de trabajo
+1. Validar brief y detectar vacios de informacion.
+2. Producir hipotesis estrategicas por objetivo.
+3. Priorizar canales con scoring (alcance, conversion, costo, esfuerzo).
+4. Disenar pilares de contenido.
+5. Construir calendario 30/60/90 con CTA y KPI por pieza.
+6. Publicar entregables en formato solicitado.
+
+## Preguntas obligatorias si faltan datos
+- Rango de edad y ubicacion del cliente ideal.
+- Presupuesto mensual estimado.
+- Recursos internos disponibles.
+- Productos/servicios con prioridad comercial.
+- Competidor directo principal.
+
+## Criterios de calidad
+- Cada recomendacion debe conectar con un objetivo de negocio.
+- Cada KPI debe incluir formula y frecuencia.
+- El calendario debe ser ejecutable sin supuestos ocultos.

--- a/social-media-agency-system/agents/strategy/metadata.yaml
+++ b/social-media-agency-system/agents/strategy/metadata.yaml
@@ -1,0 +1,25 @@
+agent_id: strategy
+display_name: Agent Strategy
+version: 1.0.0
+language: es
+default_industry: b2b-servicios
+primary_platform: linkedin
+primary_objective: lead-generation
+budget_profile: organic-first
+inputs:
+  - business_brief
+outputs:
+  - strategic-plan.md
+  - buyer-personas.md
+  - kpi-matrix.json
+  - platform-recommendations.json
+  - editorial-calendar-30-60-90.csv
+  - tone-of-voice-guide.md
+handoff_to:
+  - content
+sla:
+  initial_plan_hours: 24
+quality_rules:
+  - no_unlinked_recommendations
+  - kpi_must_include_formula
+  - calendar_must_include_cta

--- a/social-media-agency-system/agents/strategy/tools.json
+++ b/social-media-agency-system/agents/strategy/tools.json
@@ -1,0 +1,58 @@
+{
+  "agent": "strategy",
+  "tools": [
+    {
+      "name": "brief_analyzer",
+      "type": "function",
+      "description": "Valida completitud del business brief y lista gaps criticos.",
+      "input_schema": {
+        "type": "object",
+        "required": ["brief"],
+        "properties": {
+          "brief": { "type": "object" }
+        }
+      }
+    },
+    {
+      "name": "persona_builder",
+      "type": "function",
+      "description": "Genera buyer personas detalladas para B2B servicios.",
+      "input_schema": {
+        "type": "object",
+        "required": ["industry", "audience", "objective"],
+        "properties": {
+          "industry": { "type": "string" },
+          "audience": { "type": "object" },
+          "objective": { "type": "string" }
+        }
+      }
+    },
+    {
+      "name": "editorial_calendar_generator",
+      "type": "function",
+      "description": "Construye plan editorial 30/60/90 con CTA y KPI por activo.",
+      "input_schema": {
+        "type": "object",
+        "required": ["pillars", "platforms", "cadence"],
+        "properties": {
+          "pillars": { "type": "array", "items": { "type": "string" } },
+          "platforms": { "type": "array", "items": { "type": "string" } },
+          "cadence": { "type": "string" }
+        }
+      }
+    },
+    {
+      "name": "kpi_matrix_generator",
+      "type": "function",
+      "description": "Define KPIs, formulas y metas por plataforma.",
+      "input_schema": {
+        "type": "object",
+        "required": ["objective", "platforms"],
+        "properties": {
+          "objective": { "type": "string" },
+          "platforms": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  ]
+}

--- a/social-media-agency-system/api-integrations.json
+++ b/social-media-agency-system/api-integrations.json
@@ -1,0 +1,55 @@
+{
+  "instagram": {
+    "api": "Meta Graph API",
+    "base_url": "https://graph.facebook.com",
+    "endpoints": ["insights", "media", "comments"],
+    "auth": {
+      "type": "oauth2",
+      "token_env": "INSTAGRAM_ACCESS_TOKEN"
+    }
+  },
+  "linkedin": {
+    "api": "LinkedIn Official API",
+    "base_url": "https://api.linkedin.com",
+    "endpoints": ["posts", "insights", "comments"],
+    "auth": {
+      "type": "oauth2",
+      "token_env": "LINKEDIN_ACCESS_TOKEN"
+    }
+  },
+  "tiktok": {
+    "api": "TikTok Official API",
+    "base_url": "https://open.tiktokapis.com",
+    "endpoints": ["video/list", "video/query"],
+    "auth": {
+      "type": "oauth2",
+      "token_env": "TIKTOK_ACCESS_TOKEN"
+    }
+  },
+  "twitter": {
+    "api": "Twitter API v2",
+    "base_url": "https://api.twitter.com/2",
+    "endpoints": ["tweets", "users", "analytics"],
+    "auth": {
+      "type": "bearer",
+      "token_env": "TWITTER_BEARER_TOKEN"
+    }
+  },
+  "email": {
+    "platform_options": ["Mailchimp", "Brevo"],
+    "endpoints": ["campaigns", "audiences", "analytics"],
+    "auth": {
+      "type": "api_key",
+      "token_env": "EMAIL_PLATFORM_API_KEY"
+    }
+  },
+  "analytics": {
+    "platform": "Google Analytics 4",
+    "base_url": "https://analyticsdata.googleapis.com",
+    "endpoints": ["runReport"],
+    "auth": {
+      "type": "service_account",
+      "credentials_env": "GA4_SERVICE_ACCOUNT_JSON"
+    }
+  }
+}

--- a/social-media-agency-system/approval-workflow.md
+++ b/social-media-agency-system/approval-workflow.md
@@ -1,0 +1,32 @@
+# Approval Workflow
+
+## Objetivo
+Estandarizar revision y aprobacion de contenido antes de publicacion.
+
+## Roles
+- Creador: Agent CONTENT
+- Revisor: Lider de cuenta / editor
+- Aprobador final: Cliente o account manager
+
+## Flujo
+1. CONTENT entrega borrador + metadata.
+2. Revisor valida mensaje, tono, claridad y CTA.
+3. Aprobador final autoriza, pide cambios o rechaza.
+4. COMMUNITY programa/publica y monitorea respuesta.
+5. ANALYTICS registra desempeno para retroalimentacion.
+
+## SLA sugerido
+- Borrador inicial: <= 8 horas
+- Revision interna: <= 12 horas
+- Aprobacion cliente: <= 24 horas
+- Ajustes finales: <= 8 horas
+
+## Cambios permitidos post-aprobacion
+- Correcciones menores ortograficas.
+- Ajuste de hora de publicacion.
+- Ajuste de hashtags sin cambiar mensaje central.
+
+## Cambios NO permitidos post-aprobacion
+- Cambio de oferta o promesa comercial.
+- Cambio de CTA principal.
+- Cambio de tono fuera de guideline.

--- a/social-media-agency-system/brand-guidelines-template.md
+++ b/social-media-agency-system/brand-guidelines-template.md
@@ -1,0 +1,46 @@
+# Brand Guidelines Template
+
+## 1. Identidad base
+- Nombre de marca:
+- Slogan:
+- Descripcion corta:
+
+## 2. Logo
+- Version principal:
+- Version secundaria:
+- Usos permitidos:
+- Usos no permitidos:
+
+## 3. Colores
+| Uso | Hex | Reglas |
+|---|---|---|
+| Primario | # | |
+| Secundario | # | |
+| Acento | # | |
+| Fondo | # | |
+| Texto | # | |
+
+## 4. Tipografia
+- Titulos:
+- Cuerpo:
+- Fallback:
+
+## 5. Tono de voz
+- Estilo base:
+- Palabras a usar:
+- Palabras prohibidas:
+- Como hablar de la competencia:
+
+## 6. Contenido
+- Angulos recomendados:
+- Restricciones legales/comerciales:
+- CTA preferidos:
+
+## 7. Ejemplos
+### Ejemplo bueno
+- Contexto:
+- Texto:
+
+### Ejemplo malo
+- Contexto:
+- Texto:

--- a/social-media-agency-system/business-brief-template.md
+++ b/social-media-agency-system/business-brief-template.md
@@ -1,0 +1,55 @@
+# Business Brief Template (Reusable)
+
+## 1. Informacion basica
+- Nombre de empresa:
+- Sitio web:
+- Industria:
+- Pais/region:
+- Contacto principal:
+
+## 2. Descripcion de negocio
+- Que vende:
+- Diferencial principal:
+- Ticket promedio:
+- Ciclo de venta:
+
+## 3. Oferta comercial
+- Producto/servicio 1:
+- Producto/servicio 2:
+- Producto/servicio 3:
+- Promocion vigente:
+
+## 4. Audiencia objetivo
+- Segmento principal:
+- Rango de edad:
+- Ubicacion:
+- Cargo/rol:
+- Problemas que busca resolver:
+
+## 5. Presupuesto y recursos
+- Presupuesto mensual marketing:
+- Equipo interno disponible:
+- Recursos externos requeridos:
+
+## 6. Plataformas
+- Activas hoy:
+- Prioridad:
+- Seguidores/base actual:
+
+## 7. Objetivos
+- Objetivo principal 30 dias:
+- Meta numerica 30 dias:
+- Meta numerica 90 dias:
+
+## 8. Competencia (max 5)
+1. Nombre + usuario:
+2. Nombre + usuario:
+3. Nombre + usuario:
+4. Nombre + usuario:
+5. Nombre + usuario:
+
+## 9. Operacion y aprobaciones
+- Quien revisa contenido:
+- Quien aprueba:
+- SLA de aprobacion:
+- SLA de respuesta a comentarios:

--- a/social-media-agency-system/metrics-definition.json
+++ b/social-media-agency-system/metrics-definition.json
@@ -1,0 +1,32 @@
+{
+  "global": {
+    "lead_conversion_rate": "leads / clicks",
+    "content_output_rate": "publicaciones_publicadas / publicaciones_planificadas",
+    "response_sla_compliance": "respuestas_en_tiempo / respuestas_totales"
+  },
+  "instagram": {
+    "engagement_rate": "(likes + comments + saves + shares) / followers / posts",
+    "reach": "usuarios_unicos_impactados",
+    "impressions": "total_de_visualizaciones",
+    "virality_coefficient": "shares / impressions"
+  },
+  "linkedin": {
+    "engagement_rate": "(reactions + comments + reposts) / impressions",
+    "ctr": "clicks / impressions",
+    "lead_rate": "leads / link_clicks",
+    "follower_growth_rate": "nuevos_followers / followers_inicio_periodo"
+  },
+  "tiktok": {
+    "completion_rate": "views_completas / views_totales",
+    "avg_watch_time": "tiempo_total_visto / views_totales",
+    "engagement_rate": "(likes + comments + shares) / views",
+    "viral_score": "views / followers"
+  },
+  "email": {
+    "open_rate": "opens / delivered",
+    "click_rate": "unique_clicks / delivered",
+    "conversion_rate": "conversions / unique_clicks",
+    "unsubscribe_rate": "unsubscribes / delivered",
+    "revenue_per_email": "ingreso_total / emails_enviados"
+  }
+}

--- a/social-media-agency-system/orchestrator.md
+++ b/social-media-agency-system/orchestrator.md
@@ -1,0 +1,27 @@
+# Orchestrator - Multi-Agent Social Media System
+
+## Secuencia principal
+1. Cliente completa `business-brief-template.md`.
+2. STRATEGY produce plan, personas, KPIs y calendario.
+3. CONTENT genera piezas segun plan aprobado.
+4. COMMUNITY publica, responde y clasifica interacciones.
+5. ANALYTICS consolida resultados y propone optimizaciones.
+6. STRATEGY ajusta el siguiente ciclo (loop continuo).
+
+## Contrato de handoff entre agentes
+Cada handoff debe incluir:
+- `context_summary`
+- `input_payload`
+- `expected_outputs`
+- `deadline`
+- `owner`
+
+## Eventos de escalacion
+- Crisis reputacional -> COMMUNITY -> responsable de crisis.
+- Desviacion KPI >20% por 2 periodos -> ANALYTICS -> STRATEGY.
+- Bloqueo por aprobacion >24h -> ORCHESTRATOR -> account owner.
+
+## Cadencia operativa recomendada
+- Daily: seguimiento de ejecucion (15 min).
+- Weekly: rendimiento y ajustes tacticos.
+- Monthly: revision de objetivos y rediseno de plan.


### PR DESCRIPTION
## Summary

This adds a reusable, client-agnostic social media agency system scaffold so teams can start from a structured baseline instead of rebuilding operations docs per account. The implementation packages four coordinated agent modules (Strategy, Content, Community, Analytics) plus global workflow/config templates aligned to a B2B services, LinkedIn-first, organic lead-generation default.

## Checklist

- [ ] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`)
- [x] Scripts (if any) run with `--help` without errors
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`)

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation
- [ ] Infrastructure / CI

## Testing

Validated JSON syntax across all new `.json` files (`python -m json.tool`) and confirmed the branch diff contains only the new `social-media-agency-system/` scaffold files.