### PR TITLE
fix(ci): don't count a Tessl CLI error as a sub-threshold quality score

### DIFF
--- a/.github/workflows/skill-quality-review.yml
+++ b/.github/workflows/skill-quality-review.yml
@@ -99,6 +99,7 @@ jobs:
           SKILLS='${{ needs.detect-skills.outputs.skills }}'
           REPORT_FILE=$(mktemp)
           OVERALL_EXIT=0
+          TESSL_ERRORS=0
           THRESHOLD=70
 
           echo "## 📊 Skill Quality Review (Tessl)" > "$REPORT_FILE"
@@ -141,8 +142,17 @@ jobs:
 
             IFS='|' read -r NAME SCORE DS CS VSTATUS SUGGESTIONS <<< "$PARSED"
 
-            # Determine verdict
-            if [ "$SCORE" -ge "$THRESHOLD" ]; then
+            # Determine verdict. VSTATUS=ERROR means the Tessl CLI or the JSON
+            # parse failed before producing a review — that is a tool outage,
+            # not a genuine 0-score skill, so it must not block the merge
+            # (a real CLI failure scores every skill an identical 0/100; see
+            # the false-negative triage on the v2.12.0 promotion PR #985).
+            if [ "$VSTATUS" = "ERROR" ]; then
+              ICON="⚙️"
+              VERDICT="TOOL ERROR (not scored)"
+              TESSL_ERRORS=$((TESSL_ERRORS + 1))
+              echo "::warning::Tessl could not score $skill_dir — CLI output (truncated): $(echo "$JSON_OUT" | head -c 300)"
+            elif [ "$SCORE" -ge "$THRESHOLD" ]; then
               ICON="✅"
               VERDICT="PASS"
             else
@@ -151,7 +161,11 @@ jobs:
               OVERALL_EXIT=1
             fi
 
-            echo "| \`$skill_dir\` | **${SCORE}/100** ${ICON} | ${DS}% | ${CS}% | ${VERDICT} |" >> "$REPORT_FILE"
+            if [ "$VSTATUS" = "ERROR" ]; then
+              echo "| \`$skill_dir\` | ${ICON} not scored | — | — | ${VERDICT} |" >> "$REPORT_FILE"
+            else
+              echo "| \`$skill_dir\` | **${SCORE}/100** ${ICON} | ${DS}% | ${CS}% | ${VERDICT} |" >> "$REPORT_FILE"
+            fi
 
             # Add suggestions as details
             SUGG_COUNT=$(echo "$SUGGESTIONS" | python3 -c "import sys,json; print(len(json.loads(sys.stdin.readline())))" 2>/dev/null || echo "0")
@@ -183,6 +197,11 @@ jobs:
 
           echo "" >> "$REPORT_FILE"
           echo "_Threshold: ${THRESHOLD}/100 — skills below this score need improvement before merge._" >> "$REPORT_FILE"
+
+          if [ "$TESSL_ERRORS" -gt 0 ]; then
+            echo "" >> "$REPORT_FILE"
+            echo "> ⚙️ ${TESSL_ERRORS} skill(s) could not be scored — the Tessl CLI errored before producing a review. Reported as a warning, not a merge blocker; if this persists, check the Tessl CLI install/auth in this workflow." >> "$REPORT_FILE"
+          fi
 
           echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           echo "exit_code=$OVERALL_EXIT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/skill-quality-review.yml
+++ b/.github/workflows/skill-quality-review.yml
@@ -200,7 +200,8 @@ jobs:
 
           if [ "$TESSL_ERRORS" -gt 0 ]; then
             echo "" >> "$REPORT_FILE"
-            echo "> ⚙️ ${TESSL_ERRORS} skill(s) could not be scored — the Tessl CLI errored before producing a review. Reported as a warning, not a merge blocker; if this persists, check the Tessl CLI install/auth in this workflow." >> "$REPORT_FILE"
+            echo "> ⚙️ ${TESSL_ERRORS} skill(s) could not be scored — the Tessl CLI errored before producing a review." >> "$REPORT_FILE"
+            echo "> Reported as a warning, not a merge blocker; if this persists, check the Tessl CLI install/auth in this workflow." >> "$REPORT_FILE"
           fi
 
           echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes the Tessl false-negative that hit both #984 and the v2.12.0 promotion PR #985 (maintainer requested this fix).

**Root cause:** `skill-quality-review.yml`'s parse fallback emits `unknown|0|0|0|ERROR` whenever the `tessl skill review` CLI dies (auth/quota/npm failure), but the verdict logic only compared `SCORE` against the 70 threshold — so a tool outage rendered as `0/100 NEEDS WORK` and **blocked the merge**, indistinguishable from a genuinely zero-quality skill. On #985 all four flagged skills scored an identical 0/100 with the whole 4-review loop finishing in ~8 seconds — the CLI was erroring instantly.

**Fix:** `VSTATUS == ERROR` now renders as a `⚙️ TOOL ERROR (not scored)` table row (score columns show `—`), emits a `::warning::` annotation carrying the CLI's actual output (truncated to 300 chars) so the underlying auth/install problem is finally visible in the run, and adds a report footer counting unscored skills. It does **not** set the blocking exit code. Genuine sub-threshold scores still block exactly as before; the security-audit blocking path is untouched.

## Verification

- Workflow YAML parses clean.
- Simulated the modified verdict block against three mocked `tessl` outputs:
  - CLI error text (`401 Unauthorized`) → `TOOL ERROR (not scored)` row + warning, non-blocking
  - Valid JSON, score 85 → `PASS`
  - Valid JSON, score 40 → `NEEDS WORK`, blocking exit code set
  - All-error run → job passes with warnings (tool outage never blocks)

Note: this PR touches only the workflow file, so the Tessl workflow itself doesn't trigger here (its path filter is `**/SKILL.md` / `**/scripts/*.py`). The live validation happens on #985: once this merges into `dev`, the promotion PR's next Tessl run will show the four unscored skills as non-blocking `⚙️` rows and the check will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgc6RYXWJPr5oW9DHU7zR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgc6RYXWJPr5oW9DHU7zR4)_