### PR TITLE
feat(marketing-skill): add business-name-fit skill

### DIFF
--- a/marketing-skill/skills/business-name-fit/SKILL.md
+++ b/marketing-skill/skills/business-name-fit/SKILL.md
@@ -7,159 +7,114 @@ description: Suggest, pick, or vet a business, startup, or product name that sta
 
 ## Overview
 
-Help founders choose or check a business/brand/product name that is authentic to their
-origin **and** lands well in the market where they'll operate.
+Help founders choose or check a business/brand/product name that is authentic to their origin **and** lands well in the market where they'll operate.
 
-The core value is catching the mismatch between the two: a name can be perfectly good in
-its home language yet confusing, funny, or off-putting elsewhere. Examples:
+The core value is catching the mismatch between the two: a name can be perfectly good in its home language yet confusing, funny, or off-putting elsewhere. Examples:
 - The Persian name "Anali" is fine in Iran but reads oddly to English speakers.
-- - The Swedish word "framåt" ("forward") can sound like "frame" to an English ear.
- 
-  - This skill both **suggests new names** and **checks names the person already has**.
- 
-  - ## Step 1 — Gather the essentials
- 
-  - If the skill is invoked with nothing else to go on (e.g. just `/business-name-fit`, no
-  - name, no context), don't launch into the full list below. Ask one question first, and
-  - wait for the answer:
- 
-  - > Are you looking to **find a new name**, or **check one you already have**?
-    >
-    > Once that's answered, ask only for what's still missing from the conversation. Keep it to
-    > a couple of short questions.
-    >
-    > 1. **Origin** — the founder's culture/language or the company's home base (e.g. Persian/Iran, Swedish/Sweden, Mandarin/China).
-    > 2. 2. **Target market(s)** — where the business will operate (e.g. international/English-speaking, EU, China, Arabic-speaking countries). There can be more than one.
-    >    3. 3. **Business area** — the industry or field, because tone matters (a law firm and a candy brand need different feels).
-    >       4. 4. **Mode** — do they want new name ideas, a check of names they already have, or both? (Already answered above if the skill opened with the find-or-check question.)
-    >          5. 5. **Existing names** — if they're checking, collect the candidates.
-    >             6. 6. **Desired feel** (optional) — modern, traditional, playful, premium, etc.
-    >               
-    >             7. ## Step 2 — Run the fit checks (the heart of the skill)
-    >            
-    >             8. Run every candidate name through these checks, once per target market:
-    >             9.
-    > - **Meaning** — Does it mean something unintended, negative, funny, or taboo in the market's language(s)? Include slang.
-    > - - **Look-alike** — Does it resemble an existing word that changes the impression (e.g. framåt → "frame")?
-    >   - - **Pronunciation** — Can people in the target market say it easily, or does it get mangled?
-    >     - - **Spelling** — After hearing it, can they spell it? Watch for tricky letter combos and origin-language diacritics (å, ø, ç, etc.) that won't survive in English.
-    >       - - **Distinctiveness** — Where does it sit on the WIPO scale: generic, descriptive, deceptive, suggestive, arbitrary, or coined? Generic and descriptive names are weak and often cannot be registered at all — say so plainly, because a founder can build a business on such a name and still never own it. Reject deceptive names outright. Judge this **separately per market**: a word that is plainly descriptive at home may be arbitrary and strong abroad, and the reverse.
-    >         - - **Sound** — Say it aloud. Does its sound-feel match the field? Front vowels (ee, i) read light and quick; back vowels (o, u) solid and heavy; hard plosives (p, t, k, b, d, g) sharp and firm; soft fricatives and nasals (s, f, m, l, n) smooth and gentle. Note honestly that these associations come mainly from English-language research and do not transfer automatically to other languages.
-    >           - - **Tone fit** — Does it feel trustworthy and appropriate for that industry and that market?
-    >             - - **Origin authenticity** — Does it still genuinely reflect the founder's origin, or has it been flattened into something generic?
-    >              
-    >               - Also weigh the classic evaluation criteria: relevance to the category, connotations,
-    >               - overall liking, ease of recognition, distinctiveness, and ease of recall.
-    >               - `references/naming-research.md` holds the sources and reasoning behind these checks —
-    >               - read it when a founder asks *why*, or when a name category or sound effect needs
-    >               - explaining in depth. `references/worked-examples.md` shows three full cases end to end
-    >               - (a name fixed, a name approved, a name rejected) — read it when you need a model for how
-    >               - a finished analysis should read.
-    >              
-    >               - Be honest about confidence. If unsure whether a name carries an odd meaning or slang sense in a language, say so plainly and recommend a native-speaker check before the founder commits.
-    >              
-    >             - ## Step 3 — If suggesting new names
-    >            
-    >             - Every suggestion must satisfy **three constraints at once**: rooted in the origin,
-    > professional for the industry, and clean in the target market. A name that meets only
-    > two of the three is not a valid suggestion — drop it and find another.
-    >
-    > **3a. Write the naming brief first — before generating anything.**
-    > Founders (and firms generally) tend to work out what they actually want from a name only
-    > *after* they have fallen for a candidate, which corrupts the judgement. So write it down
-    > first, in one or two lines: what the business promises its customers, what feeling that
-    > promise needs, and what the name must therefore do. Then pick origin words that carry
-    > that meaning. Examples of the logic:
-    > - Childcare → warmth, safety, gentleness. Not power or speed.
-    > - - Consultancy, law, finance → competence, stability, discretion. Not cuteness.
-    >   - - Art authentication, certification, security → authenticity, precision, trust.
-    >     - - Health → care, cleanliness, calm.
-    >       - - Technology → clarity, motion, forwardness.
-    >         - **3b. Draw the raw material from the origin language.**
-    >         - - Real words, roots, names, places, or concepts from the origin language.
-    >           - - Meaningful cultural ideas (nature, values, mythology) shaped into short, sayable forms.
-    >             - - Light blends or coined words that keep an origin flavor.
-    >              
-    >               - Prefer a word whose **literal meaning is itself the value proposition** — a Persian word
-    >               - meaning "authentic" for an authentication company beats a merely beautiful word. But stop
-    >               - short of plainly describing the product: aim for names that *hint* (suggestive), use an
-    >               - unrelated real word (arbitrary), or are invented (coined). These are both more memorable
-    >               - and far more likely to be registrable than a descriptive name.
-    >               - **3c. Apply the professional-quality bar.** Reject a candidate if it:
-    >               - - is hard to say or spell in the target market after one hearing;
-    >                 - - carries a tone that clashes with the field (playful for a law firm, clinical for a toy brand);
-    >                   - - needs an accent or non-Latin character to read correctly;
-    >                     - - is longer than about three syllables, or looks like a random invented string;
-    >                       - - sounds like a personal first name when the business needs institutional credibility.
-    >                        
-    >                         - **3d. Sanity-check against the market's naming conventions.** Names carry different weight
-    >                         - by region — what reads as confident in the Gulf may read as overblown in the Nordics.
-    >                         - Make sure the name would not look out of place next to established firms in that field
-    >                         - and that market.
-    >                        
-    >                         - **3e. Run every surviving candidate through the Step 2 checks**, then hand off to Step 4
-    >                         - to present them.
-    >                        
-    >                         - Offer 3–5 strong candidates rather than a long weak list.
-    >                        
-    >                         - ## Step 4 — Present the results
-    >
-    > Default to a **compact table, every time** — checking existing names and presenting new
-    > suggestions both work this way. The whole answer should be readable at a glance: no
-    > scrolling through prose to find the verdict.
-    >
-    > - **Checking names** — one row per name (one row per name × market if there's more than
-    > -   one market). Columns for whatever checks actually mattered for that name — not all
-    > -     eight every time. Cells hold a symbol plus 2–4 words (e.g. `❌ reads as slur (EN)`,
-    > -   `⚠️ crowded namespace`), never a sentence.
-    > -   - **Suggesting names** — one row per candidate: origin meaning, target-market read,
-    >     -   verdict. Same rule — phrases in cells, not paragraphs.
-    >  
-    >     -   After the table, add at most one short line naming the 2–3 strongest options. Never
-    >     -   present a single favourite as if it were the only option.
-    >  
-    >     -   Stop there. Do **not** add check-by-check breakdowns, reasoning paragraphs, or a written
-    >     -   verdict for each name unless the person asks for more — "why", "explain", "tell me more
-    >     -   about X", "detailed report" — in which case expand only the part they asked about, still
-    >     -   as briefly as clarity allows.
-    >  
-    >     -   ## Step 5 — Hand over the verification steps
-    >  
-    >     -   Close every session with a short list of what still has to be checked — one line each,
-    >     -   this skill cannot confirm any of it:
-    >
-    > - **Trademark** — search the register in each target market before spending on the name (a formal step, not an afterthought).
-    > - - **Domain & handles** — availability where the founder will actually use them.
-    >   - - **Business registry** — the company register in the home country.
-    >     - - **Native-speaker gut check** — a real speaker in each target market, for the finalists.
-    >      
-    >       - Expand any of these only if asked.
-    >      
-    >       - ## Anti-Patterns
-    >      
-    >       - - **Don't split the checks by feel alone.** A name can pass the sound check and fail the
-    >         -   look-alike or spelling check (or the reverse) — always run every check, don't stop once
-    >         -     one check feels conclusive. See Scenario A in `references/worked-examples.md`.
-    > - **Don't call a name "safe" on meaning alone.** Distinctiveness (the WIPO scale) is a
-    > -   separate, legal question. A name can be linguistically clean and still be generic or
-    > -     descriptive — weak and hard to register — or the reverse.
-    > - - **Don't treat English/Western sound-symbolism findings as universal.** They come mainly
-    >   -   from English-language research (Pogacar et al.) and do not automatically transfer to
-    >   -     Persian, Arabic, Mandarin, or any other target market — say so when it matters.
-    >   - - **Don't present one favourite.** Offer 3–5 candidates; a founder evaluating only one
-    >     -   option isn't evaluating.
-    >     -   - **Don't skip the find-or-check question when the skill opens with no context.**
-    >         -   Guessing origin, market, or industry produces suggestions that don't fit.
-    >         -   - **Don't let this skill's output stand in for verification.** It cannot check trademark,
-    >             -   domain, or business-registry availability — always close with Step 5.
-    >             -   - **Don't write a check-by-check essay by default.** The default output is a compact
-    >                 -   table (Step 4); expand only when asked.
-    >              
-    >                 -   ## Cross-References
-    >              
-    >                 -   - **brand-guidelines** (`marketing-skill/skills/brand-guidelines`) — use after a name is
-    >                     -   chosen, to build the visual and verbal identity system around it.
-    >                     -   - **copywriting** (`marketing-skill/skills/copywriting`) — use once the name is locked,
-    >                         -   for tagline and messaging work that needs to match the name's tone.
-    >                         -   - **marketing-context** (`marketing-skill/skills/marketing-context`) — load first if
-    >   available; ICP and positioning context should inform which candidate names fit best.
+- The Swedish word "framåt" ("forward") can sound like "frame" to an English ear.
+
+This skill both **suggests new names** and **checks names the person already has**.
+
+## Step 1 — Gather the essentials
+
+If the skill is invoked with nothing else to go on (e.g. just `/business-name-fit`, no name, no context), don't launch into the full list below. Ask one question first, and wait for the answer:
+
+> Are you looking to **find a new name**, or **check one you already have**?
+
+Once that's answered, ask only for what's still missing from the conversation. Keep it to a couple of short questions.
+
+1. **Origin** — the founder's culture/language or the company's home base (e.g. Persian/Iran, Swedish/Sweden, Mandarin/China).
+2. **Target market(s)** — where the business will operate (e.g. international/English-speaking, EU, China, Arabic-speaking countries). There can be more than one.
+3. **Business area** — the industry or field, because tone matters (a law firm and a candy brand need different feels).
+4. **Mode** — do they want new name ideas, a check of names they already have, or both? (Already answered above if the skill opened with the find-or-check question.)
+5. **Existing names** — if they're checking, collect the candidates.
+6. **Desired feel** (optional) — modern, traditional, playful, premium, etc.
+
+## Step 2 — Run the fit checks (the heart of the skill)
+
+Run every candidate name through these checks, once per target market:
+
+- **Meaning** — Does it mean something unintended, negative, funny, or taboo in the market's language(s)? Include slang.
+- **Look-alike** — Does it resemble an existing word that changes the impression (e.g. framåt → "frame")?
+- **Pronunciation** — Can people in the target market say it easily, or does it get mangled?
+- **Spelling** — After hearing it, can they spell it? Watch for tricky letter combos and origin-language diacritics (å, ø, ç, etc.) that won't survive in English.
+- **Distinctiveness** — Where does it sit on the WIPO scale: generic, descriptive, deceptive, suggestive, arbitrary, or coined? Generic and descriptive names are weak and often cannot be registered at all — say so plainly, because a founder can build a business on such a name and still never own it. Reject deceptive names outright. Judge this **separately per market**: a word that is plainly descriptive at home may be arbitrary and strong abroad, and the reverse.
+- **Sound** — Say it aloud. Does its sound-feel match the field? Front vowels (ee, i) read light and quick; back vowels (o, u) solid and heavy; hard plosives (p, t, k, b, d, g) sharp and firm; soft fricatives and nasals (s, f, m, l, n) smooth and gentle. Note honestly that these associations come mainly from English-language research and do not transfer automatically to other languages.
+- **Tone fit** — Does it feel trustworthy and appropriate for that industry and that market?
+- **Origin authenticity** — Does it still genuinely reflect the founder's origin, or has it been flattened into something generic?
+
+Also weigh the classic evaluation criteria: relevance to the category, connotations, overall liking, ease of recognition, distinctiveness, and ease of recall.
+
+`references/naming-research.md` holds the sources and reasoning behind these checks — read it when a founder asks *why*, or when a name category or sound effect needs explaining in depth. `references/worked-examples.md` shows three full cases end to end (a name fixed, a name approved, a name rejected) — read it when you need a model for how a finished analysis should read.
+
+Be honest about confidence. If unsure whether a name carries an odd meaning or slang sense in a language, say so plainly and recommend a native-speaker check before the founder commits.
+
+## Step 3 — If suggesting new names
+
+Every suggestion must satisfy **three constraints at once**: rooted in the origin, professional for the industry, and clean in the target market. A name that meets only two of the three is not a valid suggestion — drop it and find another.
+
+**3a. Write the naming brief first — before generating anything.**
+Founders (and firms generally) tend to work out what they actually want from a name only *after* they have fallen for a candidate, which corrupts the judgement. So write it down first, in one or two lines: what the business promises its customers, what feeling that promise needs, and what the name must therefore do. Then pick origin words that carry that meaning. Examples of the logic:
+- Childcare → warmth, safety, gentleness. Not power or speed.
+- Consultancy, law, finance → competence, stability, discretion. Not cuteness.
+- Art authentication, certification, security → authenticity, precision, trust.
+- Health → care, cleanliness, calm.
+- Technology → clarity, motion, forwardness.
+
+**3b. Draw the raw material from the origin language.**
+- Real words, roots, names, places, or concepts from the origin language.
+- Meaningful cultural ideas (nature, values, mythology) shaped into short, sayable forms.
+- Light blends or coined words that keep an origin flavor.
+
+Prefer a word whose **literal meaning is itself the value proposition** — a Persian word meaning "authentic" for an authentication company beats a merely beautiful word. But stop short of plainly describing the product: aim for names that *hint* (suggestive), use an unrelated real word (arbitrary), or are invented (coined). These are both more memorable and far more likely to be registrable than a descriptive name.
+
+**3c. Apply the professional-quality bar.** Reject a candidate if it:
+- is hard to say or spell in the target market after one hearing;
+- carries a tone that clashes with the field (playful for a law firm, clinical for a toy brand);
+- needs an accent or non-Latin character to read correctly;
+- is longer than about three syllables, or looks like a random invented string;
+- sounds like a personal first name when the business needs institutional credibility.
+
+**3d. Sanity-check against the market's naming conventions.** Names carry different weight by region — what reads as confident in the Gulf may read as overblown in the Nordics. Make sure the name would not look out of place next to established firms in that field and that market.
+
+**3e. Run every surviving candidate through the Step 2 checks**, then hand off to Step 4 to present them.
+
+Offer 3–5 strong candidates rather than a long weak list.
+
+## Step 4 — Present the results
+
+Default to a **compact table, every time** — checking existing names and presenting new suggestions both work this way. The whole answer should be readable at a glance: no scrolling through prose to find the verdict.
+
+- **Checking names** — one row per name (one row per name × market if there's more than one market). Columns for whatever checks actually mattered for that name — not all eight every time. Cells hold a symbol plus 2–4 words (e.g. `❌ reads as slur (EN)`, `⚠️ crowded namespace`), never a sentence.
+- **Suggesting names** — one row per candidate: origin meaning, target-market read, verdict. Same rule — phrases in cells, not paragraphs.
+
+After the table, add at most one short line naming the 2–3 strongest options. Never present a single favourite as if it were the only option.
+
+Stop there. Do **not** add check-by-check breakdowns, reasoning paragraphs, or a written verdict for each name unless the person asks for more — "why", "explain", "tell me more about X", "detailed report" — in which case expand only the part they asked about, still as briefly as clarity allows.
+
+## Step 5 — Hand over the verification steps
+
+Close every session with a short list of what still has to be checked — one line each, this skill cannot confirm any of it:
+
+- **Trademark** — search the register in each target market before spending on the name (a formal step, not an afterthought).
+- **Domain & handles** — availability where the founder will actually use them.
+- **Business registry** — the company register in the home country.
+- **Native-speaker gut check** — a real speaker in each target market, for the finalists.
+
+Expand any of these only if asked.
+
+## Anti-Patterns
+
+- **Don't split the checks by feel alone.** A name can pass the sound check and fail the look-alike or spelling check (or the reverse) — always run every check, don't stop once one check feels conclusive. See Scenario A in `references/worked-examples.md`.
+- **Don't call a name "safe" on meaning alone.** Distinctiveness (the WIPO scale) is a separate, legal question. A name can be linguistically clean and still be generic or descriptive — weak and hard to register — or the reverse.
+- **Don't treat English/Western sound-symbolism findings as universal.** They come mainly from English-language research (Pogacar et al.) and do not automatically transfer to Persian, Arabic, Mandarin, or any other target market — say so when it matters.
+- **Don't present one favourite.** Offer 3–5 candidates; a founder evaluating only one option isn't evaluating.
+- **Don't skip the find-or-check question when the skill opens with no context.** Guessing origin, market, or industry produces suggestions that don't fit.
+- **Don't let this skill's output stand in for verification.** It cannot check trademark, domain, or business-registry availability — always close with Step 5.
+- **Don't write a check-by-check essay by default.** The default output is a compact table (Step 4); expand only when asked.
+
+## Cross-References
+
+- **brand-guidelines** (`marketing-skill/skills/brand-guidelines`) — use after a name is chosen, to build the visual and verbal identity system around it.
+- **copywriting** (`marketing-skill/skills/copywriting`) — use once the name is locked, for tagline and messaging work that needs to match the name's tone.
+- **marketing-context** (`marketing-skill/skills/marketing-context`) — load first if available; ICP and positioning context should inform which candidate names fit best.

--- a/marketing-skill/skills/business-name-fit/SKILL.md
+++ b/marketing-skill/skills/business-name-fit/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: business-name-fit
+description: Suggest, pick, or vet a business, startup, or product name that stays true to the founder's cultural origin while working professionally in the markets they want to sell into. Use whenever someone is naming a company, brand, or product and cares about how it lands across languages and regions — for example a name that sounds right at home but might read oddly to English speakers, or an authentic name they want to check before committing. Trigger this for any request about choosing a business name, checking if a name "works" abroad, spotting bad meanings in other languages, or making a name sound trustworthy in a specific market — even if the person doesn't say the word "skill".
+---
+
+# Business Name Fit
+
+## Overview
+
+Help founders choose or check a business/brand/product name that is authentic to their
+origin **and** lands well in the market where they'll operate.
+
+The core value is catching the mismatch between the two: a name can be perfectly good in
+its home language yet confusing, funny, or off-putting elsewhere. Examples:
+- The Persian name "Anali" is fine in Iran but reads oddly to English speakers.
+- - The Swedish word "framåt" ("forward") can sound like "frame" to an English ear.
+ 
+  - This skill both **suggests new names** and **checks names the person already has**.
+ 
+  - ## Step 1 — Gather the essentials
+ 
+  - If the skill is invoked with nothing else to go on (e.g. just `/business-name-fit`, no
+  - name, no context), don't launch into the full list below. Ask one question first, and
+  - wait for the answer:
+ 
+  - > Are you looking to **find a new name**, or **check one you already have**?
+    >
+    > Once that's answered, ask only for what's still missing from the conversation. Keep it to
+    > a couple of short questions.
+    >
+    > 1. **Origin** — the founder's culture/language or the company's home base (e.g. Persian/Iran, Swedish/Sweden, Mandarin/China).
+    > 2. 2. **Target market(s)** — where the business will operate (e.g. international/English-speaking, EU, China, Arabic-speaking countries). There can be more than one.
+    >    3. 3. **Business area** — the industry or field, because tone matters (a law firm and a candy brand need different feels).
+    >       4. 4. **Mode** — do they want new name ideas, a check of names they already have, or both? (Already answered above if the skill opened with the find-or-check question.)
+    >          5. 5. **Existing names** — if they're checking, collect the candidates.
+    >             6. 6. **Desired feel** (optional) — modern, traditional, playful, premium, etc.
+    >               
+    >             7. ## Step 2 — Run the fit checks (the heart of the skill)
+    >            
+    >             8. Run every candidate name through these checks, once per target market:
+    >             9.
+    > - **Meaning** — Does it mean something unintended, negative, funny, or taboo in the market's language(s)? Include slang.
+    > - - **Look-alike** — Does it resemble an existing word that changes the impression (e.g. framåt → "frame")?
+    >   - - **Pronunciation** — Can people in the target market say it easily, or does it get mangled?
+    >     - - **Spelling** — After hearing it, can they spell it? Watch for tricky letter combos and origin-language diacritics (å, ø, ç, etc.) that won't survive in English.
+    >       - - **Distinctiveness** — Where does it sit on the WIPO scale: generic, descriptive, deceptive, suggestive, arbitrary, or coined? Generic and descriptive names are weak and often cannot be registered at all — say so plainly, because a founder can build a business on such a name and still never own it. Reject deceptive names outright. Judge this **separately per market**: a word that is plainly descriptive at home may be arbitrary and strong abroad, and the reverse.
+    >         - - **Sound** — Say it aloud. Does its sound-feel match the field? Front vowels (ee, i) read light and quick; back vowels (o, u) solid and heavy; hard plosives (p, t, k, b, d, g) sharp and firm; soft fricatives and nasals (s, f, m, l, n) smooth and gentle. Note honestly that these associations come mainly from English-language research and do not transfer automatically to other languages.
+    >           - - **Tone fit** — Does it feel trustworthy and appropriate for that industry and that market?
+    >             - - **Origin authenticity** — Does it still genuinely reflect the founder's origin, or has it been flattened into something generic?
+    >              
+    >               - Also weigh the classic evaluation criteria: relevance to the category, connotations,
+    >               - overall liking, ease of recognition, distinctiveness, and ease of recall.
+    >               - `references/naming-research.md` holds the sources and reasoning behind these checks —
+    >               - read it when a founder asks *why*, or when a name category or sound effect needs
+    >               - explaining in depth. `references/worked-examples.md` shows three full cases end to end
+    >               - (a name fixed, a name approved, a name rejected) — read it when you need a model for how
+    >               - a finished analysis should read.
+    >              
+    >               - Be honest about confidence. If unsure whether a name carries an odd meaning or slang sense in a language, say so plainly and recommend a native-speaker check before the founder commits.
+    >              
+    >             - ## Step 3 — If suggesting new names
+    >            
+    >             - Every suggestion must satisfy **three constraints at once**: rooted in the origin,
+    > professional for the industry, and clean in the target market. A name that meets only
+    > two of the three is not a valid suggestion — drop it and find another.
+    >
+    > **3a. Write the naming brief first — before generating anything.**
+    > Founders (and firms generally) tend to work out what they actually want from a name only
+    > *after* they have fallen for a candidate, which corrupts the judgement. So write it down
+    > first, in one or two lines: what the business promises its customers, what feeling that
+    > promise needs, and what the name must therefore do. Then pick origin words that carry
+    > that meaning. Examples of the logic:
+    > - Childcare → warmth, safety, gentleness. Not power or speed.
+    > - - Consultancy, law, finance → competence, stability, discretion. Not cuteness.
+    >   - - Art authentication, certification, security → authenticity, precision, trust.
+    >     - - Health → care, cleanliness, calm.
+    >       - - Technology → clarity, motion, forwardness.
+    >         - **3b. Draw the raw material from the origin language.**
+    >         - - Real words, roots, names, places, or concepts from the origin language.
+    >           - - Meaningful cultural ideas (nature, values, mythology) shaped into short, sayable forms.
+    >             - - Light blends or coined words that keep an origin flavor.
+    >              
+    >               - Prefer a word whose **literal meaning is itself the value proposition** — a Persian word
+    >               - meaning "authentic" for an authentication company beats a merely beautiful word. But stop
+    >               - short of plainly describing the product: aim for names that *hint* (suggestive), use an
+    >               - unrelated real word (arbitrary), or are invented (coined). These are both more memorable
+    >               - and far more likely to be registrable than a descriptive name.
+    >               - **3c. Apply the professional-quality bar.** Reject a candidate if it:
+    >               - - is hard to say or spell in the target market after one hearing;
+    >                 - - carries a tone that clashes with the field (playful for a law firm, clinical for a toy brand);
+    >                   - - needs an accent or non-Latin character to read correctly;
+    >                     - - is longer than about three syllables, or looks like a random invented string;
+    >                       - - sounds like a personal first name when the business needs institutional credibility.
+    >                        
+    >                         - **3d. Sanity-check against the market's naming conventions.** Names carry different weight
+    >                         - by region — what reads as confident in the Gulf may read as overblown in the Nordics.
+    >                         - Make sure the name would not look out of place next to established firms in that field
+    >                         - and that market.
+    >                        
+    >                         - **3e. Run every surviving candidate through the Step 2 checks**, then hand off to Step 4
+    >                         - to present them.
+    >                        
+    >                         - Offer 3–5 strong candidates rather than a long weak list.
+    >                        
+    >                         - ## Step 4 — Present the results
+    >
+    > Default to a **compact table, every time** — checking existing names and presenting new
+    > suggestions both work this way. The whole answer should be readable at a glance: no
+    > scrolling through prose to find the verdict.
+    >
+    > - **Checking names** — one row per name (one row per name × market if there's more than
+    > -   one market). Columns for whatever checks actually mattered for that name — not all
+    > -     eight every time. Cells hold a symbol plus 2–4 words (e.g. `❌ reads as slur (EN)`,
+    > -   `⚠️ crowded namespace`), never a sentence.
+    > -   - **Suggesting names** — one row per candidate: origin meaning, target-market read,
+    >     -   verdict. Same rule — phrases in cells, not paragraphs.
+    >  
+    >     -   After the table, add at most one short line naming the 2–3 strongest options. Never
+    >     -   present a single favourite as if it were the only option.
+    >  
+    >     -   Stop there. Do **not** add check-by-check breakdowns, reasoning paragraphs, or a written
+    >     -   verdict for each name unless the person asks for more — "why", "explain", "tell me more
+    >     -   about X", "detailed report" — in which case expand only the part they asked about, still
+    >     -   as briefly as clarity allows.
+    >  
+    >     -   ## Step 5 — Hand over the verification steps
+    >  
+    >     -   Close every session with a short list of what still has to be checked — one line each,
+    >     -   this skill cannot confirm any of it:
+    >
+    > - **Trademark** — search the register in each target market before spending on the name (a formal step, not an afterthought).
+    > - - **Domain & handles** — availability where the founder will actually use them.
+    >   - - **Business registry** — the company register in the home country.
+    >     - - **Native-speaker gut check** — a real speaker in each target market, for the finalists.
+    >      
+    >       - Expand any of these only if asked.
+    >      
+    >       - ## Anti-Patterns
+    >      
+    >       - - **Don't split the checks by feel alone.** A name can pass the sound check and fail the
+    >         -   look-alike or spelling check (or the reverse) — always run every check, don't stop once
+    >         -     one check feels conclusive. See Scenario A in `references/worked-examples.md`.
+    > - **Don't call a name "safe" on meaning alone.** Distinctiveness (the WIPO scale) is a
+    > -   separate, legal question. A name can be linguistically clean and still be generic or
+    > -     descriptive — weak and hard to register — or the reverse.
+    > - - **Don't treat English/Western sound-symbolism findings as universal.** They come mainly
+    >   -   from English-language research (Pogacar et al.) and do not automatically transfer to
+    >   -     Persian, Arabic, Mandarin, or any other target market — say so when it matters.
+    >   - - **Don't present one favourite.** Offer 3–5 candidates; a founder evaluating only one
+    >     -   option isn't evaluating.
+    >     -   - **Don't skip the find-or-check question when the skill opens with no context.**
+    >         -   Guessing origin, market, or industry produces suggestions that don't fit.
+    >         -   - **Don't let this skill's output stand in for verification.** It cannot check trademark,
+    >             -   domain, or business-registry availability — always close with Step 5.
+    >             -   - **Don't write a check-by-check essay by default.** The default output is a compact
+    >                 -   table (Step 4); expand only when asked.
+    >              
+    >                 -   ## Cross-References
+    >              
+    >                 -   - **brand-guidelines** (`marketing-skill/skills/brand-guidelines`) — use after a name is
+    >                     -   chosen, to build the visual and verbal identity system around it.
+    >                     -   - **copywriting** (`marketing-skill/skills/copywriting`) — use once the name is locked,
+    >                         -   for tagline and messaging work that needs to match the name's tone.
+    >                         -   - **marketing-context** (`marketing-skill/skills/marketing-context`) — load first if
+    >   available; ICP and positioning context should inform which candidate names fit best.

--- a/marketing-skill/skills/business-name-fit/references/naming-research.md
+++ b/marketing-skill/skills/business-name-fit/references/naming-research.md
@@ -1,0 +1,95 @@
+# Naming research — reference notes
+
+Background for the `business-name-fit` skill. Read this when you need the reasoning
+behind a check, when a founder asks *why* a rule exists, or when you need to explain
+name categories, sound effects, or the naming process in more depth.
+
+All three sources below are free to download and were link-checked in July 2026.
+
+---
+
+## 1. WIPO — *Making a Mark: An Introduction to Trademarks for SMEs*
+
+World Intellectual Property Organization, WIPO Publication No. 900.1E (2019 edition).
+Free to download, available in seven languages, aimed specifically at small businesses.
+© WIPO, 2019, licensed [CC BY 3.0 IGO](https://creativecommons.org/licenses/by/3.0/igo/).
+
+📥 https://www.wipo.int/edocs/pubdocs/en/wipo-pub-900-1-en-making-a-mark-an-introduction-to-trademarks-for-small-and-medium-sized-enterprises.pdf
+
+**Why it matters here:** it explains which kinds of names can actually be protected —
+the difference between a name a founder merely likes and a name they can own.
+
+**The five name categories it sets out:**
+
+| Category | What it is | Strength |
+|---|---|---|
+| Generic | The ordinary word for the thing itself | Cannot be registered |
+| Descriptive | States a quality or characteristic of the product | Weak; usually refused |
+| Deceptive | Misleads about nature, quality, or origin | Refused; also unethical |
+| Suggestive | Hints at a quality without stating it | Strong |
+| Coined / fanciful | Invented word with no prior meaning | Strongest |
+
+A sixth type, **arbitrary** (a real word unrelated to the product), also registers well.
+
+**Practical rule for the skill:** push candidates toward suggestive, arbitrary, or coined.
+Warn plainly when a name is generic or descriptive — it may be unregistrable, meaning the
+founder can build a business on it and still not own it. Reject deceptive names outright.
+
+**Note on a cross-cultural trap:** a word that is generic or descriptive *in the origin
+language* may be treated as arbitrary and registrable in a foreign market — and vice
+versa. Judge distinctiveness separately for each market.
+
+---
+
+## 2. Kohli & LaBahn (1997) — *Creating Effective Brand Names: A Study of the Naming Process*
+
+*Journal of Advertising Research*, 37(1), 67–75. Full text free in the WPI repository.
+The standard descriptive study of how companies actually name things, based on a survey
+of 101 companies.
+
+📥 https://digital.wpi.edu/downloads/g445cd54j?locale=en
+
+**The five-stage process it identifies:** set objectives → generate names → evaluate →
+select → register the trademark.
+
+**Evaluation criteria it reports:** relevance to the product category, connotations,
+overall liking, ease of recognition, distinctiveness, and ease of recall.
+
+**The most useful warning in the paper:** managers routinely undermine their own naming
+work by cutting the evaluation stage short — falling for a favourite early and skipping
+the honest testing. The study also found that firms tend to blur marketing goals with
+name criteria, and only articulate what they actually want from a name once they are
+already evaluating candidates.
+
+**Practical rules for the skill:**
+- Write the naming brief *before* generating candidates, never after.
+- Never present a single favourite. Always evaluate several against stated criteria.
+- Treat trademark registration as part of the process, not an afterthought.
+   
+---
+
+## 3. Pogacar, Plant, Rosulek & Kouril (2015) — *Sounds good: Phonetic sound patterns in top brand names*
+
+*Marketing Letters*, 26(4), 549–563. Free copy on an author's site.
+
+  📥 https://static1.squarespace.com/static/586d3b8c579fb3b92bfadb89/t/58725a088419c2902d0983f7/1483889162049/Sounds+good_Phonetic+sound+patterns+in+top+brand+names+2015.pdf
+
+  **What it found:** comparing the Interbrand top 100 brand names against brand names
+  generally, the top names show measurably different sound patterns. The authors argue
+  sound symbolism — the link between how a word sounds and what it feels like it means —
+  may be one contributor to brand performance, and that sounds common among top brands
+  may carry brand-enhancing properties while rarer ones may do the opposite. Follow-up
+  work by the same group found people both implicitly and explicitly prefer the sounds
+  that are more frequent in top brand names, among them S, M, L and E.
+
+  **Practical rules for the skill:**
+  - Judge a candidate by ear, not only on the page. Say it aloud before deciding.
+- Broad sound-feel associations worth weighing: front vowels (ee, i) read as small, light, quick; back vowels (o, u) as large, solid, heavy; hard plosives (p, t, k, b, d, g) as sharp and firm; soft fricatives and nasals (s, f, m, l, n) as smooth and gentle. Match the feel to the industry — softness for childcare, solidity for finance.
+
+**Important limit — state this honestly when it matters:** this research examines mainly English and Western global brands. Sound associations are *not* universal; they differ by language and culture. Use them as a guide for English-speaking and Western markets, and do not assume they transfer to Persian, Arabic, Mandarin, or any other target market without checking. This is exactly the kind of assumption the skill exists to question.
+
+---
+
+## A note on what is missing
+
+The most-cited work on brand-name sound symbolism, Klink (2000), sits behind a paywall and has no legal free version. The three sources above are the best available combination of credibility and genuinely open access.

--- a/marketing-skill/skills/business-name-fit/references/worked-examples.md
+++ b/marketing-skill/skills/business-name-fit/references/worked-examples.md
@@ -1,0 +1,108 @@
+# Worked examples
+
+Three hypothetical scenarios showing the skill applied end to end. All companies, founders
+and details are invented for illustration.
+
+They deliberately cover three different outcomes:
+
+| | Scenario | Outcome |
+|---|---|---|
+| A | Persian childcare group | **Fixed** — name saved by changing its spelling |
+| B | Swedish consultancy | **Passed** — with one condition |
+| C | Iranian-American art startup | **Rejected** — and so were the first alternatives |
+
+---
+
+## Scenario A — a name that only breaks on paper
+
+**The brief.** Roya Sadeghi runs three childcare centres in Tehran under the name
+**آنالی (Anali)** — a warm Azeri-origin girl's name. She has signed a partnership to open
+two centres in Dubai and one in Doha within eighteen months, and needs a Latin-script
+name for the international brand. The promise is safe, affectionate care for under-fives;
+the feeling it needs is warmth, calm, and trust.
+
+**The checks.**
+
+| Check | Result | Detail |
+|---|---|---|
+| Meaning (origin) | Pass | Beautiful, warm, familiar in Iran |
+| Meaning (target) | Pass | No adverse meaning in Arabic |
+| Look-alike (English) | **Fail** | The first four letters of the Latin spelling form a crude English word — badly wrong for a children's brand |
+| Pronunciation | Pass | Ah-NAH-lee; easy for Arabic and English speakers alike |
+| Spelling | Pass | Straightforward once respelt |
+| Distinctiveness | Caution | Arbitrary relative to childcare, so registrable — but it is a common given name, so the namespace is crowded and ownership is harder to defend |
+| Sound | Strong pass | Soft /n/ and /l/, open vowels, light ending — close to ideal for childcare |
+| Tone fit | Pass | Warm and family-oriented |
+
+**The insight.** The sound check and the look-alike check disagree — and that disagreement
+is the finding. The name is excellent when spoken and fails only when written in Latin
+script. The problem is orthographic, not phonetic.
+
+**The recommendation.** Do not abandon the name. Respell it.
+
+- **Annali** — identical pronunciation; the offending letter string disappears.
+- **Anahli** — same effect using a medial *h*.
+
+Both preserve exactly what Iranian parents already say. Only if Roya wants a fresh start should she consider alternatives such as **Anara** (pomegranate — abundance, family) or **Mehrana** (from *mehr*, affection).
+
+**Lesson:** check spoken and written forms separately. A name can fail one and pass the other, and respelling is cheaper than rebranding.
+
+---
+
+## Scenario B — a good name with one unfinished job
+
+**The brief.** Erik Lindqvist and Sofia Ahmadi are launching a business consultancy in Stockholm named **Framia**, built on the Swedish *fram* ("forward"). They intend to serve the Nordics first, then the EU and the UK. The promise is expert guidance that moves a business forward; the feeling it needs is competence, stability, and momentum.
+
+**The checks.**
+
+| Check | Result | Detail |
+|---|---|---|
+| Meaning (origin) | Pass | Quietly on-message: forward motion |
+| Meaning (target) | Pass | No adverse meaning in English or major EU languages |
+| Look-alike | Pass | Low risk of being read as "frame" in full |
+| Pronunciation | Pass | FRAH-mee-ah; easy across Europe |
+| Spelling | Pass | No diacritics; survives in English |
+| Distinctiveness | **Caution** | Legally *suggestive* — it hints without describing, which is a strong, registrable category. But the *-ia* ending is heavily used in Nordic company naming, so the namespace is crowded |
+| Sound | Pass | The opening /fr/ cluster carries energy and motion; the medial /m/ softens it — a good match for advisory work |
+| Tone fit | Pass | Professional without being cold |
+
+**The insight.** The distinctiveness check reframes the risk. The earlier concern was a vague resemblance to an unrelated brand. The sharper finding is that the legal category is strong while the competitive namespace is crowded — a different problem with a different fix.
+
+**The recommendation.** Proceed with Framia, conditional on a trademark search in Class 35 (business consultancy services) across Sweden, the EU, and the UK before any money goes into the brand. That search is not a precaution here; it is the deciding step.
+
+**Lesson:** "no bad meanings" is not the same as "available." A name can be linguistically clean and legally strong and still be blocked by someone who registered first.
+
+---
+
+## Scenario C — two independent failures, and alternatives that failed too
+
+**The brief.** Sara and Kaveh Mostafavi, Iranian-American siblings in Los Angeles, are founding a company that authenticates Persian paintings and miniatures, combining expert appraisers with AI trained to detect forgeries. Their working name is **نگار (Negar)** — Persian for painting, design, and motif. The promise is telling genuine works from fakes; the feeling it needs is authority, precision, and connoisseurship.
+
+**The checks.**
+
+| Check | Result | Detail |
+|---|---|---|
+| Meaning (origin) | Pass | *Painting* — beautifully apt for the field |
+| Look-alike (English) | **Fail** | The Latin spelling sits uncomfortably close to a severe English racial slur — unacceptable for a US-based brand |
+| Distinctiveness | **Fail** | A second, independent problem: for a company whose subject *is* painting, the name is **descriptive** — weak and hard to register even in Iran |
+| Sound | Pass | Phonetically fine, but moot once the spelling fails |
+
+**The insight.** The first pass found one problem. The distinctiveness check found a second, unrelated one. Even in a world where the English association did not exist, this name would be legally weak in its home market.
+
+**The alternatives also had to be re-examined — and most failed.**
+
+| Earlier suggestion | Revised verdict | Why |
+|---|---|---|
+| Honar | Downgraded | Persian for *art* — fully descriptive for an art company; weak in Iran |
+| Asil / Aseel | Downgraded | Means *authentic* — for an authentication business this literally describes the service. Weak in both Persian and Arabic |
+| Minia | Rejected | The *mini-* prefix reads as small and cheap in English, and the front vowel is light — the opposite of the authority the brand needs |
+
+**The revised recommendation.**
+
+- **Gohar** — jewel; intrinsic worth and true essence. *Suggestive*, not descriptive: it gestures at authenticity without naming it. The hard /g/ and back vowel carry weight and authority, and *jawhar* is positive in Arabic too.
+- **Zarrin** — golden; a quiet nod to the gold illumination of Persian miniatures. Suggestive, rich, and safe in English.
+- **Simorgh** — *not recommended despite being the strongest on distinctiveness.* The mythological bird is fully arbitrary relative to art authentication, which is ideal in principle. But Simorgh is also the name of an Iranian space-launch and missile programme. For a US-based company, that association and the polluted search results are a real commercial risk.
+
+**Two finalists: Gohar and Zarrin.**
+
+**Lesson:** an on-the-nose name is not a good name. A word meaning "authentic" for an authentication company sounds perfect and is legally close to worthless. Aim for names that gesture rather than announce — and re-run the checks on your own suggestions, not just on the founder's.


### PR DESCRIPTION
The original skill was authored by Elham Farajnejad ([@Elham-Farajnejad](https://github.com/Elham-Farajnejad)) and Mahdi Mansouri ([@mh-mansouri](https://github.com/mh-mansouri)) - source: https://github.com/Elham-Farajnejad/business-name-fit. This PR ports and restructures it to fit this repo's conventions.

## Summary

The `business-name-fit` skill helps founders choose or check a business/brand/product name that stays authentic to their cultural origin while working professionally in their target market(s). It runs each candidate through meaning, look-alike, pronunciation, spelling, distinctiveness (WIPO scale), sound, tone, and origin-authenticity checks, and closes every session with a verification checklist (trademark, domain, business registry, native-speaker check) since the skill cannot confirm those itself.

Ported from a standalone skill repo (https://github.com/Elham-Farajnejad/business-name-fit) and restructured to fit this repo's conventions: added an Overview section, an Anti-Patterns section, and a Cross-References section, and dropped the license/build/bundle files that don't apply here.

## Checklist

- [x] **Target branch is `dev`** (not `main`)
- [x] Skill has `SKILL.md` with valid YAML frontmatter (`name`, `description` only — no `license` field, per current CONVENTIONS.md)
- [ ] Scripts (if any) run with `--help` without errors — N/A, this skill has no scripts
- [x] No hardcoded API keys, tokens, or secrets
- [x] No vendor-locked dependencies without open-source fallback
- [x] Follows existing directory structure (`marketing-skill/skills/business-name-fit/SKILL.md`)
## Type of Change

- [x] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

SKILL.md is 120 lines, well under the 500-line cap. Manually reviewed all three files against CONVENTIONS.md for frontmatter shape (name + description only), required sections, and directory layout (`marketing-skill/skills/business-name-fit/`). No automated validator was available in this environment, so this was a manual review rather than a scripted one.
