### PR TITLE
docs(c-level-advisor): fix broken SKILL.md links in README

### DIFF
--- a/c-level-advisor/README.md
+++ b/c-level-advisor/README.md
@@ -104,7 +104,7 @@ This C-Level advisory skills collection provides executive leadership guidance f
 - Building organizational culture
 - Managing stakeholder relationships
 
-**Learn More:** [ceo-advisor/SKILL.md](ceo-advisor/SKILL.md)
+**Learn More:** [ceo-advisor/SKILL.md](skills/ceo-advisor/SKILL.md)
 
 ---
 
@@ -138,7 +138,7 @@ This C-Level advisory skills collection provides executive leadership guidance f
 - Making architecture decisions
 - Measuring engineering performance
 
-**Learn More:** [cto-advisor/SKILL.md](cto-advisor/SKILL.md)
+**Learn More:** [cto-advisor/SKILL.md](skills/cto-advisor/SKILL.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- `c-level-advisor/README.md` linked to `ceo-advisor/SKILL.md` and `cto-advisor/SKILL.md`, but both files actually live one directory deeper at `c-level-advisor/skills/ceo-advisor/SKILL.md` and `c-level-advisor/skills/cto-advisor/SKILL.md`.
- Updated both "Learn More" links to include the `skills/` path segment so they resolve correctly.

## Test plan
- [x] Confirmed both target files exist at the corrected paths
- [x] Diff is a 2-line change limited to `c-level-advisor/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)