### PR TITLE
fix(docs): true two stale skill counts to 380 and bring them under the counter gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -720,4 +720,4 @@ When I correct you, or you catch yourself making a mistake: before continuing ad
 
 **Last Updated:** August 24, 2026
 **Version:** v2.12.0 (consolidated release — see CHANGELOG.md)
-**Status:** 379 skills deployed across 20 domains, 96 marketplace plugins, docs site live (counters derived via `scripts/derive_counters.py`)
+**Status:** 380 production-ready skills across 20 domains, 96 marketplace plugins, docs site live (counters derived via `scripts/derive_counters.py`)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run `./scripts/convert.sh --tool all` to generate tool-specific outputs locally.
 
 ## Skills Overview
 
-**370 skills across 20 domains:**
+**380 production-ready skills across 20 domains:**
 
 | Domain | Skills | Highlights | Details |
 |--------|--------|------------|---------|

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -149,12 +149,18 @@ CLAIM_PATTERNS = {
 
 
 def extract_claims(text: str) -> dict:
-    """Return {counter_name: first claimed int} for every pattern found in text."""
+    """Return {counter_name: [every claimed int]} for every pattern found in text.
+
+    All occurrences are collected (not just the first) so a stale duplicate of a
+    headline claim elsewhere in the same file — e.g. a section heading that
+    repeats the skill count — is gated too (caught live on the v2.12.0
+    promotion PR #985, where the README banner said 380 while a section
+    heading still said 370)."""
     claims = {}
     for key, pattern in CLAIM_PATTERNS.items():
-        match = pattern.search(text)
-        if match:
-            claims[key] = int(match.group(1))
+        values = [int(m.group(1)) for m in pattern.finditer(text)]
+        if values:
+            claims[key] = values
     return claims
 
 
@@ -272,9 +278,11 @@ def run_check(root: Path, derived: dict) -> int:
     claude_md = root / "CLAUDE.md"
     if claude_md.is_file():
         text = claude_md.read_text(encoding="utf-8")
-        # Restrict to the "Current Scope" line so history sections don't trip the gate.
-        scope_lines = [ln for ln in text.splitlines() if ln.startswith("**Current Scope:**")]
-        sources.append(("CLAUDE.md (Current Scope line)", "\n".join(scope_lines)))
+        # Restrict to the "Current Scope" and footer "Status:" lines so
+        # history sections don't trip the gate.
+        scope_lines = [ln for ln in text.splitlines()
+                       if ln.startswith("**Current Scope:**") or ln.startswith("**Status:**")]
+        sources.append(("CLAUDE.md (Current Scope / Status lines)", "\n".join(scope_lines)))
 
     marketplace = root / ".claude-plugin" / "marketplace.json"
     if marketplace.is_file():
@@ -292,12 +300,13 @@ def run_check(root: Path, derived: dict) -> int:
         if not claims:
             mismatches.append(f"{label}: no recognizable counter claims found")
             continue
-        for key, claimed in claims.items():
+        for key, values in claims.items():
             actual = derived[key]
-            if claimed != actual:
-                mismatches.append(
-                    f"{label}: claims {key}={claimed}, derived {key}={actual}"
-                )
+            for claimed in values:
+                if claimed != actual:
+                    mismatches.append(
+                        f"{label}: claims {key}={claimed}, derived {key}={actual}"
+                    )
 
     mismatches.extend(check_domain_table(root))
     mismatches.extend(check_readme_badges(root, derived))

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -273,6 +273,10 @@ def run_check(root: Path, derived: dict) -> int:
 
     readme = root / "README.md"
     if readme.is_file():
+        # README is scanned in full (unlike CLAUDE.md below): it carries no
+        # version-history prose, so every claim-pattern match in it is a live
+        # headline that must agree with the derived values. If a history
+        # section is ever added to README, restrict this the same way.
         sources.append(("README.md", readme.read_text(encoding="utf-8")))
 
     claude_md = root / "CLAUDE.md"


### PR DESCRIPTION
## Summary

Second review catch on promotion PR #985, same class as #986: two stale skill counts survived the release true-up —

- `README.md` "Skills Overview" heading: **370** → **380** (the per-domain table below it already sums to 380)
- `CLAUDE.md` footer `**Status:**` line: **379** → **380**

## Why the gate missed these

Both wordings ("370 skills across…", "379 skills deployed across…") were invisible to `derive_counters.py`'s standardized claim patterns — which is exactly how they could drift. Three changes close the gap:

1. Both lines reworded into the standardized `<N> production-ready skills across <D> domains` phrasing the patterns recognize.
2. `extract_claims()` now validates **every occurrence** of each claim pattern, not just the first — so a stale duplicate elsewhere in the same file (like this README heading) is gated even when the banner above it is correct.
3. `run_check()` now reads CLAUDE.md's `**Status:**` footer line alongside `**Current Scope:**`.

## Verification

- Planted `999`/`998` in the two fixed lines → gate fails naming both (`README.md: claims skills=999…`, `CLAUDE.md (Current Scope / Status lines): claims skills=998…`); restored values → pass.
- Full-file sweep confirmed README contains no historical claim-pattern values that the all-occurrences check would false-positive on.
- `scripts/derive_counters.py --check` → clean on the fixed tree.

Merging into `dev` updates promotion PR #985 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgc6RYXWJPr5oW9DHU7zR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgc6RYXWJPr5oW9DHU7zR4)_