### PR TITLE
Add LinkedIn Skills to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ python3 product-team/landing-page-generator/scripts/landing_page_scaffolder.py c
 | [**Claude Code Tresor**](https://github.com/alirezarezvani/claude-code-tresor) | Productivity toolkit with 60+ prompt templates |
 | [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, career coaching, AI product craft |
 | [**toprank**](https://github.com/nowork-studio/toprank) | 9 SEO and Google Ads skills for Claude Code — connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag, schema markup, and keyword bid fixes to source or CMS. MIT, 107 stars |
+| [**LinkedIn Skills**](https://github.com/sergebulaev/linkedin-skills) | 10 LinkedIn skills for Claude Code and Codex: post writer with 16 tested hook formulas, humanizer that scrubs AI tells, pre-publish audit, comment and reply drafting, hook extractor, content planner, profile optimizer, engager analytics, and thread monitoring. MIT, 303 stars |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **LinkedIn Skills** under Related Projects (README table row, docs-only change; no skill count or generated files touched).

LinkedIn Skills is an open-source (MIT) bundle of 10 skills for Claude Code and OpenAI Codex covering the full LinkedIn content workflow: a post writer with 16 tested hook formulas, a humanizer that scrubs AI tells, a pre-publish audit, comment and reply drafting, a hook extractor, a content planner, a profile optimizer, engager analytics, and thread monitoring.

- Source: https://github.com/sergebulaev/linkedin-skills
- Install: `/plugin marketplace add sergebulaev/linkedin-skills`
- **303 GitHub stars, 44 forks**, MIT licensed, actively maintained (v1.0.9)

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [x] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`) — N/A, docs-only change (no skill files added)
- [x] Scripts (if any) run with `--help` without errors — N/A, no scripts in this PR
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [x] Follows existing directory structure (`domain/skill-name/SKILL.md`) — N/A, README-only edit

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation
- [ ] Infrastructure / CI

## Testing

Verified the new table row renders correctly in Markdown, matches the format of the existing Related Projects entries (same style as the toprank row, added via #517/#601), and that the diff touches only the Related Projects table in README.md (one line added).
