### PR TITLE
fix(aws-solution-architect): correct stale DynamoDB on-demand pricing

### DIFF
--- a/engineering-team/skills/aws-solution-architect/references/service_selection.md
+++ b/engineering-team/skills/aws-solution-architect/references/service_selection.md
@@ -119,7 +119,7 @@ Limits:
 - GSI: 20 per table
 
 Pricing:
-- On-demand: $1.25 per million writes, $0.25 per million reads
+- On-demand: $0.625 per million writes, $0.125 per million reads
 - Provisioned: Per RCU/WCU
 ```
 


### PR DESCRIPTION
## Summary

- **What:** updates the DynamoDB on-demand throughput rates in
  `engineering-team/skills/aws-solution-architect/references/service_selection.md` to current AWS pricing.
- **Why:** AWS halved DynamoDB on-demand throughput prices effective **November 1, 2024**
  ([announcement](https://aws.amazon.com/blogs/database/new-amazon-dynamodb-lowers-pricing-for-on-demand-throughput-and-global-tables/)).
  The file lists the pre-cut rates, so the skill overstates on-demand cost by 2x. Because this is a
  reference file loaded into model context as authority, the stale figure propagates into generated
  architecture and cost recommendations with no human in the loop.

| | Before | After |
|---|---|---|
| Write request units | $1.25 /M | **$0.625 /M** |
| Read request units (strongly consistent) | $0.25 /M | **$0.125 /M** |

Verifiable against the versioned AWS Price List API:

```
https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonDynamoDB/current/region_index.json
```

### Scope

One line changed. Deliberately left alone, because the 2024 cut did not apply to them: storage at
`$0.25/GB-month`, provisioned capacity at `$0.00065/WCU-hr` and `$0.00013/RCU-hr`, transactional
writes at `$1.25/M`, and eventually-consistent reads at `$0.0625/M`.

Worth flagging for review: `$1.25/M` is both the stale standard-write rate and the correct
*transactional*-write rate, and `$0.125/M` is both the stale eventual-read rate and the correct
*strongly-consistent* read rate. The changed line is in a plain `On-demand:` context, so it refers
to standard throughput.

## Checklist

- [x] Targets `dev` branch
- [x] Clean diff, rebased on `dev`, no merge commit history
- [x] No SKILL.md frontmatter change (reference file only, no schema impact)
- [x] No scripts added or modified
- [x] No modifications to `.codex/`, `.gemini/`, `marketplace.json`, or index files
- [x] No 3rd party links added to README
- [x] Security audit: not applicable, single-line documentation change with no executable content
