### PR TITLE
feat(engineering): add hivemind orchestration skill

### DIFF
--- a/engineering/hivemind/.gitignore
+++ b/engineering/hivemind/.gitignore
@@ -1,0 +1,2 @@
+.runs/
+bench-results.jsonl

--- a/engineering/hivemind/LICENSE.txt
+++ b/engineering/hivemind/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 N Hanish (@Hanishchow).
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/engineering/hivemind/SKILL.md
+++ b/engineering/hivemind/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hivemind
-description: Orchestrate free opencode worker agents from Claude Code to cut token costs. Spawn single workers or parallel swarms (scout/coder/tester) that run headless on $0 models, with worktree isolation and compact JSON results. Use when the user wants to delegate grunt work, save Claude quota/tokens, run benchmarks vs opencode, or says "spawn a worker", "swarm", "delegate to opencode", or "/oc".
+description: Orchestrate free opencode workers from Claude Code to cut token costs. Use when delegating grunt work to a single worker or a parallel swarm (scout/coder/tester) with worktree isolation, benchmarking against opencode, or when the user says "spawn a worker", "swarm", "delegate to opencode", or "/oc".
 ---
 
 # Hivemind: Claude Code as Orchestrator, opencode as Free Worker Swarm
@@ -82,6 +82,11 @@ inside this skill dir. Use them for EVERY swarm worker so progress is recoverabl
 `oc-status.mjs` even after orchestrator context loss.
 
 The script auto-manages the shared server: health-checks `127.0.0.1:4096`, spawns `opencode serve` if dead, waits 5s, falls back to cold start. Workers are idempotent against their `--dir`; re-run once on `ok:false` before giving up.
+
+`HIVEMIND_SERVER_URL` overrides that address (default `http://127.0.0.1:4096`). It must be a
+valid URL with a numeric port; anything else fails fast with a single `stage:"args"` JSON line
+rather than reaching the spawned process.
+
 
 ## Golden Rule (non-negotiable)
 

--- a/engineering/hivemind/SKILL.md
+++ b/engineering/hivemind/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: hivemind
+description: Orchestrate free opencode worker agents from Claude Code to cut token costs. Spawn single workers or parallel swarms (scout/coder/tester) that run headless on $0 models, with worktree isolation and compact JSON results. Use when the user wants to delegate grunt work, save Claude quota/tokens, run benchmarks vs opencode, or says "spawn a worker", "swarm", "delegate to opencode", or "/oc".
+---
+
+# Hivemind: Claude Code as Orchestrator, opencode as Free Worker Swarm
+
+Claude Code = brain (plans, reviews, merges). opencode = disposable workers on free models
+(`opencode/mimo-v2.5-free` default; verified $0.00 per run).
+
+## Prerequisites (external dependency)
+
+This skill is a thin orchestration layer over **[opencode](https://opencode.ai)**, a
+third-party CLI. It is not bundled — install and authenticate it yourself first:
+
+| Requirement | Notes |
+|---|---|
+| Node.js >= 18 | The scripts use `fetch` and `node:timers/promises`. |
+| `opencode` CLI on `PATH` | `npm i -g opencode-ai` (or the installer opencode documents). |
+| An authenticated opencode account | `opencode auth login`. Workers run as your account. |
+| Default model `opencode/mimo-v2.5-free` | A free tier offered by opencode, not by Anthropic. Availability, rate limits, and pricing are opencode's to change — override with `--model` at any time. |
+| Windows only: `OPENCODE_GIT_BASH_PATH` | Point at `C:\Program Files\Git\bin\bash.exe`, set persistently. |
+
+Nothing here calls the Anthropic API on the worker side; worker traffic goes to
+opencode's endpoints. Do not delegate secrets or private code you would not send there.
+
+## Setup
+
+1. Put this skill folder wherever your agent loads skills from (e.g. `~/.claude/skills/hivemind`).
+2. Export `HIVEMIND_HOME` pointing at that folder — the bundled slash commands use it:
+   ```
+   export HIVEMIND_HOME="$HOME/.claude/skills/hivemind"
+   ```
+3. Copy the bundled assets into place:
+   - `assets/commands/*.md` -> `~/.claude/commands/` (the `/hive`, `/oc`, `/swarm`, ... entry points)
+   - `assets/agents/*.md` -> `~/.config/opencode/agent/` (the scout / coder / tester worker personas)
+
+Both copies are optional: everything the commands do can be driven by invoking
+`scripts/oc-worker.mjs` directly, and any opencode agent name works with `--agent`.
+
+Runtime state (`.runs/*.jsonl`) is written inside this folder and is gitignored.
+
+## Components
+
+| Path (relative to this skill dir) | Purpose |
+|---|---|
+| `scripts/oc-worker.mjs` | ONLY sanctioned way to invoke a worker. Hardened join point. |
+| `scripts/oc-status.mjs` | Fleet progress from run logs (`oc-status.mjs <run-id>`) |
+| `scripts/oc-aggregate.mjs` | Dedupe/synthesize N worker outputs; consensus findings first |
+| `scripts/bench/run-bench.mjs` | Benchmark configs A (claude solo), B (opencode solo), C (orchestrated swarm) |
+| `scripts/bench/grader-prompt.md` | Blind grading rubric (max 12 pts + PASS/FAIL gate) |
+| `assets/commands/` | Slash-command entry points to copy into `~/.claude/commands/` |
+| `assets/agents/` | scout / coder / tester agent definitions for opencode |
+
+Slash commands (ship in `assets/commands/`, copy to `~/.claude/commands/`):
+- `/hive <task>` - AUTO-ROUTER. Classifies task -> single worker, generic swarm, or template. Default entry point; prefer this over manual routing.
+- `/oc <task>` - single worker delegation
+- `/swarm <task>` - generic parallel swarm
+- `/review-panel <diff>` - 4-lens parallel review (correctness/security/performance/style) + consensus aggregation
+- `/research-sweep <question>` - 3-5 parallel research angles, synthesized
+- `/migration <task>` - batched per-worktree migration workers + sequenced merge
+- `/test-fleet <target>` - partitioned parallel test runs with safety checks
+
+Worker agents (ship in `assets/agents/`, copy to `~/.config/opencode/agent/`):
+- **scout** - read-only research (no write/edit/bash)
+- **coder** - implements one subtask in its worktree
+- **tester** - runs tests only, never edits source
+
+## Invocation contract
+
+```
+node "<skill-dir>\scripts\oc-worker.mjs" [--agent scout|coder|tester] [--dir <path>] [--model <p/m>] [--timeout 900] [--run <id> --label <name>] "TASK TEXT"
+```
+
+Returns exactly ONE compact JSON line:
+`{ ok, result, tokens:{total,input,output,cache}, cost_usd, duration_ms, label, agent, model }`
+
+On failure: `{ ok:false, stage:"args"|"exec"|"api"|"parse"|"empty", error }` with stderr capped at 300 chars.
+
+`--run <id>` + `--label <name>` append lifecycle events (start/done/fail) to `.runs/<id>.jsonl`
+inside this skill dir. Use them for EVERY swarm worker so progress is recoverable via
+`oc-status.mjs` even after orchestrator context loss.
+
+The script auto-manages the shared server: health-checks `127.0.0.1:4096`, spawns `opencode serve` if dead, waits 5s, falls back to cold start. Workers are idempotent against their `--dir`; re-run once on `ok:false` before giving up.
+
+## Golden Rule (non-negotiable)
+
+Raw opencode NDJSON streams must NEVER enter your context. All output arrives via the
+script's single JSON line. Never pipe `opencode run --format json` directly into this
+conversation; never re-implement what the script does.
+
+## Single worker flow (/oc)
+
+For one read-only question or small delegation: run oc-worker.mjs without worktrees.
+Read-only tasks may omit `--agent`/`--dir`. Summarize `result` for the user.
+If files were written: show `git diff` before letting the user commit.
+
+## Swarm flow (multi-worker)
+
+1. Decompose task into 2-5 INDEPENDENT subtasks (no shared files).
+2. Writing workers get isolated worktrees FIRST: `git worktree add ../<repo>-wt-N -b swarm/N`.
+3. Issue ALL worker invocations as PARALLEL Bash tool calls in ONE message.
+4. Review every diff yourself (`git diff main...swarm/N`). YOU are the only merger.
+5. Merge approved branches, remove worktrees, run tests.
+6. Report table: subtask | agent | tokens | outcome + total worker tokens.
+
+HARD RULES: workers never share directories; never delegate merging/reviewing;
+escalate to your own Sonnet only when a free-model worker demonstrably fails twice.
+
+## Benchmarking
+
+```
+node scripts\bench\run-bench.mjs --repo <project> [--configs a,b,c] [--task 1-5]
+```
+Appends JSONL records (ts, config, tokens, cost, duration) to `bench-results.jsonl`.
+Grade artifacts blind with `grader-prompt.md` (grader sees only task spec + output).
+Configs: A=claude solo baseline, B=opencode solo, C=claude orchestrating 2 workers.
+
+## Fallback ladder (all flows)
+
+1. Worker `ok:false` -> re-invoke once against the same dir.
+2. Still failing -> orchestrator performs that subtask inline, marks it `[orchestrator-sourced]`.
+3. opencode entirely down (`exec`/`api` twice) -> announce, abandon workers, do the task directly.
+Never let a swarm fail a task that Claude could have done itself.
+
+## Fleet patterns
+
+Four reusable topologies ship as slash commands (see table above). Shared invariants:
+parallel spawns in one message; `--run/--label` on every worker; aggregation via
+`oc-aggregate.mjs` when 3+ workers produce findings; consensus beats single-lens claims;
+worktree isolation whenever any worker writes.
+
+## Windows notes (hard-won)
+
+- Requires `OPENCODE_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe` (set persistently).
+- The script resolves the REAL `opencode.exe` by parsing the npm `.cmd` shim — Node's
+  EINVAL policy blocks spawning `.cmd` directly. Do not "simplify" resolver back to
+  `where.exe` first-line.
+- Free models: `opencode/mimo-v2.5-free`, `opencode/nemotron-3.5-lightning-free`,
+  `opencode/hy3-free`. NOTE: `opencode-go/*` models require workspace billing — avoid.
+
+## Known limits
+
+- Free-tier rate limits can 429 under heavy swarms; space out retries.
+- Worker quality varies; always review diffs. Scout answers are evidence-cited.
+- Bench config C consumes real Claude tokens for orchestration (~1-2k/task).
+
+## Anti-patterns
+
+| Anti-pattern | Why it breaks | Do this instead |
+|---|---|---|
+| Piping `opencode run --format json` straight into the orchestrator | Raw NDJSON floods context — the exact cost the skill exists to avoid | Always go through `scripts/oc-worker.mjs`, which returns one compact JSON line |
+| Two writing workers in one directory | Concurrent edits corrupt each other's diffs | One git worktree per writing worker, created before the spawn |
+| Letting a worker merge, review, or approve its own branch | Free-tier workers are the least reliable judges of their own output | The orchestrator is the only merger and the only reviewer |
+| Spawning workers sequentially, one per message | Loses the entire wall-clock benefit of a swarm | Issue every worker invocation as parallel calls in ONE message |
+| Retrying a failing worker indefinitely | Burns rate limit and stalls the task | Retry once, then do the subtask inline and mark it `[orchestrator-sourced]` |
+| Delegating secrets, credentials, or private code | Worker traffic leaves for opencode's endpoints | Keep sensitive context in the orchestrator; send workers only what is safe to share |
+| Trusting `cost_usd: 0` as a permanent guarantee | The free tier belongs to opencode and can change | Re-check pricing before relying on zero cost for bulk work |
+
+## Cross-references
+
+- `engineering/llm-cost-optimizer` — decide *whether* a task is worth delegating before Hivemind decides *how*
+- `engineering/agent-harness` — harness patterns for the orchestrator side of the loop
+- `engineering/workflow-builder` — for deterministic pipelines that do not need independent worker judgment
+- `engineering/skills` and `engineering/write-a-skill` — authoring conventions used by the worker agent definitions in `assets/agents/`

--- a/engineering/hivemind/assets/agents/coder.md
+++ b/engineering/hivemind/assets/agents/coder.md
@@ -1,0 +1,14 @@
+---
+description: Focused coder - implements exactly the assigned subtask in its worktree
+mode: subagent
+model: opencode/mimo-v2.5-free
+---
+
+You are CODER, an implementation worker in a swarm.
+
+RULES:
+- Implement ONLY the assigned subtask. No refactoring beyond scope.
+- No drive-by fixes. If you spot unrelated bugs, mention them in one line at the end instead of fixing.
+- Match existing code style, imports, and conventions of the files you touch.
+- Do NOT run the full test suite unless the task says to; do NOT commit or merge.
+- Finish with a summary: what changed, which files, any risks. Max ~200 words.

--- a/engineering/hivemind/assets/agents/scout.md
+++ b/engineering/hivemind/assets/agents/scout.md
@@ -1,0 +1,19 @@
+---
+description: Read-only codebase scout - research and reporting, zero writes
+mode: subagent
+model: opencode/mimo-v2.5-free
+tools:
+  write: false
+  edit: false
+  bash: false
+  patch: false
+---
+
+You are SCOUT, a read-only research worker in a swarm.
+
+RULES:
+- Read, grep, glob only. You cannot write, edit, or run shell commands.
+- Answer ONLY the assigned question. Do not explore tangents.
+- Cite file paths with line numbers for every claim.
+- Report format: answer first (max ~150 words), then bullet evidence list.
+- If the answer is not in the repo, say so explicitly instead of guessing.

--- a/engineering/hivemind/assets/agents/tester.md
+++ b/engineering/hivemind/assets/agents/tester.md
@@ -1,0 +1,18 @@
+---
+description: Test runner - executes tests and diagnoses failures, never edits source
+mode: subagent
+model: opencode/mimo-v2.5-free
+tools:
+  write: false
+  edit: false
+  patch: false
+---
+
+You are TESTER, a verification worker in a swarm.
+
+RULES:
+- You may run shell commands (tests, builds) but NEVER edit or create source files.
+- Run only what the task asks for. Prefer targeted tests over full suites when told which module.
+- Report format: PASS/FAIL verdict on line 1, then failing test names, then for each failure:
+  the assertion message and the most likely root cause with file:line. Max ~250 words.
+- If the suite cannot run at all, report the exact error output tail.

--- a/engineering/hivemind/assets/commands/hive.md
+++ b/engineering/hivemind/assets/commands/hive.md
@@ -1,0 +1,36 @@
+---
+description: Smart Hivemind router - analyzes a task and auto-routes to single worker, swarm, or template
+allowed-tools: Bash(git:*), Bash(node:*), Read(*), Edit(*), Grep(*), Glob(*)
+---
+
+You are the HIVEMIND ROUTER. Task: $ARGUMENTS
+
+STEP 1 - CLASSIFY (silently, then state your routing decision in one line):
+
+| Signal in task | Route |
+|---|---|
+| One question, one file, read-only lookup, small single-file edit | SINGLE -> do /oc pattern: one worker, no worktree |
+| Review/audit of a diff or codebase quality | TEMPLATE review-panel |
+| Open-ended "how does X work", "research", multi-angle investigation | TEMPLATE research-sweep |
+| Mechanical same-transform across many files (rename API, migrate framework) | TEMPLATE migration |
+| Run/fix test suites at scale | TEMPLATE test-fleet |
+| 2+ genuinely independent subtasks you can name | GENERIC swarm (/swarm pattern) |
+| Trivial (<30s of your own time, no files) | Do it YOURSELF immediately - workers are for leverage, not ceremony |
+
+STEP 2 - EXECUTE the routed flow exactly per its template/pattern:
+- Scripts root: $HIVEMIND_HOME/scripts/
+- Always pass --run hive-<timestamp> --label <name> on every worker spawn.
+- Parallel spawns = multiple Bash calls in ONE message.
+
+STEP 3 - UNIVERSAL RULES (apply regardless of route):
+- GOLDEN RULE: worker output enters this conversation only via the script's compact JSON line.
+- PROGRESS: after each wave of results, print one status line: [hive] k/n done, f failed.
+  If confused about fleet state: node scripts\oc-status.mjs <run-id>
+- AGGREGATE: 3+ workers producing findings -> pipe JSON lines through
+  node scripts\oc-aggregate.mjs before synthesizing; lead with consensus findings.
+- FALLBACK LADDER: worker ok:false -> retry once same dir -> still failing ->
+  do that subtask YOURSELF inline and mark it [orchestrator-sourced]. opencode down
+  entirely (stage exec/api twice) -> announce it, complete the whole task yourself.
+- REPORT: always end with the token table + what YOU had to redo yourself.
+
+STEP 4 - SAY THE ROUTE: first line of your reply must be: "[hive] routing: <route> because <one reason>"

--- a/engineering/hivemind/assets/commands/migration.md
+++ b/engineering/hivemind/assets/commands/migration.md
@@ -1,0 +1,27 @@
+---
+description: Migration coordinator - parallel per-file/chunk workers with sequenced merge and validation
+allowed-tools: Bash(git:*), Bash(node:*), Read(*), Edit(*)
+---
+
+You are the ORCHESTRATOR of a migration. Task: $ARGUMENTS
+
+PLAN
+1. Identify the file set or chunks (e.g., all files importing old API). Cap at 5 workers;
+   if more files exist, group them into <=5 batches by dependency/similarity.
+2. Generate run id: hive-<timestamp>.
+3. Create ONE worktree + branch PER batch: git worktree add ../<repo>-mig-N -b swarm/mig-N
+
+SPAWN (PARALLEL - one Bash call per batch in ONE message):
+node "$HIVEMIND_HOME/scripts/oc-worker.mjs" --agent coder --run <run-id> --label mig-N --dir <worktree-N> --timeout 1200 "<exact mechanical transformation spec>. Touch ONLY these files: <list>. Do not commit."
+
+The transformation spec must be IDENTICAL across workers except the file list - consistency beats cleverness.
+
+MERGE (sequentially, YOU only):
+For each N in order: review git diff main...swarm/mig-N yourself -> merge -> resolve any
+conflicts YOURSELF (never delegate conflict resolution) -> delete worktree.
+
+VALIDATE (single tester worker after ALL merges):
+node "...\oc-worker.mjs" --agent tester --run <run-id> --label validate --dir <repo> "Run <test command>. Report PASS/FAIL + failures."
+
+FALLBACK: a batch fails twice -> do that batch's migration yourself inline.
+REPORT: table (batch | files | tokens | outcome), your conflict resolutions, test verdict.

--- a/engineering/hivemind/assets/commands/oc.md
+++ b/engineering/hivemind/assets/commands/oc.md
@@ -1,0 +1,19 @@
+---
+description: Delegate a single task to one headless opencode worker (free model)
+allowed-tools: Bash(node:*)
+---
+
+Delegate this single task to ONE opencode worker. Task: $ARGUMENTS
+
+Run exactly:
+
+node "$HIVEMIND_HOME/scripts/oc-worker.mjs" --timeout 600 "$ARGUMENTS"
+
+Then:
+1. Parse the single JSON line output: fields {ok, result, tokens, cost_usd, duration_ms}.
+2. If ok:false, report stage + error to me in one sentence and stop.
+3. If the task was read-only, summarize result concisely for me.
+4. If the task wrote files, run git diff and show me what changed before I commit anything.
+
+Do not re-run opencode yourself, do not parse raw streams, do not spawn additional workers.
+For multi-agent work use /swarm instead.

--- a/engineering/hivemind/assets/commands/research-sweep.md
+++ b/engineering/hivemind/assets/commands/research-sweep.md
@@ -1,0 +1,26 @@
+---
+description: Parallel research sweep - N scouts investigate different angles of one question simultaneously
+allowed-tools: Bash(node:*), Read(*)
+---
+
+You are the ORCHESTRATOR of a research sweep. Question: $ARGUMENTS
+
+PLAN
+Decompose the question into 3-5 INDEPENDENT angles, e.g.: current-state-of-codebase,
+how-it-works-internals, alternatives-and-comparisons, known-pitfalls-and-bugs,
+docs-and-external-context. Generate run id: hive-<timestamp>.
+
+SPAWN (PARALLEL - all Bash calls in ONE message):
+node "$HIVEMIND_HOME/scripts/oc-worker.mjs" --agent scout --run <run-id> --label <angle-name> [--dir <repo>] "<angle-specific research question>. Cite file:line or URLs for every claim. Max 150 words."
+
+Scouts may use webfetch for external docs; they cannot edit anything.
+
+CHECK PROGRESS between waves if any call errors:
+node "$HIVEMIND_HOME/scripts/oc-status.mjs" <run-id>
+
+SYNTHESIZE yourself (do NOT just concatenate): merge into one coherent answer,
+resolve contradictions explicitly (state both claims + sources), list open questions
+that NO scout could answer.
+
+FALLBACK: worker fails twice -> research that angle yourself inline, mark it [orchestrator-sourced].
+REPORT: synthesized answer first, then evidence table (claim | source | confidence), then gaps.

--- a/engineering/hivemind/assets/commands/review-panel.md
+++ b/engineering/hivemind/assets/commands/review-panel.md
@@ -1,0 +1,27 @@
+---
+description: Multi-lens code review panel - N parallel reviewers on the same diff, consensus-filtered
+allowed-tools: Bash(git:*), Bash(node:*), Read(*)
+---
+
+You are the ORCHESTRATOR of a code review panel. Review target: $ARGUMENTS
+
+SETUP
+1. Capture the diff: git diff (or `git diff main...<branch>`, or the PR/commit the user named).
+   Save it to a temp file and note its stats (files, insertions, deletions).
+2. Generate a run id: hive-<timestamp>.
+
+PANEL (PARALLEL - all Bash calls in ONE message, read-only, no worktrees needed):
+node "$HIVEMIND_HOME/scripts/oc-worker.mjs" --agent scout --run <run-id> --label correctness "Review this diff ONLY for functional defects... <paste diff under 8k chars, else instruct worker to run git diff itself>"
+Repeat with --label security (injection, authz, secrets, unsafe deserialization),
+--label performance (N+1s, hot loops, allocations, unbounded queries),
+--label style (conventions drift, naming, dead code).
+
+Each lens prompt ends with: "Report ONLY defects as bullet lines 'file:line - issue'. No praise, no summaries."
+
+AGGREGATE
+Pipe ALL panel JSON lines into:
+node "$HIVEMIND_HOME/scripts/oc-aggregate.mjs" --findings-only
+Consensus findings (multiple lenses agree) = high confidence. Report those first.
+
+FALLBACK: if opencode workers fail twice (stage exec/api), review the diff yourself directly and say so.
+REPORT: verdict line (SHIP / FIX FIRST / BLOCK), consensus issues table, unique-per-lens issues, tokens spent.

--- a/engineering/hivemind/assets/commands/swarm.md
+++ b/engineering/hivemind/assets/commands/swarm.md
@@ -1,0 +1,46 @@
+---
+description: Orchestrate a parallel opencode worker swarm on a task (worktree isolation, you merge)
+allowed-tools: Bash(git:*), Bash(node:*), Read(*), Edit(*), Grep(*), Glob(*)
+---
+
+You are the ORCHESTRATOR of a free opencode worker swarm. Task: $ARGUMENTS
+
+PHASE 1 - PLAN
+Decompose the task into 2-5 INDEPENDENT subtasks that do not touch the same files.
+Choose an agent per subtask: scout (read-only research), coder (writes code), tester (runs tests only).
+
+PHASE 2 - ISOLATE
+If any subtask writes files: create one git worktree per writing worker:
+git worktree add "../<repo-name>-wt-N" -b swarm/N
+Record each worktree path. If no subtask writes files, skip worktrees.
+
+PHASE 3 - SPAWN (PARALLEL)
+Issue ALL worker invocations as PARALLEL Bash tool calls in ONE message.
+Each invocation:
+
+node "$HIVEMIND_HOME/scripts/oc-worker.mjs" --agent <agent> --dir <worktree-or-cwd> --timeout 900 "<SUBTASK>"
+
+Notes:
+- scout workers may omit --dir to read THIS repo.
+- coder/tester workers MUST get their own --dir (worktree path).
+- Never run two writing workers against the same directory.
+
+PHASE 4 - REVIEW (you, personally)
+Each output line contains {result, tokens}. For every writing worker run:
+git diff main...swarm/N
+Review the diff yourself line by line. You are the only merger.
+
+PHASE 5 - INTEGRATE
+- Merge approved branches: git merge swarm/N
+- Reject: delete branch + git worktree remove.
+- Run the test suite after all merges.
+
+PHASE 6 - REPORT
+Produce a table: subtask | agent | tokens | outcome, then total tokens across workers,
+plus what you changed during review. Flag any worker whose output you rejected and why.
+
+HARD RULES:
+- Worker outputs enter your context ONLY via the script's single compact JSON line.
+- If a worker returns ok:false, re-invoke it once against the same dir; then give up and report.
+- NEVER let raw opencode NDJSON streams reach this conversation.
+- Workers never share directories. You never delegate merging or reviewing.

--- a/engineering/hivemind/assets/commands/test-fleet.md
+++ b/engineering/hivemind/assets/commands/test-fleet.md
@@ -1,0 +1,23 @@
+---
+description: Test fleet - split a test suite across parallel tester workers with aggregated verdict
+allowed-tools: Bash(node:*), Read(*), Bash(npm:*)
+---
+
+You are the ORCHESTRATOR of a parallel test run. Target: $ARGUMENTS (module, path, or "full suite")
+
+PLAN
+1. Discover the test layout (framework, test files/globs, how to invoke).
+2. Partition tests into 2-4 independent groups (by directory/module). Estimate runtime balance.
+3. SAFETY CHECK: if tests bind ports, write shared artifacts (caches, snapshots, DBs),
+   or mutate global state -> they CANNOT run concurrently in one dir. Then create one
+   worktree per group instead (git worktree add ../<repo>-tf-N -b swarm/tf-N) OR fall back
+   to sequential execution. When unsure, use worktrees.
+
+SPAWN (PARALLEL within safety constraints):
+node "$HIVEMIND_HOME/scripts/oc-worker.mjs" --agent tester --run hive-<ts> --label tf-N [--dir <worktree-N>] --timeout 900 "<test invocation for group N>. Report PASS/FAIL line 1, then failures."
+
+AGGREGATE: pipe all JSON lines through oc-aggregate.mjs; merge into single verdict:
+TOTAL pass/fail counts = sum of groups. A failure in ANY group = suite FAIL.
+
+FALLBACK: fleet unusable -> run the full suite once yourself, report normally.
+REPORT: suite verdict, per-group table (group | tests | pass/fail | tokens), failure details.

--- a/engineering/hivemind/scripts/bench/grader-prompt.md
+++ b/engineering/hivemind/scripts/bench/grader-prompt.md
@@ -1,0 +1,39 @@
+You are a BLIND GRADER evaluating an AI agent's output on a coding task.
+
+You will receive: (1) the original task spec, (2) the agent's final output/diff.
+You do NOT know which system produced it. Do not speculate about it.
+
+Score each dimension honestly using these anchors:
+
+CORRECTNESS (0-4)
+4 = logic correct; tests pass if any were required by the task
+2 = works for the main path but has minor defects or missed edge cases
+0   = broken, incorrect, or does not run
+1/3 = in between; justify your pick
+
+COMPLETENESS (0-3)
+3 = every requirement in the task spec addressed
+2 = most requirements, one gap
+1 = major gaps
+0 = essentially not done
+
+CODE QUALITY (0-2)
+2 = clean, idiomatic, matches conventions of surrounding code
+1 = functional but sloppy (naming, structure, dead code)
+0 = unacceptable quality
+
+SCOPE DISCIPLINE (0-1)
+1 = touched only what the task required
+0 = unrelated changes, drive-by refactors, or collateral damage
+
+OUTPUT FORMAT (exactly this):
+SCORE: <n>/12
+GATE: PASS | FAIL | N/A
+CORRECTNESS: <n>/4 - <one line justification>
+COMPLETENESS: <n>/3 - <one line justification>
+QUALITY: <n>/2 - <one line justification>
+SCOPE: <n>/1 - <one line justification>
+TOP ISSUE: <the single worst defect, one line>
+
+Be strict. A pretty answer that fails the task's objective must get GATE: FAIL
+and low CORRECTNESS regardless of style.

--- a/engineering/hivemind/scripts/bench/run-bench.mjs
+++ b/engineering/hivemind/scripts/bench/run-bench.mjs
@@ -1,0 +1,128 @@
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKER = join(__dirname, "..", "oc-worker.mjs");
+const RESULTS_FILE = process.env.HIVEMIND_BENCH_RESULTS || "bench-results.jsonl";
+
+function parseArgs(argv) {
+  const out = { repo: process.cwd(), configs: "a,b,c", tasks: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--repo") out.repo = resolve(argv[++i]);
+    else if (a === "--configs") out.configs = argv[++i].toLowerCase();
+    else if (a === "--task") out.tasks = [Number(argv[++i])];
+  }
+  return out;
+}
+
+function resolveBin(name) {
+  const probe = spawnSync("where.exe", [name], { encoding: "utf8" });
+  if (probe.status === 0) {
+    const first = probe.stdout.split(/\r?\n/).map(s => s.trim()).filter(Boolean)[0];
+    if (first) return first;
+  }
+  return name;
+}
+
+const TASKS = [
+  { id: 1, kind: "explain", prompt: "Read the main entry point of this repository and explain in under 200 words what the project does, how it starts, and its three most important files. Cite file paths." },
+  { id: 2, kind: "tests", prompt: "Find one small, pure utility function in this codebase and write a unit test file for it using the project's existing test framework and conventions. Do not modify source files." },
+  { id: 3, kind: "bugfix", prompt: "Scan for a TODO or FIXME comment that marks a small, self-contained fix (under ~30 lines). Implement exactly that fix. If none is suitable, fix the smallest real bug you can identify instead." },
+  { id: 4, kind: "refactor", prompt: "Pick ONE function longer than 40 lines with high cyclomatic complexity and extract 1-2 well-named helper functions from it. Behavior must be unchanged. Touch nothing else." },
+  { id: 5, kind: "review", prompt: "Review the most recently modified source file in this repository as a senior engineer. Report only defects that would actually occur at runtime, each with the input that triggers it, plus file:line references. If there are none, say so in one line." },
+];
+
+function runA(task, bin) {
+  const t0 = Date.now();
+  const r = spawnSync(bin, ["-p", task.prompt, "--output-format", "json"], {
+    cwd: task.cwd, encoding: "utf8", maxBuffer: 256 * 1024 * 1024,
+    timeout: 900000, windowsHide: true,
+    env: { ...process.env },
+  });
+  let usage = null, costUsd = null, result = "";
+  try {
+    const j = JSON.parse(r.stdout.trim().split(/\r?\n/).filter(Boolean).pop());
+    result = j.result || "";
+    costUsd = j.total_cost_usd ?? null;
+    usage = j.usage ? { in: j.usage.input_tokens, out: j.usage.output_tokens } : null;
+  } catch {
+    result = ((r.stdout || "") + (r.stderr || "")).trim().slice(-2000);
+  }
+  return { ok: Boolean(result), result, tokens: usage, cost_usd: costUsd, duration_ms: Date.now() - t0 };
+}
+
+function runB(task, node) {
+  const t0 = Date.now();
+  const r = spawnSync(node, [WORKER, "--dir", task.cwd, "--timeout", "900", task.prompt], {
+    cwd: task.cwd, encoding: "utf8", maxBuffer: 256 * 1024 * 1024,
+    timeout: 960000, windowsHide: true,
+  });
+  try {
+    const j = JSON.parse((r.stdout || "").trim().split(/\r?\n/).filter(Boolean).pop());
+    return { ok: j.ok === true, result: j.result || "", tokens: j.tokens ? { in: j.tokens.input, out: j.tokens.output } : null, cost_usd: j.cost_usd, duration_ms: j.duration_ms ?? Date.now() - t0 };
+  } catch {
+    return { ok: false, result: ((r.stderr || "") + (r.error || "")).slice(0, 500), tokens: null, cost_usd: null, duration_ms: Date.now() - t0 };
+  }
+}
+
+function runC(task, claudeBin, node) {
+  const orchestratorPrompt =
+    `You are an orchestrator with access to Bash. Complete this task by delegating to TWO free opencode workers ` +
+    `using parallel Bash tool calls in one message:\n` +
+    `node "${WORKER}" --dir "${task.cwd}" --timeout 900 "<SUBTASK_A>"\n` +
+    `node "${WORKER}" --dir "${task.cwd}" --timeout 900 "<SUBTASK_B>"\n` +
+    `Split the work sensibly, wait for both compact JSON results, then integrate their outputs yourself ` +
+    `and produce the final answer. Never paste raw streams into your context.\nTASK: ${task.prompt}`;
+  const t0 = Date.now();
+  const r = spawnSync(claudeBin, ["-p", orchestratorPrompt, "--output-format", "json",
+    "--allowedTools", "Bash(node:*) Read(*) Grep(*) Glob(*)"], {
+    cwd: task.cwd, encoding: "utf8", maxBuffer: 256 * 1024 * 1024,
+    timeout: 1200000, windowsHide: true, env: { ...process.env },
+  });
+  let usage = null, costUsd = null, result = "";
+  try {
+    const j = JSON.parse(r.stdout.trim().split(/\r?\n/).filter(Boolean).pop());
+    result = j.result || "";
+    costUsd = j.total_cost_usd ?? null;
+    usage = j.usage ? { in: j.usage.input_tokens, out: j.usage.output_tokens } : null;
+  } catch {
+    result = ((r.stdout || "") + (r.stderr || "")).trim().slice(-2000);
+  }
+  return { ok: Boolean(result), result, tokens: usage, cost_usd: costUsd, duration_ms: Date.now() - t0 };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!existsSync(opts.repo)) { console.error(`repo not found: ${opts.repo}`); process.exit(1); }
+  const configs = opts.configs.split(",").map(s => s.trim()).filter(Boolean);
+  const tasks = TASKS.filter(t => !opts.tasks || opts.tasks.includes(t.id))
+    .map(t => ({ ...t, cwd: opts.repo }));
+
+  const claudeBin = resolveBin("claude");
+  const nodeBin = process.execPath;
+
+  console.log(`hivemind bench | repo=${opts.repo} | configs=${configs.join("+")} | tasks=${tasks.map(t => t.id).join(",")}`);
+
+  for (const task of tasks) {
+    for (const cfg of configs) {
+      const runner = cfg === "a" ? () => runA(task, claudeBin)
+        : cfg === "b" ? () => runB(task, nodeBin)
+        : cfg === "c" ? () => runC(task, claudeBin, nodeBin)
+        : null;
+      if (!runner) continue;
+      process.stdout.write(`task ${task.id} (${task.kind}) config ${cfg.toUpperCase()} ... `);
+      const res = runner();
+      const record = { ts: new Date().toISOString(), task_id: task.id, kind: task.kind, config: cfg.toUpperCase(), repo: opts.repo, ...res };
+      appendFileSync(resolve(RESULTS_FILE), JSON.stringify(record) + "\n");
+      console.log(`${res.ok ? "ok" : "FAIL"} | ${Math.round(res.duration_ms / 1000)}s | tokens=${JSON.stringify(res.tokens)} | cost=$${res.cost_usd ?? "?"}`);
+    }
+  }
+
+  console.log(`\nresults appended to ${resolve(RESULTS_FILE)}`);
+  console.log("next: grade each artifact blind with scripts/bench/grader-prompt.md, add score field per line.");
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/engineering/hivemind/scripts/oc-aggregate.mjs
+++ b/engineering/hivemind/scripts/oc-aggregate.mjs
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+
+function readInput() {
+  const args = process.argv.slice(2).filter(a => a !== "--findings-only");
+  const findingsOnly = process.argv.includes("--findings-only");
+  let raw = "";
+  if (args.length) {
+    for (const f of args) {
+      try { raw += readFileSync(f, "utf8") + "\n"; }
+      catch { console.log(JSON.stringify({ ok: false, stage: "aggregate", error: `cannot read file: ${f}` })); process.exit(0); }
+    }
+  } else raw = readFileSync(0, "utf8");
+  return { raw, findingsOnly };
+}
+
+function normalizeLine(s) {
+  return s.toLowerCase().replace(/[\s\p{P}]+/gu, " ").trim();
+}
+
+function extractFindings(text) {
+  const out = [];
+  for (const line of text.split(/\r?\n/)) {
+    const t = line.trim();
+    if (/^([-*•]|\d+[.)])\s+/.test(t) && t.length > 12) out.push(t.replace(/^([-*•]|\d+[.)])\s+/, "").trim());
+    else if (/^(file|path|src|lib)\b.*:\d+/i.test(t) && t.length > 12) out.push(t);
+  }
+  return out;
+}
+
+function main() {
+  const { raw, findingsOnly } = readInput();
+  const workers = [];
+  for (const line of raw.split(/\r?\n/).filter(l => l.trim())) {
+    try {
+      const j = JSON.parse(line.trim());
+      if (!("ok" in j)) continue;
+      workers.push(j);
+    } catch {}
+  }
+  if (!workers.length) { console.log(JSON.stringify({ ok: false, stage: "aggregate", error: "no worker JSON lines found in input" })); return; }
+
+  const ok = workers.filter(w => w.ok === true);
+  const failed = workers.filter(w => w.ok !== true);
+  const totalTokens = ok.reduce((n, w) => n + (w.tokens?.total ?? 0), 0);
+
+  const seen = new Map();
+  let anonIdx = 0;
+  for (const w of ok) {
+    const src = w.label || w.agent || `worker-${++anonIdx}`;
+    for (const f of extractFindings(w.result || "")) {
+      const key = normalizeLine(f);
+      if (!seen.has(key)) seen.set(key, { finding: f, sources: [src] });
+      else if (!seen.get(key).sources.includes(src)) seen.get(key).sources.push(src);
+    }
+  }
+  const unique = [...seen.values()].sort((a, b) => b.sources.length - a.sources.length).slice(0, 60);
+
+  const digest = {
+    ok: true,
+    workers: workers.length,
+    succeeded: ok.length,
+    failed: failed.length,
+    total_tokens: totalTokens,
+    unique_findings: unique.length,
+    failures: failed.map(w => ({ label: w.label || w.agent, error: (w.error || "unknown").slice(0, 120) })),
+    consensus: unique.filter(u => u.sources.length > 1),
+    findings: unique,
+  };
+
+  if (findingsOnly) {
+    console.log(digest.consensus.map(c => `[${c.sources.join("+")}] ${c.finding}`).join("\n"));
+    console.log("---");
+    console.log(digest.findings.filter(f => f.sources.length === 1).map(c => `[${c.sources[0]}] ${c.finding}`).join("\n"));
+    return;
+  }
+  console.log(JSON.stringify(digest, null, 1));
+}
+
+main();

--- a/engineering/hivemind/scripts/oc-status.mjs
+++ b/engineering/hivemind/scripts/oc-status.mjs
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RUNS_DIR = join(dirname(dirname(fileURLToPath(import.meta.url))), ".runs");
+
+function loadRun(path) {
+  const workers = new Map();
+  for (const line of readFileSync(path, "utf8").split(/\r?\n/).filter(Boolean)) {
+    let ev;
+    try { ev = JSON.parse(line); } catch { continue; }
+    const key = ev.label || "worker";
+    const w = workers.get(key) || { label: key, agent: ev.agent || null, status: "running", tokens_total: null, duration_ms: null, error: null };
+    if (ev.event === "start") { w.status = "running"; w.agent = ev.agent || w.agent; }
+    if (ev.event === "done") { w.status = "done"; w.tokens_total = ev.tokens_total ?? w.tokens_total; w.duration_ms = ev.duration_ms ?? w.duration_ms; }
+    if (ev.event === "fail") { w.status = "failed"; w.error = ev.error || ev.stage; }
+    workers.set(key, w);
+  }
+  return [...workers.values()];
+}
+
+function summarize(runId, workers) {
+  const done = workers.filter(w => w.status === "done");
+  const failed = workers.filter(w => w.status === "failed");
+  const running = workers.filter(w => w.status === "running");
+  const lines = [
+    `run ${runId}: ${done.length}/${workers.length} done, ${failed.length} failed, ${running.length} in flight`,
+  ];
+  for (const w of workers) {
+    const tok = w.tokens_total != null ? `, ${w.tokens_total} tok` : "";
+    lines.push(`  [${w.status.toUpperCase().padEnd(6)}] ${w.label}${w.agent ? ` (${w.agent})` : ""}${tok}${w.status === "failed" ? ` - ${w.error}` : ""}`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  if (!existsSync(RUNS_DIR)) { console.log("no runs recorded"); return; }
+  const ids = process.argv.slice(2).filter(a => !a.startsWith("-"));
+  const files = ids.length
+    ? ids.map(id => ({ id, path: join(RUNS_DIR, `${id}.jsonl`) })).filter(f => existsSync(f.path))
+    : readdirSync(RUNS_DIR).filter(f => f.endsWith(".jsonl")).sort().map(f => ({ id: f.replace(/\.jsonl$/, ""), path: join(RUNS_DIR, f) }));
+  if (!files.length) { console.log("no matching runs"); return; }
+  for (const f of files) console.log(summarize(f.id, loadRun(f.path)));
+}
+
+main();

--- a/engineering/hivemind/scripts/oc-worker.mjs
+++ b/engineering/hivemind/scripts/oc-worker.mjs
@@ -5,7 +5,23 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SERVER = process.env.HIVEMIND_SERVER_URL || "http://127.0.0.1:4096";
-const PORT = new URL(SERVER).port || "4096";
+// SERVER comes from the environment and PORT is handed to a child process, so validate
+// both here - and still emit exactly one JSON line when they are unusable.
+const PORT = resolvePort(SERVER);
+
+function bail(error) {
+  console.log(JSON.stringify({ ok: false, stage: "args", error, result: "", tokens: null, cost_usd: null, duration_ms: 0 }));
+  process.exit(0);
+}
+
+function resolvePort(server) {
+  let url;
+  try { url = new URL(server); } catch { bail("HIVEMIND_SERVER_URL is not a valid URL"); }
+  const port = url.port || "4096";
+  if (!/^[0-9]{1,5}$/.test(port) || Number(port) < 1 || Number(port) > 65535) bail("HIVEMIND_SERVER_URL has an invalid port");
+  return port;
+}
+
 const DEFAULT_MODEL = "opencode/mimo-v2.5-free";
 const STDERR_TAIL = 300;
 const RUNS_DIR = join(dirname(dirname(fileURLToPath(import.meta.url))), ".runs");
@@ -79,8 +95,9 @@ function resolveOpencode() {
 
 async function ensureServer(bin) {
   if (await alive()) return [];
-  const quoted = /\s/.test(bin) ? `"${bin}"` : bin;
-  const child = spawn(`${quoted} serve --port ${PORT}`, { shell: true, detached: true, stdio: "ignore" });
+  // Args array with shell:false - nothing here is shell-interpolated, so a hostile
+  // HIVEMIND_SERVER_URL cannot inject syntax and paths with spaces need no quoting.
+  const child = spawn(bin, ["serve", "--port", PORT], { shell: false, detached: true, stdio: "ignore", windowsHide: true });
   child.unref();
   for (let i = 0; i < 10; i++) {
     await delay(500);

--- a/engineering/hivemind/scripts/oc-worker.mjs
+++ b/engineering/hivemind/scripts/oc-worker.mjs
@@ -1,0 +1,180 @@
+import { spawnSync, spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { readFileSync, statSync, mkdirSync, appendFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SERVER = process.env.HIVEMIND_SERVER_URL || "http://127.0.0.1:4096";
+const PORT = new URL(SERVER).port || "4096";
+const DEFAULT_MODEL = "opencode/mimo-v2.5-free";
+const STDERR_TAIL = 300;
+const RUNS_DIR = join(dirname(dirname(fileURLToPath(import.meta.url))), ".runs");
+
+let RUN = null, LABEL = null, AGENT = null;
+
+function logRun(event, extra = {}) {
+  if (!RUN) return;
+  try {
+    mkdirSync(RUNS_DIR, { recursive: true });
+    appendFileSync(join(RUNS_DIR, `${RUN}.jsonl`), JSON.stringify({ ts: Date.now(), event, label: LABEL, agent: AGENT, ...extra }) + "\n");
+  } catch {}
+}
+
+function parseArgs(argv) {
+  const out = { agent: null, model: null, dir: null, timeoutMs: 600000, run: null, label: null, task: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--agent") out.agent = argv[++i] ?? null;
+    else if (a === "--model") out.model = argv[++i] ?? null;
+    else if (a === "--dir") out.dir = argv[++i] ?? null;
+    else if (a === "--timeout") out.timeoutMs = Number(argv[++i]) * 1000 || out.timeoutMs;
+    else if (a === "--run") out.run = argv[++i] ?? null;
+    else if (a === "--label") out.label = argv[++i] ?? null;
+    else out.task.push(a);
+  }
+  out.task = out.task.join(" ").trim();
+  return out;
+}
+
+function fail(stage, message, extra = {}) {
+  const payload = { ok: false, stage, error: String(message).slice(0, STDERR_TAIL), result: "", tokens: null, cost_usd: null, duration_ms: 0, ...extra };
+  if (payload.duration_ms) logRun("fail", { stage, error: payload.error, duration_ms: payload.duration_ms });
+  console.log(JSON.stringify(payload));
+  process.exit(0);
+}
+
+async function alive(url = SERVER, ms = 500) {
+  try {
+    await fetch(url, { signal: AbortSignal.timeout(ms) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveOpencode() {
+  if (process.platform !== "win32") {
+    const posix = spawnSync("which", ["opencode"], { encoding: "utf8" });
+    const path = posix.status === 0 ? posix.stdout.trim().split(/\r?\n/)[0] : "";
+    return path || "opencode";
+  }
+  // Windows: npm installs a .cmd shim, and Node's EINVAL policy blocks spawning
+  // .cmd directly - so resolve the real .exe (parsing the shim when needed).
+  const probe = spawnSync("where.exe", ["opencode"], { encoding: "utf8" });
+  if (probe.status === 0) {
+    const lines = probe.stdout.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+    const exe = lines.find(l => l.toLowerCase().endsWith(".exe"));
+    if (exe) return exe;
+    const cmdShim = lines.find(l => l.toLowerCase().endsWith(".cmd"));
+    if (cmdShim) {
+      try {
+        const body = readFileSync(cmdShim, "utf8");
+        const m = body.match(/"%dp0%\\(.*?\.exe)"/i);
+        if (m) return join(dirname(cmdShim), m[1]);
+      } catch {}
+    }
+  }
+  return "opencode";
+}
+
+async function ensureServer(bin) {
+  if (await alive()) return [];
+  const quoted = /\s/.test(bin) ? `"${bin}"` : bin;
+  const child = spawn(`${quoted} serve --port ${PORT}`, { shell: true, detached: true, stdio: "ignore" });
+  child.unref();
+  for (let i = 0; i < 10; i++) {
+    await delay(500);
+    if (await alive()) return ["--attach", SERVER];
+  }
+  return [];
+}
+
+async function main() {
+  const t0 = Date.now();
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.task) fail("args", "no task given");
+  RUN = opts.run; LABEL = opts.label || opts.agent || "worker"; AGENT = opts.agent;
+  logRun("start", { model: opts.model, dir: opts.dir });
+  if (opts.dir && !existsDir(opts.dir)) fail("args", `--dir does not exist: ${opts.dir}`);
+
+  const bin = resolveOpencode();
+  const attachArgs = await ensureServer(bin);
+
+  const baseArgs = ["run"];
+  if (opts.agent) baseArgs.push("--agent", opts.agent);
+  if (opts.model) baseArgs.push("--model", opts.model);
+  if (opts.dir) baseArgs.push("--dir", opts.dir);
+  baseArgs.push(...attachArgs);
+
+  let r = spawnSync(bin, [...baseArgs, "--format", "json", opts.task], {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+    timeout: opts.timeoutMs,
+    env: { ...process.env },
+    windowsHide: true,
+  });
+
+  if (!r.stdout || !r.stdout.trim()) {
+    const tailErr = ((r.stderr || "") + " " + (r.error ? String(r.error) : "")).trim();
+    const retry = spawnSync(bin, [...baseArgs, opts.task], {
+      encoding: "utf8", maxBuffer: 64 * 1024 * 1024, timeout: opts.timeoutMs, windowsHide: true,
+    });
+    const text = (retry.stdout || "").trim();
+    if (text) {
+      logRun("done", { degraded: true, duration_ms: Date.now() - t0 });
+      console.log(JSON.stringify({ ok: true, degraded: "plain-format-fallback", result: text.slice(-20000), tokens: null, cost_usd: null, duration_ms: Date.now() - t0, agent: opts.agent, model: opts.model }));
+      return;
+    }
+    fail("exec", tailErr || `opencode exited ${r.status}`, { duration_ms: Date.now() - t0 });
+  }
+
+  const parsed = parseNdjson(r.stdout);
+  if (!parsed.ok) {
+    fail(parsed.stage, parsed.error, { duration_ms: Date.now() - t0, model: opts.model });
+  }
+
+  const duration = Date.now() - t0;
+  logRun("done", { tokens_total: parsed.tokens?.total ?? null, duration_ms: duration });
+  console.log(JSON.stringify({
+    ok: true,
+    result: parsed.result.slice(-20000),
+    tokens: parsed.tokens,
+    cost_usd: parsed.costUsd,
+    session_id: parsed.sessionId,
+    duration_ms: duration,
+    label: LABEL,
+    agent: opts.agent,
+    model: opts.model ?? DEFAULT_MODEL,
+  }));
+}
+
+function parseNdjson(stdout) {
+  const lines = stdout.split(/\r?\n/).filter(l => l.trim());
+  const texts = [];
+  let tokens = null, costUsd = null, sessionId = null, sawFinish = false;
+  for (const line of lines) {
+    let ev;
+    try { ev = JSON.parse(line); } catch { continue; }
+    if (ev.type === "error") {
+      const msg = ev.error?.data?.message || ev.error?.message || "APIError";
+      return { ok: false, stage: "api", error: msg };
+    }
+    if (ev.type === "text" && ev.part?.text != null) texts.push(ev.part.text);
+    if (ev.type === "step_finish" && ev.part) {
+      sawFinish = true;
+      sessionId = ev.sessionID || sessionId;
+      if (ev.part.tokens) tokens = ev.part.tokens;
+      if (typeof ev.part.cost === "number") costUsd = ev.part.cost;
+    }
+  }
+  const result = texts.join("\n").trim();
+  if (!result && !sawFinish) return { ok: false, stage: "parse", error: "no text parts and no step_finish in stream" };
+  if (!result) return { ok: false, stage: "empty", error: "worker produced no text output" };
+  return { ok: true, result, tokens, costUsd, sessionId };
+}
+
+function existsDir(p) {
+  try { return statSync(p).isDirectory(); } catch { return false; }
+}
+
+main().catch(e => fail("crash", e?.stack || e));


### PR DESCRIPTION
## Summary
- **What:** adds `engineering/hivemind`, a skill that lets an orchestrating agent delegate mechanical work to headless [opencode](https://opencode.ai) workers (scout / coder / tester) running on free models, while the orchestrator stays the only planner, reviewer, and merger.
- **Why:** the expensive model's context is the scarce resource. Hivemind moves grunt work (multi-lens review, research sweeps, bulk migrations, partitioned test runs) onto disposable workers and returns one compact JSON line per worker, so raw agent streams never enter the orchestrator's context.

Supersedes #976, which targeted `main` and was auto-closed. This one targets `dev` and is rebased on it.

## What is in the skill
- `SKILL.md` (165 lines) — invocation contract, swarm flow, fallback ladder, anti-patterns, cross-references
- `scripts/oc-worker.mjs` — the single sanctioned worker entry point (server watchdog, NDJSON parsing, stderr caps, run logging)
- `scripts/oc-status.mjs`, `scripts/oc-aggregate.mjs` — fleet progress and consensus aggregation
- `scripts/bench/` — A/B/C benchmark runner and a blind grading rubric
- `assets/commands/`, `assets/agents/` — the slash commands and worker personas the skill references

## Dependency disclosure
Scripts are Node (>= 18), not Python, and the skill wraps the external `opencode` CLI — both are documented in a Prerequisites section at the top of SKILL.md, including that the free tier belongs to opencode and can change. Flagging this explicitly against CONVENTIONS: if Node scripts or the external-CLI dependency are disqualifying, say so and I will close this rather than have you triage it.

## Canonical home

Maintained at **https://github.com/Hanishchow/hivemind** (Apache 2.0). This PR is a snapshot; fixes land there first and get ported here.

## Checklist
- [x] Targets `dev` branch
- [x] SKILL.md frontmatter: `name` + `description` only
- [x] Under 500 lines (165)
- [x] Anti-patterns section included
- [x] Cross-references to related skills included
- [x] No modifications to `.codex/`, `.gemini/`, `marketplace.json`, or index files
- [x] No 3rd party links added to README
- [x] Clean diff — single commit rebased on `dev`, no merge history
- [x] Scripts are `.mjs`, so `python3 script.py --help` does not apply

