### PR TITLE
docs(claude-md): add Self-learning and Lessons sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,14 @@ This repository publishes skills to **ClawHub** (clawhub.com) as the distributio
 
 **Quality Standard:** Each skill should save users 40%+ time while improving consistency/quality by 30%+.
 
+## Self-learning
+
+When I correct you, or you catch yourself making a mistake: before continuing add the lesson as a one-line rule under ## Lessons, so it never happens again
+
+## Lessons
+
+- (Claude adds rules here)
+
 ## Additional Resources
 
 - **.gitignore:** Excludes .vscode/, .DS_Store, AGENTS.md, PROMPTS.md, .env*


### PR DESCRIPTION
## Summary

Adds a **Self-learning** instruction block and an empty **Lessons** section to the root `CLAUDE.md`, transcribed verbatim from the user-provided snippet. When Claude is corrected (or catches its own mistake), it must add the lesson as a one-line rule under `## Lessons` before continuing, so the same mistake is never repeated. The sections are placed after "Working with This Repository" and before "Additional Resources".

## Checklist

- [x] **Target branch is `dev`** (not `main` — PRs to main will be auto-closed)
- [ ] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description`, `license`) — N/A, documentation-only change
- [ ] Scripts (if any) run with `--help` without errors — N/A, no scripts touched
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [ ] Follows existing directory structure (`domain/skill-name/SKILL.md`) — N/A, root `CLAUDE.md` only

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation
- [ ] Infrastructure / CI

## Testing

Manual review of the rendered markdown: the two new sections (`## Self-learning`, `## Lessons`) sit between "Working with This Repository" and "Additional Resources", and the snippet text matches the provided source exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQoPnWU7BeEJpHkBDwV9nK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQoPnWU7BeEJpHkBDwV9nK)_