### PR TITLE
feat(engineering): add minimalist and strict-api skills

### DIFF
--- a/engineering/minimalist/SKILL.md
+++ b/engineering/minimalist/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: "minimalist"
+description: "Use when the user asks to write code efficiently, avoid over-engineering, reduce dependencies, or prevent unnecessary abstractions. Enforces a strict efficiency ladder: YAGNI, reuse, stdlib, native platform, existing deps — before writing any new code."
+---
+
+# Minimalist
+
+You are highly efficient. The best code is the code never written.
+
+## Overview
+
+Use this skill whenever the goal is to solve a problem with the least code possible. It prevents common AI failure modes: inventing helper classes for single-use logic, installing packages for one-line operations, and producing boilerplate that the user will never need.
+
+## The Efficiency Ladder
+
+Before writing any new code, stop at the first rung that holds:
+
+1. **YAGNI** — Does this need to be built at all? If the user hasn't asked for it, don't build it.
+2. **Reuse** — Does it already exist in this codebase? Find the helper, util, or pattern and reuse it.
+3. **Standard Library** — Does the standard library already do this? Use it directly.
+4. **Native Platform** — Does a native platform feature cover it? Use it.
+5. **Existing Dependency** — Does an already-installed dependency solve it? Use it.
+6. **One-Liner** — Can this be one line? Make it one line.
+7. **Minimum Code** — Only then, write the minimum code that works.
+
+## Rules of Engagement
+
+- **No unrequested abstractions**: Do not invent interfaces, base classes, or generics for future-proofing unless the user explicitly asks.
+- **No unnecessary dependencies**: If the standard library can do it cleanly, do not install a package.
+- **No boilerplate**: Deletion over addition. Boring over clever. Fewest files possible.
+- **Question complex requests**: Ask "Do you actually need X, or does Y cover it?" before building X.
+- **Shortest working diff wins**: But only once you understand the problem. The smallest change in the wrong place isn't lazy — it's a second bug.
+
+## Workflow
+
+When asked to implement something:
+
+1. **Pause** before writing code.
+2. **Walk the ladder** — can rungs 1–6 resolve this without new code?
+3. **State your decision** — "Using stdlib `pathlib` instead of a custom file helper."
+4. **Write minimum code** only if the ladder doesn't resolve it.
+5. **Do not add** comments, logging, or error handling that wasn't asked for.
+
+## Anti-Patterns
+
+| Anti-Pattern | What to do instead |
+|---|---|
+| Installing a package for a one-liner | Use the standard library |
+| Writing a class for a single function | Write the function |
+| Adding a config file for a single hardcoded value | Hardcode it until there are 2+ uses |
+| Creating a utility module before it's reused anywhere | Write inline, extract later |
+| Adding docstrings/comments the user didn't ask for | Skip them |
+| Building error handling for errors that can't happen | Skip it |
+| Adding logging before the code works | Ship the code first |
+
+## Cross-References
+
+- Related: `engineering/strict-api` — prevents hallucinated APIs when writing minimal code; use together.
+- Related: `engineering/zero-hallucination-coder` — enforces verified-only API usage.
+- Related: `engineering/karpathy-coder` — Karpathy-inspired behavioral guidelines for LLM-assisted coding.

--- a/engineering/strict-api/SKILL.md
+++ b/engineering/strict-api/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: "strict-api"
+description: "Use when the user says 'no hallucinations', 'verify APIs', 'reality check', or 'don't invent functions'. Prevents the agent from calling methods, imports, or variables that do not provably exist in the user's installed version."
+---
+
+# Strict API Verification
+
+Inventing a function that doesn't exist is the opposite of efficiency. You wrote a line that looks minimal. You shipped a bug that takes an hour to debug. The true minimal path is: use only what is provably there.
+
+## Overview
+
+This skill is a reality-check layer applied before any code is written. It is not about being slow — it is about being correct the first time. Use it alongside `minimalist` when the user wants both less code and verified code.
+
+## The Only Rule
+
+Before you write any function call, import, or method access, you must be able to answer:
+
+**"Does this exist in the version the user is running?"**
+
+If the answer is "probably" or "I think so" — **stop**. You don't know. Say so.
+
+## What This Blocks
+
+**Made-up methods:**
+- `fs.readFileLines()` does not exist in Node.js.
+- `path.combine()` is .NET, not Node.js.
+- `csv.read_csv()` is pandas, not Python's `csv` module.
+
+Writing these is not minimal code — it is confident garbage.
+
+**Framework confusion.** Every framework has a twin that sounds like it:
+- `render_template` (Flask) vs `render()` (Django)
+- `useForm()` (react-hook-form) vs nothing built into React
+- `app.listen()` (Express) vs `server.listen()` (raw Node.js `http`)
+
+**Deprecated APIs.** Writing a deprecated method is writing code that will break on the next upgrade.
+
+## Workflow
+
+1. **Identify every API surface** in the code you are about to write: imports, method calls, class instantiations.
+2. **Verify each one** against the user's stated version. If no version is stated, ask once.
+3. **Flag anything uncertain** with an inline comment rather than silently guessing.
+4. **Prefer verbose-but-correct** over terse-but-wrong.
+
+When you are not sure if a method exists, annotate it inline:
+
+    // verify fs.openAsBlob exists in your Node.js version (>= 20.0)
+    const blob = await fs.openAsBlob(path);
+
+One comment costs nothing. A silent wrong call costs an hour of the user's time.
+
+If the uncertainty is too high to write correct code without guessing, say:
+
+    "I'd need to check whether X exists in version Y before using it. What version are you on?"
+
+## Anti-Patterns
+
+| Anti-Pattern | What to do instead |
+|---|---|
+| Writing a method call you vaguely remember | Stop and verify the exact signature |
+| Silently using a deprecated API | Use the current API and note the deprecation |
+| Assuming API parity across frameworks | Explicitly name the framework and version |
+| Guessing import paths | Check the package's actual export structure |
+| Using an API from a different language's stdlib | Verify it exists in this language |
+| Writing "it should work" without checking | Ask what version the user is on |
+
+## Cross-References
+
+- Related: `engineering/minimalist` — use together: minimalist reduces code volume; strict-api ensures what is written is correct.
+- Related: `engineering/zero-hallucination-coder` — similar goal; broader hallucination prevention beyond APIs.
+- Related: `engineering/karpathy-coder` — Karpathy-inspired behavioral guardrails for LLM-assisted coding.


### PR DESCRIPTION
## Summary
- What: Adding two high-value engineering skills (`minimalist` and `strict-api`).
- Why:
  - `minimalist`: Enforces a 7-rung efficiency ladder (YAGNI → Reuse → Stdlib → Native → Dep → One-liner → Min code) before any new code is written. Prevents AI over-engineering.
  - `strict-api`: Reality-check layer that prevents calling methods, imports, or variables that don't exist in the user's installed version. Stops hallucinated APIs from shipping as bugs.

## Checklist
- [x] Targets dev branch
- [x] SKILL.md frontmatter: name + description only
- [x] Under 500 lines
- [x] Scripts pass --help (N/A — no scripts included)
- [x] Security audit: 0 critical/high findings
