### PR TITLE
docs: fix pull request template path casing

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -302,7 +302,7 @@ These commands work seamlessly with the GitHub automation:
 ## 🔗 Related Documentation
 
 - **Automation Setup**: `.github/AUTOMATION_SETUP.md`
-- **PR Template**: `.github/pull_request_template.md`
+- **PR Template**: `.github/PULL_REQUEST_TEMPLATE.md`
 - **Commit Template**: `.github/commit-template.txt`
 - **Workflow Guide**: See factory project for detailed reference
 


### PR DESCRIPTION
## Summary

Update the related-documentation link to the tracked `.github/PULL_REQUEST_TEMPLATE.md` path. This docs-only correction was found with the attest static instruction-binding scan.

## Checklist

- [x] **Target branch is `dev`**
- [x] No hardcoded API keys, tokens, or secrets
- [x] Follows the existing directory structure

## Type of Change

- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation
- [ ] Infrastructure / CI

## Testing

The uppercase path exists at the submitted base commit, and the modified command README reports zero broken bindings under attest.
