### PR TITLE
fix(docs): true up nine-release-stale Codex manifest, gate it and mkdocs.yml in the counter check

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-skills",
-  "version": "2.2.0",
-  "description": "223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, C-level advisory, and more. The largest open-source skills library for AI coding agents.",
+  "version": "2.12.0",
+  "description": "380 production-ready skills across 20 domains — engineering, marketing, product, compliance, C-level advisory, research, business operations, and more. 706 Python tools, 823 reference guides, 114 agents (cs-* + personas), 138 slash commands, 96 marketplace plugins. The largest open-source skills library for AI coding agents.",
   "author": {
     "name": "Alireza Rezvani",
     "url": "https://alirezarezvani.com"
@@ -27,8 +27,8 @@
     "type": "cli",
     "composerIcon": "./assets/icon.png",
     "displayName": "Claude Code Skills",
-    "shortDescription": "223 production-ready skills for AI coding agents across 9 domains",
-    "longDescription": "The largest open-source skills library for AI coding agents. 223 skills covering engineering (architecture, DevOps, security, AI/ML), marketing (SEO, CRO, content), product management, C-level advisory, regulatory compliance (ISO 13485, SOC 2, GDPR), project management, business growth, and finance. Includes 298 stdlib-only Python CLI tools, 416 reference guides, 23 orchestration agents, and 22 slash commands. Works with Codex, Claude Code, Gemini CLI, Cursor, Aider, Windsurf, and 5 more tools.",
+    "shortDescription": "380 production-ready skills for AI coding agents across 20 domains",
+    "longDescription": "The largest open-source skills library for AI coding agents. 380 skills covering engineering (architecture, DevOps, security, AI/ML, agent tooling), marketing (SEO, AEO, CRO, content), product management, C-level advisory, regulatory compliance (ISO 13485, SOC 2, GDPR), project management, research and research operations, business operations, commercial, finance, and personal productivity. Includes 706 stdlib-only Python CLI tools, 823 reference guides, 114 orchestration agents, and 138 slash commands. Works with Codex, Claude Code, Gemini CLI, Cursor, Hermes Agent, Mistral Vibe, and 7 more tools.",
     "developerName": "Alireza Rezvani",
     "category": "Coding",
     "capabilities": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Claude Code Skills & Agent Plugins
 site_url: https://alirezarezvani.github.io/claude-skills/
-site_description: "380 production-ready agent skills, 96 installable plugins, and 138 slash commands across 20 domains — engineering, product, marketing, compliance, finance, research, and agent tooling. Works with Claude Code, OpenAI Codex, Gemini CLI, Cursor, Hermes Agent, Mistral Vibe, OpenClaw, and 6 more AI coding tools. Open source, MIT licensed, zero dependencies."
+site_description: "380 production-ready skills across 20 domains, 96 marketplace plugins, and 138 slash commands — engineering, product, marketing, compliance, finance, research, and agent tooling. Works with Claude Code, OpenAI Codex, Gemini CLI, Cursor, Hermes Agent, Mistral Vibe, OpenClaw, and 6 more AI coding tools. Open source, MIT licensed, zero dependencies."
 site_author: Alireza Rezvani
 repo_url: https://github.com/alirezarezvani/claude-skills
 repo_name: alirezarezvani/claude-skills

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -298,6 +298,26 @@ def run_check(root: Path, derived: dict) -> int:
             print(f"FAIL: cannot parse marketplace.json: {exc}")
             return 1
 
+    # The two sites PR #940 found drifting ungated: the docs-site description
+    # and the Codex plugin manifest (which had lagged nine releases behind).
+    mkdocs = root / "mkdocs.yml"
+    if mkdocs.is_file():
+        # mkdocs.yml carries !!python tags safe_load rejects — read as text and
+        # restrict to the site_description line, mirroring the CLAUDE.md approach.
+        desc_lines = [ln for ln in mkdocs.read_text(encoding="utf-8").splitlines()
+                      if ln.startswith("site_description:")]
+        sources.append(("mkdocs.yml (site_description)", "\n".join(desc_lines)))
+
+    codex_manifest = root / ".codex-plugin" / "plugin.json"
+    if codex_manifest.is_file():
+        try:
+            data = json.loads(codex_manifest.read_text(encoding="utf-8"))
+            sources.append((".codex-plugin/plugin.json description",
+                            data.get("description", "")))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"FAIL: cannot parse .codex-plugin/plugin.json: {exc}")
+            return 1
+
     mismatches = []
     for label, text in sources:
         claims = extract_claims(text)
@@ -322,7 +342,7 @@ def run_check(root: Path, derived: dict) -> int:
         print("\nRun `python3 scripts/derive_counters.py` for the ground-truth table.")
         return 1
 
-    print("Counter check passed: README.md, CLAUDE.md, marketplace.json match derived values.")
+    print("Counter check passed: README.md, CLAUDE.md, marketplace.json, mkdocs.yml, .codex-plugin match derived values.")
     return 0
 
 

--- a/scripts/derive_counters.py
+++ b/scripts/derive_counters.py
@@ -312,8 +312,14 @@ def run_check(root: Path, derived: dict) -> int:
     if codex_manifest.is_file():
         try:
             data = json.loads(codex_manifest.read_text(encoding="utf-8"))
-            sources.append((".codex-plugin/plugin.json description",
-                            data.get("description", "")))
+            # Include the interface descriptions too — they carry their own
+            # counts; only standardized-phrasing claims in them are gated.
+            iface = data.get("interface", {})
+            codex_text = " ".join(str(s) for s in (
+                data.get("description", ""),
+                iface.get("shortDescription", ""),
+                iface.get("longDescription", "")))
+            sources.append((".codex-plugin/plugin.json descriptions", codex_text))
         except (json.JSONDecodeError, OSError) as exc:
             print(f"FAIL: cannot parse .codex-plugin/plugin.json: {exc}")
             return 1


### PR DESCRIPTION
## Summary

Adopts the two verified findings from PR #940 (credit: @benrfairless), which was closed as unmergeable — see the closing comment there for the full rationale.

**1. `.codex-plugin/plugin.json` was nine releases stale** — still v2.2.0 / 223 skills / 23 agents / 298 tools / 9 domains, and it's the manifest Codex users see. Trued to v2.12.0 counters (380 skills · 20 domains · 706 tools · 823 refs · 114 agents · 138 commands · 96 plugins) across `version`, `description`, and both `interface` short/long descriptions. The top-level description is written in the standardized claim phrasing so the counter gate can read it.

**2. Both previously-ungated sites are now claim sources in `derive_counters.py --check`:**
- `mkdocs.yml` `site_description` — content was correct after v2.12.0 but phrased invisibly to `extract_claims` ("agent skills" / "installable plugins"); reworded to the standardized phrasing and read as a source (restricted to the `site_description:` line, since mkdocs.yml's `!!python` tags reject `safe_load`).
- `.codex-plugin/plugin.json` `description`.

## Verification

- `derive_counters.py --check` → pass on the fixed tree (now covering README, CLAUDE.md, marketplace.json, mkdocs.yml, .codex-plugin).
- Drift injection: planting `999`/`998` in the two new sites → gate fails naming both; restored → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgc6RYXWJPr5oW9DHU7zR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgc6RYXWJPr5oW9DHU7zR4)_