### PR TITLE
feat(gold-scalper): 20-strategy XAUUSD scalping agent harness for MT5

### DIFF
--- a/gold-scalper/.gitignore
+++ b/gold-scalper/.gitignore
@@ -1,0 +1,4 @@
+logs/
+__pycache__/
+HALT
+config/calendar.json

--- a/gold-scalper/backtest/run_backtest.py
+++ b/gold-scalper/backtest/run_backtest.py
@@ -1,0 +1,225 @@
+"""Backtest runner — replays M1 history through the strategy fleet.
+
+Usage:
+    python run_backtest.py --csv path/to/xauusd_m1.csv \
+        [--strategies name1,name2] [--equity 10000] [--spread 300] [--json out.json]
+
+Replicates core/engine.py's per-bar dispatch inline (the live engine has a
+sleep/signal loop that makes no sense against replayed data): each SimBroker
+step, every strategy whose primary-timeframe bar just closed gets on_bar()
+while flat or manage_position() while holding, every Signal is sized through
+the RiskManager, and pending_sl_move is honored exactly as in the engine.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import tempfile
+
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.risk import RiskConfig, RiskManager          # noqa: E402
+from core.strategy_base import MarketContext, Side     # noqa: E402
+from backtest.sim_broker import SimBroker              # noqa: E402
+
+try:
+    from strategies import ALL_STRATEGIES
+except ImportError as e:
+    print(f"ERROR: cannot import strategy registry: {e}\n"
+          f"A module under strategies/ is missing or broken "
+          f"(strategies/__init__.py imports momentum, mean_reversion, "
+          f"microstructure, indicator_hybrid). Fix or stub it, then rerun.",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "volume" in df.columns and "tick_volume" not in df.columns:
+        df = df.rename(columns={"volume": "tick_volume"})
+    need = {"time", "open", "high", "low", "close", "tick_volume"}
+    missing = need - set(df.columns)
+    if missing:
+        print(f"ERROR: CSV missing columns: {sorted(missing)}", file=sys.stderr)
+        sys.exit(1)
+    df["time"] = pd.to_datetime(df["time"], utc=True)
+    return df.set_index("time").sort_index()
+
+
+def run(sim: SimBroker, strategies: list, risk: RiskManager) -> None:
+    last_bar: dict[str, object] = {}
+    errors: dict[str, int] = {}
+    disabled: set[str] = set()
+    bars_held: dict[int, tuple[int, int]] = {}      # magic -> (ticket, bars_held)
+
+    while not sim.done:
+        sim.step()                                   # advance bar, resolve SL/TP
+        now = sim.now.to_pydatetime()
+        equity = sim.equity()
+        risk.roll(now, equity)
+        allowed, why = risk.trading_allowed(now, equity)
+        if not allowed:
+            for pos in sim.open_positions():
+                sim.close_position(pos, "risk_halt")
+            continue
+
+        for idx, strat in enumerate(strategies):
+            if strat.name in disabled:
+                continue
+            tf = strat.primary_timeframe
+            df = sim.bars(tf, strat.lookback_bars)
+            if len(df) < strat.lookback_bars:
+                continue                             # not enough history yet
+            last = df.index[-1]
+            if last_bar.get(strat.name) == last:
+                continue                             # no new closed bar
+            last_bar[strat.name] = last
+
+            magic = sim.magic_for(idx)
+            try:
+                t = sim.tick()
+                pos = sim.position_for_magic(magic)
+                if pos is not None:                  # restore bars-held counter
+                    tkt, held = bars_held.get(magic, (pos.ticket, 0))
+                    held = held + 1 if tkt == pos.ticket else 1
+                    bars_held[magic] = (pos.ticket, held)
+                    pos.bars_held = held
+                ctx = MarketContext(
+                    symbol=sim.symbol, now=now, bid=t.bid, ask=t.ask,
+                    spread_points=sim.spread_points(),
+                    bars={f: sim.bars(f, strat.lookback_bars)
+                          for f in (tf, *strat.extra_timeframes)},
+                    aux={}, position=pos)
+
+                if pos is not None:
+                    strat.pending_sl_move = None
+                    reason = strat.manage_position(ctx)
+                    if reason is not None:
+                        sim.close_position(pos, reason.value)
+                        bars_held.pop(magic, None)
+                    elif strat.pending_sl_move is not None:
+                        sim.modify_sl(pos, strat.pending_sl_move)
+                elif (strat.in_session(now)
+                      and ctx.spread_points <= strat.max_spread_points):
+                    sig = strat.on_bar(ctx)
+                    if sig is not None:
+                        sig.comment = sig.comment or strat.name
+                        info = sim.info
+                        lots = risk.size_signal(
+                            sig, equity=equity,
+                            requested_risk_pct=strat.default_risk_pct,
+                            tick_value=info.trade_tick_value,
+                            tick_size=info.trade_tick_size,
+                            volume_min=info.volume_min,
+                            volume_step=info.volume_step,
+                            volume_max=info.volume_max,
+                            open_positions=sim.open_positions())
+                        if lots is not None:
+                            strat._time_stop_bars = sig.time_stop_bars
+                            sim.market_order(sig, lots, magic)
+                            bars_held[magic] = (sim.position_for_magic(magic).ticket, 0)
+                errors[strat.name] = 0
+            except Exception as e:
+                errors[strat.name] = errors.get(strat.name, 0) + 1
+                print(f"[warn] {strat.name} error "
+                      f"({errors[strat.name]}/3): {e}", file=sys.stderr)
+                if errors[strat.name] >= 3:
+                    disabled.add(strat.name)
+                    print(f"[warn] DISABLED {strat.name}: 3 consecutive errors",
+                          file=sys.stderr)
+
+    for pos in sim.open_positions():                 # flatten at end of data
+        sim.close_position(pos, "end_of_data")
+
+
+def scorecard(sim: SimBroker, strategies: list) -> list[dict]:
+    by_magic = {sim.magic_for(i): s.name for i, s in enumerate(strategies)}
+    rows = []
+    for magic, name in by_magic.items():
+        trades = sorted((t for t in sim.trade_log if t["magic"] == magic),
+                        key=lambda t: t["close_time"])
+        rows.append(_score_row(name, trades))
+    rows.append(_score_row("TOTAL", sorted(sim.trade_log,
+                                           key=lambda t: t["close_time"])))
+    return rows
+
+
+def _score_row(name: str, trades: list[dict]) -> dict:
+    wins = [t for t in trades if t["pnl"] > 0]
+    gp = sum(t["pnl"] for t in wins)
+    gl = sum(t["pnl"] for t in trades if t["pnl"] <= 0)
+    cum = peak = max_dd = 0.0
+    for t in trades:
+        cum += t["pnl"]
+        peak = max(peak, cum)
+        max_dd = max(max_dd, peak - cum)
+    n = len(trades)
+    return {"strategy": name, "trades": n, "wins": len(wins),
+            "win_pct": 100.0 * len(wins) / n if n else 0.0,
+            "gross_profit": gp, "gross_loss": gl,
+            "profit_factor": gp / abs(gl) if gl else (float("inf") if gp else 0.0),
+            "expectancy": (gp + gl) / n if n else 0.0,
+            "max_drawdown": max_dd}
+
+
+def print_table(rows: list[dict]) -> None:
+    hdr = f"{'strategy':<28}{'trades':>7}{'wins':>6}{'win%':>7}" \
+          f"{'gross P':>11}{'gross L':>11}{'PF':>7}{'expect':>9}{'maxDD':>10}"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        pf = f"{r['profit_factor']:.2f}" if r["profit_factor"] != float("inf") else "inf"
+        print(f"{r['strategy']:<28}{r['trades']:>7}{r['wins']:>6}"
+              f"{r['win_pct']:>6.1f}%{r['gross_profit']:>11.2f}"
+              f"{r['gross_loss']:>11.2f}{pf:>7}{r['expectancy']:>9.2f}"
+              f"{r['max_drawdown']:>10.2f}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Replay M1 history through the fleet")
+    ap.add_argument("--csv", required=True, help="M1 OHLCV CSV (time,open,high,low,close,tick_volume)")
+    ap.add_argument("--strategies", default="", help="comma-separated strategy names to run (default: all)")
+    ap.add_argument("--equity", type=float, default=10_000)
+    ap.add_argument("--spread", type=float, default=300, help="spread in points")
+    ap.add_argument("--json", default="", help="also dump scorecard + trade log to this file")
+    args = ap.parse_args()
+
+    m1 = load_csv(args.csv)
+    strategies = [cls() for cls in ALL_STRATEGIES]
+    if args.strategies:
+        wanted = {n.strip() for n in args.strategies.split(",") if n.strip()}
+        unknown = wanted - {s.name for s in strategies}
+        if unknown:
+            print(f"ERROR: unknown strategies: {sorted(unknown)}\n"
+                  f"available: {sorted(s.name for s in strategies)}", file=sys.stderr)
+            sys.exit(1)
+        strategies = [s for s in strategies if s.name in wanted]
+
+    sim = SimBroker("XAUUSD", m1, spread_points=args.spread,
+                    initial_equity=args.equity)
+    with tempfile.TemporaryDirectory() as td:
+        risk = RiskManager(RiskConfig(),
+                           pathlib.Path(td) / "risk_state.json")
+        run(sim, strategies, risk)
+
+    rows = scorecard(sim, strategies)
+    print(f"\nBacktest {m1.index[0]} -> {m1.index[-1]} "
+          f"({len(m1)} M1 bars), final equity {sim.equity():.2f}\n")
+    print_table(rows)
+
+    if args.json:
+        payload = {"scorecard": rows,
+                   "final_equity": sim.equity(),
+                   "trades": [{**t, "open_time": str(t["open_time"]),
+                               "close_time": str(t["close_time"])}
+                              for t in sim.trade_log]}
+        pathlib.Path(args.json).write_text(json.dumps(payload, indent=2, default=str))
+        print(f"\nwrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gold-scalper/backtest/sim_broker.py
+++ b/gold-scalper/backtest/sim_broker.py
@@ -1,0 +1,239 @@
+"""Simulated broker for backtesting — same public surface as core.broker_mt5.MT5Broker.
+
+Replays a historical M1 OHLCV DataFrame bar by bar. The engine-side contract
+is identical to MT5Broker: tick(), bars(), spread_points(), equity(),
+magic_for(), open_positions(), position_for_magic(), market_order(),
+close_position(), modify_sl(), shutdown(), plus .symbol and .info — so the
+same strategy executors run unchanged against history.
+
+Fill model (deliberately conservative):
+  * longs enter at ask (+ slippage), exit on the bid side of each bar;
+  * shorts enter at bid (- slippage), exit on the ask side (bar high/low
+    shifted up by the spread) so the spread is paid once per round trip;
+  * if both SL and TP fall inside one bar's range, the SL is assumed hit first.
+"""
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import sys
+import types
+from typing import Optional
+
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.strategy_base import PositionState, Side, Signal  # noqa: E402
+
+TF_RULES = {"M1": "1min", "M5": "5min", "M15": "15min", "M30": "30min",
+            "H1": "1h", "H4": "4h", "D1": "1D"}
+TF_DELTAS = {tf: pd.Timedelta(rule) for tf, rule in TF_RULES.items()}
+
+_AGG = {"open": "first", "high": "max", "low": "min",
+        "close": "last", "tick_volume": "sum"}
+
+
+@dataclasses.dataclass
+class _SimPosition:
+    ticket: int
+    magic: int
+    side: Side
+    entry: float
+    sl: float
+    tp: Optional[float]
+    volume: float
+    open_time: pd.Timestamp
+    comment: str = ""
+
+
+class SimBroker:
+    def __init__(self, symbol: str, m1_df: pd.DataFrame,
+                 spread_points: float = 300, initial_equity: float = 10_000,
+                 point: float = 0.01, tick_value: float = 1.0,
+                 tick_size: float = 0.01, volume_min: float = 0.01,
+                 volume_step: float = 0.01, volume_max: float = 10.0,
+                 slippage_points: float = 20, magic_base: int = 770000):
+        df = m1_df.copy()
+        if "tick_volume" not in df.columns and "volume" in df.columns:
+            df = df.rename(columns={"volume": "tick_volume"})
+        missing = [c for c in _AGG if c not in df.columns]
+        if missing:
+            raise ValueError(f"m1_df missing columns: {missing}")
+        if not isinstance(df.index, pd.DatetimeIndex):
+            raise ValueError("m1_df must have a DatetimeIndex")
+        df = df[list(_AGG)].sort_index()
+        df.index = (df.index.tz_localize("UTC") if df.index.tz is None
+                    else df.index.tz_convert("UTC"))
+        if df.empty:
+            raise ValueError("m1_df is empty")
+        self._m1 = df
+
+        self.symbol = symbol
+        self.magic_base = magic_base
+        self._point = point
+        self._spread_pts = float(spread_points)
+        self._slippage_pts = float(slippage_points)
+        self._tick_value = tick_value
+        self._tick_size = tick_size
+        self._initial_equity = float(initial_equity)
+        self.info = types.SimpleNamespace(
+            point=point, spread=spread_points,
+            trade_tick_value=tick_value, trade_tick_size=tick_size,
+            volume_min=volume_min, volume_step=volume_step,
+            volume_max=volume_max, filling_mode=1)
+
+        self._i = 0                          # index pointer into the M1 data
+        self._next_ticket = 1
+        self._realized = 0.0
+        self._positions: list[_SimPosition] = []
+        self.trade_log: list[dict] = []
+        self._resampled: dict[str, tuple[pd.DataFrame, pd.DatetimeIndex]] = {}
+
+    # ---------- clock ----------
+    @property
+    def now(self) -> pd.Timestamp:
+        return self._m1.index[self._i]
+
+    @property
+    def done(self) -> bool:
+        return self._i >= len(self._m1) - 1
+
+    def step(self) -> None:
+        """Advance one M1 bar, then mark open positions to the new bar."""
+        if self.done:
+            return
+        self._i += 1
+        self._check_exits(self._m1.iloc[self._i], self.now)
+
+    # ---------- market data ----------
+    def tick(self):
+        close = float(self._m1["close"].iloc[self._i])
+        return types.SimpleNamespace(bid=close,
+                                     ask=close + self._spread_pts * self._point,
+                                     time=self.now)
+
+    def bars(self, timeframe: str, count: int,
+             symbol: Optional[str] = None) -> pd.DataFrame:
+        if symbol is not None and symbol != self.symbol:
+            raise KeyError(f"sim broker has no data for symbol {symbol!r}")
+        if timeframe not in TF_RULES:
+            raise KeyError(f"unknown timeframe {timeframe!r}")
+        if timeframe == "M1":
+            # the engine acts on bar close, so the current M1 bar counts as closed
+            return self._m1.iloc[:self._i + 1].tail(count)
+        res, completion = self._get_resampled(timeframe)
+        # a resampled bar is complete once its period end is covered by the
+        # current (closed) M1 bar: bar_start + tf <= now + 1min
+        cutoff = self.now + pd.Timedelta(minutes=1)
+        pos = completion.searchsorted(cutoff, side="right")
+        return res.iloc[:pos].tail(count)
+
+    def _get_resampled(self, timeframe: str):
+        cached = self._resampled.get(timeframe)
+        if cached is None:
+            res = (self._m1.resample(TF_RULES[timeframe],
+                                     label="left", closed="left")
+                   .agg(_AGG).dropna(subset=["open"]))
+            cached = (res, res.index + TF_DELTAS[timeframe])
+            self._resampled[timeframe] = cached
+        return cached
+
+    def spread_points(self) -> float:
+        return self._spread_pts
+
+    # ---------- account ----------
+    def equity(self) -> float:
+        close = float(self._m1["close"].iloc[self._i])
+        unrealized = sum(self._pnl(p.side, p.entry, close, p.volume)
+                         for p in self._positions)
+        return self._initial_equity + self._realized + unrealized
+
+    # ---------- positions ----------
+    def magic_for(self, strategy_index: int) -> int:
+        return self.magic_base + strategy_index
+
+    def open_positions(self) -> list[PositionState]:
+        return [self._to_state(p) for p in self._positions]
+
+    def position_for_magic(self, magic: int) -> Optional[PositionState]:
+        for p in self._positions:
+            if p.magic == magic:
+                return self._to_state(p)
+        return None
+
+    def _to_state(self, p: _SimPosition) -> PositionState:
+        return PositionState(ticket=p.ticket, side=p.side, entry_price=p.entry,
+                             stop_loss=p.sl, take_profit=p.tp, volume=p.volume,
+                             opened_at=p.open_time.to_pydatetime())
+
+    # ---------- orders ----------
+    def market_order(self, sig: Signal, lots: float, magic: int,
+                     deviation: int = 20) -> Optional[int]:
+        t = self.tick()
+        slip = self._slippage_pts * self._point       # adverse slippage
+        price = t.ask + slip if sig.side == Side.LONG else t.bid - slip
+        pos = _SimPosition(ticket=self._next_ticket, magic=magic, side=sig.side,
+                           entry=price, sl=sig.stop_loss,
+                           tp=sig.take_profit or None, volume=lots,
+                           open_time=self.now, comment=sig.comment[:31])
+        self._next_ticket += 1
+        self._positions.append(pos)
+        return pos.ticket
+
+    def close_position(self, pos: PositionState, reason: str = "") -> bool:
+        p = self._find(pos.ticket)
+        if p is None:
+            return False
+        t = self.tick()
+        exit_price = t.bid if p.side == Side.LONG else t.ask
+        self._close(p, exit_price, reason or "strategy_exit", self.now)
+        return True
+
+    def modify_sl(self, pos: PositionState, new_sl: float) -> bool:
+        p = self._find(pos.ticket)
+        if p is None:
+            return False
+        p.sl = new_sl
+        return True
+
+    def shutdown(self) -> None:
+        pass
+
+    # ---------- internals ----------
+    def _find(self, ticket: int) -> Optional[_SimPosition]:
+        for p in self._positions:
+            if p.ticket == ticket:
+                return p
+        return None
+
+    def _pnl(self, side: Side, entry: float, exit_price: float,
+             volume: float) -> float:
+        diff = exit_price - entry if side == Side.LONG else entry - exit_price
+        return diff / self._tick_size * self._tick_value * volume
+
+    def _close(self, p: _SimPosition, exit_price: float, reason: str,
+               close_time: pd.Timestamp) -> None:
+        pnl = self._pnl(p.side, p.entry, exit_price, p.volume)
+        self._realized += pnl
+        self.trade_log.append({
+            "magic": p.magic, "side": p.side.value, "entry": p.entry,
+            "exit": exit_price, "volume": p.volume, "pnl": pnl,
+            "open_time": p.open_time, "close_time": close_time,
+            "reason": reason, "comment": p.comment})
+        self._positions.remove(p)
+
+    def _check_exits(self, bar, when: pd.Timestamp) -> None:
+        spread = self._spread_pts * self._point
+        hi, lo = float(bar["high"]), float(bar["low"])
+        for p in list(self._positions):
+            if p.side == Side.LONG:                    # exits on the bid side
+                sl_hit = p.sl > 0 and lo <= p.sl
+                tp_hit = p.tp is not None and hi >= p.tp
+            else:                                      # exits on the ask side
+                sl_hit = p.sl > 0 and hi + spread >= p.sl
+                tp_hit = p.tp is not None and lo + spread <= p.tp
+            if sl_hit:                # conservative: SL first when both inside bar
+                self._close(p, p.sl, "stop_loss", when)
+            elif tp_hit:
+                self._close(p, p.tp, "take_profit", when)

--- a/gold-scalper/backtest/walk_forward.py
+++ b/gold-scalper/backtest/walk_forward.py
@@ -1,0 +1,240 @@
+"""Walk-forward validation — rolling out-of-sample windows over the fleet.
+
+Usage:
+    python walk_forward.py --csv path/to/xauusd_m1.csv \
+        [--window-days 30] [--step-days 7] [--min-windows 4] \
+        [--equity 10000] [--spread 300] [--json out.json] \
+        [--strategies name1,name2]
+
+Our strategies have FIXED parameters — there is no optimization step — so
+every window is pure out-of-sample: this is a consistency test, not an
+optimize-then-validate walk-forward. Window k covers
+[start + k*step, start + k*step + window). Each window gets a fresh
+SimBroker, fresh strategy instances, and a fresh RiskManager state file in
+its own tempdir, so no state bleeds between windows.
+
+Reuses run_backtest.py's load_csv() and run() (the per-bar engine loop)
+unchanged; only the slicing, aggregation, and verdict logic live here.
+
+Verdicts per strategy:
+  ROBUST            >= min-windows windows with trades AND >= 60% of those
+                    profitable AND pooled PF > 1.1
+  NEGATIVE          pooled PF < 0.9
+  INCONSISTENT      traded, but fails the consistency bar
+  INSUFFICIENT-DATA fewer than min-windows windows with >= 5 trades each
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import statistics
+import sys
+import tempfile
+
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.risk import RiskConfig, RiskManager                    # noqa: E402
+from backtest.sim_broker import SimBroker                        # noqa: E402
+from backtest.run_backtest import load_csv, run, ALL_STRATEGIES  # noqa: E402
+
+MIN_TRADES_PER_WINDOW = 5      # a window "counts" for the data gate at >= 5
+VERDICT_RANK = {"NEGATIVE": 0, "INCONSISTENT": 1,
+                "INSUFFICIENT-DATA": 2, "ROBUST": 3}
+
+
+def make_windows(index: pd.DatetimeIndex, window_days: int,
+                 step_days: int) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
+    """Rolling out-of-sample windows: [start + k*step, start + k*step + window)."""
+    start, end = index[0], index[-1]
+    window = pd.Timedelta(days=window_days)
+    step = pd.Timedelta(days=step_days)
+    out, k = [], 0
+    while True:
+        ws = start + k * step
+        we = ws + window
+        if we > end + pd.Timedelta(minutes=1):     # only full windows
+            break
+        out.append((ws, we))
+        k += 1
+    return out
+
+
+def run_window(m1: pd.DataFrame, names: set[str], equity: float,
+               spread: float) -> tuple[list, SimBroker]:
+    """One fully isolated backtest: fresh broker, strategies, risk state."""
+    strategies = [cls() for cls in ALL_STRATEGIES]
+    if names:
+        strategies = [s for s in strategies if s.name in names]
+    sim = SimBroker("XAUUSD", m1, spread_points=spread, initial_equity=equity)
+    with tempfile.TemporaryDirectory() as td:
+        risk = RiskManager(RiskConfig(), pathlib.Path(td) / "risk_state.json")
+        run(sim, strategies, risk)
+    return strategies, sim
+
+
+def window_rows(sim: SimBroker, strategies: list) -> dict[str, dict]:
+    """Per-strategy stats for one window, keyed by strategy name."""
+    rows = {}
+    for idx, strat in enumerate(strategies):
+        magic = sim.magic_for(idx)
+        trades = [t for t in sim.trade_log if t["magic"] == magic]
+        gp = sum(t["pnl"] for t in trades if t["pnl"] > 0)
+        gl = sum(t["pnl"] for t in trades if t["pnl"] <= 0)
+        rows[strat.name] = {"trades": len(trades),
+                            "wins": sum(1 for t in trades if t["pnl"] > 0),
+                            "pnl": gp + gl,
+                            "gross_profit": gp, "gross_loss": gl}
+    return rows
+
+
+def aggregate(name: str, per_window: list[dict], min_windows: int) -> dict:
+    """Roll one strategy's window rows up into stats + verdict."""
+    traded = [w for w in per_window if w["trades"] > 0]
+    pnls = [w["pnl"] for w in traded]
+    profitable = sum(1 for p in pnls if p > 0)
+    pct_profitable = 100.0 * profitable / len(traded) if traded else 0.0
+    gp = sum(w["gross_profit"] for w in per_window)
+    gl = sum(w["gross_loss"] for w in per_window)
+    pooled_pf = gp / abs(gl) if gl else (float("inf") if gp else 0.0)
+    windows_5plus = sum(1 for w in per_window
+                        if w["trades"] >= MIN_TRADES_PER_WINDOW)
+
+    if windows_5plus < min_windows:
+        verdict = "INSUFFICIENT-DATA"
+    elif pooled_pf < 0.9:
+        verdict = "NEGATIVE"
+    elif (len(traded) >= min_windows and pct_profitable >= 60.0
+          and pooled_pf > 1.1):
+        verdict = "ROBUST"
+    else:
+        verdict = "INCONSISTENT"
+
+    return {"strategy": name,
+            "windows_traded": len(traded),
+            "windows_5plus_trades": windows_5plus,
+            "pct_windows_profitable": pct_profitable,
+            "mean_window_pnl": statistics.mean(pnls) if pnls else 0.0,
+            "median_window_pnl": statistics.median(pnls) if pnls else 0.0,
+            "worst_window_pnl": min(pnls) if pnls else 0.0,
+            "stdev_window_pnl": statistics.stdev(pnls) if len(pnls) > 1 else 0.0,
+            "total_trades": sum(w["trades"] for w in per_window),
+            "pooled_pf": pooled_pf,
+            "verdict": verdict}
+
+
+def print_table(rows: list[dict]) -> None:
+    hdr = f"{'strategy':<28}{'wins':>5}{'w5+':>5}{'%prof':>7}{'meanPnL':>10}" \
+          f"{'medPnL':>10}{'worst':>10}{'stdev':>10}{'trades':>8}" \
+          f"{'PF':>7}  {'verdict':<17}"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        pf = "inf" if r["pooled_pf"] == float("inf") else f"{r['pooled_pf']:.2f}"
+        print(f"{r['strategy']:<28}{r['windows_traded']:>5}"
+              f"{r['windows_5plus_trades']:>5}"
+              f"{r['pct_windows_profitable']:>6.0f}%"
+              f"{r['mean_window_pnl']:>10.2f}{r['median_window_pnl']:>10.2f}"
+              f"{r['worst_window_pnl']:>10.2f}{r['stdev_window_pnl']:>10.2f}"
+              f"{r['total_trades']:>8}{pf:>7}  {r['verdict']:<17}")
+    print("\n(wins = windows with >=1 trade, w5+ = windows with >=5 trades, "
+          "%prof = of traded windows)")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Walk-forward validation over rolling out-of-sample windows")
+    ap.add_argument("--csv", required=True,
+                    help="M1 OHLCV CSV (time,open,high,low,close,tick_volume)")
+    ap.add_argument("--window-days", type=int, default=30)
+    ap.add_argument("--step-days", type=int, default=7)
+    ap.add_argument("--min-windows", type=int, default=4,
+                    help="windows with >=5 trades required to escape "
+                         "INSUFFICIENT-DATA; also the ROBUST floor")
+    ap.add_argument("--equity", type=float, default=10_000)
+    ap.add_argument("--spread", type=float, default=300, help="spread in points")
+    ap.add_argument("--json", default="",
+                    help="dump full per-window detail to this file")
+    ap.add_argument("--strategies", default="",
+                    help="comma-separated strategy names (default: all)")
+    args = ap.parse_args()
+
+    m1 = load_csv(args.csv)
+
+    all_names = {cls.name for cls in ALL_STRATEGIES}
+    wanted: set[str] = set()
+    if args.strategies:
+        wanted = {n.strip() for n in args.strategies.split(",") if n.strip()}
+        unknown = wanted - all_names
+        if unknown:
+            print(f"ERROR: unknown strategies: {sorted(unknown)}\n"
+                  f"available: {sorted(all_names)}", file=sys.stderr)
+            sys.exit(1)
+    strat_names = sorted(wanted) if wanted else sorted(all_names)
+
+    windows = make_windows(m1.index, args.window_days, args.step_days)
+    if not windows:
+        print(f"ERROR: data span {m1.index[0]} -> {m1.index[-1]} is shorter "
+              f"than one {args.window_days}-day window", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Walk-forward validation: {len(windows)} rolling windows of "
+          f"{args.window_days}d, step {args.step_days}d, over "
+          f"{m1.index[0]} -> {m1.index[-1]} ({len(m1)} M1 bars)")
+    print("All strategy parameters are FIXED (no optimization step): every "
+          "window is pure out-of-sample.\n")
+
+    per_window_detail: list[dict] = []
+    per_strategy: dict[str, list[dict]] = {n: [] for n in strat_names}
+
+    for k, (ws, we) in enumerate(windows):
+        chunk = m1[(m1.index >= ws) & (m1.index < we)]
+        if len(chunk) < 10:                      # e.g. all-weekend window
+            print(f"[window {k + 1}/{len(windows)}] {ws.date()} -> {we.date()}"
+                  f"  SKIPPED ({len(chunk)} bars)")
+            continue
+        strategies, sim = run_window(chunk, wanted, args.equity, args.spread)
+        rows = window_rows(sim, strategies)
+        for name, row in rows.items():
+            per_strategy[name].append(row)
+        fleet_trades = sum(r["trades"] for r in rows.values())
+        fleet_pnl = sum(r["pnl"] for r in rows.values())
+        print(f"[window {k + 1}/{len(windows)}] {ws.date()} -> {we.date()}"
+              f"  bars={len(chunk)}  fleet trades={fleet_trades}"
+              f"  fleet pnl={fleet_pnl:+.2f}")
+        per_window_detail.append({
+            "window": k + 1, "start": str(ws), "end": str(we),
+            "bars": len(chunk), "fleet_trades": fleet_trades,
+            "fleet_pnl": fleet_pnl, "final_equity": sim.equity(),
+            "strategies": rows})
+
+    agg = [aggregate(n, per_strategy[n], args.min_windows)
+           for n in strat_names]
+    agg.sort(key=lambda r: (VERDICT_RANK[r["verdict"]],
+                            r["pooled_pf"], r["mean_window_pnl"]))
+
+    print()
+    print_table(agg)
+    robust = sum(1 for r in agg if r["verdict"] == "ROBUST")
+    print(f"\n{robust} of {len(agg)} strategies clear the walk-forward gate")
+
+    if args.json:
+        payload = {"config": {"csv": args.csv,
+                              "window_days": args.window_days,
+                              "step_days": args.step_days,
+                              "min_windows": args.min_windows,
+                              "equity": args.equity, "spread": args.spread,
+                              "strategies": strat_names},
+                   "data_span": [str(m1.index[0]), str(m1.index[-1])],
+                   "windows": per_window_detail,
+                   "aggregate": agg,
+                   "robust_count": robust}
+        pathlib.Path(args.json).write_text(
+            json.dumps(payload, indent=2, default=str))
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gold-scalper/config/enabled.json
+++ b/gold-scalper/config/enabled.json
@@ -1,0 +1,22 @@
+{
+  "london_breakout": true,
+  "ny_open_momentum": true,
+  "orb_ny": true,
+  "asian_range_break": true,
+  "vol_expansion": true,
+  "vwap_reversion": true,
+  "bollinger_fade": true,
+  "rsi_extreme_fade": true,
+  "round_number_bounce": true,
+  "pivot_reversion": true,
+  "news_spike_fade": true,
+  "tick_velocity_ignition": true,
+  "spread_aware_liquidity": true,
+  "dxy_divergence": true,
+  "liquidity_sweep_reversal": true,
+  "ema_ribbon_pullback": true,
+  "stoch_trend_scalp": true,
+  "macd_zero_cross": true,
+  "keltner_supertrend_ride": true,
+  "heikin_ashi_atr": true
+}

--- a/gold-scalper/config/settings.json
+++ b/gold-scalper/config/settings.json
@@ -1,0 +1,22 @@
+{
+  "symbol": "XAUUSD",
+  "magic_base": 770000,
+  "mt5": {
+    "login": null,
+    "password": "",
+    "server": "",
+    "terminal_path": null
+  },
+  "risk": {
+    "max_risk_per_trade_pct": 0.5,
+    "max_daily_loss_pct": 2.0,
+    "max_weekly_loss_pct": 5.0,
+    "max_open_positions": 6,
+    "max_same_direction": 4,
+    "max_total_volume_lots": 3.0,
+    "min_equity": 100.0,
+    "news_blackout": true
+  },
+  "calendar_path": "config/calendar.json",
+  "i_understand_this_is_real_money": false
+}

--- a/gold-scalper/core/broker_mt5.py
+++ b/gold-scalper/core/broker_mt5.py
@@ -1,0 +1,198 @@
+"""MT5 broker adapter.
+
+The only module that imports MetaTrader5. Everything above it (engine,
+strategies, risk) is broker-agnostic, which is what lets the same executors
+run against the backtest broker in backtest/sim_broker.py unchanged.
+
+Requires: pip install MetaTrader5 pandas  (Windows + running MT5 terminal).
+"""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Optional
+
+import pandas as pd
+
+try:
+    import MetaTrader5 as mt5
+except ImportError:            # allows backtesting on non-Windows machines
+    mt5 = None
+
+from .strategy_base import PositionState, Side, Signal
+
+log = logging.getLogger("broker")
+
+TIMEFRAME_MAP = {}
+if mt5:
+    TIMEFRAME_MAP = {
+        "M1": mt5.TIMEFRAME_M1, "M5": mt5.TIMEFRAME_M5,
+        "M15": mt5.TIMEFRAME_M15, "M30": mt5.TIMEFRAME_M30,
+        "H1": mt5.TIMEFRAME_H1, "H4": mt5.TIMEFRAME_H4, "D1": mt5.TIMEFRAME_D1,
+    }
+
+TF_SECONDS = {"M1": 60, "M5": 300, "M15": 900, "M30": 1800,
+              "H1": 3600, "H4": 14400, "D1": 86400}
+
+
+class MT5Broker:
+    last_fill: Optional[dict] = None       # requested vs filled on the latest order
+
+    def __init__(self, symbol: str, magic_base: int = 770000,
+                 login: Optional[int] = None, password: str = "",
+                 server: str = "", terminal_path: Optional[str] = None):
+        if mt5 is None:
+            raise RuntimeError("MetaTrader5 package not installed — live mode "
+                               "needs Windows + `pip install MetaTrader5`")
+        self.symbol = symbol
+        self.magic_base = magic_base
+        kwargs = {}
+        if terminal_path:
+            kwargs["path"] = terminal_path
+        if login:
+            kwargs.update(login=login, password=password, server=server)
+        if not mt5.initialize(**kwargs):
+            raise RuntimeError(f"mt5.initialize failed: {mt5.last_error()}")
+        if not mt5.symbol_select(symbol, True):
+            raise RuntimeError(f"symbol_select({symbol}) failed: {mt5.last_error()}")
+        self.info = mt5.symbol_info(symbol)
+        self.utc_offset_s = self._probe_server_offset()
+        log.info("connected: %s, spread=%s pts, tick_value=%s, server offset %+dh",
+                 symbol, self.info.spread, self.info.trade_tick_value,
+                 self.utc_offset_s // 3600)
+
+    def _probe_server_offset(self) -> int:
+        """MT5 bar timestamps are broker-server time (usually UTC+2/+3, DST-shifting).
+        Session logic runs in UTC, so all bars are normalized: compare the newest
+        M1 bar's timestamp to actual UTC now, rounded to the nearest 30 minutes."""
+        rates = mt5.copy_rates_from_pos(self.symbol, mt5.TIMEFRAME_M1, 0, 1)
+        if rates is None or not len(rates):
+            log.warning("server-offset probe failed — assuming server time == UTC")
+            return 0
+        now = dt.datetime.now(dt.timezone.utc).timestamp()
+        raw = float(rates[0]["time"]) - now
+        return int(round(raw / 1800.0)) * 1800
+
+    # ---------- market data ----------
+    def tick(self):
+        return mt5.symbol_info_tick(self.symbol)
+
+    def bars(self, timeframe: str, count: int, symbol: Optional[str] = None) -> pd.DataFrame:
+        rates = mt5.copy_rates_from_pos(symbol or self.symbol,
+                                        TIMEFRAME_MAP[timeframe], 0, count)
+        if rates is None:
+            raise RuntimeError(f"copy_rates failed: {mt5.last_error()}")
+        df = pd.DataFrame(rates)
+        # normalize broker-server timestamps to true UTC so session windows hold
+        df["time"] = pd.to_datetime(df["time"] - self.utc_offset_s, unit="s", utc=True)
+        return df.set_index("time")
+
+    def spread_points(self) -> float:
+        t = self.tick()
+        return (t.ask - t.bid) / self.info.point
+
+    # ---------- account ----------
+    def equity(self) -> float:
+        acc = mt5.account_info()
+        return acc.equity if acc else 0.0
+
+    # ---------- positions (one magic number per strategy) ----------
+    def magic_for(self, strategy_index: int) -> int:
+        return self.magic_base + strategy_index
+
+    def open_positions(self) -> list[PositionState]:
+        out = []
+        for p in (mt5.positions_get(symbol=self.symbol) or []):
+            if not (self.magic_base <= p.magic < self.magic_base + 1000):
+                continue                      # not ours — never touch it
+            out.append(PositionState(
+                ticket=p.ticket,
+                side=Side.LONG if p.type == mt5.POSITION_TYPE_BUY else Side.SHORT,
+                entry_price=p.price_open, stop_loss=p.sl,
+                take_profit=p.tp or None, volume=p.volume,
+                opened_at=dt.datetime.fromtimestamp(p.time, dt.timezone.utc)))
+        return out
+
+    def position_for_magic(self, magic: int) -> Optional[PositionState]:
+        for p in (mt5.positions_get(symbol=self.symbol) or []):
+            if p.magic == magic:
+                return PositionState(
+                    ticket=p.ticket,
+                    side=Side.LONG if p.type == mt5.POSITION_TYPE_BUY else Side.SHORT,
+                    entry_price=p.price_open, stop_loss=p.sl,
+                    take_profit=p.tp or None, volume=p.volume,
+                    opened_at=dt.datetime.fromtimestamp(p.time, dt.timezone.utc))
+        return None
+
+    # ---------- orders ----------
+    def market_order(self, sig: Signal, lots: float, magic: int,
+                     deviation: int = 20) -> Optional[int]:
+        t = self.tick()
+        price = t.ask if sig.side == Side.LONG else t.bid
+        req = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": self.symbol,
+            "volume": lots,
+            "type": mt5.ORDER_TYPE_BUY if sig.side == Side.LONG else mt5.ORDER_TYPE_SELL,
+            "price": price,
+            "sl": sig.stop_loss,
+            "tp": sig.take_profit or 0.0,
+            "deviation": deviation,
+            "magic": magic,
+            "comment": sig.comment[:31],
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": self._filling_mode(),
+        }
+        res = mt5.order_send(req)
+        if res is None or res.retcode != mt5.TRADE_RETCODE_DONE:
+            log.error("order_send failed for %s: %s", sig.comment,
+                      res.retcode if res else mt5.last_error())
+            self.last_fill = None
+            return None
+        slip = (res.price - price) / self.info.point
+        if sig.side == Side.SHORT:
+            slip = -slip                    # positive = adverse for either side
+        self.last_fill = {"requested": price, "filled": res.price,
+                          "slippage_points": round(slip, 1)}
+        log.info("OPENED %s %s %.2f lots @ %.2f (slip %+.1f pts) sl=%.2f tp=%s (magic=%d)",
+                 sig.side.value, self.symbol, lots, res.price, slip,
+                 sig.stop_loss, sig.take_profit, magic)
+        return res.order
+
+    def close_position(self, pos: PositionState, reason: str = "") -> bool:
+        t = self.tick()
+        req = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": self.symbol,
+            "volume": pos.volume,
+            "type": mt5.ORDER_TYPE_SELL if pos.side == Side.LONG else mt5.ORDER_TYPE_BUY,
+            "position": pos.ticket,
+            "price": t.bid if pos.side == Side.LONG else t.ask,
+            "deviation": 30,
+            "comment": f"close:{reason}"[:31],
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": self._filling_mode(),
+        }
+        res = mt5.order_send(req)
+        ok = res is not None and res.retcode == mt5.TRADE_RETCODE_DONE
+        (log.info if ok else log.error)("close ticket %d (%s): %s",
+                                        pos.ticket, reason,
+                                        "done" if ok else (res.retcode if res else mt5.last_error()))
+        return ok
+
+    def modify_sl(self, pos: PositionState, new_sl: float) -> bool:
+        req = {"action": mt5.TRADE_ACTION_SLTP, "symbol": self.symbol,
+               "position": pos.ticket, "sl": new_sl, "tp": pos.take_profit or 0.0}
+        res = mt5.order_send(req)
+        return res is not None and res.retcode == mt5.TRADE_RETCODE_DONE
+
+    def _filling_mode(self):
+        fm = self.info.filling_mode
+        if fm & 1:
+            return mt5.ORDER_FILLING_FOK
+        if fm & 2:
+            return mt5.ORDER_FILLING_IOC
+        return mt5.ORDER_FILLING_RETURN
+
+    def shutdown(self):
+        mt5.shutdown()

--- a/gold-scalper/core/engine.py
+++ b/gold-scalper/core/engine.py
@@ -1,0 +1,301 @@
+"""Harness engine — the loop controller that runs all 20 executors.
+
+Design (mirrors this repo's engineering/agent-harness discipline):
+  goal -> per-strategy executors -> every action verified -> bounded retries
+  -> circuit breakers escalate to human -> journal is the audit trail.
+
+One process, one account, N strategies. Each strategy gets its own MT5 magic
+number so positions are attributable and restart-safe: on boot the engine
+re-adopts any open position whose magic falls in our range.
+
+Per iteration (each new closed primary bar, checked every POLL_SECONDS):
+  1. roll risk day/week counters, check circuit breakers
+  2. build one shared MarketContext snapshot (bars fetched once per TF)
+  3. for each ENABLED strategy: flat -> on_bar() may emit a Signal;
+     holding -> manage_position() may exit / trail
+  4. every Signal passes the RiskManager gate before order_send
+  5. everything is journaled to logs/journal.jsonl (one JSON per event)
+
+The supervisor (supervisor.py) reads the journal and can flip strategies
+on/off via config/enabled.json — the engine re-reads it every iteration, so
+a human or a Claude Fable 5 review loop can intervene without a restart.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import pathlib
+import signal as os_signal
+import time
+from typing import Optional
+
+from .strategy_base import ExitReason, MarketContext, Signal, StrategyBase
+from .risk import RiskConfig, RiskManager
+
+log = logging.getLogger("engine")
+
+POLL_SECONDS = 2.0
+ROLLOVER_START, ROLLOVER_END = (21, 50), (22, 10)   # UTC swap window: spreads 5-10x
+MAX_TRADES_PER_DAY = 5                              # per strategy — stops SL-loops
+
+
+def in_rollover(now: dt.datetime) -> bool:
+    hm = (now.hour, now.minute)
+    return ROLLOVER_START <= hm < ROLLOVER_END
+
+
+class Journal:
+    def __init__(self, path: pathlib.Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(self, kind: str, **fields) -> None:
+        rec = {"ts": dt.datetime.now(dt.timezone.utc).isoformat(), "kind": kind, **fields}
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, default=str) + "\n")
+
+
+class Engine:
+    def __init__(self, broker, strategies: list[StrategyBase],
+                 risk: RiskManager, base_dir: pathlib.Path,
+                 calendar: Optional[list] = None):
+        self.broker = broker
+        self.strategies = strategies
+        self.risk = risk
+        self.base = base_dir
+        self.journal = Journal(base_dir / "logs" / "journal.jsonl")
+        self.enabled_path = base_dir / "config" / "enabled.json"
+        self.calendar = calendar or []          # [{"time": iso, "impact": "high"}, ...]
+        self._last_bar_time: dict[str, object] = {}
+        self._trades_day: str = ""
+        self._trades_today: dict[str, int] = {}
+        self._adopted_bars: dict[int, int] = self._load_adopted()
+        self._stop = False
+        os_signal.signal(os_signal.SIGINT, self._sigint)
+        os_signal.signal(os_signal.SIGTERM, self._sigint)
+
+    def _sigint(self, *_):
+        log.warning("shutdown requested — finishing iteration then stopping")
+        self._stop = True
+
+    # ---------- liveness + restart persistence ----------
+    def _heartbeat(self, now: dt.datetime, equity: float) -> None:
+        p = self.base / "logs" / "heartbeat.json"
+        tmp = p.with_suffix(".tmp")
+        try:
+            tmp.write_text(json.dumps({
+                "ts": now.isoformat(), "equity": equity,
+                "open_positions": len(self.broker.open_positions())}))
+            tmp.replace(p)
+        except OSError:
+            pass                                    # liveness is best-effort
+
+    def _bars_path(self) -> pathlib.Path:
+        return self.base / "logs" / "bars_held.json"
+
+    def _load_adopted(self) -> dict[int, int]:
+        try:
+            return {int(k): v for k, v in
+                    json.loads(self._bars_path().read_text()).items()}
+        except (OSError, json.JSONDecodeError, ValueError):
+            return {}
+
+    def _save_adopted(self) -> None:
+        tmp = self._bars_path().with_suffix(".tmp")
+        try:
+            tmp.write_text(json.dumps(self._adopted_bars))
+            tmp.replace(self._bars_path())
+        except OSError:
+            pass
+
+    # ---------- config hot-reload ----------
+    def enabled_map(self) -> dict:
+        try:
+            return json.loads(self.enabled_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    # ---------- news blackout ----------
+    def in_news_blackout(self, now: dt.datetime, minutes: int = 5) -> bool:
+        for ev in self.calendar:
+            if ev.get("impact") != "high":
+                continue
+            t = dt.datetime.fromisoformat(ev["time"])
+            if abs((t - now).total_seconds()) <= minutes * 60:
+                return True
+        return False
+
+    # ---------- context assembly (one snapshot shared by all strategies) ----------
+    def build_context(self, strategy: StrategyBase, shared_bars: dict,
+                      shared_aux: dict, now: dt.datetime) -> MarketContext:
+        t = self.broker.tick()
+        magic = self.broker.magic_for(self.strategies.index(strategy))
+        return MarketContext(
+            symbol=self.broker.symbol, now=now,
+            bid=t.bid, ask=t.ask,
+            spread_points=self.broker.spread_points(),
+            bars={tf: shared_bars[tf] for tf in
+                  (strategy.primary_timeframe, *strategy.extra_timeframes)},
+            aux={k: shared_aux[k] for k in strategy.aux_feeds if k in shared_aux},
+            position=self.broker.position_for_magic(magic))
+
+    def fetch_shared(self) -> tuple[dict, dict]:
+        tfs, aux_names = set(), set()
+        for s in self.strategies:
+            tfs.add(s.primary_timeframe)
+            tfs.update(s.extra_timeframes)
+            aux_names.update(s.aux_feeds)
+        lookback = max(s.lookback_bars for s in self.strategies)
+        bars = {tf: self.broker.bars(tf, lookback) for tf in tfs}
+        aux = {}
+        if "DXY" in aux_names:
+            for sym in ("DXY", "USDX", "USDollar", "DX"):
+                try:
+                    aux["DXY"] = self.broker.bars("M5", lookback, symbol=sym)
+                    break
+                except Exception:
+                    continue
+        if "calendar" in aux_names:
+            aux["calendar"] = self.calendar
+        return bars, aux
+
+    # ---------- main loop ----------
+    def run(self) -> None:
+        log.info("engine start: %d strategies on %s", len(self.strategies), self.broker.symbol)
+        self.journal.write("engine_start",
+                           strategies=[s.name for s in self.strategies])
+        for s in self.strategies:
+            try:
+                bars, aux = self.fetch_shared()
+                s.warmup(self.build_context(s, bars, aux,
+                                            dt.datetime.now(dt.timezone.utc)))
+            except Exception:
+                log.exception("warmup failed for %s — disabling", s.name)
+                self._disable(s.name, "warmup failure")
+
+        errors: dict[str, int] = {}
+        while not self._stop:
+            try:
+                self.iterate(errors)
+            except Exception:
+                log.exception("iteration error")
+            time.sleep(POLL_SECONDS)
+        self.journal.write("engine_stop")
+        log.info("engine stopped")
+
+    def iterate(self, errors: dict[str, int]) -> None:
+        now = dt.datetime.now(dt.timezone.utc)
+        equity = self.broker.equity()
+        self._heartbeat(now, equity)
+        if (self.base / "HALT").exists():          # manual kill switch: touch HALT
+            log.error("HALT file present — flattening and stopping")
+            self._flatten_all(ExitReason.SUPERVISOR, "manual HALT file")
+            self._stop = True
+            return
+        self.risk.roll(now, equity)
+        allowed, why = self.risk.trading_allowed(now, equity)
+        if not allowed:
+            self._flatten_all(ExitReason.RISK_HALT, why)
+            return
+
+        bars, aux = self.fetch_shared()
+        enabled = self.enabled_map()
+        blackout = ((self.risk.cfg.news_blackout and self.in_news_blackout(now))
+                    or in_rollover(now))
+        open_positions = self.broker.open_positions()
+        day = now.strftime("%Y-%m-%d")
+        if self._trades_day != day:
+            self._trades_day, self._trades_today = day, {}
+
+        for idx, strat in enumerate(self.strategies):
+            if errors.get(strat.name, 0) >= 3:
+                continue                                  # tripped — needs human/supervisor reset
+            # new-bar gate per strategy timeframe
+            tf = strat.primary_timeframe
+            last = bars[tf].index[-1]
+            key = f"{strat.name}:{tf}"
+            if self._last_bar_time.get(key) == last:
+                continue
+            self._last_bar_time[key] = last
+
+            try:
+                ctx = self.build_context(strat, bars, aux, now)
+                if ctx.position is not None:
+                    self._manage(strat, ctx, idx)
+                elif (enabled.get(strat.name, True) and not blackout
+                      and strat.in_session(now)
+                      and ctx.spread_points <= strat.max_spread_points):
+                    self._maybe_enter(strat, ctx, idx, equity, open_positions)
+                errors[strat.name] = 0
+            except Exception as e:
+                errors[strat.name] = errors.get(strat.name, 0) + 1
+                log.exception("strategy %s error (%d/3)", strat.name, errors[strat.name])
+                self.journal.write("strategy_error", strategy=strat.name,
+                                   error=str(e), count=errors[strat.name])
+                if errors[strat.name] >= 3:
+                    self._disable(strat.name, "3 consecutive errors — escalated")
+
+    def _maybe_enter(self, strat: StrategyBase, ctx: MarketContext, idx: int,
+                     equity: float, open_positions: list) -> None:
+        if self._trades_today.get(strat.name, 0) >= MAX_TRADES_PER_DAY:
+            return                              # pathological signal-loop guard
+        sig = strat.on_bar(ctx)
+        if sig is None:
+            return
+        sig.comment = sig.comment or strat.name
+        info = self.broker.info
+        lots = self.risk.size_signal(
+            sig, equity=equity, requested_risk_pct=strat.default_risk_pct,
+            tick_value=info.trade_tick_value, tick_size=info.trade_tick_size,
+            volume_min=info.volume_min, volume_step=info.volume_step,
+            volume_max=info.volume_max, open_positions=open_positions)
+        self.journal.write("signal", strategy=strat.name, side=sig.side.value,
+                           entry=sig.entry, sl=sig.stop_loss, tp=sig.take_profit,
+                           sized_lots=lots, vetoed=lots is None)
+        if lots is None:
+            return
+        strat._time_stop_bars = sig.time_stop_bars
+        ticket = self.broker.market_order(sig, lots, self.broker.magic_for(idx))
+        fill = getattr(self.broker, "last_fill", None)
+        self.journal.write("order", strategy=strat.name, ticket=ticket,
+                           lots=lots, filled=ticket is not None,
+                           slippage_points=fill["slippage_points"] if fill else None)
+        if ticket is not None:
+            self._trades_today[strat.name] = self._trades_today.get(strat.name, 0) + 1
+
+    def _manage(self, strat: StrategyBase, ctx: MarketContext, idx: int) -> None:
+        t = ctx.position.ticket
+        # bars_held persists across restarts so adopted positions keep their
+        # time-stop clock instead of resetting to zero
+        ctx.position.bars_held = self._adopted_bars.get(t, 0) + 1
+        self._adopted_bars[t] = ctx.position.bars_held
+        self._save_adopted()
+        strat.pending_sl_move = None
+        reason = strat.manage_position(ctx)
+        if reason is not None:
+            ok = self.broker.close_position(ctx.position, reason.value)
+            if ok:
+                self._adopted_bars.pop(t, None)
+                self._save_adopted()
+            self.journal.write("close", strategy=strat.name,
+                               ticket=t,
+                               reason=reason.value, ok=ok)
+        elif strat.pending_sl_move is not None:
+            ok = self.broker.modify_sl(ctx.position, strat.pending_sl_move)
+            self.journal.write("sl_move", strategy=strat.name,
+                               ticket=ctx.position.ticket,
+                               new_sl=strat.pending_sl_move, ok=ok)
+
+    def _flatten_all(self, reason: ExitReason, why: str) -> None:
+        for pos in self.broker.open_positions():
+            self.broker.close_position(pos, reason.value)
+        self.journal.write("halt", reason=why)
+
+    def _disable(self, name: str, why: str) -> None:
+        m = self.enabled_map()
+        m[name] = False
+        self.enabled_path.parent.mkdir(parents=True, exist_ok=True)
+        self.enabled_path.write_text(json.dumps(m, indent=2))
+        self.journal.write("disabled", strategy=name, reason=why)
+        log.error("DISABLED %s: %s", name, why)

--- a/gold-scalper/core/indicators.py
+++ b/gold-scalper/core/indicators.py
@@ -1,0 +1,131 @@
+"""Shared indicator kit — pandas-only, no TA-Lib dependency.
+
+Kept deliberately small: every function is a pure transform of an OHLCV
+DataFrame so strategies stay deterministic and backtest-identical to live.
+All functions use only closed-bar data (no lookahead).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def ema(s: pd.Series, period: int) -> pd.Series:
+    return s.ewm(span=period, adjust=False).mean()
+
+
+def sma(s: pd.Series, period: int) -> pd.Series:
+    return s.rolling(period).mean()
+
+
+def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    hl = df["high"] - df["low"]
+    hc = (df["high"] - df["close"].shift()).abs()
+    lc = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([hl, hc, lc], axis=1).max(axis=1)
+    return tr.ewm(alpha=1 / period, adjust=False).mean()
+
+
+def rsi(s: pd.Series, period: int = 14) -> pd.Series:
+    delta = s.diff()
+    gain = delta.clip(lower=0).ewm(alpha=1 / period, adjust=False).mean()
+    loss = (-delta.clip(upper=0)).ewm(alpha=1 / period, adjust=False).mean()
+    rs = gain / loss.replace(0, np.nan)
+    return (100 - 100 / (1 + rs)).fillna(50)
+
+
+def bollinger(s: pd.Series, period: int = 20, stds: float = 2.0):
+    mid = sma(s, period)
+    sd = s.rolling(period).std(ddof=0)
+    return mid - stds * sd, mid, mid + stds * sd
+
+
+def stochastic(df: pd.DataFrame, k: int = 5, smooth_k: int = 3, d: int = 3):
+    lo = df["low"].rolling(k).min()
+    hi = df["high"].rolling(k).max()
+    raw = 100 * (df["close"] - lo) / (hi - lo).replace(0, np.nan)
+    k_line = raw.rolling(smooth_k).mean()
+    return k_line, k_line.rolling(d).mean()
+
+
+def macd(s: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9):
+    line = ema(s, fast) - ema(s, slow)
+    sig = ema(line, signal)
+    return line, sig, line - sig
+
+
+def keltner(df: pd.DataFrame, period: int = 20, mult: float = 2.0, atr_period: int = 10):
+    mid = ema(df["close"], period)
+    rng = atr(df, atr_period) * mult
+    return mid - rng, mid, mid + rng
+
+
+def supertrend(df: pd.DataFrame, period: int = 10, mult: float = 3.0) -> pd.Series:
+    """Returns +1 (uptrend) / -1 (downtrend) per bar."""
+    a = atr(df, period)
+    hl2 = (df["high"] + df["low"]) / 2
+    upper = hl2 + mult * a
+    lower = hl2 - mult * a
+    trend = np.ones(len(df), dtype=int)
+    ub = upper.to_numpy().copy()
+    lb = lower.to_numpy().copy()
+    close = df["close"].to_numpy()
+    for i in range(1, len(df)):
+        ub[i] = min(ub[i], ub[i - 1]) if close[i - 1] <= ub[i - 1] else ub[i]
+        lb[i] = max(lb[i], lb[i - 1]) if close[i - 1] >= lb[i - 1] else lb[i]
+        if close[i] > ub[i - 1]:
+            trend[i] = 1
+        elif close[i] < lb[i - 1]:
+            trend[i] = -1
+        else:
+            trend[i] = trend[i - 1]
+    return pd.Series(trend, index=df.index)
+
+
+def heikin_ashi(df: pd.DataFrame) -> pd.DataFrame:
+    ha = pd.DataFrame(index=df.index)
+    ha["close"] = (df["open"] + df["high"] + df["low"] + df["close"]) / 4
+    ha_open = [(df["open"].iloc[0] + df["close"].iloc[0]) / 2]
+    for i in range(1, len(df)):
+        ha_open.append((ha_open[-1] + ha["close"].iloc[i - 1]) / 2)
+    ha["open"] = ha_open
+    ha["high"] = pd.concat([df["high"], ha["open"], ha["close"]], axis=1).max(axis=1)
+    ha["low"] = pd.concat([df["low"], ha["open"], ha["close"]], axis=1).min(axis=1)
+    return ha
+
+
+def vwap_session(df: pd.DataFrame) -> pd.Series:
+    """Session VWAP resetting at UTC midnight; volume = tick_volume."""
+    day = df.index.date
+    tp = (df["high"] + df["low"] + df["close"]) / 3
+    vol = df["tick_volume"].astype(float)
+    pv = (tp * vol).groupby(day).cumsum()
+    cv = vol.groupby(day).cumsum().replace(0, np.nan)
+    return pv / cv
+
+
+def adx(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    up = df["high"].diff()
+    dn = -df["low"].diff()
+    plus_dm = np.where((up > dn) & (up > 0), up, 0.0)
+    minus_dm = np.where((dn > up) & (dn > 0), dn, 0.0)
+    a = atr(df, period)
+    plus_di = 100 * pd.Series(plus_dm, index=df.index).ewm(alpha=1/period, adjust=False).mean() / a
+    minus_di = 100 * pd.Series(minus_dm, index=df.index).ewm(alpha=1/period, adjust=False).mean() / a
+    dx = 100 * (plus_di - minus_di).abs() / (plus_di + minus_di).replace(0, np.nan)
+    return dx.ewm(alpha=1/period, adjust=False).mean().fillna(0)
+
+
+def session_range(df: pd.DataFrame, start_h: int, end_h: int, now) -> tuple[float, float] | None:
+    """High/low of today's bars in [start_h, end_h) UTC. None if no bars yet."""
+    today = df[(df.index.date == now.date())
+               & (df.index.hour >= start_h) & (df.index.hour < end_h)]
+    if today.empty:
+        return None
+    return float(today["high"].max()), float(today["low"].min())
+
+
+def round_levels(price: float, step: float = 10.0, n: int = 3) -> list[float]:
+    """Nearest n round-number levels each side (gold: $10 steps → 2360, 2370…)."""
+    base = round(price / step) * step
+    return [base + i * step for i in range(-n, n + 1)]

--- a/gold-scalper/core/risk.py
+++ b/gold-scalper/core/risk.py
@@ -1,0 +1,133 @@
+"""Portfolio-level risk gate.
+
+Sits between every strategy Signal and the broker. Enforces the survival >
+preservation > growth hierarchy: per-trade risk caps, daily/weekly loss
+circuit breakers, max concurrent exposure across all 20 executors, and a
+correlation guard so five momentum bots can't all pile into the same London
+breakout at full size.
+
+All strategies share ONE account; this module is the only thing standing
+between an over-eager executor and a blown account. Nothing trades around it.
+"""
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+import logging
+import pathlib
+from typing import Optional
+
+from .strategy_base import Signal, Side
+
+log = logging.getLogger("risk")
+
+
+@dataclasses.dataclass
+class RiskConfig:
+    max_risk_per_trade_pct: float = 0.5      # hard cap regardless of strategy ask
+    max_daily_loss_pct: float = 2.0          # halt all entries for the day
+    max_weekly_loss_pct: float = 5.0         # halt all entries for the week
+    max_open_positions: int = 6              # across all strategies
+    max_same_direction: int = 4              # long OR short concurrently
+    max_total_volume_lots: float = 3.0
+    min_equity: float = 100.0                # stop trading below this
+    news_blackout: bool = True               # honored by engine via calendar feed
+
+
+class RiskManager:
+    def __init__(self, cfg: RiskConfig, state_path: pathlib.Path):
+        self.cfg = cfg
+        self.state_path = state_path
+        self._state = self._load()
+
+    # ---------- persistence (atomic, survives restarts) ----------
+    def _load(self) -> dict:
+        if self.state_path.exists():
+            try:
+                return json.loads(self.state_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                log.warning("risk state unreadable, starting fresh")
+        return {"day": None, "day_start_equity": None,
+                "week": None, "week_start_equity": None,
+                "halted_until": None}
+
+    def _save(self) -> None:
+        tmp = self.state_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._state, indent=2, default=str))
+        tmp.replace(self.state_path)
+
+    # ---------- rollover ----------
+    def roll(self, now: dt.datetime, equity: float) -> None:
+        day = now.strftime("%Y-%m-%d")
+        week = now.strftime("%G-W%V")
+        if self._state["day"] != day:
+            self._state.update(day=day, day_start_equity=equity)
+        if self._state["week"] != week:
+            self._state.update(week=week, week_start_equity=equity)
+        self._save()
+
+    # ---------- circuit breakers ----------
+    def trading_allowed(self, now: dt.datetime, equity: float) -> tuple[bool, str]:
+        if equity < self.cfg.min_equity:
+            return False, f"equity {equity:.2f} below floor {self.cfg.min_equity}"
+        halted = self._state.get("halted_until")
+        if halted and now < dt.datetime.fromisoformat(halted):
+            return False, f"halted until {halted}"
+        d0 = self._state.get("day_start_equity")
+        if d0:
+            dd = (d0 - equity) / d0 * 100
+            if dd >= self.cfg.max_daily_loss_pct:
+                self.halt(now, hours=24, reason=f"daily loss {dd:.2f}%")
+                return False, f"daily loss limit hit ({dd:.2f}%)"
+        w0 = self._state.get("week_start_equity")
+        if w0:
+            dd = (w0 - equity) / w0 * 100
+            if dd >= self.cfg.max_weekly_loss_pct:
+                self.halt(now, hours=24 * 7, reason=f"weekly loss {dd:.2f}%")
+                return False, f"weekly loss limit hit ({dd:.2f}%)"
+        return True, "ok"
+
+    def halt(self, now: dt.datetime, hours: float, reason: str) -> None:
+        until = now + dt.timedelta(hours=hours)
+        self._state["halted_until"] = until.isoformat()
+        self._save()
+        log.error("TRADING HALTED until %s: %s", until, reason)
+
+    # ---------- per-signal gate ----------
+    def size_signal(self, sig: Signal, *, equity: float, requested_risk_pct: float,
+                    tick_value: float, tick_size: float,
+                    volume_min: float, volume_step: float, volume_max: float,
+                    open_positions: list) -> Optional[float]:
+        """Return lot size for the signal, or None to veto it."""
+        if len(open_positions) >= self.cfg.max_open_positions:
+            log.info("veto %s: max open positions", sig.comment)
+            return None
+        same_dir = sum(1 for p in open_positions if p.side == sig.side)
+        if same_dir >= self.cfg.max_same_direction:
+            log.info("veto %s: %d positions already %s", sig.comment, same_dir, sig.side.value)
+            return None
+
+        sl_dist = abs(sig.entry - sig.stop_loss)
+        if sl_dist <= 0 or tick_size <= 0 or tick_value <= 0:
+            log.warning("veto %s: degenerate SL/contract params", sig.comment)
+            return None
+
+        risk_pct = min(requested_risk_pct, self.cfg.max_risk_per_trade_pct)
+        risk_pct *= max(0.0, min(sig.confidence, 1.0))
+        risk_amount = equity * risk_pct / 100.0
+        loss_per_lot = (sl_dist / tick_size) * tick_value
+        lots = risk_amount / loss_per_lot
+
+        # broker constraints
+        lots = max(volume_min, min(lots, volume_max))
+        lots = round(lots / volume_step) * volume_step
+        lots = round(lots, 2)
+        if lots < volume_min:
+            return None
+
+        total_vol = sum(p.volume for p in open_positions) + lots
+        if total_vol > self.cfg.max_total_volume_lots:
+            log.info("veto %s: total volume %.2f > cap", sig.comment, total_vol)
+            return None
+        return lots

--- a/gold-scalper/core/strategy_base.py
+++ b/gold-scalper/core/strategy_base.py
@@ -1,0 +1,121 @@
+"""Strategy executor contract.
+
+Every one of the 20 strategy executors subclasses StrategyBase. The harness
+only ever talks to this interface — a strategy never touches MT5 directly,
+never sizes its own position, and never bypasses the risk gate. It consumes
+a MarketContext and emits Signals; everything else is the harness's job.
+"""
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import enum
+from typing import Optional
+
+
+class Side(enum.Enum):
+    LONG = "long"
+    SHORT = "short"
+
+
+class ExitReason(enum.Enum):
+    TAKE_PROFIT = "take_profit"
+    STOP_LOSS = "stop_loss"
+    TIME_STOP = "time_stop"
+    STRATEGY_EXIT = "strategy_exit"
+    RISK_HALT = "risk_halt"
+    SUPERVISOR = "supervisor"
+
+
+@dataclasses.dataclass
+class Signal:
+    """An order intent. Prices are absolute; the harness converts SL distance
+    into lot size via the risk manager. tp may be None when the strategy
+    manages its own exit through on_bar/manage_position."""
+    side: Side
+    entry: float               # intended entry price (market orders fill at bid/ask)
+    stop_loss: float           # absolute price, required — no SL, no trade
+    take_profit: Optional[float]
+    comment: str = ""
+    time_stop_bars: Optional[int] = None   # force-close after N primary bars
+    confidence: float = 1.0    # 0..1, scales risk down (never up)
+
+
+@dataclasses.dataclass
+class PositionState:
+    ticket: int
+    side: Side
+    entry_price: float
+    stop_loss: float
+    take_profit: Optional[float]
+    volume: float
+    opened_at: dt.datetime
+    bars_held: int = 0
+
+
+@dataclasses.dataclass
+class MarketContext:
+    """Everything a strategy is allowed to see for one evaluation tick."""
+    symbol: str
+    now: dt.datetime            # broker/server time, UTC
+    bid: float
+    ask: float
+    spread_points: float
+    bars: dict                  # timeframe -> pandas.DataFrame (OHLCV, tick_volume), oldest->newest
+    aux: dict                   # extra feeds keyed by name, e.g. {"DXY": DataFrame, "calendar": [...]}
+    position: Optional[PositionState]  # this strategy's open position, if any
+
+    def bars_for(self, timeframe: str):
+        df = self.bars.get(timeframe)
+        if df is None:
+            raise KeyError(f"strategy requested timeframe {timeframe!r} "
+                           f"not declared in required_data()")
+        return df
+
+
+class StrategyBase:
+    # --- identity / declaration (override in subclass) ---
+    name: str = "unnamed"
+    category: str = "uncategorized"      # momentum | mean-reversion | microstructure | indicator-hybrid
+    primary_timeframe: str = "M5"
+    extra_timeframes: tuple = ()         # e.g. ("M15",)
+    aux_feeds: tuple = ()                # e.g. ("DXY", "calendar")
+    lookback_bars: int = 200
+    # sessions the strategy may open trades in, as UTC (start_hour, end_hour) pairs;
+    # empty tuple = any time. Exits are always allowed.
+    sessions_utc: tuple = ()
+    default_risk_pct: float = 0.25       # % of equity risked per trade
+    max_spread_points: float = 350.0     # skip entries when spread wider than this
+
+    def warmup(self, ctx: MarketContext) -> None:
+        """Called once with full lookback history before the live loop starts."""
+
+    def on_bar(self, ctx: MarketContext) -> Optional[Signal]:
+        """Called on each closed primary-timeframe bar while flat.
+        Return a Signal to request an entry, or None."""
+        raise NotImplementedError
+
+    def manage_position(self, ctx: MarketContext) -> Optional[ExitReason]:
+        """Called on each closed primary bar while holding a position.
+        Return an ExitReason to request a close, or None to hold.
+        Trailing-stop moves go through ctx.position mutation requests via
+        the returned None + self.pending_sl_move (see below)."""
+        # default: honor time stop only
+        pos = ctx.position
+        if pos and self._time_stop_bars is not None and pos.bars_held >= self._time_stop_bars:
+            return ExitReason.TIME_STOP
+        return None
+
+    # A strategy may set this inside manage_position to ask the harness to
+    # move the stop (e.g. trail / break-even). Harness reads and clears it.
+    pending_sl_move: Optional[float] = None
+    _time_stop_bars: Optional[int] = None
+
+    def in_session(self, now: dt.datetime) -> bool:
+        if not self.sessions_utc:
+            return True
+        h = now.hour + now.minute / 60.0
+        for start, end in self.sessions_utc:
+            if start <= h < end:
+                return True
+        return False

--- a/gold-scalper/dashboard.py
+++ b/gold-scalper/dashboard.py
@@ -1,0 +1,922 @@
+#!/usr/bin/env python3
+"""Single-file HTML dashboard generator for the gold-scalper fleet.
+
+Reads the engine journal (logs/journal.jsonl), the fleet switchboard
+(config/enabled.json), optional realized-deal history (logs/deals.json,
+exported from MT5: list of {magic, profit, time}) and optional
+config/settings.json, and renders one self-contained HTML file:
+
+    python dashboard.py [--journal logs/journal.jsonl]
+                        [--deals logs/deals.json]
+                        [--enabled config/enabled.json]
+                        [--out logs/dashboard.html]
+                        [--refresh 10]
+
+Discipline (markdown-html rules): single file, zero framework runtimes,
+inline CSS custom-property design tokens, Google Fonts is the only external,
+WCAG AA >= 4.5:1 contrast, prefers-reduced-motion honored. Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import pathlib
+import sys
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(BASE_DIR))
+
+# Reuse the supervisor's aggregation if importable; otherwise carry a
+# faithful stdlib copy so this file also works extracted on its own.
+try:
+    from supervisor import STRATEGY_ORDER, build_scorecard  # type: ignore
+except Exception:                                            # pragma: no cover
+    STRATEGY_ORDER = [
+        "london_breakout", "ny_open_momentum", "orb_ny",
+        "asian_range_break", "vol_expansion",
+        "vwap_reversion", "bollinger_fade", "rsi_extreme_fade",
+        "round_number_bounce", "pivot_reversion",
+        "news_spike_fade", "tick_velocity_ignition", "spread_aware_liquidity",
+        "dxy_divergence", "liquidity_sweep_reversal",
+        "ema_ribbon_pullback", "stoch_trend_scalp", "macd_zero_cross",
+        "keltner_supertrend_ride", "heikin_ashi_atr",
+    ]
+
+    def _pnl_metrics(profits):
+        wins = [p for p in profits if p > 0]
+        losses = [p for p in profits if p < 0]
+        gross_win, gross_loss = sum(wins), -sum(losses)
+        peak = run = max_dd = 0.0
+        for p in profits:
+            run += p
+            peak = max(peak, run)
+            max_dd = max(max_dd, peak - run)
+        return {
+            "trades": len(profits),
+            "pnl": round(sum(profits), 2),
+            "win_pct": round(100 * len(wins) / len(profits), 1) if profits else 0.0,
+            "profit_factor": (round(gross_win / gross_loss, 2) if gross_loss > 0
+                              else (float("inf") if gross_win > 0 else 0.0)),
+            "expectancy": round(sum(profits) / len(profits), 2) if profits else 0.0,
+            "max_drawdown": round(max_dd, 2),
+        }
+
+    def build_scorecard(events, deals):
+        per = {}
+
+        def row(name):
+            return per.setdefault(name, {
+                "signals": 0, "vetoed": 0, "orders_filled": 0, "orders_failed": 0,
+                "closes": {}, "errors": 0, "disabled_events": 0, "sl_moves": 0,
+            })
+
+        for ev in events:
+            name = ev.get("strategy")
+            if not name:
+                continue
+            kind = ev.get("kind")
+            r = row(name)
+            if kind == "signal":
+                r["signals"] += 1
+                if ev.get("vetoed"):
+                    r["vetoed"] += 1
+            elif kind == "order":
+                r["orders_filled" if ev.get("filled") else "orders_failed"] += 1
+            elif kind == "close":
+                reason = ev.get("reason", "unknown")
+                r["closes"][reason] = r["closes"].get(reason, 0) + 1
+            elif kind == "strategy_error":
+                r["errors"] += 1
+            elif kind == "disabled":
+                r["disabled_events"] += 1
+            elif kind == "sl_move":
+                r["sl_moves"] += 1
+
+        for name, profits in deals.items():
+            row(name)["pnl_metrics"] = _pnl_metrics(profits)
+
+        for name, r in per.items():
+            flags = []
+            pm = r.get("pnl_metrics")
+            if pm and pm["trades"] >= 30 and pm["profit_factor"] < 0.8:
+                flags.append(f"profit factor {pm['profit_factor']} < 0.8 over {pm['trades']} trades")
+            if r["errors"] >= 3:
+                flags.append(f"{r['errors']} errors")
+            if r["signals"] >= 20:
+                veto_rate = 100 * r["vetoed"] / r["signals"]
+                if veto_rate > 80:
+                    flags.append(f"veto rate {veto_rate:.0f}% over {r['signals']} signals")
+            r["disable_candidate"] = bool(flags)
+            r["flags"] = flags
+
+        halts = sum(1 for ev in events if ev.get("kind") == "halt")
+        return {"generated": dt.datetime.now(dt.timezone.utc).isoformat(),
+                "events_total": len(events), "halts": halts, "strategies": per}
+
+
+# Fleet taxonomy — canonical order groups of five (mirrors strategies/__init__).
+CATEGORY_SLICES = [("breakout", 0, 5), ("reversion", 5, 10),
+                   ("event", 10, 15), ("trend", 15, 20)]
+CATEGORY_OF = {name: cat for cat, lo, hi in CATEGORY_SLICES
+               for name in STRATEGY_ORDER[lo:hi]}
+
+KIND_CLASS = {
+    "engine_start": "neutral", "engine_stop": "neutral",
+    "signal": "gold", "order": "info", "close": "up", "sl_move": "neutral",
+    "strategy_error": "down", "disabled": "warn", "halt": "down",
+    "supervisor_apply": "info",
+}
+
+esc = html.escape
+
+
+# ---------------------------------------------------------------- loading ---
+def load_journal_counted(path: pathlib.Path):
+    """Journal events + count of malformed/torn lines that were skipped."""
+    if not path.exists():
+        return [], 0
+    events, skipped = [], 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+            if isinstance(ev, dict):
+                events.append(ev)
+            else:
+                skipped += 1
+        except json.JSONDecodeError:
+            skipped += 1
+    return events, skipped
+
+
+def load_deals(path: pathlib.Path, magic_base: int):
+    """Returns (name -> [profits] in time order, chronological deal list)."""
+    if not path.exists():
+        return {}, []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}, []
+    deals = []
+    for d in raw if isinstance(raw, list) else []:
+        if not isinstance(d, dict):
+            continue
+        idx = int(d.get("magic", -1)) - magic_base
+        if 0 <= idx < len(STRATEGY_ORDER):
+            deals.append({"strategy": STRATEGY_ORDER[idx],
+                          "profit": float(d.get("profit", 0.0)),
+                          "time": str(d.get("time", ""))})
+    deals.sort(key=lambda d: d["time"])
+    per: dict[str, list[float]] = {}
+    for d in deals:
+        per.setdefault(d["strategy"], []).append(d["profit"])
+    return per, deals
+
+
+def load_json_or(path: pathlib.Path, default):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def fleet_state(events):
+    """Last engine_start / engine_stop / halt wins."""
+    state, reason, last_ts = "NO DATA", "", None
+    for ev in events:
+        k = ev.get("kind")
+        if k == "engine_start":
+            state, reason = "RUNNING", ""
+        elif k == "engine_stop":
+            state, reason = "STOPPED", ""
+        elif k == "halt":
+            state, reason = "HALTED", str(ev.get("reason", ""))
+        ts = ev.get("ts")
+        if ts:
+            last_ts = str(ts)
+    return state, reason, last_ts
+
+
+def parse_ts(ts: str):
+    try:
+        d = dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return d if d.tzinfo else d.replace(tzinfo=dt.timezone.utc)
+    except (ValueError, AttributeError):
+        return None
+
+
+# ------------------------------------------------------------- formatting ---
+def money(v: float) -> str:
+    return f"{v:+,.2f}"
+
+
+def ts_html(ts: str, long_fmt: bool = False) -> str:
+    d = parse_ts(ts)
+    if d is None:
+        return esc(ts)
+    utc = d.astimezone(dt.timezone.utc)
+    label = utc.strftime("%b %d %H:%M:%S" if long_fmt else "%H:%M:%S")
+    extra = ' data-long="1"' if long_fmt else ""
+    return (f'<time datetime="{esc(ts)}">{label} UTC</time>'
+            f' <span class="local" data-ts="{esc(ts)}"{extra}></span>')
+
+
+# ------------------------------------------------------------- SVG charts ---
+def _yticks(lo: float, hi: float, n: int = 4):
+    if hi <= lo:
+        hi = lo + 1.0
+    step = (hi - lo) / n
+    return [lo + i * step for i in range(n + 1)]
+
+
+def equity_svg(deals: list) -> str:
+    """Cumulative realized P&L line + shared-x underwater drawdown area."""
+    W, PL, PR = 960, 66, 14
+    T, H_EQ, GAP, H_DD, B = 16, 208, 34, 92, 24
+    H = T + H_EQ + GAP + H_DD + B
+    plot_w = W - PL - PR
+    n = len(deals)
+    cum, run = [], 0.0
+    for d in deals:
+        run += d["profit"]
+        cum.append(run)
+    peaks, peak = [], float("-inf")
+    for c in cum:
+        peak = max(peak, c)
+        peaks.append(peak)
+    dds = [c - p for c, p in zip(cum, peaks)]          # <= 0
+    lo, hi = min(0.0, min(cum)), max(0.0, max(cum))
+    dd_lo = min(dds) if dds else 0.0
+    if dd_lo == 0.0:
+        dd_lo = -1.0
+
+    def x(i):
+        return PL + (plot_w * i / (n - 1) if n > 1 else plot_w / 2)
+
+    def y_eq(v):
+        return T + H_EQ * (1 - (v - lo) / (hi - lo or 1))
+
+    def y_dd(v):
+        return T + H_EQ + GAP + H_DD * (v / dd_lo)
+
+    parts = []
+    # equity gridlines + labels
+    for tv in _yticks(lo, hi):
+        yy = y_eq(tv)
+        parts.append(f'<line class="grid" x1="{PL}" y1="{yy:.1f}" x2="{W - PR}" y2="{yy:.1f}"/>')
+        parts.append(f'<text class="ax" x="{PL - 8}" y="{yy + 4:.1f}" text-anchor="end">{money(tv)}</text>')
+    zy = y_eq(0)
+    parts.append(f'<line class="zero" x1="{PL}" y1="{zy:.1f}" x2="{W - PR}" y2="{zy:.1f}"/>')
+    # equity line, gold; soft fill down to zero line
+    pts = " ".join(f"{x(i):.1f},{y_eq(c):.1f}" for i, c in enumerate(cum))
+    area = f"M{x(0):.1f},{zy:.1f} L" + " L".join(
+        f"{x(i):.1f},{y_eq(c):.1f}" for i, c in enumerate(cum)) + f" L{x(n - 1):.1f},{zy:.1f} Z"
+    parts.append(f'<path class="eq-fill" d="{area}"/>')
+    parts.append(f'<polyline class="eq-line" points="{pts}"/>')
+    for i, d in enumerate(deals):
+        cls = "pt up" if d["profit"] >= 0 else "pt down"
+        tip = (f"{d['strategy']}  {d['time']}\n"
+               f"deal {money(d['profit'])}   cumulative {money(cum[i])}")
+        parts.append(f'<circle class="{cls}" cx="{x(i):.1f}" cy="{y_eq(cum[i]):.1f}" r="3">'
+                     f'<title>{esc(tip)}</title></circle>')
+    # drawdown pane
+    dz = T + H_EQ + GAP
+    parts.append(f'<line class="zero" x1="{PL}" y1="{dz}" x2="{W - PR}" y2="{dz}"/>')
+    for tv in (dd_lo / 2, dd_lo):
+        yy = y_dd(tv)
+        parts.append(f'<line class="grid" x1="{PL}" y1="{yy:.1f}" x2="{W - PR}" y2="{yy:.1f}"/>')
+        parts.append(f'<text class="ax" x="{PL - 8}" y="{yy + 4:.1f}" text-anchor="end">{money(tv)}</text>')
+    dd_area = f"M{x(0):.1f},{dz} L" + " L".join(
+        f"{x(i):.1f},{y_dd(v):.1f}" for i, v in enumerate(dds)) + f" L{x(n - 1):.1f},{dz} Z"
+    parts.append(f'<path class="dd-fill" d="{dd_area}"/>')
+    for i, v in enumerate(dds):
+        if v < 0:
+            parts.append(f'<circle class="pt dd" cx="{x(i):.1f}" cy="{y_dd(v):.1f}" r="2.5">'
+                         f'<title>{esc(deals[i]["time"])}\ndrawdown {money(v)}</title></circle>')
+    parts.append(f'<text class="ax lbl" x="{PL}" y="{T - 4}">cumulative realized P&amp;L</text>')
+    parts.append(f'<text class="ax lbl" x="{PL}" y="{dz - 6}">underwater drawdown</text>')
+    if deals:
+        parts.append(f'<text class="ax" x="{PL}" y="{H - 6}">{esc(deals[0]["time"][:16])}</text>')
+        parts.append(f'<text class="ax" x="{W - PR}" y="{H - 6}" text-anchor="end">{esc(deals[-1]["time"][:16])}</text>')
+    label = f"Equity curve: {n} deals, net {money(cum[-1])}, max drawdown {money(min(dds))}"
+    return (f'<svg viewBox="0 0 {W} {H}" role="img" aria-label="{esc(label)}" '
+            f'preserveAspectRatio="xMidYMid meet">{"".join(parts)}</svg>')
+
+
+def activity_svg(events: list) -> str:
+    """Fallback sparkline: journal events bucketed per hour."""
+    buckets: dict[str, int] = {}
+    for ev in events:
+        ts = str(ev.get("ts", ""))
+        if len(ts) >= 13:
+            buckets[ts[:13]] = buckets.get(ts[:13], 0) + 1
+    keys = sorted(buckets)
+    W, H, PL, T, B = 960, 180, 66, 16, 24
+    plot_w, plot_h = W - PL - 14, H - T - B
+    n, mx = len(keys), max(buckets.values(), default=1)
+    parts = []
+    bw = max(4.0, min(38.0, plot_w / max(n, 1) - 4))
+    for i, k in enumerate(keys):
+        v = buckets[k]
+        bh = plot_h * v / mx
+        bx = PL + (plot_w * i / max(n - 1, 1)) - bw / 2 if n > 1 else PL + plot_w / 2 - bw / 2
+        parts.append(f'<rect class="bar" x="{bx:.1f}" y="{T + plot_h - bh:.1f}" '
+                     f'width="{bw:.1f}" height="{bh:.1f}" rx="2">'
+                     f'<title>{esc(k)}:00 UTC — {v} events</title></rect>')
+    parts.append(f'<line class="zero" x1="{PL}" y1="{T + plot_h}" x2="{W - 14}" y2="{T + plot_h}"/>')
+    parts.append(f'<text class="ax" x="{PL - 8}" y="{T + 8}" text-anchor="end">{mx}</text>')
+    parts.append(f'<text class="ax lbl" x="{PL}" y="{T - 4}">journal events per hour</text>')
+    if keys:
+        parts.append(f'<text class="ax" x="{PL}" y="{H - 6}">{esc(keys[0])}:00</text>')
+        parts.append(f'<text class="ax" x="{W - 14}" y="{H - 6}" text-anchor="end">{esc(keys[-1])}:00</text>')
+    return (f'<svg viewBox="0 0 {W} {H}" role="img" '
+            f'aria-label="Journal activity per hour, peak {mx} events">{"".join(parts)}</svg>')
+
+
+# ------------------------------------------------------------- HTML parts ---
+def close_bucket(reason: str) -> str:
+    r = reason.lower()
+    if "tp" in r or "take" in r:
+        return "tp"
+    if r == "sl" or "stop_loss" in r or ("sl" in r and "move" not in r and "trail" not in r):
+        return "sl"
+    if "time" in r:
+        return "time"
+    return "other"
+
+
+def fleet_table(per: dict, enabled: dict, deals_present: bool) -> str:
+    head_cells = [
+        ("strategy", "s", "Strategy"), ("cat", "s", "Category"),
+        ("state", "s", "State"), ("signals", "n", "Signals"),
+        ("veto", "n", "Veto rate"), ("orders", "n", "Orders"),
+        ("closes", "n", "Closes tp/sl/time/other"), ("errors", "n", "Errors"),
+    ]
+    if deals_present:
+        head_cells += [("pnl", "n", "P&amp;L"), ("pf", "n", "PF")]
+    ths = "".join(
+        f'<th data-k="{k}" data-t="{t}" scope="col" aria-sort="none">{lbl}'
+        f'<span class="arrow" aria-hidden="true"></span></th>'
+        for k, t, lbl in head_cells)
+
+    rows = []
+    for name in STRATEGY_ORDER:
+        r = per.get(name, {"signals": 0, "vetoed": 0, "orders_filled": 0,
+                           "orders_failed": 0, "closes": {}, "errors": 0,
+                           "sl_moves": 0, "flags": [], "disable_candidate": False})
+        cat = CATEGORY_OF.get(name, "other")
+        is_on = bool(enabled.get(name, True))
+        sig, veto = r["signals"], r["vetoed"]
+        veto_pct = 100.0 * veto / sig if sig else 0.0
+        orders = r["orders_filled"] + r["orders_failed"]
+        buckets = {"tp": 0, "sl": 0, "time": 0, "other": 0}
+        for reason, cnt in r.get("closes", {}).items():
+            buckets[close_bucket(str(reason))] += cnt
+        closes_total = sum(buckets.values())
+        flags = r.get("flags", [])
+        flagged = bool(r.get("disable_candidate"))
+        row_cls = ' class="flagged"' if flagged else ""
+        flag_note = (f'<div class="flagnote">&#9888; DISABLE-CANDIDATE: '
+                     f'{esc("; ".join(flags))}</div>') if flagged else ""
+        state_txt = "on" if is_on else "off"
+        state = (f'<span class="dot {"on" if is_on else "off"}" aria-hidden="true"></span>'
+                 f'<span class="statetxt">{state_txt}</span>')
+        veto_bar = (f'<div class="micro" role="img" aria-label="veto rate {veto_pct:.0f} percent">'
+                    f'<div class="micro-fill" style="width:{veto_pct:.0f}%"></div></div>'
+                    f'<span class="num">{veto_pct:.0f}%</span>' if sig else
+                    '<span class="num muted">&mdash;</span>')
+        if closes_total:
+            segs = "".join(
+                f'<div class="seg {b}" style="width:{100 * buckets[b] / closes_total:.1f}%"></div>'
+                for b in ("tp", "sl", "time", "other") if buckets[b])
+            closes_tip = " / ".join(f"{b}:{buckets[b]}" for b in ("tp", "sl", "time", "other"))
+            closes_cell = (f'<div class="stack" title="{esc(closes_tip)}" role="img" '
+                           f'aria-label="closes {esc(closes_tip)}">{segs}</div>'
+                           f'<span class="num">{closes_total}</span>')
+        else:
+            closes_cell = '<span class="num muted">&mdash;</span>'
+        cells = [
+            f'<td data-v="{esc(name)}"><span class="sname">{esc(name)}</span>{flag_note}</td>',
+            f'<td data-v="{cat}"><span class="badge cat-{cat}">{cat}</span></td>',
+            f'<td data-v="{state_txt}">{state}</td>',
+            f'<td class="num" data-v="{sig}">{sig}</td>',
+            f'<td data-v="{veto_pct:.1f}">{veto_bar}</td>',
+            f'<td class="num" data-v="{orders}">{orders}'
+            + (f'<span class="muted"> ({r["orders_failed"]}&#10007;)</span>' if r["orders_failed"] else "")
+            + '</td>',
+            f'<td data-v="{closes_total}">{closes_cell}</td>',
+            f'<td class="num{" bad" if r["errors"] >= 3 else ""}" data-v="{r["errors"]}">{r["errors"]}</td>',
+        ]
+        if deals_present:
+            pm = r.get("pnl_metrics")
+            if pm:
+                pnl, pf = pm["pnl"], pm["profit_factor"]
+                pf_v = 999999 if pf == float("inf") else pf
+                pf_s = "&#8734;" if pf == float("inf") else f"{pf:.2f}"
+                pcls = "up" if pnl >= 0 else "down"
+                cells.append(f'<td class="num {pcls}" data-v="{pnl}">{money(pnl)}</td>')
+                cells.append(f'<td class="num" data-v="{pf_v}" '
+                             f'title="{pm["trades"]} trades, win {pm["win_pct"]}%, '
+                             f'expectancy {money(pm["expectancy"])}">{pf_s}</td>')
+            else:
+                cells.append('<td class="num muted" data-v="-1e18">&mdash;</td>')
+                cells.append('<td class="num muted" data-v="-1e18">&mdash;</td>')
+        title = f' title="{esc("; ".join(flags))}"' if flagged else ""
+        rows.append(f"<tr{row_cls} data-name=\"{esc(name)}\"{title}>{''.join(cells)}</tr>")
+
+    return (f'<table id="fleet" aria-label="Strategy fleet scorecard">'
+            f'<thead><tr>{ths}</tr></thead><tbody>{"".join(rows)}</tbody></table>')
+
+
+def event_detail(ev: dict) -> str:
+    skip = {"ts", "kind", "strategy"}
+    bits = []
+    for k, v in ev.items():
+        if k in skip:
+            continue
+        if isinstance(v, float):
+            v = f"{v:g}"
+        bits.append(f'<span class="kv"><span class="k">{esc(str(k))}</span>={esc(str(v))}</span>')
+    return " ".join(bits)
+
+
+def event_stream(events: list) -> str:
+    last = list(reversed(events[-100:]))
+    kinds = sorted({str(ev.get("kind", "?")) for ev in last})
+    btns = ['<button type="button" data-kind="all" class="on" aria-pressed="true">all</button>']
+    btns += [f'<button type="button" data-kind="{esc(k)}" aria-pressed="false">{esc(k)}</button>'
+             for k in kinds]
+    rows = []
+    for ev in last:
+        kind = str(ev.get("kind", "?"))
+        cls = KIND_CLASS.get(kind, "neutral")
+        strat = ev.get("strategy")
+        strat_html = f'<span class="estrat">{esc(str(strat))}</span>' if strat else ""
+        rows.append(
+            f'<tr data-kind="{esc(kind)}">'
+            f'<td class="ets">{ts_html(str(ev.get("ts", "")))}</td>'
+            f'<td><span class="badge kb-{cls}">{esc(kind)}</span></td>'
+            f'<td>{strat_html}</td>'
+            f'<td class="edetail">{event_detail(ev)}</td></tr>')
+    if not rows:
+        rows.append('<tr><td colspan="4" class="empty">No journal events yet.</td></tr>')
+    return (f'<div class="efilter" role="group" aria-label="Filter events by kind">{"".join(btns)}</div>'
+            f'<div class="escroll"><table id="events" aria-label="Last 100 journal events, newest first">'
+            f'<thead><tr><th scope="col">time</th><th scope="col">kind</th>'
+            f'<th scope="col">strategy</th><th scope="col">detail</th></tr></thead>'
+            f'<tbody>{"".join(rows)}</tbody></table></div>')
+
+
+def risk_panel(settings, events: list, halts: int) -> str:
+    risk = (settings or {}).get("risk", {}) if isinstance(settings, dict) else {}
+    labels = [
+        ("max_risk_per_trade_pct", "risk / trade", "%"),
+        ("max_daily_loss_pct", "max daily loss", "%"),
+        ("max_weekly_loss_pct", "max weekly loss", "%"),
+        ("max_open_positions", "max open positions", ""),
+        ("max_same_direction", "max same direction", ""),
+        ("max_total_volume_lots", "max total volume", " lots"),
+        ("min_equity", "min equity", ""),
+        ("news_blackout", "news blackout", ""),
+    ]
+    items = []
+    for key, lbl, unit in labels:
+        v = risk.get(key)
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            v = "on" if v else "off"
+        items.append(f'<div class="riskrow"><dt>{esc(lbl)}</dt>'
+                     f'<dd class="num">{esc(str(v))}{unit}</dd></div>')
+    body = (f'<dl class="risklist">{"".join(items)}</dl>' if items else
+            '<p class="empty">config/settings.json not readable &mdash; '
+            'circuit-breaker limits unknown.</p>')
+    recent_halts = [ev for ev in events if ev.get("kind") == "halt"][-3:]
+    hrows = "".join(
+        f'<li>{ts_html(str(ev.get("ts", "")), long_fmt=True)} &mdash; '
+        f'{esc(str(ev.get("reason", "")))}</li>' for ev in reversed(recent_halts))
+    halt_html = (f'<div class="halts"><h3>{halts} halt{"s" if halts != 1 else ""} in journal</h3>'
+                 f'<ul>{hrows}</ul></div>' if halts else
+                 '<p class="okline"><span class="dot on" aria-hidden="true"></span>'
+                 'No circuit-breaker halts in journal.</p>')
+    return body + halt_html
+
+
+# ------------------------------------------------------------ CSS + JS -----
+CSS = """
+:root{
+  --bg:#0b0e14; --surface:#121722; --surface-2:#1a2130; --border:#252e40;
+  --text:#e7eaf1; --muted:#9aa3b5;
+  --gold:#d4af37; --gold-soft:rgba(212,175,55,.13);
+  --up:#63c97e; --down:#f0716f; --warn:#e5b567; --info:#72b9ee;
+  --shadow:0 1px 0 rgba(0,0,0,.4);
+}
+@media (prefers-color-scheme: light){
+  :root{
+    --bg:#f6f5f1; --surface:#ffffff; --surface-2:#efede6; --border:#d9d5c9;
+    --text:#1d222c; --muted:#59627a;
+    --gold:#7c5f10; --gold-soft:rgba(124,95,16,.10);
+    --up:#1e7c3d; --down:#c22f2c; --warn:#8a5a00; --info:#175f9e;
+    --shadow:0 1px 2px rgba(0,0,0,.06);
+  }
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0; background:var(--bg); color:var(--text);
+  font:14px/1.5 'Inter',system-ui,sans-serif;
+  font-variant-numeric:tabular-nums;
+}
+.num,td.num,time,.local,.ets,.edetail,.kv,.riskrow dd,.big{
+  font-family:'JetBrains Mono',ui-monospace,monospace;
+}
+a{color:var(--gold)}
+:focus-visible{outline:2px solid var(--gold); outline-offset:2px; border-radius:3px}
+.wrap{max-width:1240px; margin:0 auto; padding:20px 22px 40px}
+.grid{display:grid; grid-template-columns:minmax(0,2.1fr) minmax(0,1fr); gap:16px}
+.full{grid-column:1/-1}
+@media (max-width:900px){ .grid{grid-template-columns:minmax(0,1fr)} }
+section.panel{
+  background:var(--surface); border:1px solid var(--border); border-radius:10px;
+  padding:16px 18px; box-shadow:var(--shadow); min-width:0;
+}
+h1{font-size:19px; font-weight:600; letter-spacing:.02em; margin:0}
+h1 .sym{color:var(--gold)}
+h2{font-size:12px; font-weight:600; letter-spacing:.14em; text-transform:uppercase;
+   color:var(--muted); margin:0 0 12px; border-bottom:1px solid var(--border);
+   padding-bottom:8px}
+h3{font-size:13px; margin:14px 0 6px}
+.muted{color:var(--muted)}
+/* ---------- header ---------- */
+header.top{display:flex; flex-wrap:wrap; gap:14px 22px; align-items:center; margin-bottom:14px}
+.pill{
+  display:inline-flex; align-items:center; gap:8px; padding:5px 14px;
+  border-radius:999px; border:1px solid var(--border); font-weight:600;
+  font-size:13px; letter-spacing:.06em; background:var(--surface);
+}
+.pill .dot{width:9px;height:9px;border-radius:50%}
+.pill.run{color:var(--up); border-color:var(--up)}
+.pill.halt{color:var(--down); border-color:var(--down); background:color-mix(in srgb,var(--down) 12%,var(--surface))}
+.pill.stop,.pill.nodata{color:var(--muted)}
+.dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px;vertical-align:baseline}
+.dot.on{background:var(--up)} .dot.off{background:var(--muted)}
+.stats{display:flex; flex-wrap:wrap; gap:10px 26px; margin-left:auto}
+.stat{min-width:72px}
+.stat .lbl{font-size:10px; letter-spacing:.12em; text-transform:uppercase; color:var(--muted)}
+.stat .big{font-size:17px; font-weight:600}
+.stat .big.up{color:var(--up)} .stat .big.down{color:var(--down)}
+#stale,.banner{
+  border-radius:8px; padding:10px 16px; margin:0 0 14px; font-weight:600;
+}
+.banner.halt{
+  background:color-mix(in srgb,var(--down) 16%,var(--surface));
+  border:1px solid var(--down); color:var(--down); font-size:15px;
+}
+#stale{
+  background:color-mix(in srgb,var(--warn) 14%,var(--surface));
+  border:1px solid var(--warn); color:var(--warn);
+}
+/* ---------- charts ---------- */
+svg{width:100%; height:auto; display:block}
+.grid-l,.grid{stroke:var(--border)}
+svg .grid{stroke:var(--border); stroke-width:1}
+svg .zero{stroke:var(--muted); stroke-width:1; stroke-dasharray:4 3}
+svg .ax{fill:var(--muted); font:10.5px 'JetBrains Mono',monospace}
+svg .ax.lbl{letter-spacing:.1em; text-transform:uppercase; fill:var(--gold)}
+svg .eq-line{fill:none; stroke:var(--gold); stroke-width:2; stroke-linejoin:round}
+svg .eq-fill{fill:var(--gold-soft)}
+svg .dd-fill{fill:color-mix(in srgb,var(--down) 30%,transparent); stroke:var(--down); stroke-width:1}
+svg .pt{fill:var(--gold); stroke:var(--bg); stroke-width:1}
+svg .pt.up{fill:var(--up)} svg .pt.down{fill:var(--down)} svg .pt.dd{fill:var(--down)}
+svg .bar{fill:var(--gold)}
+.chartnote{font-size:12px; color:var(--muted); margin:8px 0 0}
+/* ---------- fleet table ---------- */
+.tscroll,.escroll{overflow-x:auto}
+table{border-collapse:collapse; width:100%; font-size:13px}
+th,td{padding:7px 10px; text-align:left; border-bottom:1px solid var(--border); white-space:nowrap}
+th{
+  font-size:10.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--muted);
+  cursor:pointer; user-select:none; position:sticky; top:0; background:var(--surface);
+}
+th .arrow::after{content:''; margin-left:4px}
+th[data-dir=asc] .arrow::after{content:'\\2191'}
+th[data-dir=desc] .arrow::after{content:'\\2193'}
+tbody tr:hover{background:var(--surface-2)}
+td.num{text-align:right}
+td .up{color:var(--up)} td .down{color:var(--down)}
+td.num.up{color:var(--up)} td.num.down{color:var(--down)} td.num.bad{color:var(--down);font-weight:600}
+tr.flagged td:first-child{box-shadow:inset 3px 0 0 var(--warn)}
+.sname{font-family:'JetBrains Mono',monospace; font-size:12.5px}
+.flagnote{font-size:11px; color:var(--warn); white-space:normal; max-width:340px}
+.badge{
+  display:inline-block; padding:1px 8px; border-radius:4px; font-size:10.5px;
+  font-weight:600; letter-spacing:.08em; text-transform:uppercase;
+  border:1px solid var(--border); color:var(--muted);
+}
+.cat-breakout{color:var(--gold); border-color:var(--gold)}
+.cat-reversion{color:var(--info); border-color:var(--info)}
+.cat-event{color:var(--warn); border-color:var(--warn)}
+.cat-trend{color:var(--up); border-color:var(--up)}
+.micro{
+  display:inline-block; width:64px; height:7px; border-radius:4px;
+  background:var(--surface-2); border:1px solid var(--border);
+  vertical-align:middle; margin-right:7px; overflow:hidden;
+}
+.micro-fill{height:100%; background:var(--warn)}
+.stack{
+  display:inline-flex; width:72px; height:9px; border-radius:4px; overflow:hidden;
+  border:1px solid var(--border); vertical-align:middle; margin-right:7px;
+}
+.seg.tp{background:var(--up)} .seg.sl{background:var(--down)}
+.seg.time{background:var(--warn)} .seg.other{background:var(--muted)}
+.legend{font-size:11px; color:var(--muted); margin-top:8px}
+.legend .seg{display:inline-block; width:9px; height:9px; border-radius:2px;
+  vertical-align:baseline; margin:0 4px 0 10px}
+/* ---------- events ---------- */
+.efilter{display:flex; flex-wrap:wrap; gap:6px; margin-bottom:10px}
+.efilter button{
+  background:var(--surface-2); color:var(--text); border:1px solid var(--border);
+  border-radius:999px; padding:3px 12px; font:600 11.5px 'JetBrains Mono',monospace;
+  cursor:pointer;
+}
+.efilter button.on{border-color:var(--gold); color:var(--gold); background:var(--gold-soft)}
+#events{font-size:12.5px}
+#events td{padding:4px 10px}
+.edetail{white-space:normal; max-width:640px; color:var(--muted); word-break:break-word}
+.kv .k{color:var(--gold)}
+.estrat{font-family:'JetBrains Mono',monospace}
+.kb-gold{color:var(--gold); border-color:var(--gold)}
+.kb-info{color:var(--info); border-color:var(--info)}
+.kb-up{color:var(--up); border-color:var(--up)}
+.kb-down{color:var(--down); border-color:var(--down)}
+.kb-warn{color:var(--warn); border-color:var(--warn)}
+.escroll{max-height:520px; overflow-y:auto}
+.local{color:var(--muted); font-size:11px}
+/* ---------- risk ---------- */
+.risklist{margin:0}
+.riskrow{display:flex; justify-content:space-between; gap:12px;
+  border-bottom:1px dotted var(--border); padding:5px 0}
+.riskrow dt{color:var(--muted)} .riskrow dd{margin:0; font-weight:600}
+.halts ul{margin:4px 0 0; padding-left:18px}
+.halts li{color:var(--down); font-size:12.5px; margin:3px 0}
+.halts h3{color:var(--down)}
+.okline{color:var(--up); font-size:13px}
+.empty{color:var(--muted); font-style:italic; padding:14px 4px}
+footer{margin-top:22px; font-size:12px; color:var(--muted);
+  border-top:1px solid var(--border); padding-top:12px;
+  display:flex; flex-wrap:wrap; gap:6px 24px}
+@media (prefers-reduced-motion: no-preference){
+  tbody tr,.efilter button{transition:background-color .15s ease, color .15s ease}
+}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation:none!important; transition:none!important; scroll-behavior:auto!important}
+}
+"""
+
+JS = """
+(function(){
+'use strict';
+function initSort(){
+  var table=document.getElementById('fleet'); if(!table) return;
+  var ths=table.querySelectorAll('th[data-k]');
+  ths.forEach(function(th,i){
+    th.tabIndex=0;
+    function go(){
+      var dir=th.dataset.dir==='asc'?'desc':'asc';
+      ths.forEach(function(o){o.removeAttribute('data-dir');o.setAttribute('aria-sort','none');});
+      th.dataset.dir=dir;
+      th.setAttribute('aria-sort',dir==='asc'?'ascending':'descending');
+      var tb=table.tBodies[0], rows=Array.prototype.slice.call(tb.rows);
+      var numeric=th.dataset.t==='n';
+      rows.sort(function(a,b){
+        var av=a.cells[i].dataset.v, bv=b.cells[i].dataset.v, c;
+        if(numeric){ c=(parseFloat(av)||0)-(parseFloat(bv)||0); }
+        else{ c=String(av||'').localeCompare(String(bv||'')); }
+        return dir==='asc'?c:-c;
+      });
+      rows.forEach(function(r){tb.appendChild(r);});
+    }
+    th.addEventListener('click',go);
+    th.addEventListener('keydown',function(e){
+      if(e.key==='Enter'||e.key===' '){e.preventDefault();go();}
+    });
+  });
+}
+function initFilter(){
+  var btns=document.querySelectorAll('.efilter button');
+  btns.forEach(function(b){
+    b.addEventListener('click',function(){
+      btns.forEach(function(o){o.classList.remove('on');o.setAttribute('aria-pressed','false');});
+      b.classList.add('on'); b.setAttribute('aria-pressed','true');
+      var k=b.dataset.kind;
+      document.querySelectorAll('#events tbody tr').forEach(function(r){
+        r.style.display=(k==='all'||r.dataset.kind===k)?'':'none';
+      });
+    });
+  });
+}
+function initTimes(){
+  var fShort=new Intl.DateTimeFormat(undefined,{hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  var fLong=new Intl.DateTimeFormat(undefined,{month:'short',day:'2-digit',hour:'2-digit',minute:'2-digit'});
+  document.querySelectorAll('.local[data-ts]').forEach(function(el){
+    var d=new Date(el.dataset.ts);
+    if(!isNaN(d)) el.textContent='\\u00b7 '+(el.dataset.long?fLong:fShort).format(d)+' local';
+  });
+}
+function initStale(){
+  var ts=document.body.dataset.lastEvent, w=document.getElementById('stale');
+  if(!ts||!w) return;
+  var age=(Date.now()-new Date(ts).getTime())/60000;
+  if(age>5){ w.hidden=false;
+    var s=w.querySelector('[data-age]'); if(s) s.textContent=Math.round(age)+' min'; }
+}
+initSort(); initFilter(); initTimes(); initStale();
+})();
+"""
+
+
+# --------------------------------------------------------------- assembly ---
+def build_page(*, events, skipped, card, enabled, settings, deals_list,
+               deals_present, refresh, journal_path, out_path) -> str:
+    now = dt.datetime.now(dt.timezone.utc)
+    state, halt_reason, last_ts = fleet_state(events)
+    per = card["strategies"]
+
+    n_enabled = sum(1 for n in STRATEGY_ORDER if enabled.get(n, True))
+    n_disabled = len(STRATEGY_ORDER) - n_enabled
+    n_tripped = sum(1 for n in STRATEGY_ORDER if per.get(n, {}).get("errors", 0) >= 3)
+
+    pill_cls = {"RUNNING": "run", "HALTED": "halt", "STOPPED": "stop"}.get(state, "nodata")
+    pill_txt = f"{state} — {esc(halt_reason)}" if state == "HALTED" and halt_reason else state
+    pill = (f'<span class="pill {pill_cls}" role="status">'
+            f'<span class="dot {"on" if state == "RUNNING" else "off"}" aria-hidden="true"></span>'
+            f'{pill_txt}</span>')
+
+    stats = []
+    if deals_present:
+        net = sum(d["profit"] for d in deals_list)
+        cls = "up" if net >= 0 else "down"
+        stats.append(('net realized P&amp;L', f'<span class="big {cls}">{money(net)}</span>'))
+    stats += [
+        ("enabled", f'<span class="big">{n_enabled}<span class="muted">/{len(STRATEGY_ORDER)}</span></span>'),
+        ("disabled", f'<span class="big">{n_disabled}</span>'),
+        ("error-tripped", f'<span class="big{" down" if n_tripped else ""}">{n_tripped}</span>'),
+        ("events", f'<span class="big">{card["events_total"]}</span>'),
+        ("last event", f'<span class="big" style="font-size:13px">{ts_html(last_ts, long_fmt=True) if last_ts else "&mdash;"}</span>'),
+    ]
+    stats_html = "".join(f'<div class="stat"><div class="lbl">{lbl}</div>{val}</div>'
+                         for lbl, val in stats)
+
+    stale_hidden = " hidden"
+    last_dt = parse_ts(last_ts) if last_ts else None
+    if last_dt and (now - last_dt).total_seconds() > 300:
+        stale_hidden = ""
+    stale = (f'<div id="stale" role="alert"{stale_hidden}>&#9888; Stale data &mdash; '
+             f'last journal event is <span data-age>&gt;5 min</span> old. '
+             f'The engine may not be writing.</div>')
+
+    halt_banner = ""
+    if state == "HALTED":
+        halt_banner = (f'<div class="banner halt" role="alert">&#9632; TRADING HALTED &mdash; '
+                       f'circuit breaker: {esc(halt_reason) or "reason not recorded"}. '
+                       f'All positions flattened; human review required before restart.</div>')
+
+    if deals_present and len(deals_list) >= 2:
+        chart = equity_svg(deals_list)
+        chart_note = (f'<p class="chartnote">{len(deals_list)} realized deals from deals.json '
+                      f'&mdash; gold line: cumulative P&amp;L; red area: underwater drawdown '
+                      f'(shared x-axis). Hover points for detail.</p>')
+    elif events:
+        chart = activity_svg(events)
+        chart_note = ('<p class="chartnote">No deals.json found &mdash; showing journal '
+                      'activity per hour instead. Export MT5 deal history to '
+                      'logs/deals.json for the equity curve.</p>')
+    else:
+        chart = ('<p class="empty">No journal yet. Start the engine '
+                 '(<code>python main.py</code>) and regenerate this dashboard.</p>')
+        chart_note = ""
+
+    table = fleet_table(per, enabled, deals_present)
+    legend = ('<p class="legend">close reasons:'
+              '<span class="seg tp" aria-hidden="true"></span>tp'
+              '<span class="seg sl" aria-hidden="true"></span>sl'
+              '<span class="seg time" aria-hidden="true"></span>time'
+              '<span class="seg other" aria-hidden="true"></span>other'
+              ' &mdash; click a column header to sort. &#9888; left border = DISABLE-CANDIDATE '
+              '(PF&lt;0.8 over &ge;30 trades, errors&ge;3, or veto&gt;80% over &ge;20 signals).</p>')
+
+    meta_refresh = (f'<meta http-equiv="refresh" content="{int(refresh)}">'
+                    if refresh and refresh > 0 else "")
+    refresh_note = (f"auto-reload every {int(refresh)}s" if refresh and refresh > 0
+                    else "auto-reload off")
+    skipped_note = (f' &middot; {skipped} malformed journal line{"s" if skipped != 1 else ""} skipped'
+                    if skipped else "")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark light">
+{meta_refresh}
+<title>gold-scalper &middot; fleet dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<style>{CSS}</style>
+</head>
+<body data-last-event="{esc(last_ts or '')}">
+<div class="wrap">
+<header class="top">
+  <h1><span class="sym">XAUUSD</span> scalper fleet</h1>
+  {pill}
+  <div class="stats">{stats_html}</div>
+</header>
+{halt_banner}
+{stale}
+<div class="grid">
+  <section class="panel" aria-labelledby="h-eq">
+    <h2 id="h-eq">Equity &amp; drawdown</h2>
+    {chart}
+    {chart_note}
+  </section>
+  <section class="panel" aria-labelledby="h-risk">
+    <h2 id="h-risk">Risk &amp; circuit breakers</h2>
+    {risk_panel(settings, events, card["halts"])}
+  </section>
+  <section class="panel full" aria-labelledby="h-fleet">
+    <h2 id="h-fleet">Strategy fleet &mdash; {len(STRATEGY_ORDER)} strategies</h2>
+    <div class="tscroll">{table}</div>
+    {legend}
+  </section>
+  <section class="panel full" aria-labelledby="h-ev">
+    <h2 id="h-ev">Event stream &mdash; last 100, newest first</h2>
+    {event_stream(events)}
+  </section>
+</div>
+<footer>
+  <span>generated {esc(now.strftime('%Y-%m-%d %H:%M:%S'))} UTC from {esc(str(journal_path))}{skipped_note}</span>
+  <span>{refresh_note} &mdash; this is a static snapshot: re-run <code>python dashboard.py</code> for live data</span>
+</footer>
+</div>
+<script>{JS}</script>
+</body>
+</html>
+"""
+
+
+# ------------------------------------------------------------------- main ---
+def resolve(p: str) -> pathlib.Path:
+    path = pathlib.Path(p)
+    if path.is_absolute():
+        return path
+    return path if path.exists() else (BASE_DIR / p)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Render the fleet journal as a single-file HTML dashboard")
+    ap.add_argument("--journal", default="logs/journal.jsonl")
+    ap.add_argument("--deals", default="logs/deals.json")
+    ap.add_argument("--enabled", default="config/enabled.json")
+    ap.add_argument("--out", default="logs/dashboard.html")
+    ap.add_argument("--refresh", type=int, default=10,
+                    help="meta-refresh seconds; 0 disables auto-reload")
+    args = ap.parse_args()
+
+    journal_path = resolve(args.journal)
+    deals_path = resolve(args.deals)
+    enabled_path = resolve(args.enabled)
+    out_path = pathlib.Path(args.out)
+    if not out_path.is_absolute():
+        out_path = BASE_DIR / args.out
+
+    settings = load_json_or(BASE_DIR / "config" / "settings.json", {})
+    magic_base = settings.get("magic_base", 770000) if isinstance(settings, dict) else 770000
+
+    events, skipped = load_journal_counted(journal_path)
+    deals_per, deals_list = load_deals(deals_path, magic_base)
+    enabled = load_json_or(enabled_path, {})
+    if not isinstance(enabled, dict):
+        enabled = {}
+    card = build_scorecard(events, deals_per)
+
+    page = build_page(events=events, skipped=skipped, card=card, enabled=enabled,
+                      settings=settings, deals_list=deals_list,
+                      deals_present=bool(deals_list), refresh=args.refresh,
+                      journal_path=journal_path, out_path=out_path)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(page, encoding="utf-8")
+    size = out_path.stat().st_size
+    print(f"wrote {out_path} ({size:,} bytes) — {len(events)} events"
+          f"{f', {skipped} malformed lines skipped' if skipped else ''}, "
+          f"{len(deals_list)} deals")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gold-scalper/docs/ARCHITECTURE.md
+++ b/gold-scalper/docs/ARCHITECTURE.md
@@ -1,0 +1,166 @@
+# Gold Scalper — Multi-Strategy Agent Harness for MT5
+
+One Python process runs **20 independent XAUUSD scalping executors** against a
+single MT5 account, coordinated by a harness that owns everything strategies
+must never own: order routing, position sizing, portfolio risk, news
+blackouts, journaling, and kill switches. A supervisor loop (Claude Fable 5,
+out-of-band) reads the journal, scores each strategy, and flips executors
+on/off between sessions.
+
+The design follows this repo's `engineering/agent-harness` discipline:
+goal → decomposed tasks (strategies) → deterministic execution → machine
+verification → bounded retries → escalate to human → refuse to run unverified.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  SUPERVISOR (supervisor.py + Claude Fable 5, out-of-band)    │
+│  journal → scorecard → keep/disable verdicts → enabled.json  │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ hot-reloaded every iteration
+┌──────────────────────────▼──────────────────────────────────┐
+│  ENGINE (core/engine.py) — one loop, all strategies          │
+│  new-bar gate · news blackout · shared market snapshot       │
+│  3-strike error trip → auto-disable · JSONL audit journal    │
+├──────────────┬───────────────────────┬───────────────────────┤
+│ RISK GATE    │ 20 STRATEGY EXECUTORS │ INDICATOR KIT         │
+│ core/risk.py │ strategies/*.py       │ core/indicators.py    │
+│ sizing, caps │ pure: Context→Signal  │ pandas-only,          │
+│ circuit brkrs│ never touch broker    │ no-lookahead          │
+└──────────────┴───────────┬───────────┴───────────────────────┘
+                           │ single choke point
+┌──────────────────────────▼──────────────────────────────────┐
+│  BROKER ADAPTER — the ONLY module importing MetaTrader5      │
+│  core/broker_mt5.py (live) / backtest/sim_broker.py (sim)    │
+│  magic-number-per-strategy · restart-safe position adoption  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## The contract
+
+A strategy sees only a `MarketContext` (bid/ask, spread, closed bars for its
+declared timeframes, declared aux feeds, its own position) and returns a
+`Signal` (side, entry, **mandatory absolute SL**, TP, optional time-stop) or
+an `ExitReason`. It declares its needs as class attributes
+(`primary_timeframe`, `sessions_utc`, `default_risk_pct`,
+`max_spread_points`, `aux_feeds`).
+
+A strategy **cannot**: place orders, size positions, see other strategies'
+positions, exceed the risk cap, or trade during a news blackout. One buggy
+executor cannot hurt the account beyond its own risk slice.
+
+**Attribution:** strategy *i* in `strategies/__init__.py:ALL_STRATEGIES` gets
+MT5 magic `magic_base + i` (default 770000+i). This gives per-strategy P&L
+from MT5 history, restart-safety (open positions re-adopted by magic on
+boot), and zero interference with anything else on the account. The registry
+is **append-only — never reorder**.
+
+## Risk model (survival > preservation > growth)
+
+| Control | Default | On breach |
+|---|---|---|
+| Per-trade risk | ≤ 0.5% equity (strategies ask 0.15–0.3%) | signal resized down |
+| Daily loss | 2% from day-start equity | flatten all + 24 h halt |
+| Weekly loss | 5% | flatten all + 7-day halt |
+| Concurrent positions | 6 total, 4 same-direction | signal vetoed |
+| Total volume | 3.0 lots | signal vetoed |
+| News blackout | ±5 min around high-impact events | no entries fleet-wide |
+| Strategy errors | 3 consecutive exceptions | strategy auto-disabled + journaled |
+
+Sizing from SL distance:
+`lots = equity × risk% / ((SL_dist / tick_size) × tick_value)`, snapped to
+broker volume constraints. No SL, no trade. Halt state persists atomically in
+`logs/risk_state.json`, so a crash-restart during a halt stays halted.
+
+## The 20 executors
+
+| # | Name | TF | Idea |
+|---|---|---|---|
+| 1 | london_breakout | M5 | Asian-range break in first London hours, ATR buffer |
+| 2 | ny_open_momentum | M5/M15 | NY-open impulse bar aligned with M15 EMA trend |
+| 3 | orb_ny | M5 | 30-min opening-range breakout, one trade/day |
+| 4 | asian_range_break | M15 | Overnight range break with retest-hold filter |
+| 5 | vol_expansion | M5 | ATR squeeze → burst-bar ignition, ADX filter |
+| 6 | vwap_reversion | M1 | Fade 2-ATR extensions from session VWAP |
+| 7 | bollinger_fade | M5 | BB(20,2.5) re-entry fade, ADX<25 regime filter |
+| 8 | rsi_extreme_fade | M1 | RSI(5) cross-back through 15/85 |
+| 9 | round_number_bounce | M5 | Rejection wicks at $10 psychological levels |
+| 10 | pivot_reversion | M5/D1 | S1/R1 daily-pivot rejections targeting pivot |
+| 11 | news_spike_fade | M1 | Fade the overreaction leg after high-impact prints |
+| 12 | tick_velocity_ignition | M1 | Tick-volume + range burst momentum ignition |
+| 13 | spread_aware_liquidity | M1 | Z-score micro-reversion, only in tight-spread regimes |
+| 14 | dxy_divergence | M5+DXY | Gold/DXY inverse-correlation break snap |
+| 15 | liquidity_sweep_reversal | M5 | Sweep of session extreme then rejection (SMC) |
+| 16 | ema_ribbon_pullback | M5 | 8/13/21 ribbon trend, enter on ribbon pullback |
+| 17 | stoch_trend_scalp | M5/M15 | Stoch(5,3,3) hooks in M15-trend direction only |
+| 18 | macd_zero_cross | M5 | MACD zero-cross with expanding histogram |
+| 19 | keltner_supertrend_ride | M5 | Supertrend + Keltner pullback, trailing exit |
+| 20 | heikin_ashi_atr | M5 | HA color-flip entries, opposite-body exit |
+
+Per-strategy spec sheets (edge hypothesis, exact rules, failure modes,
+sources) live in `docs/STRATEGIES.md`.
+
+## Engine iteration
+
+1. Roll day/week equity anchors; check circuit breakers → tripped = flatten
+   everything and halt.
+2. Fetch bars **once per unique timeframe** (20 strategies share ~4 fetches)
+   plus aux feeds (DXY bars, calendar).
+3. Hot-reload `config/enabled.json` — the supervisor/human control surface.
+4. Per strategy, gated on *its* new closed bar: holding →
+   `manage_position()` (exit / trail via `pending_sl_move` / time-stop);
+   flat and enabled and in-session and spread OK and no blackout →
+   `on_bar()` → Signal → risk gate → `order_send`.
+5. Every event (signal, veto+why, order, SL move, close, error, disable,
+   halt) appended to `logs/journal.jsonl`.
+
+Entries only happen on closed bars, so backtest and live evaluate identical
+data — the indicator kit has no intra-bar lookahead anywhere.
+
+## Supervisor — where Fable 5 sits
+
+Deliberately out-of-band; analysis can never block or crash execution.
+
+- **Deterministic layer** (`supervisor.py score`): journal + MT5 deal history
+  per magic → per-strategy scorecard (trades, win%, profit factor,
+  expectancy, max DD, veto rate, errors). Mechanical flags: PF < 0.8 over
+  ≥ 30 trades, 3-strike error trips, veto rate > 80%.
+- **Fable 5 layer** (`supervisor.py review`): packages scorecard + recent
+  journal into a review prompt; Claude Fable 5 reasons about *why* a strategy
+  bleeds (regime shift? spread widening? session drift?) and returns
+  keep/disable/tune verdicts, applied via `supervisor.py apply` — a one-line,
+  auditable, reversible edit to `enabled.json`. It never touches orders.
+- **Escalation:** circuit-breaker halts and auto-disables notify the
+  operator; re-enabling after a halt is always a human decision.
+
+## Backtest parity
+
+`backtest/sim_broker.py` implements the same interface as `MT5Broker`
+replaying M1 history with configurable spread and slippage — the exact same
+strategy code runs in sim. `backtest/run_backtest.py` emits the same
+scorecard the supervisor uses.
+
+**Promotion pipeline (non-negotiable):** each strategy must show positive
+expectancy after spread on ≥ 6 months of M1 data → whole fleet on a **demo
+account ≥ 2 weeks** → only then real money, at minimum size.
+
+## Running
+
+```bash
+pip install MetaTrader5 pandas numpy   # live needs Windows + running MT5 terminal
+
+python main.py --dry-run               # full pipeline, orders logged not sent
+python main.py                         # live (demo account first!)
+python backtest/run_backtest.py --csv xauusd_m1.csv
+python supervisor.py score             # scorecard
+python supervisor.py review            # generate Fable 5 review prompt
+```
+
+## Honest caveat
+
+Retail gold scalping fights spread and slippage first and the market second —
+a 25–35 cent spread against a 60-cent target eats most naive edges. That is
+exactly why the harness enforces spread gates, per-strategy attribution, and
+the backtest → demo → live pipeline: the point of running 20 executors is to
+let the journal **kill** the majority that don't survive transaction costs
+and keep the few that do. Expect to disable most of the fleet. That is the
+system working, not failing.

--- a/gold-scalper/main.py
+++ b/gold-scalper/main.py
@@ -1,0 +1,153 @@
+"""Entrypoint — wires config, broker, risk, and the 20-strategy fleet.
+
+Live:     python main.py
+Dry run:  python main.py --dry-run          (reads live data, sends no orders)
+Subset:   python main.py --strategies london_breakout,vwap_reversion
+
+Requires Windows + a running MT5 terminal + `pip install MetaTrader5 pandas`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import pathlib
+import sys
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(BASE_DIR))
+
+from core.risk import RiskConfig, RiskManager       # noqa: E402
+from core.engine import Engine                       # noqa: E402
+from strategies import ALL_STRATEGIES                # noqa: E402
+
+log = logging.getLogger("main")
+
+
+class DryRunBroker:
+    """Proxy around MT5Broker: all reads pass through to live data, all
+    order-mutating calls only log what would happen and report fake success.
+    Lets a full engine loop run against a live feed without sending orders."""
+
+    def __init__(self, real):
+        self._real = real
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def market_order(self, sig, lots, magic, deviation=20):
+        log.info("[DRY-RUN] would OPEN %s %s %.2f lots entry=%.2f sl=%.2f tp=%s (magic=%d)",
+                 sig.side.value, self._real.symbol, lots,
+                 sig.entry, sig.stop_loss, sig.take_profit, magic)
+        return -1
+
+    def close_position(self, pos, reason=""):
+        log.info("[DRY-RUN] would CLOSE ticket %s (%s)", pos.ticket, reason)
+        return True
+
+    def modify_sl(self, pos, new_sl):
+        log.info("[DRY-RUN] would MOVE SL on ticket %s to %.2f", pos.ticket, new_sl)
+        return True
+
+
+def setup_logging(base: pathlib.Path) -> None:
+    logs = base / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    fmt = "%(asctime)s %(name)s %(levelname)s %(message)s"
+    logging.basicConfig(
+        level=logging.INFO, format=fmt,
+        handlers=[logging.StreamHandler(sys.stdout),
+                  logging.FileHandler(logs / "harness.log", encoding="utf-8")])
+
+
+def load_calendar(base: pathlib.Path, rel_path: str) -> list:
+    p = pathlib.Path(rel_path)
+    if not p.is_absolute():
+        p = base / p
+    if p.exists():
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            log.warning("calendar file %s unreadable — trading without it", p)
+    return []
+
+
+def build_strategies(name_filter: str | None) -> list:
+    strategies = [cls() for cls in ALL_STRATEGIES]
+    if not name_filter:
+        return strategies
+    wanted = {n.strip() for n in name_filter.split(",") if n.strip()}
+    unknown = wanted - {s.name for s in strategies}
+    if unknown:
+        sys.exit(f"unknown strategy name(s): {', '.join(sorted(unknown))}\n"
+                 f"available: {', '.join(s.name for s in strategies)}")
+    return [s for s in strategies if s.name in wanted]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Gold scalper harness — 20-strategy MT5 fleet")
+    ap.add_argument("--config", default=str(BASE_DIR / "config" / "settings.json"),
+                    help="path to settings.json")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="read live data but log orders instead of sending them")
+    ap.add_argument("--strategies", default=None,
+                    help="comma-separated strategy names to run (default: all 20)")
+    args = ap.parse_args()
+
+    setup_logging(BASE_DIR)
+
+    cfg_path = pathlib.Path(args.config)
+    try:
+        settings = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        sys.exit(f"cannot read config {cfg_path}: {e}")
+
+    risk = RiskManager(RiskConfig(**settings.get("risk", {})),
+                       state_path=BASE_DIR / "logs" / "risk_state.json")
+    calendar = load_calendar(BASE_DIR, settings.get("calendar_path", "config/calendar.json"))
+    strategies = build_strategies(args.strategies)
+
+    try:
+        from core.broker_mt5 import MT5Broker
+        mt5_cfg = settings.get("mt5", {})
+        broker = MT5Broker(symbol=settings.get("symbol", "XAUUSD"),
+                           magic_base=settings.get("magic_base", 770000),
+                           login=mt5_cfg.get("login"),
+                           password=mt5_cfg.get("password", ""),
+                           server=mt5_cfg.get("server", ""),
+                           terminal_path=mt5_cfg.get("terminal_path"))
+    except (ImportError, RuntimeError) as e:
+        sys.exit(
+            f"MT5 connection failed: {e}\n"
+            "This harness needs:\n"
+            "  1. Windows (the MetaTrader5 Python package is Windows-only)\n"
+            "  2. A running MT5 terminal logged into your broker account\n"
+            "  3. pip install MetaTrader5 pandas\n"
+            "Check config/settings.json mt5.login/password/server/terminal_path.")
+
+    if args.dry_run:
+        log.info("DRY-RUN mode: no orders will be sent")
+        broker = DryRunBroker(broker)
+    else:
+        acc = None
+        try:
+            import MetaTrader5 as mt5
+            acc = mt5.account_info()
+        except ImportError:
+            pass
+        is_demo = acc is not None and getattr(acc, "trade_mode", None) == 0
+        if not is_demo and not settings.get("i_understand_this_is_real_money", False):
+            broker.shutdown()
+            sys.exit("REFUSED: this account is not a demo account.\n"
+                     "Sending real orders requires  \"i_understand_this_is_real_money\": true\n"
+                     "in settings.json — or use --dry-run / a demo account.")
+
+    engine = Engine(broker, strategies, risk, base_dir=BASE_DIR, calendar=calendar)
+    try:
+        engine.run()
+    finally:
+        broker.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/gold-scalper/strategies/__init__.py
+++ b/gold-scalper/strategies/__init__.py
@@ -1,0 +1,39 @@
+"""Strategy registry — all 20 executors, one import point.
+
+The engine builds its fleet from ALL_STRATEGIES; order matters because each
+strategy's index becomes its MT5 magic-number offset. Append only — never
+reorder — or restart position re-adoption will mis-attribute tickets.
+"""
+from .momentum import (
+    LondonBreakout, NYOpenMomentum, OpeningRangeBreakout,
+    AsianRangeBreakout, VolatilityExpansion,
+)
+from .mean_reversion import (
+    VWAPReversion, BollingerFade, RSIExtremeFade,
+    RoundNumberBounce, PivotReversion,
+)
+from .microstructure import (
+    NewsSpikeFade, TickVelocityIgnition, SpreadAwareLiquidity,
+    DXYDivergence, LiquiditySweepReversal,
+)
+from .indicator_hybrid import (
+    EMARibbonPullback, StochTrendScalp, MACDZeroCross,
+    KeltnerSupertrendRide, HeikinAshiATR,
+)
+
+ALL_STRATEGIES = [
+    # momentum (magic offsets 0-4)
+    LondonBreakout, NYOpenMomentum, OpeningRangeBreakout,
+    AsianRangeBreakout, VolatilityExpansion,
+    # mean-reversion (5-9)
+    VWAPReversion, BollingerFade, RSIExtremeFade,
+    RoundNumberBounce, PivotReversion,
+    # microstructure (10-14)
+    NewsSpikeFade, TickVelocityIgnition, SpreadAwareLiquidity,
+    DXYDivergence, LiquiditySweepReversal,
+    # indicator-hybrid (15-19)
+    EMARibbonPullback, StochTrendScalp, MACDZeroCross,
+    KeltnerSupertrendRide, HeikinAshiATR,
+]
+
+assert len(ALL_STRATEGIES) == 20

--- a/gold-scalper/strategies/indicator_hybrid.py
+++ b/gold-scalper/strategies/indicator_hybrid.py
@@ -1,0 +1,244 @@
+"""Indicator-hybrid executors (strategies 16-20).
+
+Shared edge family: classic indicator setups sharpened with regime and
+structure filters — pullbacks into stacked EMAs, oscillator turns with a
+higher-timeframe trend gate, zero-line momentum ignition, and two managed
+trend rides (Supertrend/Keltner and Heikin-Ashi) that trail instead of
+taking a fixed target.
+"""
+from __future__ import annotations
+
+import math
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.strategy_base import StrategyBase, Signal, Side, ExitReason, MarketContext
+from core.indicators import atr, ema, stochastic, macd, keltner, supertrend, heikin_ashi
+
+
+def _finite(*vals: float) -> bool:
+    return all(math.isfinite(v) for v in vals)
+
+
+class EMARibbonPullback(StrategyBase):
+    """#16 — Pullback into a stacked 8/13/21 EMA ribbon that closes back out."""
+    name = "ema_ribbon_pullback"
+    category = "indicator-hybrid"
+    primary_timeframe = "M5"
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.25
+
+    SL_ATR = 0.5
+    RR = 1.5
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        if len(df) < 30:
+            return None
+        c = df["close"]
+        e8, e13, e21 = ema(c, 8), ema(c, 13), ema(c, 21)
+        f8, f13, f21 = float(e8.iloc[-1]), float(e13.iloc[-1]), float(e21.iloc[-1])
+        e21_prev = float(e21.iloc[-4])                # 3 bars ago
+        a = float(atr(df, 14).iloc[-1])
+        if not _finite(f8, f13, f21, e21_prev, a) or a <= 0:
+            return None
+        bar = df.iloc[-1]
+        if f8 > f13 > f21 and f21 > e21_prev:         # bullish ribbon, rising base
+            if bar["low"] <= f13 and bar["close"] > f8:
+                sl = f21 - self.SL_ATR * a
+                risk = ctx.ask - sl
+                if risk <= 0:
+                    return None
+                return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * risk,
+                              comment=self.name, time_stop_bars=24)
+        if f8 < f13 < f21 and f21 < e21_prev:         # bearish ribbon, falling base
+            if bar["high"] >= f13 and bar["close"] < f8:
+                sl = f21 + self.SL_ATR * a
+                risk = sl - ctx.bid
+                if risk <= 0:
+                    return None
+                return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * risk,
+                              comment=self.name, time_stop_bars=24)
+        return None
+
+
+class StochTrendScalp(StrategyBase):
+    """#17 — Stochastic turn out of an extreme, traded only with the M15 trend."""
+    name = "stoch_trend_scalp"
+    category = "indicator-hybrid"
+    primary_timeframe = "M5"
+    extra_timeframes = ("M15",)
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.25
+
+    SL_ATR = 1.2
+    RR = 1.5
+
+    def on_bar(self, ctx: MarketContext):
+        m5, m15 = ctx.bars_for("M5"), ctx.bars_for("M15")
+        if len(m5) < 30 or len(m15) < 60:
+            return None
+        k, d = stochastic(m5, 5, 3, 3)
+        k1, k2 = float(k.iloc[-1]), float(k.iloc[-2])
+        d1, d2 = float(d.iloc[-1]), float(d.iloc[-2])
+        a = float(atr(m5, 14).iloc[-1])
+        t_fast = float(ema(m15["close"], 20).iloc[-1])
+        t_slow = float(ema(m15["close"], 50).iloc[-1])
+        if not _finite(k1, k2, d1, d2, a, t_fast, t_slow) or a <= 0:
+            return None
+        if t_fast > t_slow and k1 > d1 and k2 <= d2 and k1 < 30 and d1 < 30:
+            sl = ctx.ask - self.SL_ATR * a
+            return Signal(Side.LONG, ctx.ask, sl,
+                          ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=20)
+        if t_fast < t_slow and k1 < d1 and k2 >= d2 and k1 > 70 and d1 > 70:
+            sl = ctx.bid + self.SL_ATR * a
+            return Signal(Side.SHORT, ctx.bid, sl,
+                          ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=20)
+        return None
+
+
+class MACDZeroCross(StrategyBase):
+    """#18 — MACD zero-line cross with an expanding histogram, dead markets skipped."""
+    name = "macd_zero_cross"
+    category = "indicator-hybrid"
+    primary_timeframe = "M5"
+    default_risk_pct = 0.25
+
+    DEAD_RATIO = 0.6                       # ATR(14) below this x ATR(100) = no energy
+    SL_ATR = 1.5
+    RR = 2.0
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        if len(df) < 120:
+            return None
+        line, _, hist = macd(df["close"], 12, 26, 9)
+        l1, l2 = float(line.iloc[-1]), float(line.iloc[-2])
+        h1, h2, h3 = float(hist.iloc[-1]), float(hist.iloc[-2]), float(hist.iloc[-3])
+        a_fast = float(atr(df, 14).iloc[-1])
+        a_slow = float(atr(df, 100).iloc[-1])
+        if not _finite(l1, l2, h1, h2, h3, a_fast, a_slow) or a_fast <= 0:
+            return None
+        if a_fast < self.DEAD_RATIO * a_slow:
+            return None
+        if l1 > 0 and l2 <= 0 and h1 > h2 > h3:
+            sl = ctx.ask - self.SL_ATR * a_fast
+            return Signal(Side.LONG, ctx.ask, sl,
+                          ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=30)
+        if l1 < 0 and l2 >= 0 and h1 < h2 < h3:
+            sl = ctx.bid + self.SL_ATR * a_fast
+            return Signal(Side.SHORT, ctx.bid, sl,
+                          ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=30)
+        return None
+
+
+class KeltnerSupertrendRide(StrategyBase):
+    """#19 — Supertrend-gated Keltner-midline reclaim, ridden with a trailing stop."""
+    name = "keltner_supertrend_ride"
+    category = "indicator-hybrid"
+    primary_timeframe = "M5"
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.3
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        if len(df) < 40:
+            return None
+        lower, mid, upper = keltner(df, 20)
+        st = int(supertrend(df, 10, 3.0).iloc[-1])
+        m1, m2 = float(mid.iloc[-1]), float(mid.iloc[-2])
+        lo_band, hi_band = float(lower.iloc[-1]), float(upper.iloc[-1])
+        if not _finite(m1, m2, lo_band, hi_band):
+            return None
+        prev, cur = df.iloc[-2], df.iloc[-1]
+        if st == 1 and prev["low"] <= m2 and cur["close"] > m1:
+            if ctx.ask - lo_band <= 0:
+                return None
+            return Signal(Side.LONG, ctx.ask, lo_band, None,
+                          comment=self.name, time_stop_bars=60)
+        if st == -1 and prev["high"] >= m2 and cur["close"] < m1:
+            if hi_band - ctx.bid <= 0:
+                return None
+            return Signal(Side.SHORT, ctx.bid, hi_band, None,
+                          comment=self.name, time_stop_bars=60)
+        return None
+
+    def manage_position(self, ctx: MarketContext):
+        pos = ctx.position
+        if pos is None:
+            return None
+        if self._time_stop_bars is not None and pos.bars_held >= self._time_stop_bars:
+            return ExitReason.TIME_STOP
+        df = ctx.bars_for("M5")
+        st = int(supertrend(df, 10, 3.0).iloc[-1])
+        if (pos.side is Side.LONG and st == -1) or (pos.side is Side.SHORT and st == 1):
+            return ExitReason.STRATEGY_EXIT
+        mid = float(keltner(df, 20)[1].iloc[-1])
+        if math.isfinite(mid):
+            if pos.side is Side.LONG and mid > pos.stop_loss:
+                self.pending_sl_move = mid
+            elif pos.side is Side.SHORT and mid < pos.stop_loss:
+                self.pending_sl_move = mid
+        return None
+
+
+class HeikinAshiATR(StrategyBase):
+    """#20 — Heikin-Ashi color flip with a flat wick, ridden until the flip reverses."""
+    name = "heikin_ashi_atr"
+    category = "indicator-hybrid"
+    primary_timeframe = "M5"
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.25
+
+    WICK_TOL = 0.9995                      # ha_low >= ha_open * this = near-flat bottom
+    SL_ATR = 1.5
+    EXIT_BODY_ATR = 0.5
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        if len(df) < 30:
+            return None
+        ha = heikin_ashi(df)
+        prev, cur = ha.iloc[-2], ha.iloc[-1]
+        a = float(atr(df, 14).iloc[-1])
+        if not _finite(float(cur["open"]), float(cur["close"]),
+                       float(prev["open"]), float(prev["close"]), a) or a <= 0:
+            return None
+        prev_red = prev["close"] < prev["open"]
+        prev_green = prev["close"] > prev["open"]
+        cur_green = cur["close"] > cur["open"]
+        cur_red = cur["close"] < cur["open"]
+        if prev_red and cur_green and cur["low"] >= cur["open"] * self.WICK_TOL:
+            sl = ctx.ask - self.SL_ATR * a
+            return Signal(Side.LONG, ctx.ask, sl, None,
+                          comment=self.name, time_stop_bars=40)
+        if prev_green and cur_red and cur["high"] <= cur["open"] * (2 - self.WICK_TOL):
+            sl = ctx.bid + self.SL_ATR * a
+            return Signal(Side.SHORT, ctx.bid, sl, None,
+                          comment=self.name, time_stop_bars=40)
+        return None
+
+    def manage_position(self, ctx: MarketContext):
+        pos = ctx.position
+        if pos is None:
+            return None
+        if self._time_stop_bars is not None and pos.bars_held >= self._time_stop_bars:
+            return ExitReason.TIME_STOP
+        df = ctx.bars_for("M5")
+        ha = heikin_ashi(df)
+        cur = ha.iloc[-1]
+        a = float(atr(df, 14).iloc[-1])
+        if not _finite(float(cur["open"]), float(cur["close"]), a) or a <= 0:
+            return None
+        body = abs(float(cur["close"]) - float(cur["open"]))
+        opposite = (cur["close"] < cur["open"]) if pos.side is Side.LONG \
+            else (cur["close"] > cur["open"])
+        if opposite and body > self.EXIT_BODY_ATR * a:
+            return ExitReason.STRATEGY_EXIT
+        return None

--- a/gold-scalper/strategies/mean_reversion.py
+++ b/gold-scalper/strategies/mean_reversion.py
@@ -1,0 +1,181 @@
+"""Mean-reversion executors (strategies 6-10).
+
+Shared edge family: outside news windows, gold on low timeframes oscillates
+around liquidity anchors (VWAP, bands, round numbers, pivots). Extensions
+away from those anchors driven by thin-book bursts tend to snap back. Every
+executor here carries a regime filter or confirmation bar, because the one
+way this family dies is fading a real breakout.
+"""
+from __future__ import annotations
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.strategy_base import StrategyBase, Signal, Side, MarketContext
+from core.indicators import (
+    atr, rsi, bollinger, adx, sma, vwap_session, round_levels,
+)
+
+
+class VWAPReversion(StrategyBase):
+    """#6 — Fade 2-ATR extensions from session VWAP back to VWAP."""
+    name = "vwap_reversion"
+    category = "mean-reversion"
+    primary_timeframe = "M1"
+    sessions_utc = ((7.0, 20.0),)
+    lookback_bars = 400
+    default_risk_pct = 0.2
+
+    K_ATR = 2.0
+    RSI_LO, RSI_HI = 25, 75
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M1")
+        vwap = vwap_session(df)
+        v = float(vwap.iloc[-1])
+        if v != v:                          # NaN — first bars of the session
+            return None
+        a = float(atr(df, 14).iloc[-1])
+        if a <= 0:
+            return None
+        close = float(df["close"].iloc[-1])
+        r = float(rsi(df["close"], 7).iloc[-1])
+        if close < v - self.K_ATR * a and r < self.RSI_LO:
+            sl = ctx.ask - 1.2 * a
+            return Signal(Side.LONG, ctx.ask, sl, v,
+                          comment=self.name, time_stop_bars=30)
+        if close > v + self.K_ATR * a and r > self.RSI_HI:
+            sl = ctx.bid + 1.2 * a
+            return Signal(Side.SHORT, ctx.bid, sl, v,
+                          comment=self.name, time_stop_bars=30)
+        return None
+
+
+class BollingerFade(StrategyBase):
+    """#7 — BB(20,2.5) band re-entry fade with ADX regime filter."""
+    name = "bollinger_fade"
+    category = "mean-reversion"
+    primary_timeframe = "M5"
+    default_risk_pct = 0.25
+
+    ADX_MAX = 25
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        lower, mid, upper = bollinger(df["close"], 20, 2.5)
+        if float(adx(df, 14).iloc[-1]) > self.ADX_MAX:
+            return None                     # trending — fades die
+        a = float(atr(df, 14).iloc[-1])
+        prev, cur = df.iloc[-2], df.iloc[-1]
+        m = float(mid.iloc[-1])
+        # re-entry confirmation: prev closed outside, current closed back inside
+        if prev["close"] < float(lower.iloc[-2]) and cur["close"] > float(lower.iloc[-1]):
+            sl = float(min(prev["low"], cur["low"])) - 0.3 * a
+            return Signal(Side.LONG, ctx.ask, sl, m,
+                          comment=self.name, time_stop_bars=20)
+        if prev["close"] > float(upper.iloc[-2]) and cur["close"] < float(upper.iloc[-1]):
+            sl = float(max(prev["high"], cur["high"])) + 0.3 * a
+            return Signal(Side.SHORT, ctx.bid, sl, m,
+                          comment=self.name, time_stop_bars=20)
+        return None
+
+
+class RSIExtremeFade(StrategyBase):
+    """#8 — RSI(5) cross-back through 15/85; high win-rate, sub-1 RR by design."""
+    name = "rsi_extreme_fade"
+    category = "mean-reversion"
+    primary_timeframe = "M1"
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.2
+
+    LO, HI = 15, 85
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M1")
+        r = rsi(df["close"], 5)
+        prev_r, cur_r = float(r.iloc[-2]), float(r.iloc[-1])
+        a = float(atr(df, 14).iloc[-1])
+        if a <= 0:
+            return None
+        bar = df.iloc[-1]
+        bullish = bar["close"] > bar["open"]
+        if prev_r < self.LO <= cur_r and bullish:
+            return Signal(Side.LONG, ctx.ask, ctx.ask - 1.5 * a, ctx.ask + 1.0 * a,
+                          comment=self.name, time_stop_bars=15)
+        if prev_r > self.HI >= cur_r and not bullish:
+            return Signal(Side.SHORT, ctx.bid, ctx.bid + 1.5 * a, ctx.bid - 1.0 * a,
+                          comment=self.name, time_stop_bars=15)
+        return None
+
+
+class RoundNumberBounce(StrategyBase):
+    """#9 — Rejection wicks at $10 psychological levels within 1 ATR of price."""
+    name = "round_number_bounce"
+    category = "mean-reversion"
+    primary_timeframe = "M5"
+    default_risk_pct = 0.2
+
+    STEP = 10.0
+    WICK_MIN = 0.6                          # recovery must span 60% of bar range
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        a = float(atr(df, 14).iloc[-1])
+        if a <= 0:
+            return None
+        bar = df.iloc[-1]
+        rng = float(bar["high"] - bar["low"])
+        if rng <= 0:
+            return None
+        price = float(bar["close"])
+        for level in round_levels(price, self.STEP):
+            if abs(level - price) > a:
+                continue
+            # long: low pierced the level, close recovered above with a strong wick
+            if bar["low"] < level < bar["close"] and (bar["close"] - bar["low"]) > self.WICK_MIN * rng:
+                sl = level - 0.8 * a
+                return Signal(Side.LONG, ctx.ask, sl, ctx.ask + 1.2 * a,
+                              comment=self.name, time_stop_bars=24)
+            if bar["high"] > level > bar["close"] and (bar["high"] - bar["close"]) > self.WICK_MIN * rng:
+                sl = level + 0.8 * a
+                return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - 1.2 * a,
+                              comment=self.name, time_stop_bars=24)
+        return None
+
+
+class PivotReversion(StrategyBase):
+    """#10 — Classic daily-pivot S1/R1 rejections targeting the pivot."""
+    name = "pivot_reversion"
+    category = "mean-reversion"
+    primary_timeframe = "M5"
+    extra_timeframes = ("D1",)
+    default_risk_pct = 0.25
+
+    MIN_TP_ATR = 0.5
+
+    def on_bar(self, ctx: MarketContext):
+        m5, d1 = ctx.bars_for("M5"), ctx.bars_for("D1")
+        if len(d1) < 2:
+            return None
+        y = d1.iloc[-2]                     # yesterday's completed daily bar
+        p = float(y["high"] + y["low"] + y["close"]) / 3
+        r1 = 2 * p - float(y["low"])
+        s1 = 2 * p - float(y["high"])
+        a = float(atr(m5, 14).iloc[-1])
+        if a <= 0:
+            return None
+        bar = m5.iloc[-1]
+        bullish = bar["close"] > bar["open"]
+        if bar["low"] <= s1 and bar["close"] > s1 and bullish:
+            if abs(p - ctx.ask) < self.MIN_TP_ATR * a:
+                return None                 # pivot too close — no room to pay spread
+            return Signal(Side.LONG, ctx.ask, s1 - 1.0 * a, p,
+                          comment=self.name, time_stop_bars=36)
+        if bar["high"] >= r1 and bar["close"] < r1 and not bullish:
+            if abs(ctx.bid - p) < self.MIN_TP_ATR * a:
+                return None
+            return Signal(Side.SHORT, ctx.bid, r1 + 1.0 * a, p,
+                          comment=self.name, time_stop_bars=36)
+        return None

--- a/gold-scalper/strategies/microstructure.py
+++ b/gold-scalper/strategies/microstructure.py
@@ -1,0 +1,261 @@
+"""Microstructure executors (strategies 11-15).
+
+Shared edge family: gold's order flow leaves fingerprints on the tape — news
+spikes overshoot and retrace, tick bursts ignite continuation, tight-spread
+regimes mean-revert, the dollar leash snaps back, and resting stops get swept
+right before reversals. Each executor reads one of those fingerprints.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.strategy_base import StrategyBase, Signal, Side, ExitReason, MarketContext
+from core.indicators import atr, sma, rsi, session_range
+
+
+class NewsSpikeFade(StrategyBase):
+    """#11 — Fade the overreaction bar 3-10 minutes after a high-impact release."""
+    name = "news_spike_fade"
+    category = "microstructure"
+    primary_timeframe = "M1"
+    aux_feeds = ("calendar",)
+    default_risk_pct = 0.15                # dangerous strategy — smallest risk
+    max_spread_points = 600.0              # spreads are wide post-news
+
+    MIN_LAG_MIN, MAX_LAG_MIN = 3.0, 10.0   # engine blackout is ±5 min; we trade after
+    SPIKE_ATR = 3.0                        # 3-bar spike must exceed this x ATR
+    SL_BUF = 0.3                           # SL beyond the spike extreme, in ATRs
+    RETRACE = 0.38                         # TP = 38% retrace of the spike leg
+
+    def _recent_high_impact(self, ctx: MarketContext):
+        now = ctx.now.replace(tzinfo=None) if ctx.now.tzinfo else ctx.now
+        for ev in ctx.aux.get("calendar") or []:
+            if not isinstance(ev, dict) or ev.get("impact") != "high":
+                continue
+            try:
+                t = dt.datetime.fromisoformat(str(ev.get("time")))
+            except ValueError:
+                continue
+            if t.tzinfo is not None:
+                t = t.astimezone(dt.timezone.utc).replace(tzinfo=None)
+            age_min = (now - t).total_seconds() / 60.0
+            if self.MIN_LAG_MIN <= age_min <= self.MAX_LAG_MIN:
+                return t
+        return None
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M1")
+        if len(df) < 20:
+            return None
+        event_time = self._recent_high_impact(ctx)
+        if event_time is None:
+            return None
+        try:
+            after = df[df.index >= event_time]
+        except TypeError:                  # tz-aware index vs naive event time
+            return None
+        if len(after) < 4:                 # 3 spike bars + the pullback bar
+            return None
+        spike = after.iloc[:3]
+        a = float(atr(df, 14).iloc[-1])
+        if not a > 0:
+            return None
+        move = float(spike["close"].iloc[-1]) - float(spike["open"].iloc[0])
+        if abs(move) < self.SPIKE_ATR * a:
+            return None
+        bar = df.iloc[-1]
+        if move > 0 and bar["close"] < bar["open"]:   # up-spike, first bearish bar
+            extreme = float(spike["high"].max())
+            leg = extreme - float(spike["low"].min())
+            if leg <= 0:
+                return None
+            sl = extreme + self.SL_BUF * a
+            tp = extreme - self.RETRACE * leg
+            return Signal(Side.SHORT, ctx.bid, sl, tp,
+                          comment=self.name, time_stop_bars=20)
+        if move < 0 and bar["close"] > bar["open"]:   # down-spike, first bullish bar
+            extreme = float(spike["low"].min())
+            leg = float(spike["high"].max()) - extreme
+            if leg <= 0:
+                return None
+            sl = extreme - self.SL_BUF * a
+            tp = extreme + self.RETRACE * leg
+            return Signal(Side.LONG, ctx.ask, sl, tp,
+                          comment=self.name, time_stop_bars=20)
+        return None
+
+
+class TickVelocityIgnition(StrategyBase):
+    """#12 — Enter with a tick-volume burst bar that closes hard at its extreme."""
+    name = "tick_velocity_ignition"
+    category = "microstructure"
+    primary_timeframe = "M1"
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.2
+
+    VOL_MULT = 2.5                         # tick_volume vs its SMA(20)
+    RANGE_ATR = 1.5                        # bar range vs ATR(14)
+    CLOSE_ZONE = 0.25                      # close within this fraction of the extreme
+    RR = 1.2
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M1")
+        if len(df) < 22:
+            return None
+        vol = df["tick_volume"].astype(float)
+        base = float(sma(vol, 20).iloc[-2])    # average of the bars before ignition
+        if not base > 0:
+            return None
+        if float(vol.iloc[-1]) < self.VOL_MULT * base:
+            return None
+        a = float(atr(df, 14).iloc[-1])
+        if not a > 0:
+            return None
+        bar = df.iloc[-1]
+        rng = bar["high"] - bar["low"]
+        if rng < self.RANGE_ATR * a or not rng > 0:
+            return None
+        if bar["close"] >= bar["high"] - self.CLOSE_ZONE * rng:
+            sl = float(bar["low"])
+            return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=10)
+        if bar["close"] <= bar["low"] + self.CLOSE_ZONE * rng:
+            sl = float(bar["high"])
+            return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=10)
+        return None
+
+
+class SpreadAwareLiquidity(StrategyBase):
+    """#13 — Micro mean-reversion to SMA(30), taken only in tight-spread regimes."""
+    name = "spread_aware_liquidity"
+    category = "microstructure"
+    primary_timeframe = "M1"
+    sessions_utc = ((7.0, 17.0),)
+    default_risk_pct = 0.2
+    max_spread_points = 150.0              # only trade when liquidity is good
+
+    Z_TRIGGER = 2.2
+    RSI_LONG, RSI_SHORT = 20.0, 80.0
+
+    def on_bar(self, ctx: MarketContext):
+        if ctx.spread_points > self.max_spread_points:
+            return None
+        df = ctx.bars_for("M1")
+        if len(df) < 32:
+            return None
+        close = df["close"]
+        mid = float(sma(close, 30).iloc[-1])
+        sd = float(close.rolling(30).std(ddof=0).iloc[-1])
+        a = float(atr(df, 14).iloc[-1])
+        if not sd > 0 or not a > 0 or not mid > 0:
+            return None
+        z = (float(close.iloc[-1]) - mid) / sd
+        r = float(rsi(close, 3).iloc[-1])
+        if z < -self.Z_TRIGGER and r < self.RSI_LONG:
+            return Signal(Side.LONG, ctx.ask, ctx.ask - a, mid,
+                          comment=self.name, time_stop_bars=12)
+        if z > self.Z_TRIGGER and r > self.RSI_SHORT:
+            return Signal(Side.SHORT, ctx.bid, ctx.bid + a, mid,
+                          comment=self.name, time_stop_bars=12)
+        return None
+
+
+class DXYDivergence(StrategyBase):
+    """#14 — Trade gold back into inverse correlation when it and DXY move together."""
+    name = "dxy_divergence"
+    category = "microstructure"
+    primary_timeframe = "M5"
+    aux_feeds = ("DXY",)
+    default_risk_pct = 0.2
+
+    RET_BARS = 12                          # lookback for both return legs
+    MIN_RET = 0.0015                       # each |return| must exceed 0.15%
+    SL_ATR = 1.5
+    RR = 1.5
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        dxy = ctx.aux.get("DXY")
+        if dxy is None or getattr(dxy, "empty", True) or "close" not in dxy:
+            return None
+        if len(df) < self.RET_BARS + 1 or len(dxy) < self.RET_BARS + 1:
+            return None
+        g0 = float(df["close"].iloc[-self.RET_BARS - 1])
+        d0 = float(dxy["close"].iloc[-self.RET_BARS - 1])
+        if not g0 > 0 or not d0 > 0:
+            return None
+        gold_ret = float(df["close"].iloc[-1]) / g0 - 1.0
+        dxy_ret = float(dxy["close"].iloc[-1]) / d0 - 1.0
+        if abs(gold_ret) < self.MIN_RET or abs(dxy_ret) < self.MIN_RET:
+            return None
+        a = float(atr(df, 14).iloc[-1])
+        if not a > 0:
+            return None
+        if gold_ret > 0 and dxy_ret > 0:   # both rose — short gold to restore inverse
+            sl = ctx.bid + self.SL_ATR * a
+            return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=24)
+        if gold_ret < 0 and dxy_ret < 0:   # both fell — long gold
+            sl = ctx.ask - self.SL_ATR * a
+            return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=24)
+        return None
+
+
+class LiquiditySweepReversal(StrategyBase):
+    """#15 — SMC stop hunt: wick through an aged session extreme, close back inside."""
+    name = "liquidity_sweep_reversal"
+    category = "microstructure"
+    primary_timeframe = "M5"
+    sessions_utc = ((7.0, 20.0),)
+    default_risk_pct = 0.25
+
+    MIN_AGE_HOURS = 2                      # extreme must be at least this old
+    MIN_BARS_AGO = 8                       # ...and from an earlier bar than this
+    SL_BUF = 0.5                           # SL beyond the sweep extreme, in ATRs
+    REJECT_ZONE = 0.4                      # close within this fraction of the far extreme
+    RR = 2.0
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        hour = int(ctx.now.hour)
+        if hour < self.MIN_AGE_HOURS or len(df) < self.MIN_BARS_AGO + 1:
+            return None
+        rng = session_range(df, 0, hour, ctx.now)
+        if rng is None:
+            return None
+        hi, lo = rng
+        today = df[(df.index.date == ctx.now.date()) & (df.index.hour < hour)]
+        if today.empty:
+            return None
+        a = float(atr(df, 14).iloc[-1])
+        if not a > 0:
+            return None
+        bar = df.iloc[-1]
+        bar_rng = bar["high"] - bar["low"]
+        if not bar_rng > 0:
+            return None
+        cutoff_time = ctx.now - dt.timedelta(hours=self.MIN_AGE_HOURS)
+        cutoff_bar = df.index[-self.MIN_BARS_AGO]
+        # long: wick below the aged session low, close back above with rejection
+        t_lo = today["low"].idxmin()
+        if (bar["low"] < lo and bar["close"] > lo
+                and bar["close"] >= bar["high"] - self.REJECT_ZONE * bar_rng
+                and t_lo <= cutoff_time and t_lo < cutoff_bar):
+            sl = float(bar["low"]) - self.SL_BUF * a
+            return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=30)
+        # short: wick above the aged session high, close back below with rejection
+        t_hi = today["high"].idxmax()
+        if (bar["high"] > hi and bar["close"] < hi
+                and bar["close"] <= bar["low"] + self.REJECT_ZONE * bar_rng
+                and t_hi <= cutoff_time and t_hi < cutoff_bar):
+            sl = float(bar["high"]) + self.SL_BUF * a
+            return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=30)
+        return None

--- a/gold-scalper/strategies/momentum.py
+++ b/gold-scalper/strategies/momentum.py
@@ -1,0 +1,185 @@
+"""Momentum / breakout executors (strategies 1-5).
+
+Shared edge family: gold concentrates volatility at session opens; range
+breaks in those windows continue more often than they revert. Each executor
+differs in which range it measures and which window it trades.
+"""
+from __future__ import annotations
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.strategy_base import StrategyBase, Signal, Side, ExitReason, MarketContext
+from core.indicators import atr, ema, adx, session_range
+
+
+class LondonBreakout(StrategyBase):
+    """#1 — Break of the Asian-session range in the first two London hours."""
+    name = "london_breakout"
+    category = "momentum"
+    primary_timeframe = "M5"
+    sessions_utc = ((7.0, 10.0),)          # London 07:00-10:00 UTC
+    lookback_bars = 300
+    default_risk_pct = 0.3
+
+    RANGE_START, RANGE_END = 0, 7          # Asian range 00:00-07:00 UTC
+    BUFFER_ATR = 0.25                      # break must clear range by this many ATRs
+    RR = 1.5
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        rng = session_range(df, self.RANGE_START, self.RANGE_END, ctx.now)
+        if rng is None:
+            return None
+        hi, lo = rng
+        if (hi - lo) < 2.0:                # dead Asian session — range too small to matter
+            return None
+        a = float(atr(df, 14).iloc[-1])
+        buf = self.BUFFER_ATR * a
+        close = float(df["close"].iloc[-1])
+        if close > hi + buf:
+            sl = hi - 0.5 * a              # back inside the range invalidates the break
+            return Signal(Side.LONG, ctx.ask, sl,
+                          ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=24)
+        if close < lo - buf:
+            sl = lo + 0.5 * a
+            return Signal(Side.SHORT, ctx.bid, sl,
+                          ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=24)
+        return None
+
+
+class NYOpenMomentum(StrategyBase):
+    """#2 — Ride the impulse in the first NY hour when it agrees with M15 trend."""
+    name = "ny_open_momentum"
+    category = "momentum"
+    primary_timeframe = "M5"
+    extra_timeframes = ("M15",)
+    sessions_utc = ((13.5, 15.5),)         # 13:30-15:30 UTC (NY equity open window)
+    default_risk_pct = 0.3
+
+    IMPULSE_ATR = 1.2                      # last bar range must exceed this x ATR
+    RR = 1.2
+
+    def on_bar(self, ctx: MarketContext):
+        m5, m15 = ctx.bars_for("M5"), ctx.bars_for("M15")
+        a = float(atr(m5, 14).iloc[-1])
+        bar = m5.iloc[-1]
+        bar_range = bar["high"] - bar["low"]
+        if bar_range < self.IMPULSE_ATR * a:
+            return None
+        trend_up = float(ema(m15["close"], 20).iloc[-1]) > float(ema(m15["close"], 50).iloc[-1])
+        body_up = bar["close"] > bar["open"]
+        if body_up and trend_up and bar["close"] > (bar["low"] + 0.7 * bar_range):
+            sl = float(bar["low"])
+            return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=12)
+        if not body_up and not trend_up and bar["close"] < (bar["low"] + 0.3 * bar_range):
+            sl = float(bar["high"])
+            return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=12)
+        return None
+
+
+class OpeningRangeBreakout(StrategyBase):
+    """#3 — Classic ORB: first 30 min of NY session defines the range; trade the break."""
+    name = "orb_ny"
+    category = "momentum"
+    primary_timeframe = "M5"
+    sessions_utc = ((14.0, 17.0),)         # trade breaks 14:00-17:00 UTC
+    default_risk_pct = 0.25
+
+    OR_START, OR_END = 13.5, 14.0          # opening range 13:30-14:00 UTC
+    RR = 2.0
+    _traded_today: str = ""
+
+    def on_bar(self, ctx: MarketContext):
+        day = ctx.now.strftime("%Y-%m-%d")
+        if self._traded_today == day:      # one break per day, first signal only
+            return None
+        df = ctx.bars_for("M5")
+        orb = df[(df.index.date == ctx.now.date())
+                 & (df.index.hour * 60 + df.index.minute >= self.OR_START * 60)
+                 & (df.index.hour * 60 + df.index.minute < self.OR_END * 60)]
+        if len(orb) < 5:
+            return None
+        hi, lo = float(orb["high"].max()), float(orb["low"].min())
+        close = float(df["close"].iloc[-1])
+        if close > hi:
+            self._traded_today = day
+            return Signal(Side.LONG, ctx.ask, lo, ctx.ask + self.RR * (ctx.ask - lo),
+                          comment=self.name, time_stop_bars=36)
+        if close < lo:
+            self._traded_today = day
+            return Signal(Side.SHORT, ctx.bid, hi, ctx.bid - self.RR * (hi - ctx.bid),
+                          comment=self.name, time_stop_bars=36)
+        return None
+
+
+class AsianRangeBreakout(StrategyBase):
+    """#4 — Fakeout-filtered break of the overnight consolidation during late Asia,
+    anticipating the pre-London push. Requires a retest hold, unlike #1."""
+    name = "asian_range_break"
+    category = "momentum"
+    primary_timeframe = "M15"
+    sessions_utc = ((4.0, 7.0),)
+    default_risk_pct = 0.2
+
+    RANGE_START, RANGE_END = 0, 4
+    RR = 1.5
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M15")
+        rng = session_range(df, self.RANGE_START, self.RANGE_END, ctx.now)
+        if rng is None:
+            return None
+        hi, lo = rng
+        a = float(atr(df, 14).iloc[-1])
+        prev, cur = df.iloc[-2], df.iloc[-1]
+        # break bar followed by a hold bar that does NOT re-enter the range
+        if prev["close"] > hi and cur["low"] > hi:
+            sl = hi - 0.3 * a
+            return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=16)
+        if prev["close"] < lo and cur["high"] < lo:
+            sl = lo + 0.3 * a
+            return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * (sl - ctx.bid),
+                          comment=self.name, time_stop_bars=16)
+        return None
+
+
+class VolatilityExpansion(StrategyBase):
+    """#5 — Squeeze-then-burst: trade the direction of the first expansion bar
+    after ATR compresses well below its own average. Session-agnostic."""
+    name = "vol_expansion"
+    category = "momentum"
+    primary_timeframe = "M5"
+    default_risk_pct = 0.25
+
+    SQUEEZE = 0.7                          # ATR(7) < 0.7 x ATR(48) = compression
+    BURST = 1.8                            # bar range > 1.8 x ATR(7) = ignition
+    RR = 1.5
+
+    def on_bar(self, ctx: MarketContext):
+        df = ctx.bars_for("M5")
+        a_fast = atr(df, 7)
+        a_slow = atr(df, 48)
+        # compression measured on the bars BEFORE the burst bar
+        if float(a_fast.iloc[-2]) > self.SQUEEZE * float(a_slow.iloc[-2]):
+            return None
+        bar = df.iloc[-1]
+        rng = bar["high"] - bar["low"]
+        if rng < self.BURST * float(a_fast.iloc[-2]):
+            return None
+        if float(adx(df, 14).iloc[-1]) < 15:   # ignition needs directional energy
+            return None
+        if bar["close"] > bar["open"]:
+            sl = float(bar["low"])
+            return Signal(Side.LONG, ctx.ask, sl, ctx.ask + self.RR * (ctx.ask - sl),
+                          comment=self.name, time_stop_bars=18)
+        sl = float(bar["high"])
+        return Signal(Side.SHORT, ctx.bid, sl, ctx.bid - self.RR * (sl - ctx.bid),
+                      comment=self.name, time_stop_bars=18)

--- a/gold-scalper/supervisor.py
+++ b/gold-scalper/supervisor.py
@@ -1,0 +1,296 @@
+"""Out-of-band supervisor — reads the journal, scores each strategy, and
+prepares/applies fleet decisions. Stdlib only; no MT5 or pandas dependency,
+so it runs anywhere (including the Linux box the terminal isn't on).
+
+  python supervisor.py score  [--journal logs/journal.jsonl] [--json]
+  python supervisor.py review [--journal logs/journal.jsonl]
+  python supervisor.py apply  --disable name1,name2 --enable name3
+
+`score`  — activity + (if logs/deals.json is present) realized-pnl metrics
+           per strategy, with mechanical DISABLE-CANDIDATE flags.
+`review` — prints a ready-to-paste Claude Fable 5 review prompt embedding the
+           scorecard and recent journal tail. It only prints; a human (or a
+           Claude Code session) runs it and applies verdicts via `apply`.
+`apply`  — flips strategies in config/enabled.json and journals the change.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import sys
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent
+
+# Canonical fleet order — must match strategies/__init__.py ALL_STRATEGIES.
+# Index = magic-number offset from magic_base; used to join logs/deals.json.
+STRATEGY_ORDER = [
+    "london_breakout", "ny_open_momentum", "orb_ny",
+    "asian_range_break", "vol_expansion",
+    "vwap_reversion", "bollinger_fade", "rsi_extreme_fade",
+    "round_number_bounce", "pivot_reversion",
+    "news_spike_fade", "tick_velocity_ignition", "spread_aware_liquidity",
+    "dxy_divergence", "liquidity_sweep_reversal",
+    "ema_ribbon_pullback", "stoch_trend_scalp", "macd_zero_cross",
+    "keltner_supertrend_ride", "heikin_ashi_atr",
+]
+
+
+# ---------- loading ----------
+def load_journal(path: pathlib.Path) -> list[dict]:
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue                      # tolerate a torn write at the tail
+    return events
+
+
+def load_deals(base: pathlib.Path) -> dict[str, list[float]]:
+    """logs/deals.json: list of {magic, profit} exported from MT5 history.
+    Returns strategy_name -> chronological list of realized profits."""
+    p = base / "logs" / "deals.json"
+    if not p.exists():
+        return {}
+    try:
+        deals = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    magic_base = 770000
+    settings = base / "config" / "settings.json"
+    if settings.exists():
+        try:
+            magic_base = json.loads(settings.read_text(encoding="utf-8")).get(
+                "magic_base", magic_base)
+        except (OSError, json.JSONDecodeError):
+            pass
+    out: dict[str, list[float]] = {}
+    for d in deals:
+        idx = d.get("magic", -1) - magic_base
+        if 0 <= idx < len(STRATEGY_ORDER):
+            out.setdefault(STRATEGY_ORDER[idx], []).append(float(d.get("profit", 0.0)))
+    return out
+
+
+# ---------- scoring ----------
+def pnl_metrics(profits: list[float]) -> dict:
+    wins = [p for p in profits if p > 0]
+    losses = [p for p in profits if p < 0]
+    gross_win, gross_loss = sum(wins), -sum(losses)
+    peak = run = max_dd = 0.0
+    for p in profits:
+        run += p
+        peak = max(peak, run)
+        max_dd = max(max_dd, peak - run)
+    return {
+        "trades": len(profits),
+        "pnl": round(sum(profits), 2),
+        "win_pct": round(100 * len(wins) / len(profits), 1) if profits else 0.0,
+        "profit_factor": (round(gross_win / gross_loss, 2) if gross_loss > 0
+                          else (float("inf") if gross_win > 0 else 0.0)),
+        "expectancy": round(sum(profits) / len(profits), 2) if profits else 0.0,
+        "max_drawdown": round(max_dd, 2),
+    }
+
+
+def build_scorecard(events: list[dict], deals: dict[str, list[float]]) -> dict:
+    per: dict[str, dict] = {}
+
+    def row(name: str) -> dict:
+        return per.setdefault(name, {
+            "signals": 0, "vetoed": 0, "orders_filled": 0, "orders_failed": 0,
+            "closes": {}, "errors": 0, "disabled_events": 0, "sl_moves": 0,
+        })
+
+    for ev in events:
+        name = ev.get("strategy")
+        if not name:
+            continue
+        kind = ev.get("kind")
+        r = row(name)
+        if kind == "signal":
+            r["signals"] += 1
+            if ev.get("vetoed"):
+                r["vetoed"] += 1
+        elif kind == "order":
+            r["orders_filled" if ev.get("filled") else "orders_failed"] += 1
+        elif kind == "close":
+            reason = ev.get("reason", "unknown")
+            r["closes"][reason] = r["closes"].get(reason, 0) + 1
+        elif kind == "strategy_error":
+            r["errors"] += 1
+        elif kind == "disabled":
+            r["disabled_events"] += 1
+        elif kind == "sl_move":
+            r["sl_moves"] += 1
+
+    for name, profits in deals.items():
+        row(name)["pnl_metrics"] = pnl_metrics(profits)
+
+    # mechanical disable-candidate rules
+    for name, r in per.items():
+        flags = []
+        pm = r.get("pnl_metrics")
+        if pm and pm["trades"] >= 30 and pm["profit_factor"] < 0.8:
+            flags.append(f"profit factor {pm['profit_factor']} < 0.8 over {pm['trades']} trades")
+        if r["errors"] >= 3:
+            flags.append(f"{r['errors']} errors")
+        if r["signals"] >= 20:
+            veto_rate = 100 * r["vetoed"] / r["signals"]
+            if veto_rate > 80:
+                flags.append(f"veto rate {veto_rate:.0f}% over {r['signals']} signals")
+        r["disable_candidate"] = bool(flags)
+        r["flags"] = flags
+
+    halts = sum(1 for ev in events if ev.get("kind") == "halt")
+    return {"generated": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "events_total": len(events), "halts": halts,
+            "strategies": per}
+
+
+def print_table(card: dict) -> None:
+    per = card["strategies"]
+    header = (f"{'strategy':<26}{'sig':>5}{'veto':>6}{'fill':>6}{'close':>7}"
+              f"{'err':>5}{'pnl':>10}{'pf':>7}{'win%':>7}  flags")
+    print(header)
+    print("-" * len(header))
+    for name in sorted(per):
+        r = per[name]
+        pm = r.get("pnl_metrics", {})
+        pf = pm.get("profit_factor", "")
+        print(f"{name:<26}{r['signals']:>5}{r['vetoed']:>6}{r['orders_filled']:>6}"
+              f"{sum(r['closes'].values()):>7}{r['errors']:>5}"
+              f"{pm.get('pnl', ''):>10}{pf if pf != '' else '':>7}"
+              f"{pm.get('win_pct', ''):>7}  "
+              f"{'DISABLE-CANDIDATE: ' + '; '.join(r['flags']) if r['disable_candidate'] else ''}")
+    print(f"\n{card['events_total']} journal events, {card['halts']} halts, "
+          f"{sum(1 for r in per.values() if r['disable_candidate'])} disable candidate(s)")
+
+
+# ---------- subcommands ----------
+def cmd_score(args) -> int:
+    events = load_journal(args.journal)
+    if not events:
+        print("no data yet")
+        return 0
+    card = build_scorecard(events, load_deals(BASE_DIR))
+    if args.json:
+        print(json.dumps(card, indent=2))
+    else:
+        print_table(card)
+    return 0
+
+
+REVIEW_INSTRUCTIONS = """\
+You are the supervisor of a 20-strategy gold scalping fleet running on one
+MT5 account. Below are the fleet scorecard (aggregated from the trade
+journal, with realized-pnl metrics where MT5 deal history was exported) and
+the last 50 raw journal events.
+
+For each strategy flagged DISABLE-CANDIDATE - and any other strategy whose
+record concerns you - decide: keep, disable, or tune. Base the decision on
+the evidence shown (profit factor, expectancy, drawdown, error counts, veto
+rates, close reasons), not on priors about the strategy style. A high veto
+rate may mean the risk gate is doing its job during a crowded regime, not
+that the strategy is broken - reason about cause before disabling.
+
+Output a JSON object mapping strategy name to verdict, e.g.
+{"news_spike_fade": "disable", "vwap_reversion": "keep", "orb_ny": "tune: widen ORB window"}
+with one short sentence of reasoning per entry. A human will apply verdicts
+with: python supervisor.py apply --disable <names> --enable <names>
+"""
+
+
+def cmd_review(args) -> int:
+    events = load_journal(args.journal)
+    if not events:
+        print("no data yet")
+        return 0
+    card = build_scorecard(events, load_deals(BASE_DIR))
+    print(REVIEW_INSTRUCTIONS)
+    print("=== SCORECARD ===")
+    print(json.dumps(card, indent=2))
+    print("\n=== LAST 50 JOURNAL EVENTS ===")
+    for ev in events[-50:]:
+        print(json.dumps(ev))
+    return 0
+
+
+def cmd_apply(args) -> int:
+    disable = [n.strip() for n in (args.disable or "").split(",") if n.strip()]
+    enable = [n.strip() for n in (args.enable or "").split(",") if n.strip()]
+    if not disable and not enable:
+        print("nothing to apply — pass --disable and/or --enable")
+        return 1
+    unknown = [n for n in disable + enable if n not in STRATEGY_ORDER]
+    if unknown:
+        print(f"unknown strategy name(s): {', '.join(unknown)}")
+        return 1
+
+    enabled_path = BASE_DIR / "config" / "enabled.json"
+    enabled_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        current = json.loads(enabled_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        current = {}
+
+    changes = {}
+    for name in disable:
+        if current.get(name, True) is not False:
+            changes[name] = False
+    for name in enable:
+        if current.get(name, True) is not True:
+            changes[name] = True
+
+    if not changes:
+        print("no changes — enabled.json already matches")
+        return 0
+
+    for name, value in changes.items():
+        old = current.get(name, True)
+        print(f"  {name}: {old} -> {value}")
+        current[name] = value
+    enabled_path.write_text(json.dumps(current, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {enabled_path}")
+
+    journal_path = BASE_DIR / "logs" / "journal.jsonl"
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    rec = {"ts": dt.datetime.now(dt.timezone.utc).isoformat(),
+           "kind": "supervisor_apply", "changes": changes}
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Journal analyzer / fleet supervisor")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    default_journal = BASE_DIR / "logs" / "journal.jsonl"
+    p_score = sub.add_parser("score", help="per-strategy scorecard from the journal")
+    p_score.add_argument("--journal", type=pathlib.Path, default=default_journal)
+    p_score.add_argument("--json", action="store_true", help="machine-readable output")
+    p_score.set_defaults(fn=cmd_score)
+
+    p_review = sub.add_parser("review", help="print a Claude Fable 5 review prompt")
+    p_review.add_argument("--journal", type=pathlib.Path, default=default_journal)
+    p_review.set_defaults(fn=cmd_review)
+
+    p_apply = sub.add_parser("apply", help="flip strategies in config/enabled.json")
+    p_apply.add_argument("--disable", default="", help="comma-separated names to disable")
+    p_apply.add_argument("--enable", default="", help="comma-separated names to enable")
+    p_apply.set_defaults(fn=cmd_apply)
+
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gold-scalper/tools/fetch_calendar.py
+++ b/gold-scalper/tools/fetch_calendar.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Fetch the ForexFactory economic calendar and write config/calendar.json.
+
+The engine's news blackout (core/engine.py:in_news_blackout) consumes a list of
+{"time": "<ISO-8601 with offset>", "impact": "high"} and parses "time" with
+datetime.fromisoformat, comparing against tz-aware UTC now — so every "time"
+written here carries an explicit +00:00 offset.
+
+Usage:
+    python tools/fetch_calendar.py [--out config/calendar.json]
+                                   [--currencies USD,EUR,GBP]
+                                   [--min-impact high] [--dry-run]
+                                   [--from-file path.json]
+
+Exit codes: 0 ok, 2 all sources failed (existing calendar.json left untouched).
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+FEED_URLS = [
+    ("this week", "https://nfs.faireconomy.media/ff_calendar_thisweek.json"),
+    ("next week", "https://nfs.faireconomy.media/ff_calendar_nextweek.json"),
+]
+USER_AGENT = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+              "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36")
+TIMEOUT = 15
+IMPACT_RANK = {"high": 3, "medium": 2, "low": 1}
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def warn(msg: str) -> None:
+    print(f"warning: {msg}", file=sys.stderr)
+
+
+def fetch_feed(label: str, url: str) -> list | None:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT,
+                                               "Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            data = json.load(resp)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError,
+            OSError, json.JSONDecodeError, ValueError) as e:
+        warn(f"fetch failed for {label} ({url}): {e}")
+        return None
+    if not isinstance(data, list):
+        warn(f"{label}: unexpected payload type {type(data).__name__}, expected list")
+        return None
+    return data
+
+
+def normalize_event(raw: dict) -> dict | None:
+    """FF feed item -> engine event, or None (with warning) on schema drift."""
+    if not isinstance(raw, dict):
+        warn(f"skipping non-object event: {raw!r:.80}")
+        return None
+    title = raw.get("title")
+    country = raw.get("country")
+    date_str = raw.get("date")
+    impact = raw.get("impact")
+    if not all(isinstance(v, str) and v for v in (title, country, date_str, impact)):
+        warn(f"skipping event with missing/invalid fields: "
+             f"title={title!r} country={country!r} date={date_str!r} impact={impact!r}")
+        return None
+    try:
+        t = datetime.fromisoformat(date_str)
+    except ValueError:
+        warn(f"skipping {title!r}: unparseable date {date_str!r}")
+        return None
+    if t.tzinfo is None:
+        warn(f"skipping {title!r}: date {date_str!r} has no timezone offset")
+        return None
+    return {
+        "time": t.astimezone(timezone.utc).isoformat(),
+        "impact": impact.strip().lower(),
+        "title": title,
+        "currency": country.strip().upper(),
+    }
+
+
+def collect(feeds: list[list], currencies: set[str], min_impact: str) -> list[dict]:
+    min_rank = IMPACT_RANK[min_impact]
+    seen = set()
+    events = []
+    for feed in feeds:
+        for raw in feed:
+            ev = normalize_event(raw)
+            if ev is None:
+                continue
+            if ev["currency"] not in currencies:
+                continue
+            if IMPACT_RANK.get(ev["impact"], 0) < min_rank:
+                continue
+            key = (ev["time"], ev["currency"], ev["title"])
+            if key in seen:
+                continue
+            seen.add(key)
+            events.append(ev)
+    events.sort(key=lambda e: e["time"])
+    return events
+
+
+def atomic_write(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(events, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def describe_delta(now: datetime, then: datetime) -> str:
+    secs = (then - now).total_seconds()
+    sign = "in " if secs >= 0 else ""
+    suffix = "" if secs >= 0 else " ago"
+    secs = abs(secs)
+    days, rem = divmod(int(secs), 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    parts.append(f"{minutes}m")
+    return f"{sign}{' '.join(parts)}{suffix}"
+
+
+def summarize(events: list[dict], now: datetime) -> None:
+    upcoming_high = [e for e in events
+                     if e["impact"] == "high" and datetime.fromisoformat(e["time"]) > now]
+    if upcoming_high:
+        nxt = upcoming_high[0]
+        when = datetime.fromisoformat(nxt["time"])
+        print(f"next high-impact: {nxt['title']} ({nxt['currency']}) at "
+              f"{nxt['time']} ({describe_delta(now, when)})")
+    else:
+        print("no upcoming high-impact events in the fetched window")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Fetch ForexFactory calendar into the engine's calendar.json format.")
+    ap.add_argument("--out", default=str(PROJECT_ROOT / "config" / "calendar.json"),
+                    help="output path (default: <project>/config/calendar.json)")
+    ap.add_argument("--currencies", default="USD",
+                    help="comma-separated calendar currencies (default: USD — "
+                         "gold's dominant driver; XAU is not a calendar currency)")
+    ap.add_argument("--min-impact", default="high", choices=sorted(IMPACT_RANK),
+                    help="minimum impact to keep (default: high — the engine only "
+                         "blacks out 'high')")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the event table instead of writing")
+    ap.add_argument("--from-file", metavar="PATH",
+                    help="debug: parse a local FF-format JSON file instead of fetching")
+    args = ap.parse_args()
+
+    currencies = {c.strip().upper() for c in args.currencies.split(",") if c.strip()}
+    if not currencies:
+        print("error: --currencies is empty", file=sys.stderr)
+        return 1
+    out_path = Path(args.out)
+    now = datetime.now(timezone.utc)
+
+    feeds = []
+    if args.from_file:
+        try:
+            feeds.append(json.loads(Path(args.from_file).read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"error: cannot read {args.from_file}: {e}", file=sys.stderr)
+            return 1
+    else:
+        for label, url in FEED_URLS:
+            feed = fetch_feed(label, url)
+            if feed is not None:
+                feeds.append(feed)
+        if not feeds:
+            print("error: all calendar sources failed", file=sys.stderr)
+            if out_path.exists():
+                age_h = (now.timestamp() - out_path.stat().st_mtime) / 3600
+                warn(f"keeping existing {out_path} untouched "
+                     f"(stale data beats no data — file is {age_h:.1f}h old)")
+            else:
+                warn(f"no existing {out_path} to fall back on — engine will have "
+                     f"no news blackout until a fetch succeeds")
+            return 2
+
+    events = collect(feeds, currencies, args.min_impact)
+
+    if args.dry_run:
+        print(f"{'time (UTC)':<26} {'impact':<7} {'cur':<4} title")
+        for ev in events:
+            print(f"{ev['time']:<26} {ev['impact']:<7} {ev['currency']:<4} {ev['title']}")
+        print(f"\n{len(events)} events matched "
+              f"(currencies={','.join(sorted(currencies))}, min-impact={args.min_impact}) "
+              f"— dry run, nothing written")
+        summarize(events, now)
+        return 0
+
+    atomic_write(out_path, events)
+    print(f"{len(events)} events written to {out_path}")
+    summarize(events, now)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gold-scalper/tools/watchdog.py
+++ b/gold-scalper/tools/watchdog.py
@@ -1,0 +1,279 @@
+"""Process supervisor for the gold-scalper engine (stdlib-only, Windows-first).
+
+Keeps `python main.py` alive: restarts on crash, detects a hung engine via the
+heartbeat file the engine writes each iteration (logs/heartbeat.json:
+{"ts": iso-utc, "equity": float, "open_positions": int}), and -- mirroring the
+repo's agent-harness loop discipline -- never crash-loops forever: after
+--max-restarts restarts inside --window-hours it writes logs/ESCALATE with the
+reason + restart history and exits 3 so a human intervenes.
+
+Usage:
+  python tools/watchdog.py [--cmd "python main.py"]
+                           [--heartbeat logs/heartbeat.json]
+                           [--stale-seconds 120] [--max-restarts 3]
+                           [--window-hours 1] [--once]
+
+--once runs a single freshness check (exit 0 fresh / 1 stale) for
+Windows Task Scheduler integration.
+
+Windows notes:
+  * The child is started with CREATE_NEW_PROCESS_GROUP so console CTRL events
+    do not propagate between watchdog and engine uncontrolled.
+  * Graceful stop sends CTRL_BREAK_EVENT to the child's group first (the only
+    console signal deliverable to another process group on Windows), waits
+    15s, then TerminateProcess via terminate(), then kill() after 10s more.
+  * On POSIX the same sequence degrades to SIGTERM -> wait -> SIGKILL.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import shlex
+import signal
+import subprocess
+import sys
+import time
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent.parent   # gold-scalper root
+LOG_PATH = BASE_DIR / "logs" / "watchdog.log"
+ESCALATE_PATH = BASE_DIR / "logs" / "ESCALATE"
+BACKOFF_SECONDS = (10, 30, 90)          # 1st, 2nd, 3rd+ restart
+GRACEFUL_WAIT = 15                      # s after CTRL_BREAK/SIGTERM before terminate()
+KILL_WAIT = 10                          # s after terminate() before kill()
+MISSING_GRACE = 180                     # s post-start before a missing heartbeat = hung
+POLL_SECONDS = 1.0
+
+IS_WINDOWS = os.name == "nt"
+_STOP = False                           # set by our own signal handlers
+
+
+def log(msg: str) -> None:
+    line = f"{dt.datetime.now(dt.timezone.utc).isoformat(timespec='seconds')} {msg}"
+    print(line, flush=True)
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass                            # never let logging kill the supervisor
+
+
+# ---------- heartbeat ----------
+
+def heartbeat_age(path: pathlib.Path) -> float | None:
+    """Seconds since the engine last proved it was alive, or None if no
+    usable heartbeat exists. Prefers the JSON `ts` field; falls back to file
+    mtime if the file is mid-write or malformed."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        ts = dt.datetime.fromisoformat(json.loads(raw)["ts"])
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.timezone.utc)
+        return (dt.datetime.now(dt.timezone.utc) - ts).total_seconds()
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        try:
+            return time.time() - path.stat().st_mtime
+        except OSError:
+            return None
+
+
+def check_hung(path: pathlib.Path, child_started: float,
+               stale_seconds: int) -> str | None:
+    """Return a reason string if the engine looks hung, else None.
+    A heartbeat that pre-dates this child (leftover from the previous run)
+    counts as missing, so a fresh restart gets the full grace period."""
+    age = heartbeat_age(path)
+    since_start = time.time() - child_started
+    if age is None or age > since_start:            # missing / stale leftover
+        if since_start > MISSING_GRACE:
+            return (f"no heartbeat from this run after {since_start:.0f}s "
+                    f"(grace {MISSING_GRACE}s)")
+        return None
+    if age > stale_seconds:
+        return f"heartbeat stale: {age:.0f}s old (limit {stale_seconds}s)"
+    return None
+
+
+# ---------- child lifecycle ----------
+
+def start_child(cmd: str) -> subprocess.Popen:
+    if IS_WINDOWS:
+        return subprocess.Popen(
+            cmd, cwd=str(BASE_DIR),
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+    return subprocess.Popen(shlex.split(cmd), cwd=str(BASE_DIR),
+                            start_new_session=True)
+
+
+def stop_child(proc: subprocess.Popen) -> None:
+    """Graceful-then-forceful: CTRL_BREAK (SIGTERM on POSIX) -> 15s ->
+    terminate() -> 10s -> kill(). The engine flattens/journals on the
+    graceful signal, so give it real time before TerminateProcess."""
+    if proc.poll() is not None:
+        return
+    try:
+        if IS_WINDOWS:
+            proc.send_signal(signal.CTRL_BREAK_EVENT)
+            log(f"sent CTRL_BREAK_EVENT to pid {proc.pid}")
+        else:
+            proc.terminate()
+            log(f"sent SIGTERM to pid {proc.pid}")
+        proc.wait(timeout=GRACEFUL_WAIT)
+        log(f"child pid {proc.pid} exited gracefully (rc={proc.returncode})")
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    except (OSError, ValueError):
+        pass                            # already dead or signal undeliverable
+    try:
+        proc.terminate()
+        log(f"terminate() sent to pid {proc.pid}")
+        proc.wait(timeout=KILL_WAIT)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        log(f"kill() sent to pid {proc.pid}")
+        try:
+            proc.wait(timeout=KILL_WAIT)
+        except subprocess.TimeoutExpired:
+            log(f"WARNING: pid {proc.pid} did not die even after kill()")
+    except OSError:
+        pass
+    if proc.poll() is not None:
+        log(f"child pid {proc.pid} stopped (rc={proc.returncode})")
+
+
+def interruptible_sleep(seconds: float) -> None:
+    end = time.time() + seconds
+    while not _STOP and time.time() < end:
+        time.sleep(min(0.5, max(0.0, end - time.time())))
+
+
+# ---------- escalation ----------
+
+def escalate(reason: str, history: list[float]) -> None:
+    body = {
+        "ts": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "reason": reason,
+        "restart_history_utc": [
+            dt.datetime.fromtimestamp(t, dt.timezone.utc).isoformat(timespec="seconds")
+            for t in history],
+        "action_required": "Engine restarted too often; watchdog stopped. "
+                           "Investigate logs/watchdog.log + logs/harness.log, "
+                           "then delete this file and restart the watchdog.",
+    }
+    ESCALATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ESCALATE_PATH.write_text(json.dumps(body, indent=2), encoding="utf-8")
+    log(f"ESCALATE: {reason} -- restart budget exhausted, wrote {ESCALATE_PATH}, exiting 3")
+
+
+# ---------- modes ----------
+
+def run_once(hb_path: pathlib.Path, stale_seconds: int) -> int:
+    age = heartbeat_age(hb_path)
+    if age is None:
+        log(f"once: STALE -- heartbeat missing/unreadable at {hb_path}")
+        return 1
+    if age > stale_seconds:
+        log(f"once: STALE -- heartbeat {age:.0f}s old (limit {stale_seconds}s)")
+        return 1
+    log(f"once: FRESH -- heartbeat {age:.0f}s old (limit {stale_seconds}s)")
+    return 0
+
+
+def supervise(args: argparse.Namespace, hb_path: pathlib.Path) -> int:
+    window = args.window_hours * 3600.0
+    restarts: list[float] = []          # epoch times of restarts performed
+    log(f"watchdog start: cmd={args.cmd!r} heartbeat={hb_path} "
+        f"stale={args.stale_seconds}s max_restarts={args.max_restarts}/"
+        f"{args.window_hours}h")
+
+    while not _STOP:
+        proc = start_child(args.cmd)
+        started = time.time()
+        log(f"started child pid {proc.pid}")
+
+        reason = None
+        while not _STOP:
+            rc = proc.poll()
+            if rc is not None:
+                reason = f"child pid {proc.pid} exited rc={rc}"
+                break
+            hung = check_hung(hb_path, started, args.stale_seconds)
+            if hung:
+                reason = f"child pid {proc.pid} hung: {hung}"
+                log(reason + " -- stopping it")
+                stop_child(proc)
+                break
+            time.sleep(POLL_SECONDS)
+
+        if _STOP:
+            log("shutdown requested -- stopping child and exiting 0")
+            stop_child(proc)
+            return 0
+
+        log(reason)
+        now = time.time()
+        restarts = [t for t in restarts if now - t <= window]
+        if len(restarts) >= args.max_restarts:
+            escalate(reason, restarts + [now])
+            return 3
+        restarts.append(now)
+        backoff = BACKOFF_SECONDS[min(len(restarts) - 1, len(BACKOFF_SECONDS) - 1)]
+        log(f"restart {len(restarts)}/{args.max_restarts} in window -- "
+            f"backing off {backoff}s")
+        interruptible_sleep(backoff)
+
+    return 0
+
+
+def _on_signal(signum, _frame):
+    global _STOP
+    _STOP = True
+    log(f"received signal {signum} -- shutting down")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Supervise the gold-scalper engine: restart on crash/hang "
+                    "with bounded retries, then escalate to a human.")
+    ap.add_argument("--cmd", default="python main.py",
+                    help="command to launch the engine (default: 'python main.py')")
+    ap.add_argument("--heartbeat", default="logs/heartbeat.json",
+                    help="heartbeat file the engine writes each iteration")
+    ap.add_argument("--stale-seconds", type=int, default=120,
+                    help="heartbeat older than this = engine hung")
+    ap.add_argument("--max-restarts", type=int, default=3,
+                    help="restarts allowed inside --window-hours before escalating")
+    ap.add_argument("--window-hours", type=float, default=1.0,
+                    help="sliding window for the restart budget")
+    ap.add_argument("--once", action="store_true",
+                    help="single freshness check: exit 0 fresh / 1 stale "
+                         "(for Windows Task Scheduler)")
+    args = ap.parse_args()
+
+    hb_path = pathlib.Path(args.heartbeat)
+    if not hb_path.is_absolute():
+        hb_path = BASE_DIR / hb_path
+
+    if args.once:
+        return run_once(hb_path, args.stale_seconds)
+
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+    if IS_WINDOWS and hasattr(signal, "SIGBREAK"):
+        signal.signal(signal.SIGBREAK, _on_signal)
+
+    try:
+        return supervise(args, hb_path)
+    except KeyboardInterrupt:
+        log("KeyboardInterrupt -- exiting 0")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

New `gold-scalper/` project: a multi-strategy **agent harness** that runs 20 sandboxed XAUUSD scalping executors against one MT5 account, applying the repo's `engineering/agent-harness` discipline to live trading: decompose → deterministic execution → machine verification → bounded retries → escalate to human. Claude Fable 5 sits in the out-of-band supervisor loop (scorecard → keep/disable verdicts → auditable `enabled.json` edits), never in the order path.

## Why

Demonstrates the agent-harness pattern on a hostile real-world domain: strategies are pure functions (`MarketContext → Signal`) that cannot place orders, size positions, or bypass the risk gate; the harness owns routing, portfolio risk, journaling, and kill switches, so one buggy executor cannot hurt the account beyond its risk slice.

## Contents

- **core/** — strategy contract, portfolio risk gate (daily 2% / weekly 5% circuit breakers, per-trade caps, position/volume limits), MT5 adapter (server-clock→UTC normalization, slippage telemetry, magic-number-per-strategy attribution), engine (news blackout, 21:50–22:10 UTC rollover guard, 5 trades/strategy/day cap, `HALT` file kill switch, heartbeat, restart-safe time-stops), pandas-only no-lookahead indicator kit
- **strategies/** — 20 executors in 4 families (momentum, mean-reversion, microstructure, indicator-hybrid); append-only registry (order = magic offset)
- **backtest/** — `SimBroker` (same interface as live, conservative SL-first intra-bar fills), fleet runner, walk-forward validator (ROBUST/INCONSISTENT/NEGATIVE/INSUFFICIENT-DATA gate)
- **supervisor.py** — journal scorecard + mechanical disable rules + Fable 5 review-prompt generator; **dashboard.py** — single-file HTML monitoring dashboard (repo design-token canon, WCAG AA, hand-rolled SVG equity/drawdown, no framework runtimes)
- **tools/** — ForexFactory calendar fetcher (verified live: pulls next week's CPI/Fed events), heartbeat watchdog (bounded restarts + `ESCALATE` file)

## Verification

- All modules `py_compile` clean; registry imports exactly 20 strategies matching `enabled.json`
- All 20 executors smoke-run against synthetic multi-TF data (0 failures)
- End-to-end fleet backtest on synthetic random walk: 23 trades across 8 strategies; **daily and weekly circuit breakers fired correctly**, halting at −5.15%
- Walk-forward gate correctly rejects 0/20 on edge-free noise with 300-pt spread (honest transaction-cost model)
- Safety: live mode on a non-demo account **refuses to start** without `"i_understand_this_is_real_money": true`

## Reviewer notes

- Python (pandas/numpy) rather than stdlib-only: this is a standalone trading application, not a skill package — it deliberately sits outside the skill-counter tree (no SKILL.md/plugin.json), so `derive_counters.py` is unaffected
- Live trading needs Windows + MT5 terminal; everything else (backtest, walk-forward, dashboard, supervisor) runs anywhere
- `logs/`, `config/calendar.json`, `HALT` are gitignored runtime artifacts
- Known limitation: strategy parameters are engineered defaults pending real-data walk-forward validation; the promotion pipeline (backtest → demo ≥2 weeks → live) is documented as non-negotiable in `docs/ARCHITECTURE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)